### PR TITLE
Feature/rad site

### DIFF
--- a/src/Ext/RadSite/Body.h
+++ b/src/Ext/RadSite/Body.h
@@ -18,8 +18,10 @@ public:
 	public:
 		WeaponTypeClass* Weapon;
 		RadType* Type;
+		HouseClass* RadHouse;
 
-		ExtData(RadSiteClass* OwnerObject) : Extension<RadSiteClass>(OwnerObject)
+		ExtData(RadSiteClass* OwnerObject) : Extension<RadSiteClass>(OwnerObject),
+			RadHouse(nullptr)
 		{ };
 
 		virtual ~ExtData() { }
@@ -31,14 +33,14 @@ public:
 		virtual void LoadFromStream(IStream* Stm);
 		virtual void SaveToStream(IStream* Stm);
 
+		virtual void Add(int amount);
+		virtual void SetRadLevel(int amount);
+		virtual double GetRadLevelAt(CellStruct const& cell);
 	};
 
 	static DynamicVectorClass<RadSiteExt::ExtData*> RadSiteInstance;
 
-	static void CreateInstance(CellStruct location, int spread, int amount, WeaponTypeExt::ExtData *pWeaponExt);
-	static void RadSiteAdd(RadSiteClass* pRad, int lvmax, int amount);
-	static void SetRadLevel(RadSiteClass* pRad, RadType* Type, int amount);
-	static double GetRadLevelAt(RadSiteClass* pThis, CellStruct const& cell);
+	static void CreateInstance(CellStruct location, int spread, int amount, WeaponTypeExt::ExtData *pWeaponExt, HouseClass* const pOwner);
 
 	class ExtContainer final : public Container<RadSiteExt> {
 	public:

--- a/src/Ext/RadSite/Hooks.cpp
+++ b/src/Ext/RadSite/Hooks.cpp
@@ -109,7 +109,7 @@ DEFINE_HOOK(43FB23, BuildingClass_Update, 5)
 
 			RadType* pType = pRadExt->Type;
 			int RadApplicationDelay = pType->BuildingApplicationDelay;
-			if ((RadApplicationDelay != 0) && (Unsorted::CurrentFrame % RadApplicationDelay != 0))
+			if ((RadApplicationDelay == 0) || (Unsorted::CurrentFrame % RadApplicationDelay != 0))
 				continue;
 
 			// for more precise dmg calculation

--- a/src/Ext/RadSite/Hooks.cpp
+++ b/src/Ext/RadSite/Hooks.cpp
@@ -52,6 +52,7 @@ DEFINE_HOOK(46ADE0, BulletClass_ApplyRadiation, 5)
 	auto const pWeapon = pThis->GetWeaponType();
 	auto const pWeaponExt = WeaponTypeExt::ExtMap.FindOrAllocate(pWeapon);
 	auto const pRadType = &pWeaponExt->RadType;
+	auto const pThisHouse = pThis->Owner ? pThis->Owner->Owner : nullptr;
 
 	if (Instances.Count > 0) {
 		auto const it = std::find_if(Instances.begin(), Instances.end(),
@@ -61,23 +62,24 @@ DEFINE_HOOK(46ADE0, BulletClass_ApplyRadiation, 5)
 					pSite->OwnerObject()->BaseCell == location &&
 					spread == pSite->OwnerObject()->Spread;
 			});
-		if (it == Instances.end()) {
 
-			RadSiteExt::CreateInstance(location, spread, amount, pWeaponExt);
+		if (it == Instances.end()) {
+			RadSiteExt::CreateInstance(location, spread, amount, pWeaponExt , pThisHouse);
 		}
 		else {
 			auto pRadExt = *it;
 			auto pRadSite = pRadExt->OwnerObject();
+
 			if (pRadSite->GetRadLevel() + amount > pRadType->LevelMax) {
 				amount = pRadType->LevelMax - pRadSite->GetRadLevel();
 			}
-			int lvmax = pRadType->DurationMultiple;
+			
 			// Handle It 
-			RadSiteExt::RadSiteAdd(pRadSite, lvmax, amount);
+			pRadExt->Add(amount);
 		}
 	}
 	else {
-		RadSiteExt::CreateInstance(location, spread, amount, pWeaponExt);
+		RadSiteExt::CreateInstance(location, spread, amount, pWeaponExt , pThisHouse);
 	}
 
 	return 0x46AE5E;
@@ -111,7 +113,7 @@ DEFINE_HOOK(43FB23, BuildingClass_Update, 5)
 				continue;
 
 			// for more precise dmg calculation
-			double RadLevel = RadSiteExt::GetRadLevelAt(pRadSite, CurrentCoord);
+			double RadLevel = pRadExt->GetRadLevelAt(CurrentCoord);
 			if (RadLevel <= 0 || !pType->RadWarhead)
 				continue;
 
@@ -124,9 +126,10 @@ DEFINE_HOOK(43FB23, BuildingClass_Update, 5)
 			int damage = static_cast<int>((RadLevel / 2) * pType->LevelFactor);
 			int distance = static_cast<int>(orDistance);
 
-			pBuilding->ReceiveDamage(&damage, distance, pType->RadWarhead, nullptr, ignore, absolute, nullptr);
+			pBuilding->ReceiveDamage(&damage, distance, pType->RadWarhead, nullptr, ignore, absolute, pRadExt->RadHouse);
 		}
 	}
+
 	return 0;
 }
 
@@ -156,14 +159,17 @@ DEFINE_HOOK(4DA554, FootClass_Update_RadSiteClass, 5)
 				continue;
 
 			// for more precise dmg calculation
-			double RadLevel = RadSiteExt::GetRadLevelAt(pRadSite, CurrentCoord);
+			double RadLevel = pRadExt->GetRadLevelAt(CurrentCoord);
 			if (RadLevel <= 0 || !pType->RadWarhead)
 				continue;
+
+			// will prevent passenger escapes
+			bool absolute = pType->RadWarhead->WallAbsoluteDestroyer;
 
 			int Damage = static_cast<int>(RadLevel * pType->LevelFactor);
 			int Distance = static_cast<int>(orDistance);
 
-			pFoot->ReceiveDamage(&Damage, Distance, pType->RadWarhead, nullptr, false, true, nullptr);
+			pFoot->ReceiveDamage(&Damage, Distance, pType->RadWarhead, nullptr, false, absolute, pRadExt->RadHouse);
 		}
 	}
 
@@ -186,6 +192,7 @@ DEFINE_HOOK(65B593, RadSiteClass_Activate_Delay, 6)
 
 	R->ECX(LevelDelay);
 	R->EAX(LightDelay);
+
 	return 0x65B59F;
 }
 
@@ -215,10 +222,12 @@ DEFINE_HOOK(65B5CE, RadSiteClass_Activate_Color, 6)
 DEFINE_HOOK(65B63E, RadSiteClass_Activate_LightFactor, 6)
 {
 	GET(RadSiteClass * const, Rad, ESI);
+
 	auto pRadExt = RadSiteExt::ExtMap.Find(Rad);
 	auto lightFactor = pRadExt->Type->LightFactor;
 
 	__asm fmul lightFactor;
+
 	return 0x65B644;
 }
 
@@ -227,10 +236,12 @@ DEFINE_HOOK_AGAIN(65B6CA, RadSiteClass_Activate_TintFactor, 6)
 DEFINE_HOOK(65B6F2, RadSiteClass_Activate_TintFactor, 6)
 {
 	GET(RadSiteClass * const, Rad, ESI);
+
 	auto pRadExt = RadSiteExt::ExtMap.Find(Rad);
 	double tintFactor = pRadExt->Type->TintFactor;
 
 	__asm fmul tintFactor;
+
 	return R->Origin() + 6;
 }
 
@@ -242,6 +253,7 @@ DEFINE_HOOK(65B843, RadSiteClass_Update_LevelDelay, 6)
 	auto delay = pRadExt->Type->LevelDelay;
 
 	R->ECX(delay);
+
 	return 0x65B849;
 }
 
@@ -253,6 +265,7 @@ DEFINE_HOOK(65B8B9, RadSiteClass_Update_LightDelay, 6)
 	auto delay = pRadExt->Type->LightDelay;
 
 	R->ECX(delay);
+
 	return 0x65B8BF;
 }
 
@@ -262,10 +275,12 @@ DEFINE_HOOK(65BB67, RadSite_Deactivate, 6)
 	GET(const RadSiteClass*, Rad, ECX);
 
 	auto pRadExt = RadSiteExt::ExtMap.Find(Rad);
-
 	auto delay = pRadExt->Type->LevelDelay;
+
 	R->ESI(delay);
+
 	__asm xor edx, edx; // fixing integer overflow crash
 	__asm idiv esi;
+
 	return 0x65BB6D;
 }

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -24,12 +24,15 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	// RadType
 	if (this->OwnerObject()->RadLevel > 0)
 		this->RadType.Read(pINI, pSection, "RadType");
+		this->Rad_NoOwner.Read(exINI, pSection, "Rad.NoOwner");
 }
+
 void WeaponTypeExt::ExtData::LoadFromStream(IStream* Stm) {
 	this->DiskLaser_Circumference.Load(Stm);
 
 	if (this->OwnerObject()->RadLevel > 0)
 		this->RadType.Load(Stm);
+	this->Rad_NoOwner.Load(Stm);
 }
 
 void WeaponTypeExt::ExtData::SaveToStream(IStream* Stm)  {
@@ -37,6 +40,7 @@ void WeaponTypeExt::ExtData::SaveToStream(IStream* Stm)  {
 
 	if (this->OwnerObject()->RadLevel > 0)
 		this->RadType.Save(Stm);
+	this->Rad_NoOwner.Save(Stm);
 }
 
 // =============================

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -19,10 +19,13 @@ public:
 		Valueable<double> DiskLaser_Radius;
 		Valueable<int> DiskLaser_Circumference;
 		RadType RadType;
+		Valueable<bool> Rad_NoOwner;
+
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject),
 			DiskLaser_Radius(38.2),
 			DiskLaser_Circumference(240),
-			RadType()
+			RadType(),
+			Rad_NoOwner(false)
 		{ }
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;


### PR DESCRIPTION
Add HouseClass for RadSite
New tag introduce on weapon to set the owner to nullptr if user wanted to use old behaviour
[WEAPON]
RadNullOwner=false ;bool

:AffectsAllies=bool now can be use with RadWarhead
:Killing  techno using Radiation now counted as scored
