### PR TITLE
Mind Control Range Limit

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -74,7 +74,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{3FAF7126-F38C-4D1E-9973-C21A37870F60}</ProjectGuid>
     <RootNamespace>Phobos</RootNamespace>
-    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <ProjectName>Phobos</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -88,7 +88,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
@@ -113,7 +113,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'">
     <GenerateManifest>false</GenerateManifest>
-    <IncludePath>$(SolutionDir)src\ExtraHeaders;$(SolutionDir)yrpp;$(VC_IncludePath);$(WindowsSdk_71A_IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)src\ExtraHeaders;$(SolutionDir)yrpp;$(VC_IncludePath);$(IncludePath)</IncludePath>
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\IntDir\</IntDir>

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -74,7 +74,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{3FAF7126-F38C-4D1E-9973-C21A37870F60}</ProjectGuid>
     <RootNamespace>Phobos</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
     <ProjectName>Phobos</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -88,7 +88,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
@@ -113,7 +113,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'">
     <GenerateManifest>false</GenerateManifest>
-    <IncludePath>$(SolutionDir)src\ExtraHeaders;$(SolutionDir)yrpp;$(VC_IncludePath);$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)src\ExtraHeaders;$(SolutionDir)yrpp;$(VC_IncludePath);$(WindowsSdk_71A_IncludePath)</IncludePath>
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\IntDir\</IntDir>

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -26,6 +26,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 		this->UIDescription = L"";
 
 	this->LowSelectionPriority = pINI->ReadBool(pSection, "LowSelectionPriority", this->LowSelectionPriority);
+	this->MindControlRangeLimit = pINI->ReadDouble(pSection, "MindControlRangeLimit", this->MindControlRangeLimit);
 
 	// Ares 0.A
 	pINI->ReadString(pSection, "GroupAs", this->GroupAs, this->GroupAs);

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -23,6 +23,7 @@ public:
 		const wchar_t* UIDescription;
 		bool LowSelectionPriority;
 		char GroupAs[32];
+		double MindControlRangeLimit;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			Deployed_RememberTarget(false),
@@ -30,7 +31,8 @@ public:
 			UIDescriptionLabel(NONE_STR),
 			UIDescription(L""),
 			LowSelectionPriority(false),
-			GroupAs(NONE_STR)
+			GroupAs(NONE_STR),
+			MindControlRangeLimit(-1.0)
 		{ }
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/TechnoType/Hook.cpp
+++ b/src/Ext/TechnoType/Hook.cpp
@@ -10,3 +10,19 @@ DEFINE_HOOK(6F64A9, HealthBar_Hide, 5)
 	}
 	return 0;
 }
+DEFINE_HOOK(6F9E50, TechnoClass_Update_2, 5) //TechnoClass_Update is in BuildingDeployerTargeting.cpp
+{
+	GET(TechnoClass*, pThis, ECX);
+	auto pType = pThis->GetTechnoType();
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+	if (auto Capturer = pThis->MindControlledBy) {
+		auto pCapturerExt = TechnoTypeExt::ExtMap.Find(Capturer->GetTechnoType());
+		if (pCapturerExt->MindControlRangeLimit > 0 && pThis->DistanceFrom(Capturer) > pCapturerExt->MindControlRangeLimit * 256.0) {
+			Capturer->CaptureManager->FreeUnit(pThis);
+			if (!pThis->IsHumanControlled) {
+				pThis->QueueMission(Mission::Hunt, 0);
+			};
+		}
+	}
+	return 0;
+}


### PR DESCRIPTION
Allow the mind controller to have the upper limit of the control distance. Greater than 0 will activate this feature.

In rulesmd.ini:

[SOMETECHNO]            ; TechnoType
MindControlRangeLimit=-1.0 ; double