### PR TITLE
Read the debug activation variable from rulesmd.ini -> [GlobalControls] -> DebugKeysEnabled

### DIFF
--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -108,8 +108,7 @@ DEFINE_HOOK(5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 5)
 {
 	Phobos::Config::ToolTipDescriptions = Unsorted::RA2MDINI->ReadBool("Phobos", "ToolTipDescriptions", true);
 	Phobos::Config::PrioritySelectionFiltering = Unsorted::RA2MDINI->ReadBool("Phobos", "PrioritySelectionFiltering", true);
-	CCINIClass* pRulesINI = Phobos::OpenConfig("rulesmd.ini");
-	Phobos::Config::DevelopmentCommands = pRulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", true);
+
 	CCINIClass *pINI = Phobos::OpenConfig("uimd.ini");
 
 	// LoadingScreen
@@ -137,6 +136,16 @@ DEFINE_HOOK(5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 5)
 	}
 
 	Phobos::CloseConfig(pINI);
+
+	return 0;
+}
+
+DEFINE_HOOK(668F6A, RulesClass_Process_Phobos, 5)
+{
+	//GET(RulesClass*, rules, EDI);
+	GET(CCINIClass*, rulesINI, ESI);
+
+	Phobos::Config::DevelopmentCommands = rulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", true);
 
 	return 0;
 }

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -140,10 +140,9 @@ DEFINE_HOOK(5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 5)
 	return 0;
 }
 
-DEFINE_HOOK(668F6A, RulesClass_Process_Phobos, 5)
+DEFINE_HOOK(66E9DF, RulesClass_Process_Phobos, 8)
 {
-	//GET(RulesClass*, rules, EDI);
-	GET(CCINIClass*, rulesINI, ESI);
+	GET(CCINIClass*, rulesINI, EDI);
 
 	Phobos::Config::DevelopmentCommands = rulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", true);
 

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -108,9 +108,9 @@ DEFINE_HOOK(5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 5)
 {
 	Phobos::Config::ToolTipDescriptions = Unsorted::RA2MDINI->ReadBool("Phobos", "ToolTipDescriptions", true);
 	Phobos::Config::PrioritySelectionFiltering = Unsorted::RA2MDINI->ReadBool("Phobos", "PrioritySelectionFiltering", true);
-	Phobos::Config::DevelopmentCommands = Unsorted::RA2MDINI->ReadBool("Phobos", "DevelopmentCommands", false);
-
-	CCINIClass* pINI = Phobos::OpenConfig("uimd.ini");
+	CCINIClass* pRulesINI = Phobos::OpenConfig("rulesmd.ini");
+	Phobos::Config::DevelopmentCommands = pRulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", true);
+	CCINIClass *pINI = Phobos::OpenConfig("uimd.ini");
 
 	// LoadingScreen
 	{


### PR DESCRIPTION
(probably, not sure) For preventing cheating the debug commands activation variable is declared inside rulesmd.ini and not in ra2md.ini that is modificable for everyone.

Same Ares behavior:
· [GlobalControls] -> DebugKeysEnabled doesn't exists means enabled feature.
· [GlobalControls] -> DebugKeysEnabled=yes means enabled tehse commands.
· [GlobalControls] -> DebugKeysEnabled=no means disable these commands.
