### PR TITLE
Allow SplashList set for a certain WarheadType

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Credits
 - ZΞPHYɌUS - win/lose themes code
 - ayylmao, SMxReaver, 4SG, FS-21 - help with docs
 - wiktorderelf, Metadorius (Kerbiter) - overhauled Unicode font
-- Thrifinesma (Uranusian) - mind control range limit implementation
+- Thrifinesma (Uranusian) - mind control range limit and custom warhead splash list implementation
 
 Also thanks to everyone who uses Phobos, tests changes and reports bugs!
 

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -1,5 +1,7 @@
 #include "Body.h"
 #include <WarheadTypeClass.h>
+#include <AnimTypeClass.h>
+#include "../../Utilities/trim.h"
 
 template<> const DWORD Extension<WarheadTypeClass>::Canary = 0x22222222;
 WarheadTypeExt::ExtContainer WarheadTypeExt::ExtMap;
@@ -18,17 +20,46 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->SpySat = pINI->ReadBool(pSection, "SpySat", this->SpySat);
 	this->BigGap = pINI->ReadBool(pSection, "BigGap", this->BigGap);
 	this->TransactMoney = pINI->ReadInteger(pSection, "TransactMoney", this->TransactMoney);
+
+	if (pINI->ReadString(pSection, "SplashList", "", this->SplashList_Buffer)) {
+		char* context = nullptr;
+		for (char* cur = strtok_s(this->SplashList_Buffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context)) {
+			this->SplashList.AddItem(AnimTypeClass::Find(Trim::FullTrim(cur)));
+		}
+	}
 }
 
 void WarheadTypeExt::ExtData::LoadFromStream(IStream* Stm) {
 	#define STM_Process(A) Stm->Read(&A, sizeof(A), 0);
 	#include "Serialize.hpp"
+	{// Load SplashList array
+		int count = this->SplashList.Count;
+		char* buf = this->SplashList_Buffer;
+
+		STM_Process(count);
+		for (int i = 0; i < count; i++) {
+			char tempBuf[sizeof(AnimTypeClass::ID)];
+			Stm->Read(tempBuf, sizeof(tempBuf), 0);
+			strcpy_s(buf, (sizeof(this->SplashList_Buffer) - (buf - this->SplashList_Buffer)), tempBuf);
+			this->SplashList.AddItem(AnimTypeClass::Find(buf));
+			buf += strlen(buf) + 1;
+		}
+	}
 	#undef STM_Process
 }
 
 void WarheadTypeExt::ExtData::SaveToStream(IStream* Stm) {
 	#define STM_Process(A) Stm->Write(&A, sizeof(A), 0);
 	#include "Serialize.hpp"
+	{// Save SplashList array
+		int count = this->SplashList.Count;
+		Stm->Write(&count, sizeof(count), 0);
+
+		for (int i = 0; i < count; i++) {
+			char* item = this->SplashList.GetItem(i)->ID;
+			Stm->Write(item, sizeof(AnimTypeClass::ID), 0);
+		}
+	}
 	#undef STM_Process
 }
 

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -24,7 +24,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	if (pINI->ReadString(pSection, "SplashList", "", this->SplashList_Buffer)) {
 		char* context = nullptr;
 		for (char* cur = strtok_s(this->SplashList_Buffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context)) {
-			this->SplashList.AddItem(AnimTypeClass::Find(Trim::FullTrim(cur)));
+			if (auto splash = AnimTypeClass::Find(Trim::FullTrim(cur))) this->SplashList.AddItem(splash);
 		}
 	}
 }

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -21,11 +21,13 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->BigGap = pINI->ReadBool(pSection, "BigGap", this->BigGap);
 	this->TransactMoney = pINI->ReadInteger(pSection, "TransactMoney", this->TransactMoney);
 
-	if (pINI->ReadString(pSection, "SplashList", "", this->SplashList_Buffer)) {
+	if (pINI->ReadString(pSection, "SplashList", this->SplashList_Buffer, this->SplashList_Buffer)) {
 		char* context = nullptr;
+		SplashList.Clear();
 		for (char* cur = strtok_s(this->SplashList_Buffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context)) {
 			if (auto splash = AnimTypeClass::Find(Trim::FullTrim(cur))) this->SplashList.AddItem(splash);
 		}
+		this->SplashList_PickRandom = pINI->ReadBool(pSection, "SplashList.PickRandom", this->SplashList_PickRandom);
 	}
 }
 

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -22,12 +22,15 @@ public:
 		int TransactMoney;
 		char SplashList_Buffer[0x400];
 		DynamicVectorClass<AnimTypeClass*> SplashList;
+		bool SplashList_PickRandom;
 
 		ExtData(WarheadTypeClass* OwnerObject) : Extension<WarheadTypeClass>(OwnerObject),
 			SpySat(false),
 			BigGap(false),
 			TransactMoney(0),
-			SplashList()
+			SplashList_Buffer(""),
+			SplashList(),
+			SplashList_PickRandom(false)
 		{ }
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -20,11 +20,14 @@ public:
 		bool SpySat;
 		bool BigGap;
 		int TransactMoney;
+		char SplashList_Buffer[0x400];
+		DynamicVectorClass<AnimTypeClass*> SplashList;
 
 		ExtData(WarheadTypeClass* OwnerObject) : Extension<WarheadTypeClass>(OwnerObject),
 			SpySat(false),
 			BigGap(false),
-			TransactMoney(0)
+			TransactMoney(0),
+			SplashList()
 		{ }
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -4,6 +4,7 @@
 #include <HouseClass.h>
 #include <MapClass.h>
 #include "Body.h"
+#include <ScenarioClass.h>
 
 void ReshroudMapForOpponents(HouseClass* pThisHouse) {
 	for (auto pOtherHouse : *HouseClass::Array) {
@@ -42,6 +43,22 @@ DEFINE_HOOK(46920B, BulletClass_Detonate, 6)
 		if (pWHExt->TransactMoney != 0) {
 			pThisHouse->TransactMoney(pWHExt->TransactMoney);
 		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(48A512, WarheadTypeClass_SplashList, 6) 
+{
+
+	GET(WarheadTypeClass* const, pThis, ESI);
+
+	if (!pThis->Conventional) return 0;
+	auto pWHExt = WarheadTypeExt::ExtMap.Find(pThis);
+
+	if (pWHExt->SplashList.Count) { //WarheadType cannot get Damage(?), so currently random. 
+		R->EAX(pWHExt->SplashList.GetItem(ScenarioClass::Instance->Random.RandomRanged(0, pWHExt->SplashList.Count - 1)));
+		return 0x48A5AD;
 	}
 
 	return 0;

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -59,7 +59,7 @@ DEFINE_HOOK(48A512, WarheadTypeClass_SplashList, 6)
 	if (pWHExt->SplashList.Count) {
 		GET(int, Damage, ECX);
 		R->EAX(pWHExt->SplashList.GetItem(
-			pThis->EMEffect ?
+			pWHExt->SplashList_PickRandom ?
 			ScenarioClass::Instance->Random.RandomRanged(0, pWHExt->SplashList.Count - 1) :
 			std::min(pWHExt->SplashList.Count * 35 - 1, Damage) / 35
 		));

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -56,8 +56,13 @@ DEFINE_HOOK(48A512, WarheadTypeClass_SplashList, 6)
 	if (!pThis->Conventional) return 0;
 	auto pWHExt = WarheadTypeExt::ExtMap.Find(pThis);
 
-	if (pWHExt->SplashList.Count) { //WarheadType cannot get Damage(?), so currently random. 
-		R->EAX(pWHExt->SplashList.GetItem(ScenarioClass::Instance->Random.RandomRanged(0, pWHExt->SplashList.Count - 1)));
+	if (pWHExt->SplashList.Count) {
+		GET(int, Damage, ECX);
+		R->EAX(pWHExt->SplashList.GetItem(
+			pThis->EMEffect ?
+			ScenarioClass::Instance->Random.RandomRanged(0, pWHExt->SplashList.Count - 1) :
+			std::min(pWHExt->SplashList.Count * 35 - 1, Damage) / 35
+		));
 		return 0x48A5AD;
 	}
 

--- a/src/Ext/WarheadType/Serialize.hpp
+++ b/src/Ext/WarheadType/Serialize.hpp
@@ -1,5 +1,4 @@
 STM_Process(this->SpySat)
 STM_Process(this->BigGap)
 STM_Process(this->TransactMoney)
-STM_Process(this->SplashList_Buffer)
 STM_Process(this->SplashList_PickRandom)

--- a/src/Ext/WarheadType/Serialize.hpp
+++ b/src/Ext/WarheadType/Serialize.hpp
@@ -1,3 +1,5 @@
 STM_Process(this->SpySat)
 STM_Process(this->BigGap)
 STM_Process(this->TransactMoney)
+STM_Process(this->SplashList_Buffer)
+STM_Process(this->SplashList_PickRandom)


### PR DESCRIPTION
Warhead with Conventional=yes sinks and causes a water splash instead of detonating when it hits water. In original game, [CombatDamage] SplashList= specifies a list of animations the game will use for this case. An animation is chosen depending on the Damage of the warhead's weapon by dividing this damage by 35, then rounding down to an integer to form a zero-based index.
Now any WarheadType can specify what animations to use for this case.

In rulesmd.ini
[SOMEWH] ; WarheadType
SplashList= ; list of animations, a random animation from the list to play if EMEffect=yes
                   ; otherwise playing rules are same as original
                   ; if no valid anim is listed, default rules will be applied here.