### PR TITLE
New Spawns Limit Range

### DIFF
--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -27,6 +27,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->Interceptor_GuardRange.Read(exINI, pSection, "Interceptor.GuardRange");
 	this->Interceptor_EliteGuardRange.Read(exINI, pSection, "Interceptor.EliteGuardRange");
 	this->Powered_KillSpawns.Read(exINI, pSection, "Powered.KillSpawns");
+	this->Spawn_LimitedRange.Read(exINI, pSection, "Spawner.LimitRange");
+	this->Spawn_LimitedExtraRange.Read(exINI, pSection, "Spawner.ExtraLimitRange");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -49,6 +51,8 @@ void TechnoTypeExt::ExtData::LoadFromStream(IStream* Stm) {
 	PhobosStreamReader::Process(Stm, this->GroupAs);
 	this->TurretOffset.Load(Stm);
 	this->Powered_KillSpawns.Load(Stm);
+	this->Spawn_LimitedRange.Load(Stm);
+	this->Spawn_LimitedExtraRange.Load(Stm);
 }
 
 void TechnoTypeExt::ExtData::SaveToStream(IStream* Stm) const {
@@ -63,6 +67,8 @@ void TechnoTypeExt::ExtData::SaveToStream(IStream* Stm) const {
 	PhobosStreamWriter::Process(Stm, this->GroupAs);
 	this->TurretOffset.Save(Stm);
 	this->Powered_KillSpawns.Save(Stm);
+	this->Spawn_LimitedRange.Save(Stm);
+	this->Spawn_LimitedExtraRange.Save(Stm);
 }
 
 // =============================

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -31,6 +31,8 @@ public:
 		Valueable<double> Interceptor_EliteGuardRange;
 		Valueable<CoordStruct> TurretOffset;
 		Valueable<bool> Powered_KillSpawns;
+		Valueable<bool> Spawn_LimitedRange;
+		Valueable<int> Spawn_LimitedExtraRange;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			Deployed_RememberTarget(false),
@@ -43,7 +45,9 @@ public:
 			Interceptor_GuardRange(0.0),
 			Interceptor_EliteGuardRange(0.0),
 			TurretOffset({0, 0, 0}),
-			Powered_KillSpawns(false)
+			Powered_KillSpawns(false),
+			Spawn_LimitedRange(false),
+			Spawn_LimitedExtraRange(0)
 		{ }
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -196,5 +196,60 @@ DEFINE_HOOK(6F9E56, TechnoClass_Update_PoweredKillSpawns, 5)
 		}
 	}
 
+	if (pTechnoData->Spawn_LimitedRange) {
+		if (auto pManager = pTechno->SpawnManager) {
+			auto pTechnoType = pTechno->GetTechnoType();
+			int weaponRange = 0;
+			int weaponRangeExtra = pTechnoData->Spawn_LimitedExtraRange * 256;
+
+			if (pTechnoType->Weapon[0].WeaponType) {
+				auto newRange = pTechnoType->Weapon[0].WeaponType->Range;
+				auto isWeaponSpawner = pTechnoType->Weapon[0].WeaponType->Spawner;
+
+				if (isWeaponSpawner) {
+					if (newRange > weaponRange) {
+						weaponRange = newRange;
+					}
+				}
+			}
+			if (pTechnoType->Weapon[1].WeaponType) {
+				auto newRange = pTechnoType->Weapon[1].WeaponType->Range;
+				auto isWeaponSpawner = pTechnoType->Weapon[1].WeaponType->Spawner;
+
+				if (isWeaponSpawner) {
+					if (newRange > weaponRange) {
+						weaponRange = newRange;
+					}
+				}
+			}
+			if (pTechnoType->EliteWeapon[0].WeaponType) {
+				auto newRange = pTechnoType->EliteWeapon[0].WeaponType->Range;
+				auto isWeaponSpawner = pTechnoType->EliteWeapon[0].WeaponType->Spawner;
+
+				if (isWeaponSpawner) {
+					if (newRange > weaponRange) {
+						weaponRange = newRange;
+					}
+				}
+			}
+			if (pTechnoType->EliteWeapon[1].WeaponType) {
+				auto newRange = pTechnoType->EliteWeapon[1].WeaponType->Range;
+				auto isWeaponSpawner = pTechnoType->EliteWeapon[1].WeaponType->Spawner;
+
+				if (isWeaponSpawner) {
+					if (newRange > weaponRange) {
+						weaponRange = newRange;
+					}
+				}
+			}
+
+			weaponRange += weaponRangeExtra;
+			if (pManager->Target && (pTechno->DistanceFrom(pManager->Target) > weaponRange))
+			{
+				pManager->ResetTarget();
+			}
+		}
+	}
+
 	return 0;
 }

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -202,52 +202,22 @@ DEFINE_HOOK(6F9E56, TechnoClass_Update_PoweredKillSpawns, 5)
 			int weaponRange = 0;
 			int weaponRangeExtra = pTechnoData->Spawn_LimitedExtraRange * 256;
 
-			if (pTechnoType->Weapon[0].WeaponType) {
-				auto newRange = pTechnoType->Weapon[0].WeaponType->Range;
-				auto isWeaponSpawner = pTechnoType->Weapon[0].WeaponType->Spawner;
+			auto setWeaponRange = [&weaponRange](WeaponTypeClass* pWeaponType)
+			{
+				if (pWeaponType)
+					if (pWeaponType->Spawner && pWeaponType->Range > weaponRange)
+						weaponRange = pWeaponType->Range;
+			};
 
-				if (isWeaponSpawner) {
-					if (newRange > weaponRange) {
-						weaponRange = newRange;
-					}
-				}
-			}
-			if (pTechnoType->Weapon[1].WeaponType) {
-				auto newRange = pTechnoType->Weapon[1].WeaponType->Range;
-				auto isWeaponSpawner = pTechnoType->Weapon[1].WeaponType->Spawner;
-
-				if (isWeaponSpawner) {
-					if (newRange > weaponRange) {
-						weaponRange = newRange;
-					}
-				}
-			}
-			if (pTechnoType->EliteWeapon[0].WeaponType) {
-				auto newRange = pTechnoType->EliteWeapon[0].WeaponType->Range;
-				auto isWeaponSpawner = pTechnoType->EliteWeapon[0].WeaponType->Spawner;
-
-				if (isWeaponSpawner) {
-					if (newRange > weaponRange) {
-						weaponRange = newRange;
-					}
-				}
-			}
-			if (pTechnoType->EliteWeapon[1].WeaponType) {
-				auto newRange = pTechnoType->EliteWeapon[1].WeaponType->Range;
-				auto isWeaponSpawner = pTechnoType->EliteWeapon[1].WeaponType->Spawner;
-
-				if (isWeaponSpawner) {
-					if (newRange > weaponRange) {
-						weaponRange = newRange;
-					}
-				}
-			}
+			setWeaponRange(pTechnoType->Weapon[0].WeaponType);
+			setWeaponRange(pTechnoType->Weapon[1].WeaponType);
+			setWeaponRange(pTechnoType->EliteWeapon[0].WeaponType);
+			setWeaponRange(pTechnoType->EliteWeapon[1].WeaponType);
 
 			weaponRange += weaponRangeExtra;
 			if (pManager->Target && (pTechno->DistanceFrom(pManager->Target) > weaponRange))
-			{
 				pManager->ResetTarget();
-			}
+
 		}
 	}
 


### PR DESCRIPTION
Added 2 new Techno tags:
Spawner.LimitRange=no
Spawner.ExtraLimitRange=0

If a spawner object has Spawner.LimitRange=yes
The spawned unit will abort the infinite pursuit it had in original YR until it ran out of ammo when the enemy is out of range.
Additionally, Spawner.ExtraLimitRange adds extra pursuit range to the spawned units.