### PR TITLE
Customizable drill ore types

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="src\Ext\TechnoType\Body.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Hooks.cpp" />
     <ClCompile Include="src\Ext\Techno\Body.cpp" />
+    <ClCompile Include="src\Ext\TerrainType\Body.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Body.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Hooks.cpp" />
@@ -78,6 +79,7 @@
     <ClInclude Include="src\Ext\Side\Body.h" />
     <ClInclude Include="src\Ext\TechnoType\Body.h" />
     <ClInclude Include="src\Ext\Techno\Body.h" />
+    <ClInclude Include="src\Ext\TerrainType\Body.h" />
     <ClInclude Include="src\Ext\WeaponType\Body.h" />
     <ClInclude Include="src\Misc\ExtendedToolTips.h" />
     <ClInclude Include="src\Misc\Savegame.h" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="src\Ext\TechnoType\Hooks.cpp" />
     <ClCompile Include="src\Ext\Techno\Body.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Body.cpp" />
+    <ClCompile Include="src\Ext\TerrainType\Hooks.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Body.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Hooks.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -57,7 +57,7 @@ Powered.KillSpawns=no ; boolean
 
 In `rulesmd.ini`:
 ```ini
-[SOMETERRAINTYPE]              ; TerrainType
-SpawnsTiberium.Type=0          ; tiberium type index
-SpawnsTiberium.CellSpread=1.5  ; double
+[SOMETERRAINTYPE]       ; TerrainType
+SpawnsTiberium.Type=0   ; tiberium type index
+SpawnsTiberium.Range=1  ; integer, radius in cells
 ```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -47,3 +47,15 @@ In `rulesmd.ini`:
 [SOMESTRUCTURE]       ; BuildingType
 Powered.KillSpawns=no ; boolean
 ```
+
+## Terrain
+
+### Customizable spawned ore types
+
+- Allows to specify which type of tiberium this TerrainType would generate.
+
+In `rulesmd.ini`:
+```ini
+[SOMETERRAINTYPE]      ; TerrainType
+SpawnsTiberium.Type=0  ; Tiberium type index
+```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -50,12 +50,14 @@ Powered.KillSpawns=no ; boolean
 
 ## Terrain
 
-### Customizable spawned ore types
+### Customizable ore spawners
 
-- Allows to specify which type of tiberium this TerrainType would generate.
+- You can now specify which type of tiberium this TerrainType would generate.
+- It's also now possible to specify a CellSpread value for an ore generation area ddifferent compared to standard 3x3 rectangle. Ore will be uniformly distributed across all affected cells in a spread range.
 
 In `rulesmd.ini`:
 ```ini
-[SOMETERRAINTYPE]      ; TerrainType
-SpawnsTiberium.Type=0  ; Tiberium type index
+[SOMETERRAINTYPE]              ; TerrainType
+SpawnsTiberium.Type=0          ; tiberium type index
+SpawnsTiberium.CellSpread=1.5  ; double
 ```

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -101,7 +101,7 @@ DEFINE_HOOK_AGAIN(71E0B4, TerrainTypeClass_LoadFromINI, A)
 DEFINE_HOOK(71E0A7, TerrainTypeClass_LoadFromINI, A)
 {
 	GET(TerrainTypeClass*, pItem, ESI);
-	GET_STACK(CCINIClass*, pINI, STACK_OFFS(0x20C, 0x4));
+	GET_STACK(CCINIClass*, pINI, STACK_OFFS(0x20C, -0x4));
 
 	TerrainTypeExt::ExtMap.LoadFromINI(pItem, pINI);
 	return 0;

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -1,0 +1,109 @@
+#include "Body.h"
+
+#include <TerrainTypeClass.h>
+
+template<> const DWORD Extension<TerrainTypeClass>::Canary = 0xBEE78007;
+TerrainTypeExt::ExtContainer TerrainTypeExt::ExtMap;
+
+// =============================
+// load / save
+
+template <typename T>
+void TerrainTypeExt::ExtData::Serialize(T& Stm) {
+	Stm
+		.Process(this->SpawnsTiberium_Type)
+		;
+}
+
+void TerrainTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
+	auto pThis = this->OwnerObject();
+	const char* pSection = pThis->ID;
+
+	if (!pINI->GetSection(pSection)) {
+		return;
+	}
+
+	INI_EX exINI(pINI);
+	this->SpawnsTiberium_Type.Read(exINI, pSection, "SpawnsTiberium.Type");
+}
+
+void TerrainTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {
+	Extension<TerrainTypeClass>::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void TerrainTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm) {
+	Extension<TerrainTypeClass>::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+bool TerrainTypeExt::LoadGlobals(PhobosStreamReader& Stm) {
+	return Stm
+		.Success();
+}
+
+bool TerrainTypeExt::SaveGlobals(PhobosStreamWriter& Stm) {
+	return Stm
+		.Success();
+}
+
+// =============================
+// container
+
+TerrainTypeExt::ExtContainer::ExtContainer() : Container("TerrainTypeClass") {
+}
+
+TerrainTypeExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// container hooks
+
+DEFINE_HOOK(71DBC2, TerrainTypeClass_CTOR, 5)
+{
+	GET(TerrainTypeClass*, pItem, ESI);
+
+	TerrainTypeExt::ExtMap.FindOrAllocate(pItem);
+	return 0;
+}
+
+DEFINE_HOOK(71E360, TerrainTypeClass_SDDTOR, A)
+{
+	GET(TerrainTypeClass*, pItem, ECX);
+
+	TerrainTypeExt::ExtMap.Remove(pItem);
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(71E1D0, TerrainTypeClass_SaveLoad_Prefix, 5)
+DEFINE_HOOK(71E240, TerrainTypeClass_SaveLoad_Prefix, 8)
+{
+	GET_STACK(TerrainTypeClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	TerrainTypeExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(71E235, TerrainTypeClass_Load_Suffix, 4)
+{
+	TerrainTypeExt::ExtMap.LoadStatic();
+	return 0;
+}
+
+DEFINE_HOOK(71E25A, TerrainTypeClass_Save_Suffix, 3)
+{
+	TerrainTypeExt::ExtMap.SaveStatic();
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(71E0B4, TerrainTypeClass_LoadFromINI, A)
+DEFINE_HOOK(71E0A7, TerrainTypeClass_LoadFromINI, A)
+{
+	GET(TerrainTypeClass*, pItem, ESI);
+	GET_STACK(CCINIClass*, pINI, STACK_OFFS(0x20C, 0x4));
+
+	TerrainTypeExt::ExtMap.LoadFromINI(pItem, pINI);
+	return 0;
+}
+

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -12,7 +12,7 @@ template <typename T>
 void TerrainTypeExt::ExtData::Serialize(T& Stm) {
 	Stm
 		.Process(this->SpawnsTiberium_Type)
-		.Process(this->SpawnsTiberium_CellSpread)
+		.Process(this->SpawnsTiberium_Range)
 		;
 }
 
@@ -26,7 +26,7 @@ void TerrainTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 
 	INI_EX exINI(pINI);
 	this->SpawnsTiberium_Type.Read(exINI, pSection, "SpawnsTiberium.Type");
-	this->SpawnsTiberium_CellSpread.Read(exINI, pSection, "SpawnsTiberium.CellSpread");
+	this->SpawnsTiberium_Range.Read(exINI, pSection, "SpawnsTiberium.Range");
 }
 
 void TerrainTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -12,6 +12,7 @@ template <typename T>
 void TerrainTypeExt::ExtData::Serialize(T& Stm) {
 	Stm
 		.Process(this->SpawnsTiberium_Type)
+		.Process(this->SpawnsTiberium_CellSpread)
 		;
 }
 
@@ -25,6 +26,7 @@ void TerrainTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 
 	INI_EX exINI(pINI);
 	this->SpawnsTiberium_Type.Read(exINI, pSection, "SpawnsTiberium.Type");
+	this->SpawnsTiberium_CellSpread.Read(exINI, pSection, "SpawnsTiberium.CellSpread");
 }
 
 void TerrainTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {

--- a/src/Ext/TerrainType/Body.h
+++ b/src/Ext/TerrainType/Body.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <TerrainTypeClass.h>
+
+#include <Helpers/Macro.h>
+#include "../_Container.hpp"
+#include "../../Utilities/TemplateDef.h"
+
+class TerrainTypeExt
+{
+public:
+    using base_type = TerrainTypeClass;
+
+    class ExtData final : public Extension<TerrainTypeClass>
+    {
+    public:
+        Valueable<int> SpawnsTiberium_Type;
+
+        ExtData(TerrainTypeClass* OwnerObject) : Extension<TerrainTypeClass>(OwnerObject),
+            SpawnsTiberium_Type(0)
+        { }
+
+        virtual ~ExtData() = default;
+
+        virtual void LoadFromINIFile(CCINIClass* pINI) override;
+
+        virtual void InvalidatePointer(void* ptr, bool bRemoved) override {}
+
+        virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+        virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+    
+    private:
+        template <typename T>
+        void Serialize(T& Stm);
+    };
+
+    class ExtContainer final : public Container<TerrainTypeExt> {
+    public:
+        ExtContainer();
+        ~ExtContainer();
+    };
+
+    static ExtContainer ExtMap;
+
+    static bool LoadGlobals(PhobosStreamReader& Stm);
+    static bool SaveGlobals(PhobosStreamWriter& Stm);
+};

--- a/src/Ext/TerrainType/Body.h
+++ b/src/Ext/TerrainType/Body.h
@@ -14,9 +14,11 @@ public:
     {
     public:
         Valueable<int> SpawnsTiberium_Type;
+        Valueable<double> SpawnsTiberium_CellSpread;
 
         ExtData(TerrainTypeClass* OwnerObject) : Extension<TerrainTypeClass>(OwnerObject),
-            SpawnsTiberium_Type(0)
+            SpawnsTiberium_Type(0),
+            SpawnsTiberium_CellSpread(1.5)
         { }
 
         virtual ~ExtData() = default;

--- a/src/Ext/TerrainType/Body.h
+++ b/src/Ext/TerrainType/Body.h
@@ -14,11 +14,11 @@ public:
     {
     public:
         Valueable<int> SpawnsTiberium_Type;
-        Valueable<double> SpawnsTiberium_CellSpread;
+        Valueable<int> SpawnsTiberium_Range;
 
         ExtData(TerrainTypeClass* OwnerObject) : Extension<TerrainTypeClass>(OwnerObject),
             SpawnsTiberium_Type(0),
-            SpawnsTiberium_CellSpread(1.5)
+            SpawnsTiberium_Range(1)
         { }
 
         virtual ~ExtData() = default;

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -1,12 +1,20 @@
 #include "Body.h"
 
-namespace TerrainTemp {
-	TerrainTypeClass* currentType = nullptr;
+#include <ScenarioClass.h>
+#include <TiberiumClass.h>
+#include <OverlayTypeClass.h>
+
+#include "../../Utilities/GeneralUtils.h"
+
+namespace TerrainTypeTemp {
+	TerrainTypeClass* pCurrentType = nullptr;
+	TerrainTypeExt::ExtData* pCurrentExt = nullptr;
 }
 
 DEFINE_HOOK(71C853, TerrainTypeClass_Context_Set, 6)
 {
-	TerrainTemp::currentType = R->ECX<TerrainTypeClass*>();
+	TerrainTypeTemp::pCurrentType = R->ECX<TerrainTypeClass*>();
+	TerrainTypeTemp::pCurrentExt = TerrainTypeExt::ExtMap.Find(TerrainTypeTemp::pCurrentType);
 
 	return 0;
 }
@@ -15,8 +23,8 @@ DEFINE_HOOK(483811, CellClass_SpreadTiberium_TiberiumType, 8)
 {
 	LEA_STACK(int*, pTibType, STACK_OFFS(0x1C, -0x4));
 
-	if (auto pTypeExt = TerrainTypeExt::ExtMap.Find(TerrainTemp::currentType)) {
-		*pTibType = pTypeExt->SpawnsTiberium_Type;
+	if (TerrainTypeTemp::pCurrentExt) {
+		*pTibType = TerrainTypeTemp::pCurrentExt->SpawnsTiberium_Type;
 
 		return 0x483819;
 	}
@@ -24,9 +32,61 @@ DEFINE_HOOK(483811, CellClass_SpreadTiberium_TiberiumType, 8)
 	return 0;
 }
 
+DEFINE_HOOK(48381D, CellClass_SpreadTiberium_CellSpread, 6)
+{
+	if (TerrainTypeTemp::pCurrentExt)
+	{
+		GET(CellClass*, pThis, EDI);
+		GET(int, tibIndex, EAX);
+
+		TiberiumClass* pTib = TiberiumClass::Array->GetItem(tibIndex);
+
+		std::vector<CellStruct> adjacentCells = GeneralUtils::CellSpreadAffectedCells(TerrainTypeTemp::pCurrentExt->SpawnsTiberium_CellSpread);
+		size_t size = adjacentCells.size();
+		int rand = ScenarioClass::Instance->Random.RandomRanged(0, size - 1);
+
+		for (unsigned int i = 0; i < size; i++) {
+			unsigned int cellIndex = (i + rand) % size;
+			CellStruct tgtPos = pThis->MapCoords + adjacentCells[cellIndex];
+			CellClass* tgtCell = MapClass::Instance->GetCellAt(tgtPos);
+
+			if (tgtCell && tgtCell->CanTiberiumGerminate(pTib))
+			{
+				// return with call to spread tib
+				R->EDX<int>(tibIndex);
+				R->ECX<CellClass*>(tgtCell);
+
+				return 0x4838BC;
+			}
+		}
+
+		// return without spreading tib
+		return 0x4838B0;
+	}
+	
+	return 0;
+}
+
 DEFINE_HOOK(71C8D7, TerrainTypeClass_Context_Unset, 5)
 {
-	TerrainTemp::currentType = nullptr;
+	TerrainTypeTemp::pCurrentType = nullptr;
+	TerrainTypeTemp::pCurrentExt = nullptr;
+
+	return 0;
+}
+
+// TODO investigate why wrong OverlayType is passed
+DEFINE_HOOK(5FDD2E, OverlayClass_GetTiberiumType_TypeOutOfBonds, 5)
+{
+	GET(int, type, ECX);
+
+	if (!OverlayTypeClass::Array->ValidIndex(type))
+	{
+		Debug::Log("[Phobos] Invalid OverlayType index %d passed to GetTiberiumType! OverlayType array size is %d.\n",
+			type, OverlayTypeClass::Array->Count);
+
+		return 0x5FDDD5;
+	}
 
 	return 0;
 }

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -24,7 +24,7 @@ DEFINE_HOOK(483811, CellClass_SpreadTiberium_TiberiumType, 8)
 	return 0;
 }
 
-DEFINE_HOOK(71C8DB, TerrainTypeClass_Context_Unset, 1)
+DEFINE_HOOK(71C8D7, TerrainTypeClass_Context_Unset, 5)
 {
 	TerrainTemp::currentType = nullptr;
 

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -53,10 +53,9 @@ DEFINE_HOOK(48381D, CellClass_SpreadTiberium_CellSpread, 6)
 			if (tgtCell && tgtCell->CanTiberiumGerminate(pTib))
 			{
 				// return with call to spread tib
-				R->EDX<int>(tibIndex);
-				R->ECX<CellClass*>(tgtCell);
+				R->EAX<bool>(tgtCell->IncreaseTiberium(tibIndex, 3));
 
-				return 0x4838BC;
+				return 0x4838CA;
 			}
 		}
 
@@ -71,22 +70,6 @@ DEFINE_HOOK(71C8D7, TerrainTypeClass_Context_Unset, 5)
 {
 	TerrainTypeTemp::pCurrentType = nullptr;
 	TerrainTypeTemp::pCurrentExt = nullptr;
-
-	return 0;
-}
-
-// TODO investigate why wrong OverlayType is passed
-DEFINE_HOOK(5FDD2E, OverlayClass_GetTiberiumType_TypeOutOfBonds, 5)
-{
-	GET(int, type, ECX);
-
-	if (!OverlayTypeClass::Array->ValidIndex(type))
-	{
-		Debug::Log("[Phobos] Invalid OverlayType index %d passed to GetTiberiumType! OverlayType array size is %d.\n",
-			type, OverlayTypeClass::Array->Count);
-
-		return 0x5FDDD5;
-	}
 
 	return 0;
 }

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -1,0 +1,31 @@
+#include "Body.h"
+
+
+TerrainTypeClass* currentType = nullptr;
+
+DEFINE_HOOK(71C853, TerrainTypeClass_Context_Set, 6)
+{
+	currentType = R->ECX<TerrainTypeClass*>();
+
+	return 0;
+}
+
+DEFINE_HOOK(483811, CellClass_SpreadTiberium_TiberiumType, 8)
+{
+	LEA_STACK(int*, pTibType, 0x20);
+
+	if (auto pTypeExt = TerrainTypeExt::ExtMap.Find(currentType)) {
+		*pTibType = pTypeExt->SpawnsTiberium_Type;
+
+		return 0x483819;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(71C8DB, TerrainTypeClass_Context_Unset, 1)
+{
+	currentType = nullptr;
+
+	return 0;
+}

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -1,20 +1,21 @@
 #include "Body.h"
 
-
-TerrainTypeClass* currentType = nullptr;
+namespace TerrainTemp {
+	TerrainTypeClass* currentType = nullptr;
+}
 
 DEFINE_HOOK(71C853, TerrainTypeClass_Context_Set, 6)
 {
-	currentType = R->ECX<TerrainTypeClass*>();
+	TerrainTemp::currentType = R->ECX<TerrainTypeClass*>();
 
 	return 0;
 }
 
 DEFINE_HOOK(483811, CellClass_SpreadTiberium_TiberiumType, 8)
 {
-	LEA_STACK(int*, pTibType, 0x20);
+	LEA_STACK(int*, pTibType, STACK_OFFS(0x1C, -0x4));
 
-	if (auto pTypeExt = TerrainTypeExt::ExtMap.Find(currentType)) {
+	if (auto pTypeExt = TerrainTypeExt::ExtMap.Find(TerrainTemp::currentType)) {
 		*pTibType = pTypeExt->SpawnsTiberium_Type;
 
 		return 0x483819;
@@ -25,7 +26,7 @@ DEFINE_HOOK(483811, CellClass_SpreadTiberium_TiberiumType, 8)
 
 DEFINE_HOOK(71C8DB, TerrainTypeClass_Context_Unset, 1)
 {
-	currentType = nullptr;
+	TerrainTemp::currentType = nullptr;
 
 	return 0;
 }

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -41,7 +41,7 @@ DEFINE_HOOK(48381D, CellClass_SpreadTiberium_CellSpread, 6)
 
 		TiberiumClass* pTib = TiberiumClass::Array->GetItem(tibIndex);
 
-		std::vector<CellStruct> adjacentCells = GeneralUtils::CellSpreadAffectedCells(TerrainTypeTemp::pCurrentExt->SpawnsTiberium_CellSpread);
+		std::vector<CellStruct> adjacentCells = GeneralUtils::AdjacentCellsInRange(TerrainTypeTemp::pCurrentExt->SpawnsTiberium_Range);
 		size_t size = adjacentCells.size();
 		int rand = ScenarioClass::Instance->Random.RandomRanged(0, size - 1);
 

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -1,7 +1,4 @@
 #include "GeneralUtils.h"
-#include <string.h>
-#include <StringTable.h>
-#include <CCINIClass.h>
 
 bool GeneralUtils::IsValidString(const char* str)
 {
@@ -21,4 +18,16 @@ const wchar_t* GeneralUtils::LoadStringOrDefault(char* key, const wchar_t* defau
 const wchar_t* GeneralUtils::LoadStringUnlessMissing(char* key, const wchar_t* defaultValue)
 {
 	return wcsstr(LoadStringOrDefault(key, defaultValue), L"MISSING:") ? defaultValue : LoadStringOrDefault(key, defaultValue);
+}
+
+std::vector<CellStruct> GeneralUtils::CellSpreadAffectedCells(const double spread)
+{
+	std::vector<CellStruct> result;
+	auto const range = static_cast<size_t>(spread + 0.99);
+
+	for (CellSpreadEnumerator it(range); it; ++it) {
+		result.push_back(*it);
+	}
+
+	return result;
 }

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -20,10 +20,9 @@ const wchar_t* GeneralUtils::LoadStringUnlessMissing(char* key, const wchar_t* d
 	return wcsstr(LoadStringOrDefault(key, defaultValue), L"MISSING:") ? defaultValue : LoadStringOrDefault(key, defaultValue);
 }
 
-std::vector<CellStruct> GeneralUtils::CellSpreadAffectedCells(const double spread)
+std::vector<CellStruct> GeneralUtils::AdjacentCellsInRange(unsigned int range)
 {
 	std::vector<CellStruct> result;
-	auto const range = static_cast<size_t>(spread + 0.99);
 
 	for (CellSpreadEnumerator it(range); it; ++it) {
 		result.push_back(*it);

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -1,4 +1,14 @@
 #pragma once
+#include <StringTable.h>
+#include <CCINIClass.h>
+#include <CellSpread.h>
+
+#include <Helpers/Iterators.h>
+#include <Helpers/Enumerators.h>
+
+#include <string.h>
+#include <iterator>
+#include <vector>
 
 class GeneralUtils
 {
@@ -6,4 +16,5 @@ public:
     static bool IsValidString(const char* str);
     static const wchar_t* LoadStringOrDefault(char* key, const wchar_t* defaultValue);
     static const wchar_t* LoadStringUnlessMissing(char* key, const wchar_t* defaultValue);
+    static std::vector<CellStruct> CellSpreadAffectedCells(const double spread);
 };

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -16,5 +16,5 @@ public:
     static bool IsValidString(const char* str);
     static const wchar_t* LoadStringOrDefault(char* key, const wchar_t* defaultValue);
     static const wchar_t* LoadStringUnlessMissing(char* key, const wchar_t* defaultValue);
-    static std::vector<CellStruct> CellSpreadAffectedCells(const double spread);
+    static std::vector<CellStruct> AdjacentCellsInRange(unsigned int range);
 };


### PR DESCRIPTION
- Allows to specify which type of tiberium this TerrainType would generate.

In `rulesmd.ini`:
```ini
[SOMETERRAINTYPE]      ; TerrainType
SpawnsTiberium.Type=0  ; Tiberium type index
```
