### PR TITLE
Specifies deploy facing for SimpleDeployers (ground units)

### DIFF
--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -221,6 +221,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Harvester_Counted.Read(exINI, pSection, "Harvester.Counted");
 	this->Promote_IncludeSpawns.Read(exINI, pSection, "Promote.IncludeSpawns");
 	this->ImmuneToCrit.Read(exINI, pSection, "ImmuneToCrit");
+	this->Deployer_Facing.Read(exINI, pSection, "Deployer.Facing");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -250,6 +251,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm) {
 		.Process(this->Harvester_Counted)
         .Process(this->Promote_IncludeSpawns)
 		.Process(this->ImmuneToCrit)
+		.Process(this->Deployer_Facing)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -32,6 +32,7 @@ public:
 		Nullable<bool> Harvester_Counted;
 		Valueable<bool> Promote_IncludeSpawns;
 		Valueable<bool> ImmuneToCrit;
+		Valueable<int> Deployer_Facing;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			Deployed_RememberTarget(false),
@@ -49,7 +50,8 @@ public:
 			Spawn_LimitedExtraRange(0),
 			Harvester_Counted(),
 			Promote_IncludeSpawns(false),
-			ImmuneToCrit(false)
+			ImmuneToCrit(false),
+			Deployer_Facing(-1)
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -72,6 +72,28 @@ DEFINE_HOOK(6F3E6E, FootClass_firecoord_6F3D60_TurretMultiOffset, 0)
 	return 0x6F3E85;
 }
 
+DEFINE_HOOK(73DE78, UnitClass_Mi_Unload_SimpleDeployer, 6)
+{
+	GET(UnitClass* const, pThis, ESI);
+
+	enum { Allowed = 0, Disallowed = 0x73DE20 };
+
+	const auto pTypeData = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+	if (pTypeData->Deployer_Facing != -1) {
+		DirStruct deployDir((pTypeData->Deployer_Facing * 4) << 11);
+
+		if (pThis->Facing.current().value() != deployDir.value()) {
+			auto& pLocomoter = pThis->Locomotor;
+			if (!pLocomoter)
+				Game::RaiseError(E_POINTER);
+			pLocomoter->Do_Turn(deployDir);
+			return Disallowed;
+		}
+	}
+
+	return Allowed;
+}
+
 DEFINE_HOOK(73B780, UnitClass_DrawVXL_TurretMultiOffset, 0)
 {
 	GET(TechnoTypeClass*, technoType, EAX);


### PR DESCRIPTION
Also works with ares convertion. Units will turn to correct dir first instead of In-place deploy