### PR TITLE
Fix loader blowfish.dll

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -34,6 +34,7 @@
     <ClCompile Include="src\Ext\WeaponType\Body.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Hooks.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Hooks.DiskLaserRadius.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Blowfish.cpp" />
     <ClCompile Include="src\Misc\Savegame.cpp" />
     <ClCompile Include="src\Misc\ExtendedToolTips.cpp" />
     <ClCompile Include="src\Misc\Selection.cpp" />

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -6,7 +6,7 @@ This page lists all user interface additions, changes, fixes that are implemente
 
 - Enabled ability to load full-color non-paletted PCX graphics of any bitness. This applies to every single PCX file that is loaded, including the Ares-supported PCX files.
 - You can specify custom `gamemd.exe` icon via `-icon` command line argument followed by absolute or relative path to an `*.ico` file (f. ex. `gamemd.exe -icon Resources/clienticon.ico`).
-- Fixed error `***FATAL*** String Manager failed to initilaized properly`, which occurred if `Blowfish.dll` could not be registered in the OS, for example, it happened when the player did not have administrator rights. With Phobos, if the game did not find a registered file in the system, it will no longer try to register this file, but will loading it bypassing registration. 
+- Fixed `Blowfish.dll`-caused error `***FATAL*** String Manager failed to initilaize properly`, which occurred if `Blowfish.dll` could not be registered in the OS, for example, it happened when the player did not have administrator rights. With Phobos, if the game did not find a registered file in the system, it will no longer try to register this file, but will load it bypassing registration. 
 
 ## Audio
 

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -2,6 +2,12 @@
 
 This page lists all user interface additions, changes, fixes that are implemented in Phobos.
 
+## Bugfixes and miscellanous
+
+- Enabled ability to load full-color non-paletted PCX graphics of any bitness. This applies to every single PCX file that is loaded, including the Ares-supported PCX files.
+- You can specify custom `gamemd.exe` icon via `-icon` command line argument followed by absolute or relative path to an `*.ico` file (f. ex. `gamemd.exe -icon Resources/clienticon.ico`).
+- Fixed error `***FATAL*** String Manager failed to initilaized properly`, which occurred if `Blowfish.dll` could not be registered in the OS, for example, it happened when the player did not have administrator rights. With Phobos, if the game did not find a registered file in the system, it will no longer try to register this file, but will loading it bypassing registration. 
+
 ## Audio
 
 - You can now specify which soundtrack themes would play on win or lose.
@@ -12,11 +18,6 @@ In `rulesmd.ini`:
 IngameScore.WinTheme=  ; soundtrack theme ID
 IngameScore.LoseTheme= ; soundtrack theme ID
 ```
-
-## Bugfixes and miscellanous
-
-- Enabled ability to load full-color non-paletted PCX graphics of any bitness. This applies to every single PCX file that is loaded, including the Ares-supported PCX files.
-- You can specify custom `gamemd.exe` icon via `-icon` command line argument followed by absolute or relative path to an `*.ico` file (f. ex. `gamemd.exe -icon Resources/clienticon.ico`).
 
 ## Hotkey Commands
 

--- a/src/Misc/Hooks.Blowfish.cpp
+++ b/src/Misc/Hooks.Blowfish.cpp
@@ -1,0 +1,54 @@
+#include <Utilities\Macro.h>
+#include "Debug.h"
+
+HRESULT __stdcall Blowfish_Loader(
+	REFCLSID  rclsid,
+	LPUNKNOWN pUnkOuter,
+	DWORD     dwClsContext,
+	REFIID    riid,
+	LPVOID* ppv)
+{
+	typedef HRESULT(__stdcall *pDllGetClassObject)(const IID&, const IID&, IClassFactory**);
+
+	auto result = REGDB_E_KEYMISSING;
+
+	// First, let's try to run the vanilla function
+	result = CoCreateInstance(rclsid, pUnkOuter, dwClsContext, riid, ppv);
+	if (SUCCEEDED(result))
+		return result;
+
+	HMODULE hDll = LoadLibrary("Blowfish.dll");
+	if (hDll) {
+		auto GetClassObject = (pDllGetClassObject)GetProcAddress(hDll, "DllGetClassObject");
+		if (GetClassObject) {
+
+			IClassFactory* pIFactory;
+			result = GetClassObject(rclsid, IID_IClassFactory, &pIFactory);
+
+			if (SUCCEEDED(result)) {
+				result = pIFactory->CreateInstance(pUnkOuter, riid, ppv);
+				pIFactory->Release();
+			}
+		}
+	}
+
+	if (!SUCCEEDED(result)) {
+		FreeLibrary(hDll);
+		
+		char* Message = "File Blowfish.dll was not found\n";
+		MessageBox(0, Message, "Fatal error ", MB_ICONERROR);
+		Debug::FatalErrorAndExit(Message);
+	}
+
+	return result;
+}
+
+DEFINE_NAKED_LJMP(0x6BEDDD, _Blowfish_Loader_Init) {
+	CALL(Blowfish_Loader);
+	JMP(0x6BEDE3);
+}
+
+DEFINE_NAKED_LJMP(0x437F6E, _Blowfish_Loader_Create) {
+	CALL(Blowfish_Loader);
+	JMP(0x437F74);
+}


### PR DESCRIPTION
Fixed error `***FATAL*** String Manager failed to initilaized properly`, which occurred if `Blowfish.dll` could not be registered in the OS, for example, it happened when the player did not have administrator rights. With Phobos, if the game did not find a registered file in the system, it will no longer try to register this file, but will loading it bypassing registration. 

Screenshot of a bug in a vanilla game:
![BlowfishError](https://user-images.githubusercontent.com/54427022/112766753-da8b2180-901b-11eb-84fa-e105ecdee820.png)