### PR TITLE
Powered Spawner structure able to Kill Spawns if low power

### DIFF
--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -3,6 +3,8 @@
 #include <Helpers/Enumerators.h>
 #include <TechnoClass.h>
 #include <BulletClass.h>
+#include <BuildingClass.h>
+#include <SpawnManagerClass.h>
 
 #include "../_Container.hpp"
 #include "../../Phobos.h"

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -26,6 +26,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->Interceptor.Read(exINI, pSection, "Interceptor");
 	this->Interceptor_GuardRange.Read(exINI, pSection, "Interceptor.GuardRange");
 	this->Interceptor_EliteGuardRange.Read(exINI, pSection, "Interceptor.EliteGuardRange");
+	this->PoweredKillSpawns.Read(exINI, pSection, "Powered.KillSpawns");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -47,6 +48,7 @@ void TechnoTypeExt::ExtData::LoadFromStream(IStream* Stm) {
 	this->Interceptor_EliteGuardRange.Load(Stm);
 	PhobosStreamReader::Process(Stm, this->GroupAs);
 	this->TurretOffset.Load(Stm);
+	this->PoweredKillSpawns.Load(Stm);
 }
 
 void TechnoTypeExt::ExtData::SaveToStream(IStream* Stm) const {
@@ -60,6 +62,7 @@ void TechnoTypeExt::ExtData::SaveToStream(IStream* Stm) const {
 	this->Interceptor_EliteGuardRange.Save(Stm);
 	PhobosStreamWriter::Process(Stm, this->GroupAs);
 	this->TurretOffset.Save(Stm);
+	this->PoweredKillSpawns.Save(Stm);
 }
 
 // =============================

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -26,7 +26,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->Interceptor.Read(exINI, pSection, "Interceptor");
 	this->Interceptor_GuardRange.Read(exINI, pSection, "Interceptor.GuardRange");
 	this->Interceptor_EliteGuardRange.Read(exINI, pSection, "Interceptor.EliteGuardRange");
-	this->PoweredKillSpawns.Read(exINI, pSection, "Powered.KillSpawns");
+	this->Powered_KillSpawns.Read(exINI, pSection, "Powered.KillSpawns");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -48,7 +48,7 @@ void TechnoTypeExt::ExtData::LoadFromStream(IStream* Stm) {
 	this->Interceptor_EliteGuardRange.Load(Stm);
 	PhobosStreamReader::Process(Stm, this->GroupAs);
 	this->TurretOffset.Load(Stm);
-	this->PoweredKillSpawns.Load(Stm);
+	this->Powered_KillSpawns.Load(Stm);
 }
 
 void TechnoTypeExt::ExtData::SaveToStream(IStream* Stm) const {
@@ -62,7 +62,7 @@ void TechnoTypeExt::ExtData::SaveToStream(IStream* Stm) const {
 	this->Interceptor_EliteGuardRange.Save(Stm);
 	PhobosStreamWriter::Process(Stm, this->GroupAs);
 	this->TurretOffset.Save(Stm);
-	this->PoweredKillSpawns.Save(Stm);
+	this->Powered_KillSpawns.Save(Stm);
 }
 
 // =============================

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -30,7 +30,7 @@ public:
 		Valueable<double> Interceptor_GuardRange;
 		Valueable<double> Interceptor_EliteGuardRange;
 		Valueable<CoordStruct> TurretOffset;
-		Valueable<bool> PoweredKillSpawns;
+		Valueable<bool> Powered_KillSpawns;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			Deployed_RememberTarget(false),
@@ -43,7 +43,7 @@ public:
 			Interceptor_GuardRange(0.0),
 			Interceptor_EliteGuardRange(0.0),
 			TurretOffset({0, 0, 0}),
-			PoweredKillSpawns(false)
+			Powered_KillSpawns(false)
 		{ }
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -30,6 +30,7 @@ public:
 		Valueable<double> Interceptor_GuardRange;
 		Valueable<double> Interceptor_EliteGuardRange;
 		Valueable<CoordStruct> TurretOffset;
+		Valueable<bool> PoweredKillSpawns;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			Deployed_RememberTarget(false),
@@ -41,7 +42,8 @@ public:
 			Interceptor(false),
 			Interceptor_GuardRange(0.0),
 			Interceptor_EliteGuardRange(0.0),
-			TurretOffset({0, 0, 0})
+			TurretOffset({0, 0, 0}),
+			PoweredKillSpawns(false)
 		{ }
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -171,37 +171,27 @@ DEFINE_HOOK(43E0C4, BuildingClass_Draw_43DA80_TurretMultiOffset, 0)
 }
 
 // Kill all Spawns if the structure has low power & reset target
-DEFINE_HOOK(6F9E56, TechnoClass_Update2, 5)
+DEFINE_HOOK(6F9E56, TechnoClass_Update_PoweredKillSpawns, 5)
 {
 	GET(TechnoClass*, pTechno, ECX);
-	auto const abs = pTechno->WhatAmI();
 	auto pTechnoData = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType());
 
-	if (abs == AbstractType::Building) {
-		BuildingClass *pBuilding = static_cast<BuildingClass*>(pTechno);
-
-		if (pTechnoData->PoweredKillSpawns == true && pBuilding->Type->Powered == true && !pBuilding->IsPowerOnline()) {
-			if (pTechno->SpawnManager != NULL) {
-				pBuilding->SpawnManager->ResetTarget();
-
-				if (pBuilding->SpawnManager->SpawnedNodes.Count)
-					for (int i = 0; i < pBuilding->SpawnManager->SpawnedNodes.Count; i++) {
-						auto pitem = pBuilding->SpawnManager->SpawnedNodes[i];
-
-						//SpawnedNodes.Status possible values:
-						//Status: 0 -> Ready ?
-						//Status: 2 -> Docked / standby
-						//Status: 3 -> Flying going to the target <---
-						//Status: 4 -> Flying returning to dock   <---
-						//Status: 6 -> Reloading ammo in the dock ?
-						//Status: 7 -> Dead
-						if (static_cast<int>(pitem->Status) == 3 || static_cast<int>(pitem->Status) == 4) {
-							pitem->Unit->ReceiveDamage(&pitem->Unit->Health, 0, RulesClass::Global()->C4Warhead, nullptr, false, false, nullptr);
-						}
-					}
+	if (pTechno->WhatAmI() == AbstractType::Building) {
+		auto pBuilding = static_cast<BuildingClass*>(pTechno);
+		if (pTechnoData->Powered_KillSpawns && pBuilding->Type->Powered && !pBuilding->IsPowerOnline()) {
+			if (auto pManager = pBuilding->SpawnManager) {
+				pManager->ResetTarget();
+				for (auto pItem : pManager->SpawnedNodes)
+				{
+					if (pItem->Status == SpawnNodeStatus::Attacking || pItem->Status == SpawnNodeStatus::Returning)
+						pItem->Unit->ReceiveDamage(
+							&pItem->Unit->Health,
+							0,
+							RulesClass::Global()->C4Warhead,
+							nullptr, false, false, nullptr);
+				}
 			}
 		}
 	}
-
 	return 0;
 }


### PR DESCRIPTION
Already spawned aircrafts from a structure in the original YR ignores the structure powered=yes value and continue attacking the target.

Powered.KillSpawns=<bool> ; default "false" for original YR experience

This tag reset the structure selected target for fix the mentioned bug and additionally kill all the flying spawns.