### PR TITLE
Initialize Transact Warhead System

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -167,6 +167,7 @@ This page lists all the individual contributions to the project by their author.
   - Building `LimboDelivery` logic
   - Fix for `Image` in art rules
   - Power delta counter
+  - Transact Warhead
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -84,6 +84,7 @@
     <ClCompile Include="src\Ext\TerrainType\Hooks.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Hooks.Passable.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.DisallowMoving.cpp" />
+    <ClCompile Include="src\Ext\WarheadType\Transact.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Firing.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Shield.cpp" />

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Credits
 - **Morton (MortonPL)** - developer
 - **Trsdy (chaserli)** - developer
 
+- **Morton (MortonPL)** - XDrawOffset, Shield passthrough & absorption, building LimboDelivery, fix for Image in art rules, power delta counter, transact warhead
 For all contributions see [full credits list](CREDITS.md).
 
 Thanks to everyone who uses Phobos, tests changes and reports bugs! You can show your appreciation and help project by displaying the logo (monochrome version can be found [here](https://github.com/Phobos-developers/Phobos/blob/develop/logo-mono.png)) in your client/launcher (make it open Phobos GitHub page for extra fanciness), linking to Phobos repository, contributing or donating to us via the links above.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Credits
 - **Morton (MortonPL)** - developer
 - **Trsdy (chaserli)** - developer
 
-- **Morton (MortonPL)** - XDrawOffset, Shield passthrough & absorption, building LimboDelivery, fix for Image in art rules, power delta counter, transact warhead
 For all contributions see [full credits list](CREDITS.md).
 
 Thanks to everyone who uses Phobos, tests changes and reports bugs! You can show your appreciation and help project by displaying the logo (monochrome version can be found [here](https://github.com/Phobos-developers/Phobos/blob/develop/logo-mono.png)) in your client/launcher (make it open Phobos GitHub page for extra fanciness), linking to Phobos repository, contributing or donating to us via the links above.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -919,6 +919,40 @@ In `rulesmd.ini`:
 BigGap=false   ; boolean
 ```
 
+### Transact Warhead
+
+- It is now possible to increase, decrease or transfer specific "values" between Technos.
+  - To enable this feature, `Transact=true` must be set and at least one source or target value needs to be non-zero.
+  - Source is the Techno that fired the warhead, Target is a Techno (or group) that is affected by the warhead.
+  - Flat values are amounts that are directly added/substracted, while percent values are calculated relatively to the unit's state.
+    - In case of experience, value from percent is calculated by multiplying it by current unit cost.
+    - By default Source.Percent (percent of value that Source will receive) is calculated from Source unit cost, however it is possible to force calculation from Target cost with `CalcFromTarget` (Target and `CalcFtomSOurce` behaves analogically).
+  - When both Flat and Percent values are set, the one that yields higher value is used.
+  - Transfer occurs only when either the calculated experience to Source or to Target is negative. If both values are positive or negative, then all units gain or lose experience, respectively.
+  - In transfer, if Source and Target values are different, then the smaller of them is used.
+  - In transfer, if it is not possible to transfer the whole amount (i.e. a unit has not enough experience), then only the maximum possible transfer amount is transferred.
+  - Source values are ignored if the warhead is not created by a unit (i.e. via a super weapon or map action). Target values are ignored if the warhead doesn't affect any units (fired at empty ground).
+    - In both cases, transfer is impossible.
+  - `Transact.SpreadAmongTargets` has effect on warheads with CellSpread. When set, instead of applying the full value to each Target separately, the value will be divided among the victims.
+
+It is impossible to revert veterancy-caused unit type conversion from Ares by demoting a unit!
+
+Currently supported "values" are:
+- Experience
+
+In `rulesmd.ini`:
+```ini
+[SOMEWARHEAD]                                           ; Warhead
+Transact=false                                          ; boolean
+Transact.SpreadAmongTargets=false                       ; boolean
+Transact.Experience.Source.Flat=0                       ; integer
+Transact.Experience.Source.Percent=0.0                  ; float, percents or absolute (-1.0 - 1.0)
+Transact.Experience.Source.Percent.CalcFromTarget=false ; boolean
+Transact.Experience.Target.Flat=0                       ; integer
+Transact.Experience.Target.Percent=0.0                  ; float, percents or absolute (-1.0 - 1.0)
+Transact.Experience.Target.Percent.CalcFromSource=false ; boolean
+```
+
 ### Trigger specific NotHuman infantry Death anim sequence
 - Warheads are now able to trigger specific `NotHuman=yes` infantry `Death` anim sequence using the corresponding tag. It's value represents sequences from `Die1` to `Die5`.
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -922,12 +922,13 @@ BigGap=false   ; boolean
 ### Transact Warhead
 
 - It is now possible to increase, decrease or transfer specific "values" (referred to as Currency) between Technos.
-  - To enable this feature, `Transact=true` must be set and at least one `X.Source` or `X.Target` tag needs to be non-zero.
+  - To enable this feature, at least one `X.Source` or `X.Target` tag needs to be non-zero.
   - Source is the Techno that fired the warhead, target is a Techno (or a group) that is affected by the warhead.
   - `X.Flat` values grant absolute Currency, while `X.Percent` values grant Currency calculated relatively to the unit's state.
     - In case of experience, value from `X.Percent` is calculated by multiplying it by current unit cost.
-    - By default `X.Source.Percent` (percent of value that Source will receive) is calculated from Source unit cost, however it is possible to force calculation from Target cost with `CalcFromTarget` (Target and `CalcFromSource` behaves analogically).
-    - When both `X.Flat` and `X.Percent` values are set, the one that yields more Currency is used.
+    - By default `X.Source.Percent` (percent of value that Source will receive) is calculated from Source unit cost, however it is possible to force calculation from Target cost with `RelativeToTarget` (Target and `RelativeToSource` behaves analogically).
+    - When both `X.Flat` and `X.Percent` values are set, they are added together.
+    - The resulting Currency can be then limited with `X.Min` and `X.Max`.
   - If final Currency amount is positive or negative for both Source and Target, then all affected units gain or lose Currency.
   - When the final amount of Currency is negative only for either Source or Target, **Transfer** occurs.
     - In transfer, if the absolute value of Currency for Source and Target are different, then the smaller of them is used.
@@ -948,17 +949,20 @@ Currently supported "values" are:
 In `rulesmd.ini`:
 ```ini
 [SOMEWARHEAD]                                           ; Warhead
-Transact=false                                          ; boolean
 Transact.RequiresAnyTarget=true                         ; boolean
 Transact.RequiresValidTarget=true                       ; boolean
 Transact.SpreadAmongTargets=false                       ; boolean
 Transact.Experience.IgnoreNotTrainable=false            ; boolean
 Transact.Experience.Source.Flat=0                       ; integer
 Transact.Experience.Source.Percent=0.0                  ; float, percents or absolute (-1.0 - 1.0)
-Transact.Experience.Source.Percent.CalcFromTarget=false ; boolean
+Transact.Experience.Source.Min=-2147483647              ; integer
+Transact.Experience.Source.Max=2147483647               ; integer
+Transact.Experience.Source.RelativeToTarget=false       ; boolean
 Transact.Experience.Target.Flat=0                       ; integer
 Transact.Experience.Target.Percent=0.0                  ; float, percents or absolute (-1.0 - 1.0)
-Transact.Experience.Target.Percent.CalcFromSource=false ; boolean
+Transact.Experience.Target.Min=-2147483647              ; integer
+Transact.Experience.Target.Max=2147483647               ; integer
+Transact.Experience.Target.RelativeToSource=false       ; boolean
 ```
 
 ### Trigger specific NotHuman infantry Death anim sequence

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -921,21 +921,26 @@ BigGap=false   ; boolean
 
 ### Transact Warhead
 
-- It is now possible to increase, decrease or transfer specific "values" between Technos.
-  - To enable this feature, `Transact=true` must be set and at least one source or target value needs to be non-zero.
-  - Source is the Techno that fired the warhead, Target is a Techno (or group) that is affected by the warhead.
-  - Flat values are amounts that are directly added/substracted, while percent values are calculated relatively to the unit's state.
-    - In case of experience, value from percent is calculated by multiplying it by current unit cost.
-    - By default Source.Percent (percent of value that Source will receive) is calculated from Source unit cost, however it is possible to force calculation from Target cost with `CalcFromTarget` (Target and `CalcFtomSOurce` behaves analogically).
-  - When both Flat and Percent values are set, the one that yields higher value is used.
-  - Transfer occurs only when either the calculated experience to Source or to Target is negative. If both values are positive or negative, then all units gain or lose experience, respectively.
-  - In transfer, if Source and Target values are different, then the smaller of them is used.
-  - In transfer, if it is not possible to transfer the whole amount (i.e. a unit has not enough experience), then only the maximum possible transfer amount is transferred.
-  - Source values are ignored if the warhead is not created by a unit (i.e. via a super weapon or map action). Target values are ignored if the warhead doesn't affect any units (fired at empty ground).
-    - In both cases, transfer is impossible.
-  - `Transact.SpreadAmongTargets` has effect on warheads with CellSpread. When set, instead of applying the full value to each Target separately, the value will be divided among the victims.
+- It is now possible to increase, decrease or transfer specific "values" (referred to as Currency) between Technos.
+  - To enable this feature, `Transact=true` must be set and at least one `X.Source` or `X.Target` tag needs to be non-zero.
+  - Source is the Techno that fired the warhead, target is a Techno (or a group) that is affected by the warhead.
+  - `X.Flat` values grant absolute Currency, while `X.Percent` values grant Currency calculated relatively to the unit's state.
+    - In case of experience, value from `X.Percent` is calculated by multiplying it by current unit cost.
+    - By default `X.Source.Percent` (percent of value that Source will receive) is calculated from Source unit cost, however it is possible to force calculation from Target cost with `CalcFromTarget` (Target and `CalcFromSource` behaves analogically).
+    - When both `X.Flat` and `X.Percent` values are set, the one that yields more Currency is used.
+  - If final Currency amount is positive or negative for both Source and Target, then all affected units gain or lose Currency.
+  - When the final amount of Currency is negative only for either Source or Target, **Transfer** occurs.
+    - In transfer, if the absolute value of Currency for Source and Target are different, then the smaller of them is used.
+    - In transfer, if it is not possible to transfer the whole amount (i.e. a unit has not enough Currency), then only the possible amount is transferred.
+  - Source values are ignored if the warhead is not created by a unit (i.e. via a super weapon, animation weapon or map action).
+  - `Transact.SpreadAmongTargets` has effect on warheads with CellSpread. When set, instead of applying the full Currency amount to each Target separately, the value will be evenly distributed among the victims.
+  - `Transact.Experience.IgnoreNotTrainable=true` will allow to give experience to units with `Trainable=false` set.
+  - `Transact.RequiresValidTarget=false` will allow the source unit to lose/obtain Currency when the warhead doesn't detonate on a valid target (i.e. having 0% versus a unit). However, target remains unaffected and if Source was supposed to take part in a transfer, nothing will happen!
+  - `Transact.RequiresAnyTarget=false` will allow the source unit to lose/obtain Currency when the warhead doesn't detonate on any target (i.e. force firing on the ground). However, if Source was supposed to take part in a transfer, nothing will happen! This tag takes priority over `Transact.RequiresValidTarget`.
 
+```{warning}
 It is impossible to revert veterancy-caused unit type conversion from Ares by demoting a unit!
+```
 
 Currently supported "values" are:
 - Experience
@@ -944,7 +949,10 @@ In `rulesmd.ini`:
 ```ini
 [SOMEWARHEAD]                                           ; Warhead
 Transact=false                                          ; boolean
+Transact.RequiresAnyTarget=true                         ; boolean
+Transact.RequiresValidTarget=true                       ; boolean
 Transact.SpreadAmongTargets=false                       ; boolean
+Transact.Experience.IgnoreNotTrainable=false            ; boolean
 Transact.Experience.Source.Flat=0                       ; integer
 Transact.Experience.Source.Percent=0.0                  ; float, percents or absolute (-1.0 - 1.0)
 Transact.Experience.Source.Percent.CalcFromTarget=false ; boolean

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -350,6 +350,7 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
+- Transact warhead (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -245,6 +245,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 New:
 - `Crit.AffectsHouses` for critical hit system (by Starkku)
 - Warhead or weapon detonation at superweapon target cell (by Starkku)
+- Transact warhead (by Morton)
 </details>
 
 
@@ -350,7 +351,6 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
-- Transact warhead (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -222,7 +222,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Crit_AnimOnAffectedTargets)
 		.Process(this->Crit_AffectBelowPercent)
 		.Process(this->Crit_SuppressWhenIntercepted)
-		
+
 		.Process(this->Transact)
 		.Process(this->Transact_RequiresAnyTarget)
 		.Process(this->Transact_RequiresValidTarget)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -117,7 +117,6 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ShakeIsLocal.Read(exINI, pSection, "ShakeIsLocal");
 
 	// Transact
-	this->Transact.Read(exINI, pSection, "Transact");
 	this->Transact_RequiresAnyTarget.Read(exINI, pSection, "Transact.RequiresAnyTarget");
 	this->Transact_RequiresValidTarget.Read(exINI, pSection, "Transact.RequiresValidTarget");
 	this->Transact_SpreadAmongTargets.Read(exINI, pSection, "Transact.SpreadAmongTargets");
@@ -125,10 +124,21 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Transact_Experience_IgnoreNotTrainable.Read(exINI, pSection, "Transact.Experience.IgnoreNotTrainable");
 	this->Transact_Experience_Source_Flat.Read(exINI, pSection, "Transact.Experience.Source.Flat");
 	this->Transact_Experience_Source_Percent.Read(exINI, pSection, "Transact.Experience.Source.Percent");
-	this->Transact_Experience_Source_Percent_CalcFromTarget.Read(exINI, pSection, "Transact.Experience.Source.Percent.CalcFromTarget");
+	this->Transact_Experience_Source_RelativeToTarget.Read(exINI, pSection, "Transact.Experience.Source.RelativeToTarget");
+	this->Transact_Experience_Source_Min.Read(exINI, pSection, "Transact.Experience.Source.Min");
+	this->Transact_Experience_Source_Max.Read(exINI, pSection, "Transact.Experience.Source.Max");
 	this->Transact_Experience_Target_Flat.Read(exINI, pSection, "Transact.Experience.Target.Flat");
 	this->Transact_Experience_Target_Percent.Read(exINI, pSection, "Transact.Experience.Target.Percent");
-	this->Transact_Experience_Target_Percent_CalcFromSource.Read(exINI, pSection, "Transact.Experience.Target.Percent.CalcFromSource");
+	this->Transact_Experience_Target_RelativeToSource.Read(exINI, pSection, "Transact.Experience.Target.RelativeToSource");
+	this->Transact_Experience_Target_Min.Read(exINI, pSection, "Transact.Experience.Target.Min");
+	this->Transact_Experience_Target_Max.Read(exINI, pSection, "Transact.Experience.Target.Max");
+	if (this->Transact_Experience_Source_Flat != 0
+		|| this->Transact_Experience_Source_Percent != 0.0
+		|| this->Transact_Experience_Target_Flat != 0
+		|| this->Transact_Experience_Target_Percent != 0.0)
+	{
+		this->Transact = true;
+	}
 
 	// Crits
 	this->Crit_Chance.Read(exINI, pSection, "Crit.Chance");
@@ -230,10 +240,14 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Transact_Experience_Value)
 		.Process(this->Transact_Experience_Source_Flat)
 		.Process(this->Transact_Experience_Source_Percent)
-		.Process(this->Transact_Experience_Source_Percent_CalcFromTarget)
+		.Process(this->Transact_Experience_Source_RelativeToTarget)
+		.Process(this->Transact_Experience_Source_Min)
+		.Process(this->Transact_Experience_Source_Max)
 		.Process(this->Transact_Experience_Target_Flat)
 		.Process(this->Transact_Experience_Target_Percent)
-		.Process(this->Transact_Experience_Target_Percent_CalcFromSource)
+		.Process(this->Transact_Experience_Target_RelativeToSource)
+		.Process(this->Transact_Experience_Target_Min)
+		.Process(this->Transact_Experience_Target_Max)
 
 		.Process(this->MindControl_Anim)
 

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -116,6 +116,12 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DecloakDamagedTargets.Read(exINI, pSection, "DecloakDamagedTargets");
 	this->ShakeIsLocal.Read(exINI, pSection, "ShakeIsLocal");
 
+	this->Experience_GivenFlat.Read(exINI, pSection, "Experience.GivenFlat");
+	this->Experience_GivenPercent.Read(exINI, pSection, "Experience.GivenPercent");
+	this->Experience_Transfer.Read(exINI, pSection, "Experience.Transfer");
+	this->Experience_FirerGetsExp.Read(exINI, pSection, "Experience.FirerGetsExp");
+	this->Experience_CalculatePercentFromFirer.Read(exINI, pSection, "Experience.CalculatePercentFromFirer");
+
 	// Crits
 	this->Crit_Chance.Read(exINI, pSection, "Crit.Chance");
 	this->Crit_ApplyChancePerTarget.Read(exINI, pSection, "Crit.ApplyChancePerTarget");
@@ -208,6 +214,12 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Crit_AnimOnAffectedTargets)
 		.Process(this->Crit_AffectBelowPercent)
 		.Process(this->Crit_SuppressWhenIntercepted)
+		
+		.Process(this->Experience_GivenFlat)
+		.Process(this->Experience_GivenPercent)
+		.Process(this->Experience_Transfer)
+		.Process(this->Experience_FirerGetsExp)
+		.Process(this->Experience_CalculatePercentFromFirer)
 
 		.Process(this->MindControl_Anim)
 

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -118,8 +118,11 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	// Transact
 	this->Transact.Read(exINI, pSection, "Transact");
+	this->Transact_RequiresAnyTarget.Read(exINI, pSection, "Transact.RequiresAnyTarget");
+	this->Transact_RequiresValidTarget.Read(exINI, pSection, "Transact.RequiresValidTarget");
 	this->Transact_SpreadAmongTargets.Read(exINI, pSection, "Transact.SpreadAmongTargets");
 	this->Transact_Experience_Value.Read(exINI, pSection, "Transact.Experience.Value");
+	this->Transact_Experience_IgnoreNotTrainable.Read(exINI, pSection, "Transact.Experience.IgnoreNotTrainable");
 	this->Transact_Experience_Source_Flat.Read(exINI, pSection, "Transact.Experience.Source.Flat");
 	this->Transact_Experience_Source_Percent.Read(exINI, pSection, "Transact.Experience.Source.Percent");
 	this->Transact_Experience_Source_Percent_CalcFromTarget.Read(exINI, pSection, "Transact.Experience.Source.Percent.CalcFromTarget");
@@ -221,6 +224,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Crit_SuppressWhenIntercepted)
 		
 		.Process(this->Transact)
+		.Process(this->Transact_RequiresAnyTarget)
+		.Process(this->Transact_RequiresValidTarget)
 		.Process(this->Transact_SpreadAmongTargets)
 		.Process(this->Transact_Experience_Value)
 		.Process(this->Transact_Experience_Source_Flat)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -116,11 +116,13 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DecloakDamagedTargets.Read(exINI, pSection, "DecloakDamagedTargets");
 	this->ShakeIsLocal.Read(exINI, pSection, "ShakeIsLocal");
 
-	this->Experience_GivenFlat.Read(exINI, pSection, "Experience.GivenFlat");
-	this->Experience_GivenPercent.Read(exINI, pSection, "Experience.GivenPercent");
-	this->Experience_Transfer.Read(exINI, pSection, "Experience.Transfer");
-	this->Experience_FirerGetsExp.Read(exINI, pSection, "Experience.FirerGetsExp");
-	this->Experience_CalculatePercentFromFirer.Read(exINI, pSection, "Experience.CalculatePercentFromFirer");
+	// Transact
+	this->Transact_Source_Experience_Flat.Read(exINI, pSection, "Transact.Source.Experience.Flat");
+	this->Transact_Source_Experience_Percent.Read(exINI, pSection, "Transact.Source.Experience.Percent");
+	this->Transact_Source_Experience_Percent_CalcFromTarget.Read(exINI, pSection, "Transact.Source.Experience.Percent.CalcFromTarget");
+	this->Transact_Target_Experience_Flat.Read(exINI, pSection, "Transact.Target.Experience.Flat");
+	this->Transact_Target_Experience_Percent.Read(exINI, pSection, "Transact.Target.Experience.Percent");
+	this->Transact_Target_Experience_Percent_CalcFromSource.Read(exINI, pSection, "Transact.Target.Experience.Percent.CalcFromSource");
 
 	// Crits
 	this->Crit_Chance.Read(exINI, pSection, "Crit.Chance");
@@ -215,11 +217,12 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Crit_AffectBelowPercent)
 		.Process(this->Crit_SuppressWhenIntercepted)
 		
-		.Process(this->Experience_GivenFlat)
-		.Process(this->Experience_GivenPercent)
-		.Process(this->Experience_Transfer)
-		.Process(this->Experience_FirerGetsExp)
-		.Process(this->Experience_CalculatePercentFromFirer)
+		.Process(this->Transact_Source_Experience_Flat)
+		.Process(this->Transact_Source_Experience_Percent)
+		.Process(this->Transact_Source_Experience_Percent_CalcFromTarget)
+		.Process(this->Transact_Target_Experience_Flat)
+		.Process(this->Transact_Target_Experience_Percent)
+		.Process(this->Transact_Target_Experience_Percent_CalcFromSource)
 
 		.Process(this->MindControl_Anim)
 

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -117,12 +117,15 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ShakeIsLocal.Read(exINI, pSection, "ShakeIsLocal");
 
 	// Transact
-	this->Transact_Source_Experience_Flat.Read(exINI, pSection, "Transact.Source.Experience.Flat");
-	this->Transact_Source_Experience_Percent.Read(exINI, pSection, "Transact.Source.Experience.Percent");
-	this->Transact_Source_Experience_Percent_CalcFromTarget.Read(exINI, pSection, "Transact.Source.Experience.Percent.CalcFromTarget");
-	this->Transact_Target_Experience_Flat.Read(exINI, pSection, "Transact.Target.Experience.Flat");
-	this->Transact_Target_Experience_Percent.Read(exINI, pSection, "Transact.Target.Experience.Percent");
-	this->Transact_Target_Experience_Percent_CalcFromSource.Read(exINI, pSection, "Transact.Target.Experience.Percent.CalcFromSource");
+	this->Transact.Read(exINI, pSection, "Transact");
+	this->Transact_SpreadAmongTargets.Read(exINI, pSection, "Transact.SpreadAmongTargets");
+	this->Transact_Experience_Value.Read(exINI, pSection, "Transact.Experience.Value");
+	this->Transact_Experience_Source_Flat.Read(exINI, pSection, "Transact.Experience.Source.Flat");
+	this->Transact_Experience_Source_Percent.Read(exINI, pSection, "Transact.Experience.Source.Percent");
+	this->Transact_Experience_Source_Percent_CalcFromTarget.Read(exINI, pSection, "Transact.Experience.Source.Percent.CalcFromTarget");
+	this->Transact_Experience_Target_Flat.Read(exINI, pSection, "Transact.Experience.Target.Flat");
+	this->Transact_Experience_Target_Percent.Read(exINI, pSection, "Transact.Experience.Target.Percent");
+	this->Transact_Experience_Target_Percent_CalcFromSource.Read(exINI, pSection, "Transact.Experience.Target.Percent.CalcFromSource");
 
 	// Crits
 	this->Crit_Chance.Read(exINI, pSection, "Crit.Chance");
@@ -217,12 +220,15 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Crit_AffectBelowPercent)
 		.Process(this->Crit_SuppressWhenIntercepted)
 		
-		.Process(this->Transact_Source_Experience_Flat)
-		.Process(this->Transact_Source_Experience_Percent)
-		.Process(this->Transact_Source_Experience_Percent_CalcFromTarget)
-		.Process(this->Transact_Target_Experience_Flat)
-		.Process(this->Transact_Target_Experience_Percent)
-		.Process(this->Transact_Target_Experience_Percent_CalcFromSource)
+		.Process(this->Transact)
+		.Process(this->Transact_SpreadAmongTargets)
+		.Process(this->Transact_Experience_Value)
+		.Process(this->Transact_Experience_Source_Flat)
+		.Process(this->Transact_Experience_Source_Percent)
+		.Process(this->Transact_Experience_Source_Percent_CalcFromTarget)
+		.Process(this->Transact_Experience_Target_Flat)
+		.Process(this->Transact_Experience_Target_Percent)
+		.Process(this->Transact_Experience_Target_Percent_CalcFromSource)
 
 		.Process(this->MindControl_Anim)
 

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -138,12 +138,6 @@ public:
 			, Experience_FirerGetsExp(false)
 			, Experience_CalculatePercentFromFirer(false)
 
-			, Crit_Chance(0.0)
-			, Crit_ExtraDamage(0)
-			, Crit_Affects(AffectedTarget::All)
-			, Crit_AnimList()
-			, RandomBuffer(0.0)
-
 			, MindControl_Anim {}
 
 			, Shield_Penetrate { false }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -33,6 +33,12 @@ public:
 
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
+		Valueable<int> Experience_GivenFlat;
+		Valueable<double> Experience_GivenPercent;
+		Valueable<bool> Experience_Transfer;
+		Valueable<bool> Experience_FirerGetsExp;
+		Valueable<bool> Experience_CalculatePercentFromFirer;
+
 		Valueable<int> Crit_ExtraDamage;
 		Nullable<WarheadTypeClass*> Crit_Warhead;
 		Valueable<AffectedTarget> Crit_Affects;
@@ -126,6 +132,17 @@ public:
 			, Crit_AnimOnAffectedTargets { false }
 			, Crit_AffectBelowPercent { 1.0 }
 			, Crit_SuppressWhenIntercepted { false }
+			, Experience_GivenFlat(0)
+			, Experience_GivenPercent(0.0)
+			, Experience_Transfer(false)
+			, Experience_FirerGetsExp(false)
+			, Experience_CalculatePercentFromFirer(false)
+
+			, Crit_Chance(0.0)
+			, Crit_ExtraDamage(0)
+			, Crit_Affects(AffectedTarget::All)
+			, Crit_AnimList()
+			, RandomBuffer(0.0)
 
 			, MindControl_Anim {}
 
@@ -184,6 +201,7 @@ public:
 		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner);
 		void ApplyShieldModifiers(TechnoClass* pTarget);
+		void ApplyModifyExperience(TechnoClass* pTarget, TechnoClass* pOwner);
 
 	public:
 		void Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletExt::ExtData* pBullet, CoordStruct coords);

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -32,6 +32,10 @@ public:
 		Valueable<bool> ShakeIsLocal;
 
 		Valueable<bool> Transact;
+		Valueable<bool> Transact_RequiresAnyTarget;
+		Valueable<bool> Transact_RequiresValidTarget;
+		Valueable<bool> Transact_SpreadAmongTargets;
+		Valueable<bool> Transact_Experience_IgnoreNotTrainable;
 		Valueable<int> Transact_Experience_Value;
 		Valueable<int> Transact_Experience_Source_Flat;
 		Valueable<double> Transact_Experience_Source_Percent;
@@ -39,7 +43,6 @@ public:
 		Valueable<int> Transact_Experience_Target_Flat;
 		Valueable<double> Transact_Experience_Target_Percent;
 		Valueable<bool> Transact_Experience_Target_Percent_CalcFromSource;
-		Valueable<bool> Transact_SpreadAmongTargets;
 
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
@@ -138,6 +141,10 @@ public:
 			, Crit_SuppressWhenIntercepted { false }
 
 			, Transact { false }
+			, Transact_RequiresAnyTarget { true }
+			, Transact_RequiresValidTarget { true }
+			, Transact_SpreadAmongTargets{ false }
+			, Transact_Experience_IgnoreNotTrainable { false }
 			, Transact_Experience_Value { 1 }
 			, Transact_Experience_Source_Flat { 0 }
 			, Transact_Experience_Source_Percent { 0.0 }
@@ -145,7 +152,6 @@ public:
 			, Transact_Experience_Target_Flat { 0 }
 			, Transact_Experience_Target_Percent { 0.0 }
 			, Transact_Experience_Target_Percent_CalcFromSource { false }
-			, Transact_SpreadAmongTargets { false }
 
 			, MindControl_Anim {}
 
@@ -199,12 +205,12 @@ public:
 
 	private:
 		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr, bool bulletWasIntercepted = false);
-		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr);
-		void DetonateOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner);
-		void TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner, int targets);
+		void DetonateOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner, bool bulletWasIntercepted = false);
+		void TransactOnOneUnitCore(HouseClass* pHouse, TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int divider, bool sourceOnly = false);
+		void TransactOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner, int divider);
 		void TransactOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner);
-		int TransactGetValue(TechnoClass* pTarget, TechnoClass* pOwner, int flat, double percent, boolean calcFromTarget, int targetValue, int ownerValue);
-		std::vector<std::vector<int>> TransactGetSourceAndTarget(TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int targets);
+		int TransactGetValue(TechnoClass* pTarget, TechnoClass* pOwner, int flat, double percent, bool calcFromTarget, int targetValue, int ownerValue);
+		std::vector<std::vector<int>> TransactGetSourceAndTarget(TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int divider);
 		int TransactOneValue(TechnoClass* pTechno, TechnoTypeClass* pTechnoType, int transactValue, TransactValueType valueType);
 
 		void ApplyRemoveDisguiseToInf(HouseClass* pHouse, TechnoClass* pTarget);

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -31,12 +31,15 @@ public:
 		Valueable<bool> DecloakDamagedTargets;
 		Valueable<bool> ShakeIsLocal;
 
-		Valueable<int> Transact_Source_Experience_Flat;
-		Valueable<double> Transact_Source_Experience_Percent;
-		Valueable<bool> Transact_Source_Experience_Percent_CalcFromTarget;
-		Valueable<int> Transact_Target_Experience_Flat;
-		Valueable<double> Transact_Target_Experience_Percent;
-		Valueable<bool> Transact_Target_Experience_Percent_CalcFromSource;
+		Valueable<bool> Transact;
+		Valueable<int> Transact_Experience_Value;
+		Valueable<int> Transact_Experience_Source_Flat;
+		Valueable<double> Transact_Experience_Source_Percent;
+		Valueable<bool> Transact_Experience_Source_Percent_CalcFromTarget;
+		Valueable<int> Transact_Experience_Target_Flat;
+		Valueable<double> Transact_Experience_Target_Percent;
+		Valueable<bool> Transact_Experience_Target_Percent_CalcFromSource;
+		Valueable<bool> Transact_SpreadAmongTargets;
 
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
@@ -134,12 +137,15 @@ public:
 			, Crit_AffectBelowPercent { 1.0 }
 			, Crit_SuppressWhenIntercepted { false }
 
-			, Transact_Source_Experience_Flat(0)
-			, Transact_Source_Experience_Percent(0.0)
-			, Transact_Source_Experience_Percent_CalcFromTarget(false)
-			, Transact_Target_Experience_Percent(0.0)
-			, Transact_Target_Experience_Percent_CalcFromSource(false)
-			, Transact_Target_Experience_Flat(0)
+			, Transact { false }
+			, Transact_Experience_Value { 1 }
+			, Transact_Experience_Source_Flat { 0 }
+			, Transact_Experience_Source_Percent { 0.0 }
+			, Transact_Experience_Source_Percent_CalcFromTarget { false }
+			, Transact_Experience_Target_Flat { 0 }
+			, Transact_Experience_Target_Percent { 0.0 }
+			, Transact_Experience_Target_Percent_CalcFromSource { false }
+			, Transact_SpreadAmongTargets { false }
 
 			, MindControl_Anim {}
 
@@ -195,9 +201,11 @@ public:
 		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr, bool bulletWasIntercepted = false);
 		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr);
 		void DetonateOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner);
-		void TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner = nullptr);
+		void TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner, int targets);
 		void TransactOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner);
-		void TransactExperience(TechnoClass* pTarget, TechnoClass* pOwner);
+		int TransactGetValue(TechnoClass* pTarget, TechnoClass* pOwner, int flat, double percent, boolean calcFromTarget, int targetValue, int ownerValue);
+		std::vector<std::vector<int>> TransactGetSourceAndTarget(TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int targets);
+		int TransactOneValue(TechnoClass* pTechno, TechnoTypeClass* pTechnoType, int transactValue, TransactValueType valueType);
 
 		void ApplyRemoveDisguiseToInf(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -31,14 +31,15 @@ public:
 		Valueable<bool> DecloakDamagedTargets;
 		Valueable<bool> ShakeIsLocal;
 
+		Valueable<int> Transact_Source_Experience_Flat;
+		Valueable<double> Transact_Source_Experience_Percent;
+		Valueable<bool> Transact_Source_Experience_Percent_CalcFromTarget;
+		Valueable<int> Transact_Target_Experience_Flat;
+		Valueable<double> Transact_Target_Experience_Percent;
+		Valueable<bool> Transact_Target_Experience_Percent_CalcFromSource;
+
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
-		Valueable<int> Experience_GivenFlat;
-		Valueable<double> Experience_GivenPercent;
-		Valueable<bool> Experience_Transfer;
-		Valueable<bool> Experience_FirerGetsExp;
-		Valueable<bool> Experience_CalculatePercentFromFirer;
-
 		Valueable<int> Crit_ExtraDamage;
 		Nullable<WarheadTypeClass*> Crit_Warhead;
 		Valueable<AffectedTarget> Crit_Affects;
@@ -132,11 +133,13 @@ public:
 			, Crit_AnimOnAffectedTargets { false }
 			, Crit_AffectBelowPercent { 1.0 }
 			, Crit_SuppressWhenIntercepted { false }
-			, Experience_GivenFlat(0)
-			, Experience_GivenPercent(0.0)
-			, Experience_Transfer(false)
-			, Experience_FirerGetsExp(false)
-			, Experience_CalculatePercentFromFirer(false)
+
+			, Transact_Source_Experience_Flat(0)
+			, Transact_Source_Experience_Percent(0.0)
+			, Transact_Source_Experience_Percent_CalcFromTarget(false)
+			, Transact_Target_Experience_Percent(0.0)
+			, Transact_Target_Experience_Percent_CalcFromSource(false)
+			, Transact_Target_Experience_Flat(0)
 
 			, MindControl_Anim {}
 
@@ -190,6 +193,11 @@ public:
 
 	private:
 		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr, bool bulletWasIntercepted = false);
+		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr);
+		void DetonateOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner);
+		void TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner = nullptr);
+		void TransactOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner);
+		void TransactExperience(TechnoClass* pTarget, TechnoClass* pOwner);
 
 		void ApplyRemoveDisguiseToInf(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -203,7 +203,6 @@ public:
 		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner);
 		void ApplyShieldModifiers(TechnoClass* pTarget);
-		void ApplyModifyExperience(TechnoClass* pTarget, TechnoClass* pOwner);
 
 	public:
 		void Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletExt::ExtData* pBullet, CoordStruct coords);

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -39,10 +39,14 @@ public:
 		Valueable<int> Transact_Experience_Value;
 		Valueable<int> Transact_Experience_Source_Flat;
 		Valueable<double> Transact_Experience_Source_Percent;
-		Valueable<bool> Transact_Experience_Source_Percent_CalcFromTarget;
+		Valueable<bool> Transact_Experience_Source_RelativeToTarget;
+		Valueable<int> Transact_Experience_Source_Min;
+		Valueable<int> Transact_Experience_Source_Max;
 		Valueable<int> Transact_Experience_Target_Flat;
 		Valueable<double> Transact_Experience_Target_Percent;
-		Valueable<bool> Transact_Experience_Target_Percent_CalcFromSource;
+		Valueable<bool> Transact_Experience_Target_RelativeToSource;
+		Valueable<int> Transact_Experience_Target_Min;
+		Valueable<int> Transact_Experience_Target_Max;
 
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
@@ -148,10 +152,14 @@ public:
 			, Transact_Experience_Value { 1 }
 			, Transact_Experience_Source_Flat { 0 }
 			, Transact_Experience_Source_Percent { 0.0 }
-			, Transact_Experience_Source_Percent_CalcFromTarget { false }
+			, Transact_Experience_Source_RelativeToTarget { false }
+			, Transact_Experience_Source_Min { -2147483647 }
+			, Transact_Experience_Source_Max { 2147483647 }
 			, Transact_Experience_Target_Flat { 0 }
 			, Transact_Experience_Target_Percent { 0.0 }
-			, Transact_Experience_Target_Percent_CalcFromSource { false }
+			, Transact_Experience_Target_RelativeToSource { false }
+			, Transact_Experience_Target_Min { -2147483647 }
+			, Transact_Experience_Target_Max { 2147483647 }
 
 			, MindControl_Anim {}
 

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -18,14 +18,6 @@
 #include <Misc/FlyingStrings.h>
 #include <Utilities/EnumFunctions.h>
 
-bool isTransact(WarheadTypeExt::ExtData* pExt)
-{
-	return pExt->Transact_Source_Experience_Flat ||
-		pExt->Transact_Source_Experience_Percent ||
-		pExt->Transact_Target_Experience_Flat ||
-		pExt->Transact_Target_Experience_Percent;
-}
-
 void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletExt::ExtData* pBulletExt, CoordStruct coords)
 {
 	auto const pBullet = pBulletExt ? pBulletExt->OwnerObject() : nullptr;
@@ -116,7 +108,7 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 		this->Shield_AttachTypes.size() > 0 ||
 		this->Shield_RemoveTypes.size() > 0 ||
 		this->Crit_Chance ||
-		isTransact(this)
+		this->Transact
 		;
 
 	bool bulletWasIntercepted = pBulletExt && pBulletExt->InterceptedStatus == InterceptedStatus::Intercepted;
@@ -125,7 +117,7 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 	if (cellSpread && isCellSpreadWarhead)
 	{
 		this->DetonateOnAllUnits(pHouse, coords, cellSpread, pOwner);
-		if (isTransact(this))
+		if (this->Transact)
 			this->TransactOnAllUnits(pHouse, coords, cellSpread, pOwner);
 	}
 	else if (pBullet && isCellSpreadWarhead)
@@ -133,8 +125,8 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 		if (auto pTarget = abstract_cast<TechnoClass*>(pBullet->Target))
 		{
 			this->DetonateOnOneUnit(pHouse, pTarget, pOwner);
-			if (isTransact(this))
-				this->TransactOnOneUnit(pTarget, pOwner);
+			if (this->Transact)
+				this->TransactOnOneUnit(pTarget, pOwner, 1);
 		}
 	}
 }

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -107,6 +107,9 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 		this->Shield_SelfHealing_Duration > 0 ||
 		this->Shield_AttachTypes.size() > 0 ||
 		this->Shield_RemoveTypes.size() > 0;
+		this->Crit_Chance ||
+		this->Experience_GivenFlat ||
+		this->Experience_GivenPercent;
 
 	bool bulletWasIntercepted = pBulletExt && pBulletExt->InterceptedStatus == InterceptedStatus::Intercepted;
 
@@ -141,6 +144,9 @@ void WarheadTypeExt::ExtData::DetonateOnOneUnit(HouseClass* pHouse, TechnoClass*
 
 	if (this->Crit_Chance && (!this->Crit_SuppressWhenIntercepted || !bulletWasIntercepted))
 		this->ApplyCrit(pHouse, pTarget, pOwner);
+
+	if (this->Experience_GivenFlat || this->Experience_GivenPercent)
+		this->ApplyModifyExperience(pTarget, pOwner);
 }
 
 void WarheadTypeExt::ExtData::ApplyShieldModifiers(TechnoClass* pTarget)
@@ -315,5 +321,78 @@ void WarheadTypeExt::ExtData::InterceptBullets(TechnoClass* pOwner, WeaponTypeCl
 			if (pTypeExt && pTypeExt->Interceptable && pBullet->Location.DistanceFrom(coords) <= cellSpread * Unsorted::LeptonsPerCell)
 				pExt->InterceptBullet(pOwner, pWeapon);
 		}
+	}
+}
+
+
+// Add or substract experience for real
+int AddExpCustom(VeterancyStruct* vstruct, int ownerCost, int victimCost) {
+	double toBeAdded = (double)victimCost
+		/ (ownerCost * RulesClass::Instance->VeteranRatio);
+	// Used in experience transfer to get the actual amount carried
+	int transffered = (int)(Math::min(vstruct->Veterancy, abs(toBeAdded))
+		* (ownerCost * RulesClass::Instance->VeteranRatio));
+	if (victimCost < 0 && transffered <= 0.0) {
+		vstruct->Reset();
+		transffered = 0;
+	}
+	else {
+		vstruct->Add(toBeAdded);
+	}
+	return transffered;
+}
+
+// General function handling experience warhead behaviour
+void WarheadTypeExt::ExtData::ApplyModifyExperience(TechnoClass* pTarget, TechnoClass* pOwner) {
+
+	bool expTransfer = this->Experience_Transfer;
+	bool expInvertDirection = this->Experience_FirerGetsExp;
+	bool expPercFromFirer = this->Experience_CalculatePercentFromFirer;
+	auto const pTargetTechno = (pTarget) ? pTarget->GetTechnoType() : nullptr;
+	auto const pOwnerTechno = (pOwner) ? pOwner->GetTechnoType() : nullptr;
+
+	int expGain = 0;
+	// Percent experience gain
+	if (this->Experience_GivenPercent) {
+		// Percent from bullet source
+		if (expPercFromFirer && pOwnerTechno)
+			expGain = (int)((pOwnerTechno->GetActualCost(pOwner->Owner) * this->Experience_GivenPercent));
+		// Percent from bullet target
+		else if (!expPercFromFirer && pTargetTechno)
+			expGain = (int)(pTargetTechno->GetActualCost(pTarget->Owner) * this->Experience_GivenPercent);
+		else return;
+	}
+	// Flat gain
+	else {
+		expGain = this->Experience_GivenFlat;
+	}
+
+	// Exp Transfer
+	if (pOwner && pTarget) {
+		if (expTransfer && !expInvertDirection) {
+			// Transfer from Source to Target
+			int diff = AddExpCustom(&pOwner->Veterancy,
+				pOwnerTechno->GetActualCost(pOwner->Owner), -expGain);
+			AddExpCustom(&pTarget->Veterancy,
+				pTargetTechno->GetActualCost(pTarget->Owner), diff);
+		}
+		else if (expTransfer && expInvertDirection) {
+			// Transfer from Target to Source
+			int diff = AddExpCustom(&pTarget->Veterancy,
+				pTargetTechno->GetActualCost(pTarget->Owner), -expGain);
+			AddExpCustom(&pOwner->Veterancy,
+				pOwnerTechno->GetActualCost(pOwner->Owner), diff);
+		}
+	}
+
+	if (!expTransfer && expInvertDirection && pOwner) {
+		// Give Source
+		AddExpCustom(&pOwner->Veterancy,
+			pOwnerTechno->GetActualCost(pOwner->Owner), expGain);
+	}
+	else if (!expTransfer && !expInvertDirection && pTarget) {
+		// Give Target
+		AddExpCustom(&pTarget->Veterancy,
+			pTargetTechno->GetActualCost(pTarget->Owner), expGain);
 	}
 }

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -18,6 +18,14 @@
 #include <Misc/FlyingStrings.h>
 #include <Utilities/EnumFunctions.h>
 
+bool isTransact(WarheadTypeExt::ExtData* pExt)
+{
+	return pExt->Transact_Source_Experience_Flat ||
+		pExt->Transact_Source_Experience_Percent ||
+		pExt->Transact_Target_Experience_Flat ||
+		pExt->Transact_Target_Experience_Percent;
+}
+
 void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletExt::ExtData* pBulletExt, CoordStruct coords)
 {
 	auto const pBullet = pBulletExt ? pBulletExt->OwnerObject() : nullptr;
@@ -108,21 +116,26 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 		this->Shield_AttachTypes.size() > 0 ||
 		this->Shield_RemoveTypes.size() > 0;
 		this->Crit_Chance ||
-		this->Experience_GivenFlat ||
-		this->Experience_GivenPercent;
+		isTransact(this)
+		;
 
 	bool bulletWasIntercepted = pBulletExt && pBulletExt->InterceptedStatus == InterceptedStatus::Intercepted;
 
 	const float cellSpread = this->OwnerObject()->CellSpread;
 	if (cellSpread && isCellSpreadWarhead)
 	{
-		for (auto pTarget : Helpers::Alex::getCellSpreadItems(coords, cellSpread, true))
-			this->DetonateOnOneUnit(pHouse, pTarget, pOwner, bulletWasIntercepted);
+		this->DetonateOnAllUnits(pHouse, coords, cellSpread, pOwner);
+		if (isTransact(this))
+			this->TransactOnAllUnits(pHouse, coords, cellSpread, pOwner);
 	}
 	else if (pBullet && isCellSpreadWarhead)
 	{
 		if (auto pTarget = abstract_cast<TechnoClass*>(pBullet->Target))
-			this->DetonateOnOneUnit(pHouse, pTarget, pOwner, bulletWasIntercepted);
+		{
+			this->DetonateOnOneUnit(pHouse, pTarget, pOwner);
+			if (isTransact(this))
+				this->TransactOnOneUnit(pTarget, pOwner);
+		}
 	}
 }
 
@@ -144,9 +157,14 @@ void WarheadTypeExt::ExtData::DetonateOnOneUnit(HouseClass* pHouse, TechnoClass*
 
 	if (this->Crit_Chance && (!this->Crit_SuppressWhenIntercepted || !bulletWasIntercepted))
 		this->ApplyCrit(pHouse, pTarget, pOwner);
+}
 
-	if (this->Experience_GivenFlat || this->Experience_GivenPercent)
-		this->ApplyModifyExperience(pTarget, pOwner);
+void WarheadTypeExt::ExtData::DetonateOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner)
+{
+	for (auto pTarget : Helpers::Alex::getCellSpreadItems(coords, cellSpread, true))
+	{
+		this->DetonateOnOneUnit(pHouse, pTarget, pOwner);
+	}
 }
 
 void WarheadTypeExt::ExtData::ApplyShieldModifiers(TechnoClass* pTarget)
@@ -321,78 +339,5 @@ void WarheadTypeExt::ExtData::InterceptBullets(TechnoClass* pOwner, WeaponTypeCl
 			if (pTypeExt && pTypeExt->Interceptable && pBullet->Location.DistanceFrom(coords) <= cellSpread * Unsorted::LeptonsPerCell)
 				pExt->InterceptBullet(pOwner, pWeapon);
 		}
-	}
-}
-
-
-// Add or substract experience for real
-int AddExpCustom(VeterancyStruct* vstruct, int ownerCost, int victimCost) {
-	double toBeAdded = (double)victimCost
-		/ (ownerCost * RulesClass::Instance->VeteranRatio);
-	// Used in experience transfer to get the actual amount carried
-	int transffered = (int)(Math::min(vstruct->Veterancy, abs(toBeAdded))
-		* (ownerCost * RulesClass::Instance->VeteranRatio));
-	if (victimCost < 0 && transffered <= 0.0) {
-		vstruct->Reset();
-		transffered = 0;
-	}
-	else {
-		vstruct->Add(toBeAdded);
-	}
-	return transffered;
-}
-
-// General function handling experience warhead behaviour
-void WarheadTypeExt::ExtData::ApplyModifyExperience(TechnoClass* pTarget, TechnoClass* pOwner) {
-
-	bool expTransfer = this->Experience_Transfer;
-	bool expInvertDirection = this->Experience_FirerGetsExp;
-	bool expPercFromFirer = this->Experience_CalculatePercentFromFirer;
-	auto const pTargetTechno = (pTarget) ? pTarget->GetTechnoType() : nullptr;
-	auto const pOwnerTechno = (pOwner) ? pOwner->GetTechnoType() : nullptr;
-
-	int expGain = 0;
-	// Percent experience gain
-	if (this->Experience_GivenPercent) {
-		// Percent from bullet source
-		if (expPercFromFirer && pOwnerTechno)
-			expGain = (int)((pOwnerTechno->GetActualCost(pOwner->Owner) * this->Experience_GivenPercent));
-		// Percent from bullet target
-		else if (!expPercFromFirer && pTargetTechno)
-			expGain = (int)(pTargetTechno->GetActualCost(pTarget->Owner) * this->Experience_GivenPercent);
-		else return;
-	}
-	// Flat gain
-	else {
-		expGain = this->Experience_GivenFlat;
-	}
-
-	// Exp Transfer
-	if (pOwner && pTarget) {
-		if (expTransfer && !expInvertDirection) {
-			// Transfer from Source to Target
-			int diff = AddExpCustom(&pOwner->Veterancy,
-				pOwnerTechno->GetActualCost(pOwner->Owner), -expGain);
-			AddExpCustom(&pTarget->Veterancy,
-				pTargetTechno->GetActualCost(pTarget->Owner), diff);
-		}
-		else if (expTransfer && expInvertDirection) {
-			// Transfer from Target to Source
-			int diff = AddExpCustom(&pTarget->Veterancy,
-				pTargetTechno->GetActualCost(pTarget->Owner), -expGain);
-			AddExpCustom(&pOwner->Veterancy,
-				pOwnerTechno->GetActualCost(pOwner->Owner), diff);
-		}
-	}
-
-	if (!expTransfer && expInvertDirection && pOwner) {
-		// Give Source
-		AddExpCustom(&pOwner->Veterancy,
-			pOwnerTechno->GetActualCost(pOwner->Owner), expGain);
-	}
-	else if (!expTransfer && !expInvertDirection && pTarget) {
-		// Give Target
-		AddExpCustom(&pTarget->Veterancy,
-			pTargetTechno->GetActualCost(pTarget->Owner), expGain);
 	}
 }

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -114,7 +114,7 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 		this->Shield_Respawn_Duration > 0 ||
 		this->Shield_SelfHealing_Duration > 0 ||
 		this->Shield_AttachTypes.size() > 0 ||
-		this->Shield_RemoveTypes.size() > 0;
+		this->Shield_RemoveTypes.size() > 0 ||
 		this->Crit_Chance ||
 		isTransact(this)
 		;

--- a/src/Ext/WarheadType/Transact.cpp
+++ b/src/Ext/WarheadType/Transact.cpp
@@ -1,5 +1,17 @@
 #include "Body.h"
 
+#include <InfantryClass.h>
+#include <BulletClass.h>
+#include <HouseClass.h>
+#include <ScenarioClass.h>
+#include <AnimTypeClass.h>
+#include <AnimClass.h>
+
+#include <Utilities/Helpers.Alex.h>
+#include <Ext/Techno/Body.h>
+#include <Ext/TechnoType/Body.h>
+#include <Utilities/EnumFunctions.h>
+
 // Add or substract experience for real
 int AddExpCustom(VeterancyStruct* vstruct, int ownerCost, int victimCost) {
 	double toBeAdded = (double)victimCost
@@ -36,7 +48,12 @@ void WarheadTypeExt::ExtData::TransactOnAllUnits(HouseClass* pHouse, const Coord
 		this->Transact_Source_Experience_Percent ||
 		this->Transact_Target_Experience_Flat ||
 		this->Transact_Target_Experience_Percent)
-		TransactExperience(pTarget, pOwner);
+	{
+		for (auto pTarget : Helpers::Alex::getCellSpreadItems(coords, cellSpread, true))
+		{
+			TransactExperience(pTarget, pOwner);
+		}
+	}
 
 	// Future transactions here
 }

--- a/src/Ext/WarheadType/Transact.cpp
+++ b/src/Ext/WarheadType/Transact.cpp
@@ -62,7 +62,7 @@ int WarheadTypeExt::ExtData::TransactGetValue(TechnoClass* pTarget, TechnoClass*
 			percentValue = (int)(ownerValue * percent);
 	}
 
-	return abs(percentValue) > abs(flat) ? percentValue : flat;
+	return flat + percentValue;
 }
 
 std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarget(TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int divider)
@@ -78,7 +78,8 @@ std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarge
 	//		Experience
 	int sourceExp = pOwner ? this->TransactGetValue(pTarget, pOwner,
 		this->Transact_Experience_Source_Flat, this->Transact_Experience_Source_Percent,
-		this->Transact_Experience_Source_Percent_CalcFromTarget, targetCost, ownerCost) : 0;
+		this->Transact_Experience_Source_RelativeToTarget, targetCost, ownerCost) : 0;
+	sourceExp = Math::clamp(sourceExp, this->Transact_Experience_Source_Min, this->Transact_Experience_Source_Max);
 	sourceValues.push_back(sourceExp / divider);
 
 	allValues.push_back(sourceValues);
@@ -87,8 +88,9 @@ std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarge
 	//		Experience
 	int targetExp = pTarget ? this->TransactGetValue(pOwner, pTarget,
 		this->Transact_Experience_Target_Flat, this->Transact_Experience_Target_Percent,
-		this->Transact_Experience_Target_Percent_CalcFromSource,
+		this->Transact_Experience_Target_RelativeToSource,
 		ownerCost, targetCost) : 0;
+	targetExp = Math::clamp(targetExp, this->Transact_Experience_Target_Min, this->Transact_Experience_Target_Max);
 	targetValues.push_back(targetExp / divider);
 
 	allValues.push_back(targetValues);

--- a/src/Ext/WarheadType/Transact.cpp
+++ b/src/Ext/WarheadType/Transact.cpp
@@ -11,12 +11,19 @@ int AddExpCustom(VeterancyStruct* vstruct, int targetCost, int exp)
 	int transffered = (int)(Math::min(vstruct->Veterancy, abs(toBeAdded))
 		* (targetCost * RulesClass::Instance->VeteranRatio));
 	// Don't do anything when current exp at 0
-	if (exp < 0 && transffered <= 0) {
+	if (exp < 0 && transffered <= 0)
+	{
 		vstruct->Reset();
 		transffered = 0;
 	}
-	else {
+	else
+	{
 		vstruct->Add(toBeAdded);
+	}
+	// Prevent going above elite level of 2.0
+	if (vstruct->IsElite())
+	{
+		vstruct->SetElite();
 	}
 	return transffered;
 }
@@ -26,13 +33,14 @@ int WarheadTypeExt::ExtData::TransactOneValue(TechnoClass* pTechno, TechnoTypeCl
 	int transferred = 0;
 	switch (valueType)
 	{
-	case TransactValueType::Experience:
-		transferred = AddExpCustom(&pTechno->Veterancy,
-			pTechnoType->GetActualCost(pTechno->Owner), transactValue);
-		break;
-	default:
-		break;
+		case TransactValueType::Experience:
+			transferred = AddExpCustom(&pTechno->Veterancy,
+				pTechnoType->GetActualCost(pTechno->Owner), transactValue);
+			break;
+		default:
+			break;
 	}
+
 	return transferred;
 }
 
@@ -41,11 +49,10 @@ int WarheadTypeExt::ExtData::TransactGetValue(TechnoClass* pTarget, TechnoClass*
 	int flatValue = 0, percentValue = 0;
 
 	// Flat
-	if (pOwner)
-		flatValue = flat;
+	flatValue = flat;
 
 	// Percent
-	if (!CLOSE_ENOUGH(percent, 0.0) && pOwner)
+	if (!CLOSE_ENOUGH(percent, 0.0))
 	{
 		if (calcFromTarget && pTarget)
 			percentValue = (int)(targetValue * percent);
@@ -64,20 +71,20 @@ std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarge
 
 	// SOURCE
 	//		Experience
-	int sourceExp = this->TransactGetValue(pTarget, pOwner,
+	int sourceExp = pOwner ? this->TransactGetValue(pTarget, pOwner,
 		this->Transact_Experience_Source_Flat, this->Transact_Experience_Source_Percent,
 		this->Transact_Experience_Source_Percent_CalcFromTarget,
-		pTargetType->GetActualCost(pTarget->Owner), pOwnerType->GetActualCost(pOwner->Owner));
+		pTargetType->GetActualCost(pTarget->Owner), pOwnerType->GetActualCost(pOwner->Owner)) : 0;
 	sourceValues.push_back(sourceExp / targets);
-	// Others ...
+	//		Others ...
 	allValues.push_back(sourceValues);
 
 	// TARGET
 	//		Experience
-	int targetExp = this->TransactGetValue(pOwner, pTarget,
+	int targetExp = pTarget ? this->TransactGetValue(pOwner, pTarget,
 		this->Transact_Experience_Target_Flat, this->Transact_Experience_Target_Percent,
 		this->Transact_Experience_Target_Percent_CalcFromSource,
-		pOwnerType->GetActualCost(pOwner->Owner), pTargetType->GetActualCost(pTarget->Owner));
+		pOwnerType->GetActualCost(pOwner->Owner), pTargetType->GetActualCost(pTarget->Owner)) : 0;
 	targetValues.push_back(targetExp / targets);
 	//		Others ...
 	allValues.push_back(targetValues);
@@ -87,8 +94,8 @@ std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarge
 
 void WarheadTypeExt::ExtData::TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner, int targets)
 {
-	auto const pTargetType = (pTarget) ? pTarget->GetTechnoType() : nullptr;
-	auto const pOwnerType = (pOwner) ? pOwner->GetTechnoType() : nullptr;
+	auto const pTargetType = pTarget ? pTarget->GetTechnoType() : nullptr;
+	auto const pOwnerType = pOwner ? pOwner->GetTechnoType() : nullptr;
 
 	std::vector<std::vector<int>> allValues = this->TransactGetSourceAndTarget(pTarget, pTargetType, pOwner, pOwnerType, targets);
 

--- a/src/Ext/WarheadType/Transact.cpp
+++ b/src/Ext/WarheadType/Transact.cpp
@@ -1,0 +1,115 @@
+#include "Body.h"
+
+// Add or substract experience for real
+int AddExpCustom(VeterancyStruct* vstruct, int ownerCost, int victimCost) {
+	double toBeAdded = (double)victimCost
+		/ (ownerCost * RulesClass::Instance->VeteranRatio);
+	// Used in experience transfer to get the actual amount carried
+	int transffered = (int)(Math::min(vstruct->Veterancy, abs(toBeAdded))
+		* (ownerCost * RulesClass::Instance->VeteranRatio));
+	if (victimCost < 0 && transffered <= 0.0) {
+		vstruct->Reset();
+		transffered = 0;
+	}
+	else {
+		vstruct->Add(toBeAdded);
+	}
+	return transffered;
+}
+
+void WarheadTypeExt::ExtData::TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner)
+{
+	// Experience transaction
+	if (this->Transact_Source_Experience_Flat ||
+		this->Transact_Source_Experience_Percent ||
+		this->Transact_Target_Experience_Flat ||
+		this->Transact_Target_Experience_Percent)
+		TransactExperience(pTarget, pOwner);
+
+	// Future transactions here
+}
+
+void WarheadTypeExt::ExtData::TransactOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner)
+{
+	// Experience transaction
+	if (this->Transact_Source_Experience_Flat ||
+		this->Transact_Source_Experience_Percent ||
+		this->Transact_Target_Experience_Flat ||
+		this->Transact_Target_Experience_Percent)
+		TransactExperience(pTarget, pOwner);
+
+	// Future transactions here
+}
+
+void WarheadTypeExt::ExtData::TransactExperience(TechnoClass* pTarget, TechnoClass* pOwner)
+{
+	auto const pTargetTechno = (pTarget) ? pTarget->GetTechnoType() : nullptr;
+	auto const pOwnerTechno = (pOwner) ? pOwner->GetTechnoType() : nullptr;
+	int sourceExp = 0, targetExp = 0;
+
+	// Flat from Source
+	if (this->Transact_Source_Experience_Flat != 0 && pOwnerTechno)
+		sourceExp = this->Transact_Source_Experience_Flat;
+
+	// Percent from Source
+	if (!CLOSE_ENOUGH(this->Transact_Source_Experience_Percent, 0.0) && pOwnerTechno)
+	{
+		int sourceValue;
+		if (this->Transact_Source_Experience_Percent_CalcFromTarget && pTargetTechno)
+			sourceValue = (int)((pOwnerTechno->GetActualCost(pTarget->Owner) * this->Transact_Source_Experience_Percent));
+		else
+			sourceValue = (int)((pOwnerTechno->GetActualCost(pOwner->Owner) * this->Transact_Source_Experience_Percent));
+
+		sourceExp = abs(sourceValue) > abs(sourceExp) ? sourceValue : sourceExp;
+	}
+
+	// Flat from Target
+	if (this->Transact_Target_Experience_Flat != 0 && pTargetTechno)
+		targetExp = this->Transact_Target_Experience_Flat;
+
+	// Percent from Target
+	if (!CLOSE_ENOUGH(this->Transact_Target_Experience_Percent, 0.0) && pTargetTechno)
+	{
+		int targetValue;
+		if (this->Transact_Target_Experience_Percent_CalcFromSource && pTargetTechno)
+			targetValue = (int)((pTargetTechno->GetActualCost(pOwner->Owner) * this->Transact_Target_Experience_Percent));
+		else
+			targetValue = (int)((pTargetTechno->GetActualCost(pTarget->Owner) * this->Transact_Target_Experience_Percent));
+
+		targetExp = abs(targetValue) > abs(targetExp) ? targetValue : targetExp;
+	}
+
+	// Transact
+	if (sourceExp != 0 && targetExp != 0 && targetExp * sourceExp < 0)
+	{
+		int transExp = abs(sourceExp) > abs(targetExp) ? targetExp : sourceExp;
+
+		if (sourceExp < 0)
+		{
+			transExp = AddExpCustom(&pOwner->Veterancy,
+				pOwnerTechno->GetActualCost(pOwner->Owner), -transExp);
+			AddExpCustom(&pTarget->Veterancy,
+				pOwnerTechno->GetActualCost(pTarget->Owner), transExp);
+		}
+		else
+		{
+			transExp = AddExpCustom(&pTarget->Veterancy,
+				pOwnerTechno->GetActualCost(pTarget->Owner), -transExp);
+			AddExpCustom(&pOwner->Veterancy,
+				pOwnerTechno->GetActualCost(pOwner->Owner), transExp);
+		}
+
+		return;
+	}
+	// Out-of-thin-air grants
+	if (sourceExp != 0)
+	{
+		AddExpCustom(&pOwner->Veterancy,
+			pOwnerTechno->GetActualCost(pOwner->Owner), sourceExp);
+	}
+	if (targetExp != 0)
+	{
+		AddExpCustom(&pTarget->Veterancy,
+			pTargetTechno->GetActualCost(pTarget->Owner), targetExp);
+	}
+}

--- a/src/Ext/WarheadType/Transact.cpp
+++ b/src/Ext/WarheadType/Transact.cpp
@@ -25,15 +25,22 @@ int AddExpCustom(VeterancyStruct* vstruct, int targetCost, int exp)
 	{
 		vstruct->SetElite();
 	}
+
 	return transffered;
 }
 
 int WarheadTypeExt::ExtData::TransactOneValue(TechnoClass* pTechno, TechnoTypeClass* pTechnoType, int transactValue, TransactValueType valueType)
 {
+	if (!pTechno || !pTechnoType)
+		return 0;
+
 	int transferred = 0;
 	switch (valueType)
 	{
 		case TransactValueType::Experience:
+			if (!pTechnoType->Trainable && !this->Transact_Experience_IgnoreNotTrainable)
+				return 0;
+
 			transferred = AddExpCustom(&pTechno->Veterancy,
 				pTechnoType->GetActualCost(pTechno->Owner), transactValue);
 			break;
@@ -44,39 +51,36 @@ int WarheadTypeExt::ExtData::TransactOneValue(TechnoClass* pTechno, TechnoTypeCl
 	return transferred;
 }
 
-int WarheadTypeExt::ExtData::TransactGetValue(TechnoClass* pTarget, TechnoClass* pOwner, int flat, double percent, boolean calcFromTarget, int targetValue, int ownerValue)
+int WarheadTypeExt::ExtData::TransactGetValue(TechnoClass* pTarget, TechnoClass* pOwner, int flat, double percent, bool calcFromTarget, int targetValue, int ownerValue)
 {
-	int flatValue = 0, percentValue = 0;
-
-	// Flat
-	flatValue = flat;
-
-	// Percent
+	int percentValue = 0;
 	if (!CLOSE_ENOUGH(percent, 0.0))
 	{
 		if (calcFromTarget && pTarget)
 			percentValue = (int)(targetValue * percent);
-		else if (!calcFromTarget)
+		else if (!calcFromTarget && pOwner)
 			percentValue = (int)(ownerValue * percent);
 	}
 
-	return abs(percentValue) > abs(flatValue) ? percentValue : flatValue;
+	return abs(percentValue) > abs(flat) ? percentValue : flat;
 }
 
-std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarget(TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int targets)
+std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarget(TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int divider)
 {
 	std::vector<std::vector<int>> allValues;
 	std::vector<int> sourceValues;
 	std::vector<int> targetValues;
+	std::vector<int> valueTypes;
+	int targetCost = pTarget ? pTargetType->GetActualCost(pTarget->Owner) : 0;
+	int ownerCost = pOwner ? pOwnerType->GetActualCost(pOwner->Owner) : 0;
 
 	// SOURCE
 	//		Experience
 	int sourceExp = pOwner ? this->TransactGetValue(pTarget, pOwner,
 		this->Transact_Experience_Source_Flat, this->Transact_Experience_Source_Percent,
-		this->Transact_Experience_Source_Percent_CalcFromTarget,
-		pTargetType->GetActualCost(pTarget->Owner), pOwnerType->GetActualCost(pOwner->Owner)) : 0;
-	sourceValues.push_back(sourceExp / targets);
-	//		Others ...
+		this->Transact_Experience_Source_Percent_CalcFromTarget, targetCost, ownerCost) : 0;
+	sourceValues.push_back(sourceExp / divider);
+
 	allValues.push_back(sourceValues);
 
 	// TARGET
@@ -84,64 +88,118 @@ std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarge
 	int targetExp = pTarget ? this->TransactGetValue(pOwner, pTarget,
 		this->Transact_Experience_Target_Flat, this->Transact_Experience_Target_Percent,
 		this->Transact_Experience_Target_Percent_CalcFromSource,
-		pOwnerType->GetActualCost(pOwner->Owner), pTargetType->GetActualCost(pTarget->Owner)) : 0;
-	targetValues.push_back(targetExp / targets);
-	//		Others ...
+		ownerCost, targetCost) : 0;
+	targetValues.push_back(targetExp / divider);
+
 	allValues.push_back(targetValues);
+
+	// TYPES
+	//		Experience
+	valueTypes.push_back((int)TransactValueType::Experience);
+
+	allValues.push_back(valueTypes);
 
 	return allValues;
 }
 
-void WarheadTypeExt::ExtData::TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner, int targets)
+void WarheadTypeExt::ExtData::TransactOnOneUnitCore(HouseClass* pHouse, TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int divider, bool sourceOnly)
 {
-	auto const pTargetType = pTarget ? pTarget->GetTechnoType() : nullptr;
-	auto const pOwnerType = pOwner ? pOwner->GetTechnoType() : nullptr;
-
-	std::vector<std::vector<int>> allValues = this->TransactGetSourceAndTarget(pTarget, pTargetType, pOwner, pOwnerType, targets);
+	// get pairs of source-target transaction values
+	std::vector<std::vector<int>> allValues = this->TransactGetSourceAndTarget(pTarget, pTargetType, pOwner, pOwnerType, divider);
 
 	for (unsigned int i = 0; i < allValues[0].size(); i++)
 	{
 		int sourceValue = allValues[0][i];
 		int targetValue = allValues[1][i];
+		auto valueType = (TransactValueType)allValues[2][i];
 
 		// Transact (A loses B gains)
-		if (sourceValue != 0 && targetValue != 0 && targetValue * sourceValue < 0)
+		if (!sourceOnly && sourceValue != 0 && targetValue != 0 && targetValue * sourceValue < 0)
 		{
 			int transactValue = abs(sourceValue) > abs(targetValue) ? abs(targetValue) : abs(sourceValue);
 
 			if (sourceValue < 0)
 			{
-				transactValue = TransactOneValue(pOwner, pOwnerType, -transactValue, TransactValueType::Experience);
-				TransactOneValue(pTarget, pTargetType, transactValue, TransactValueType::Experience);
+				transactValue = TransactOneValue(pOwner, pOwnerType, -transactValue, valueType);
+				TransactOneValue(pTarget, pTargetType, transactValue, valueType);
 			}
 			else
 			{
-				transactValue = TransactOneValue(pTarget, pTargetType, -transactValue, TransactValueType::Experience);
-				TransactOneValue(pOwner, pOwnerType, transactValue, TransactValueType::Experience);
+				transactValue = TransactOneValue(pTarget, pTargetType, -transactValue, valueType);
+				TransactOneValue(pOwner, pOwnerType, transactValue, valueType);
 			}
 
 			return;
 		}
+
 		// Out-of-thin-air grants
 		if (sourceValue != 0)
-		{
-			TransactOneValue(pOwner, pOwnerType, sourceValue, TransactValueType::Experience);
-		}
-		if (targetValue != 0)
-		{
-			TransactOneValue(pTarget, pTargetType, targetValue, TransactValueType::Experience);
-		}
+			TransactOneValue(pOwner, pOwnerType, sourceValue, valueType);
+
+		if (!sourceOnly && targetValue != 0)
+			TransactOneValue(pTarget, pTargetType, targetValue, valueType);
 	}
+}
+
+void WarheadTypeExt::ExtData::TransactOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner, int divider)
+{
+	bool targetedAnything = true;
+
+	if (!pTarget)
+	{
+		if (this->Transact_RequiresAnyTarget)
+			return;
+		targetedAnything = false;
+	}
+
+	auto const pTargetType = pTarget ? pTarget->GetTechnoType() : nullptr;
+	auto const pOwnerType = pOwner ? pOwner->GetTechnoType() : nullptr;
+
+	// Check if target is immune
+	if (targetedAnything && (CLOSE_ENOUGH(GeneralUtils::GetWarheadVersusArmor(this->OwnerObject(), pTargetType->Armor), 0.0)
+		|| (!pTargetType->Trainable && !this->Transact_Experience_IgnoreNotTrainable) || !this->CanTargetHouse(pHouse, pTarget)))
+	{
+		targetedAnything = false;
+	}
+
+	// Apply transction to valid target
+	if (targetedAnything)
+		TransactOnOneUnitCore(pHouse, pTarget, pTargetType, pOwner, pOwnerType, divider);
+
+	// Apply transaction in source-only mode if we permit shooting at immune targets or no targets
+	if (!targetedAnything && (!this->Transact_RequiresAnyTarget || (pTarget && !this->Transact_RequiresValidTarget)))
+		TransactOnOneUnitCore(pHouse, nullptr, nullptr, pOwner, pOwnerType, 1, true);
 }
 
 void WarheadTypeExt::ExtData::TransactOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner)
 {
-	int targets = 1;
-	if (this->Transact_SpreadAmongTargets)
-		targets = Helpers::Alex::getCellSpreadItems(coords, cellSpread, true).size();
+	auto targets = Helpers::Alex::getCellSpreadItems(coords, cellSpread, true);
+	int initialNumberOfTargets = targets.size();
+	int numberOfTargets = initialNumberOfTargets;
+	bool targetedAnything = false;
+	auto const pOwnerType = pOwner ? pOwner->GetTechnoType() : nullptr;
 
-	for (auto pTarget : Helpers::Alex::getCellSpreadItems(coords, cellSpread, true))
+	// Search for not immune targets
+	for (unsigned int i = 0; i < targets.size(); i++)
 	{
-		TransactOnOneUnit(pTarget, pOwner, targets);
+		if (CLOSE_ENOUGH(GeneralUtils::GetWarheadVersusArmor(this->OwnerObject(), targets[i]->GetTechnoType()->Armor), 0.0)
+			|| (!targets[i]->GetTechnoType()->Trainable && !this->Transact_Experience_IgnoreNotTrainable))
+		{
+			numberOfTargets--;
+			targets[i] = nullptr;
+		}
 	}
+
+	// Apply transction to valid targets
+	for (auto pTarget : targets)
+	{
+		if (!pTarget)
+			continue;
+		TransactOnOneUnitCore(pHouse, pTarget, pTarget->GetTechnoType(), pOwner, pOwnerType, this->Transact_SpreadAmongTargets ? numberOfTargets : 1);
+		targetedAnything = true;
+	}
+
+	// Apply transaction in source-only mode if we permit shooting at immune targets or no targets
+	if (!targetedAnything && (!this->Transact_RequiresAnyTarget || (initialNumberOfTargets > 0 && !this->Transact_RequiresValidTarget)))
+		TransactOnOneUnitCore(pHouse, nullptr, nullptr, pOwner, pOwnerType, 1, true);
 }

--- a/src/Ext/WarheadType/Transact.cpp
+++ b/src/Ext/WarheadType/Transact.cpp
@@ -1,9 +1,11 @@
 #include "Body.h"
 
+#include <Utilities/Enum.h>
 #include <Utilities/Helpers.Alex.h>
 
 // Add or substract experience for real
-int AddExpCustom(VeterancyStruct* vstruct, int targetCost, int exp) {
+int AddExpCustom(VeterancyStruct* vstruct, int targetCost, int exp)
+{
 	double toBeAdded = (double)exp / (targetCost * RulesClass::Instance->VeteranRatio);
 	// Used in experience transfer to get the actual amount substracted
 	int transffered = (int)(Math::min(vstruct->Veterancy, abs(toBeAdded))
@@ -19,104 +21,120 @@ int AddExpCustom(VeterancyStruct* vstruct, int targetCost, int exp) {
 	return transffered;
 }
 
-void WarheadTypeExt::ExtData::TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner)
+int WarheadTypeExt::ExtData::TransactOneValue(TechnoClass* pTechno, TechnoTypeClass* pTechnoType, int transactValue, TransactValueType valueType)
 {
-	// Experience transaction
-	if (this->Transact_Source_Experience_Flat ||
-		this->Transact_Source_Experience_Percent ||
-		this->Transact_Target_Experience_Flat ||
-		this->Transact_Target_Experience_Percent)
-		TransactExperience(pTarget, pOwner);
+	int transferred = 0;
+	switch (valueType)
+	{
+	case TransactValueType::Experience:
+		transferred = AddExpCustom(&pTechno->Veterancy,
+			pTechnoType->GetActualCost(pTechno->Owner), transactValue);
+		break;
+	default:
+		break;
+	}
+	return transferred;
+}
 
-	// Future transactions here
+int WarheadTypeExt::ExtData::TransactGetValue(TechnoClass* pTarget, TechnoClass* pOwner, int flat, double percent, boolean calcFromTarget, int targetValue, int ownerValue)
+{
+	int flatValue = 0, percentValue = 0;
+
+	// Flat
+	if (pOwner)
+		flatValue = flat;
+
+	// Percent
+	if (!CLOSE_ENOUGH(percent, 0.0) && pOwner)
+	{
+		if (calcFromTarget && pTarget)
+			percentValue = (int)(targetValue * percent);
+		else if (!calcFromTarget)
+			percentValue = (int)(ownerValue * percent);
+	}
+
+	return abs(percentValue) > abs(flatValue) ? percentValue : flatValue;
+}
+
+std::vector<std::vector<int>> WarheadTypeExt::ExtData::TransactGetSourceAndTarget(TechnoClass* pTarget, TechnoTypeClass* pTargetType, TechnoClass* pOwner, TechnoTypeClass* pOwnerType, int targets)
+{
+	std::vector<std::vector<int>> allValues;
+	std::vector<int> sourceValues;
+	std::vector<int> targetValues;
+
+	// SOURCE
+	//		Experience
+	int sourceExp = this->TransactGetValue(pTarget, pOwner,
+		this->Transact_Experience_Source_Flat, this->Transact_Experience_Source_Percent,
+		this->Transact_Experience_Source_Percent_CalcFromTarget,
+		pTargetType->GetActualCost(pTarget->Owner), pOwnerType->GetActualCost(pOwner->Owner));
+	sourceValues.push_back(sourceExp / targets);
+	// Others ...
+	allValues.push_back(sourceValues);
+
+	// TARGET
+	//		Experience
+	int targetExp = this->TransactGetValue(pOwner, pTarget,
+		this->Transact_Experience_Target_Flat, this->Transact_Experience_Target_Percent,
+		this->Transact_Experience_Target_Percent_CalcFromSource,
+		pOwnerType->GetActualCost(pOwner->Owner), pTargetType->GetActualCost(pTarget->Owner));
+	targetValues.push_back(targetExp / targets);
+	//		Others ...
+	allValues.push_back(targetValues);
+
+	return allValues;
+}
+
+void WarheadTypeExt::ExtData::TransactOnOneUnit(TechnoClass* pTarget, TechnoClass* pOwner, int targets)
+{
+	auto const pTargetType = (pTarget) ? pTarget->GetTechnoType() : nullptr;
+	auto const pOwnerType = (pOwner) ? pOwner->GetTechnoType() : nullptr;
+
+	std::vector<std::vector<int>> allValues = this->TransactGetSourceAndTarget(pTarget, pTargetType, pOwner, pOwnerType, targets);
+
+	for (unsigned int i = 0; i < allValues[0].size(); i++)
+	{
+		int sourceValue = allValues[0][i];
+		int targetValue = allValues[1][i];
+
+		// Transact (A loses B gains)
+		if (sourceValue != 0 && targetValue != 0 && targetValue * sourceValue < 0)
+		{
+			int transactValue = abs(sourceValue) > abs(targetValue) ? abs(targetValue) : abs(sourceValue);
+
+			if (sourceValue < 0)
+			{
+				transactValue = TransactOneValue(pOwner, pOwnerType, -transactValue, TransactValueType::Experience);
+				TransactOneValue(pTarget, pTargetType, transactValue, TransactValueType::Experience);
+			}
+			else
+			{
+				transactValue = TransactOneValue(pTarget, pTargetType, -transactValue, TransactValueType::Experience);
+				TransactOneValue(pOwner, pOwnerType, transactValue, TransactValueType::Experience);
+			}
+
+			return;
+		}
+		// Out-of-thin-air grants
+		if (sourceValue != 0)
+		{
+			TransactOneValue(pOwner, pOwnerType, sourceValue, TransactValueType::Experience);
+		}
+		if (targetValue != 0)
+		{
+			TransactOneValue(pTarget, pTargetType, targetValue, TransactValueType::Experience);
+		}
+	}
 }
 
 void WarheadTypeExt::ExtData::TransactOnAllUnits(HouseClass* pHouse, const CoordStruct coords, const float cellSpread, TechnoClass* pOwner)
 {
-	// Experience transaction
-	if (this->Transact_Source_Experience_Flat ||
-		this->Transact_Source_Experience_Percent ||
-		this->Transact_Target_Experience_Flat ||
-		this->Transact_Target_Experience_Percent)
+	int targets = 1;
+	if (this->Transact_SpreadAmongTargets)
+		targets = Helpers::Alex::getCellSpreadItems(coords, cellSpread, true).size();
+
+	for (auto pTarget : Helpers::Alex::getCellSpreadItems(coords, cellSpread, true))
 	{
-		for (auto pTarget : Helpers::Alex::getCellSpreadItems(coords, cellSpread, true))
-		{
-			TransactExperience(pTarget, pOwner);
-		}
-	}
-
-	// Future transactions here
-}
-
-void WarheadTypeExt::ExtData::TransactExperience(TechnoClass* pTarget, TechnoClass* pOwner)
-{
-	auto const pTargetTechno = (pTarget) ? pTarget->GetTechnoType() : nullptr;
-	auto const pOwnerTechno = (pOwner) ? pOwner->GetTechnoType() : nullptr;
-	int sourceExp = 0, targetExp = 0;
-
-	// Flat from Source
-	if (this->Transact_Source_Experience_Flat != 0 && pOwnerTechno)
-		sourceExp = this->Transact_Source_Experience_Flat;
-
-	// Percent from Source
-	if (!CLOSE_ENOUGH(this->Transact_Source_Experience_Percent, 0.0) && pOwnerTechno)
-	{
-		int sourceExpFromPercent;
-		if (this->Transact_Source_Experience_Percent_CalcFromTarget && pTargetTechno)
-			sourceExpFromPercent = (int)((pTargetTechno->GetActualCost(pTarget->Owner) * this->Transact_Source_Experience_Percent));
-		else
-			sourceExpFromPercent = (int)((pOwnerTechno->GetActualCost(pOwner->Owner) * this->Transact_Source_Experience_Percent));
-
-		sourceExp = abs(sourceExpFromPercent) > abs(sourceExp) ? sourceExpFromPercent : sourceExp;
-	}
-
-	// Flat from Target
-	if (this->Transact_Target_Experience_Flat != 0 && pTargetTechno)
-		targetExp = this->Transact_Target_Experience_Flat;
-
-	// Percent from Target
-	if (!CLOSE_ENOUGH(this->Transact_Target_Experience_Percent, 0.0) && pTargetTechno)
-	{
-		int targetExpFromPercent;
-		if (this->Transact_Target_Experience_Percent_CalcFromSource && pOwnerTechno)
-			targetExpFromPercent = (int)((pOwnerTechno->GetActualCost(pOwner->Owner) * this->Transact_Target_Experience_Percent));
-		else
-			targetExpFromPercent = (int)((pTargetTechno->GetActualCost(pTarget->Owner) * this->Transact_Target_Experience_Percent));
-
-		targetExp = abs(targetExpFromPercent) > abs(targetExp) ? targetExpFromPercent : targetExp;
-	}
-
-	// Transact (A loses B gains)
-	if (sourceExp != 0 && targetExp != 0 && targetExp * sourceExp < 0)
-	{
-		int transExp = abs(sourceExp) > abs(targetExp) ? abs(targetExp) : abs(sourceExp);
-
-		if (sourceExp < 0)
-		{
-			transExp = AddExpCustom(&pOwner->Veterancy,
-				pOwnerTechno->GetActualCost(pOwner->Owner), -transExp);
-			AddExpCustom(&pTarget->Veterancy,
-				pTargetTechno->GetActualCost(pTarget->Owner), transExp);
-		}
-		else
-		{
-			transExp = AddExpCustom(&pTarget->Veterancy,
-				pTargetTechno->GetActualCost(pTarget->Owner), -transExp);
-			AddExpCustom(&pOwner->Veterancy,
-				pOwnerTechno->GetActualCost(pOwner->Owner), transExp);
-		}
-
-		return;
-	}
-	// Out-of-thin-air grants
-	if (sourceExp != 0)
-	{
-		AddExpCustom(&pOwner->Veterancy,
-			pOwnerTechno->GetActualCost(pOwner->Owner), sourceExp);
-	}
-	if (targetExp != 0)
-	{
-		AddExpCustom(&pTarget->Veterancy,
-			pTargetTechno->GetActualCost(pTarget->Owner), targetExp);
+		TransactOnOneUnit(pTarget, pOwner, targets);
 	}
 }

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -180,6 +180,11 @@ enum class TextAlign : int
 
 MAKE_ENUM_FLAGS(TextAlign);
 
+enum class TransactValueType: int {
+	Experience = 0,
+	// Other....
+};
+
 class MouseCursorHotSpotX
 {
 public:


### PR DESCRIPTION
### Transact Warhead

- It is now possible to increase, decrease or transfer specific "values" (referred to as Currency) between Technos.
  - To enable this feature, `Transact=true` must be set and at least one `X.Source` or `X.Target` tag needs to be non-zero.
  - Source is the Techno that fired the warhead, target is a Techno (or a group) that is affected by the warhead.
  - `X.Flat` values grant absolute Currency, while `X.Percent` values grant Currency calculated relatively to the unit's state.
    - In case of experience, value from `X.Percent` is calculated by multiplying it by current unit cost.
    - By default `X.Source.Percent` (percent of value that Source will receive) is calculated from Source unit cost, however it is possible to force calculation from Target cost with `CalcFromTarget` (Target and `CalcFromSource` behaves analogically).
    - When both `X.Flat` and `X.Percent` values are set, the one that yields more Currency is used.
  - If final Currency amount is positive or negative for both Source and Target, then all affected units gain or lose Currency.
  - When the final amount of Currency is negative only for either Source or Target, **Transfer** occurs.
    - In transfer, if the absolute value of Currency for Source and Target are different, then the smaller of them is used.
    - In transfer, if it is not possible to transfer the whole amount (i.e. a unit has not enough Currency), then only the possible amount is transferred.
  - Source values are ignored if the warhead is not created by a unit (i.e. via a super weapon, animation weapon or map action).
  - `Transact.SpreadAmongTargets` has effect on warheads with CellSpread. When set, instead of applying the full Currency amount to each Target separately, the value will be evenly distributed among the victims.
  - `Transact.Experience.IgnoreNotTrainable=true` will allow to give experience to units with `Trainable=false` set.
  - `Transact.RequiresValidTarget=false` will allow the source unit to lose/obtain Currency when the warhead doesn't detonate on a valid target (i.e. having 0% versus a unit). However, target remains unaffected and if Source was supposed to take part in a transfer, nothing will happen!
  - `Transact.RequiresAnyTarget=false` will allow the source unit to lose/obtain Currency when the warhead doesn't detonate on any target (i.e. force firing on the ground). However, if Source was supposed to take part in a transfer, nothing will happen! This tag takes priority over `Transact.RequiresValidTarget`.

```{warning}
It is impossible to revert veterancy-caused unit type conversion from Ares by demoting a unit!
```

Currently supported "values" are:
- Experience

In `rulesmd.ini`:
```ini
[SOMEWARHEAD]                                           ; Warhead
Transact=false                                          ; boolean
Transact.RequiresAnyTarget=true                         ; boolean
Transact.RequiresValidTarget=true                       ; boolean
Transact.SpreadAmongTargets=false                       ; boolean
Transact.Experience.IgnoreNotTrainable=false            ; boolean
Transact.Experience.Source.Flat=0                       ; integer
Transact.Experience.Source.Percent=0.0                  ; float, percents or absolute (-1.0 - 1.0)
Transact.Experience.Source.Percent.CalcFromTarget=false ; boolean
Transact.Experience.Target.Flat=0                       ; integer
Transact.Experience.Target.Percent=0.0                  ; float, percents or absolute (-1.0 - 1.0)
Transact.Experience.Target.Percent.CalcFromSource=false ; boolean
```