### PR TITLE
Shield logic additions / improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Credits
 - AutoGavy - interceptor logic, warhead critical damage system
 - Xkein - general assistance, YRpp edits
 - thomassneddon - general assistance
+- Starkku - Warhead shield penetration & breaking
 
 Thanks to everyone who uses Phobos, tests changes and reports bugs! You can show your appreciation and help project by displaying the logo (monochrome version can be found [here](https://github.com/Phobos-developers/Phobos/logo-mono.png)) in your client/launcher, contributing or donating to us via links on the right and the `Sponsor` button on top of the repo.
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -77,13 +77,19 @@ Promote.IncludeSpawns=no  ; boolean
 *Buildings, Infantries and Vehicles with Shield in [Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-adventure)*
 
 - Now you can have a shield for any TechnoType if `Shield.Strength` is set greater than 0. It serves as a second health pool with independent `Armor` and `Strength` values.
+- `Shield.AbsorbOverDamage`controls whether or not the shield absorbs damage dealt beyond shield's current strength when the shield breaks.
 - `Shield.SelfHealing` and `Shield.Respawn` respect the following settings: 0.0 disables the feature, 1%-100% recovers/respawns the shield strength in percentage, other number recovers/respawns the shield strength directly. Specially, `Shield.SelfHealing` with a negative number deducts the shield strength.
 - `Shield.SelfHealing.Rate` and `Shield.Respawn.Rate` respect the following settings: 0.0 instantly recovers the shield, other values determine the frequency of shield recovers/respawns in ingame minutes.
-- `Shield.HitAnim` will be played if set when Shield is attacked, similiar to Iron Curtaion.
-- A TechnoType with a Shield will show its Shield Strength. An empty shield strength bar will be left after destroyed if it is respawnable.
+- `Shield.IdleAnim`, if set, will be played while the shield is intact. This animation is automatically set to loop indefinitely.
+- `Shield.BreakAnim`, if set, will be played when the shield has been broken.
+- `Shield.HitAnim`, if set, will be played when the shield is attacked, similar to `WeaponNullifyAnim` for Iron Curtain.
+- A TechnoType with a shield will show its shield Strength. An empty shield strength bar will be left after destroyed if it is respawnable.
   - Buildings now use the 5th frame of `pips.shp` to display the shield strength while other units uses the 16th frame by default.
   - `Pips.Shield` can be used to specify which pip frame should be used as shield strength. If only 1 digit set, then it will always display it, or if 3 digits set, it will respect `ConditionYellow` and `ConditionRed`. `Pips.Shield.Building` is used for BuildingTypes. 
   - `pipbrd.shp` will use its 4th frame to display an infantry's shield strength and the 3th frame for other units if `pipbrd.shp` has extra 2 frames. And `Shield.BracketDelta` can be used as additonal `PixelSelectionBracketDelta` for shield strength. 
+- Warheads have new options that interact with shields.
+  - `PenetratesShield` allows the warhead ignore the shield and always deal full damage to the TechnoType itself. It also allows targeting the TechnoType even if weapons using the warhead cannot target or damage the shield.
+  - `BreaksShield` allows the warhead to always break shields of TechnoTypes, regardless of the amount of strength the shield has remaining or the damage dealt, assuming it affects the shield's armor type. Residual damage, if there is any, still respects `Shield.AbsorbOverDamage`.
 
 In `rulesmd.ini`:
 ```ini
@@ -91,17 +97,22 @@ In `rulesmd.ini`:
 Pips.Shield=-1,-1,-1           ; int, frames of pips.shp for Green, Yellow, Red
 Pips.Shield.Building=-1,-1,-1  ; int, frames of pips.shp for Green, Yellow, Red
 
-[SOMETECHNO]	            ; TechnoTypes
-Shield.Strength=0           ; integer
-Shield.Armor=none           ; ArmorType
-Shield.SelfHealing=0.0      ; double, percents or absolute
-Shield.SelfHealing.Rate=0.0 ; double, ingame minutes
-Shield.Respawn=0.0          ; double, percents or absolute
-Shield.Respawn.Rate=0.0     ; double, ingame minutes
-Shield.BracketDelta=0       ; integer - pixels
-Shield.IdleAnim=            ; animation
-Shield.BreakAnim=           ; animation
-Shield.HitAnim=             ; animation
+[SOMETECHNO]	               ; TechnoType
+Shield.Strength=0              ; integer
+Shield.Armor=none              ; ArmorType
+Shield.AbsorbOverDamage=false  ; boolean
+Shield.SelfHealing=0.0         ; double, percents or absolute
+Shield.SelfHealing.Rate=0.0    ; double, ingame minutes
+Shield.Respawn=0.0             ; double, percents or absolute
+Shield.Respawn.Rate=0.0        ; double, ingame minutes
+Shield.BracketDelta=0          ; integer - pixels
+Shield.IdleAnim=               ; animation
+Shield.BreakAnim=              ; animation
+Shield.HitAnim=                ; animation
+
+[SOMEWARHEAD]                  ; WarheadType
+PenetratesShield=false         ; boolean
+BreaksShield=false             ; boolean
 ```
 
 ## Weapons

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -96,6 +96,9 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 	this->AffectsEnemies.Read(exINI, pSection, "AffectsEnemies");
 	this->AffectsOwner.Read(exINI, pSection, "AffectsOwner");
+
+	this->PenetratesShield.Read(exINI, pSection, "PenetratesShield");
+	this->BreaksShield.Read(exINI, pSection, "BreaksShield");
 }
 
 template <typename T>
@@ -121,6 +124,9 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm) {
 		// Ares tags
 		.Process(this->AffectsEnemies)
 		.Process(this->AffectsOwner)
+
+		.Process(this->PenetratesShield)
+		.Process(this->BreaksShield)
 		;
 }
 

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -34,6 +34,9 @@ public:
 		Valueable<bool> AffectsEnemies;
 		Nullable<bool> AffectsOwner;
 		
+		Valueable<bool> PenetratesShield;
+		Valueable<bool> BreaksShield;
+
 		double RandomBuffer;
 
 		ExtData(WarheadTypeClass* OwnerObject) : Extension<WarheadTypeClass>(OwnerObject),
@@ -54,7 +57,10 @@ public:
 			MindControl_Anim(),
 
 			AffectsEnemies(true),
-			AffectsOwner()
+			AffectsOwner(),
+
+			PenetratesShield(false),
+			BreaksShield(false)
 		{ }
 	private:
 		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr);

--- a/src/Misc/Shield.cpp
+++ b/src/Misc/Shield.cpp
@@ -76,6 +76,11 @@ int ShieldTechnoClass::ReceiveDamage(args_ReceiveDamage* args)
 
         auto residueDamage = nDamage - this->HP;
         if (residueDamage >= 0 || pWHExt -> BreaksShield) {
+
+			if (pWHExt->BreaksShield && residueDamage < 0) {
+				residueDamage = 0;
+			}
+
             this->BreakShield();
             return pWHExt->PenetratesShield ? *args->Damage : this->GetExt()->Shield_AbsorbOverDamage ? 0 : residueDamage;
         }
@@ -124,8 +129,9 @@ bool ShieldTechnoClass::CanBeTargeted(WeaponTypeClass* pWeapon, TechnoClass* pSo
     auto pWHExt = WarheadTypeExt::ExtMap.Find(pWeapon->Warhead);
     UNREFERENCED_PARAMETER(pWHExt);
     
-	if (pWHExt->PenetratesShield)
+	if (pWHExt->PenetratesShield) {
 		return true;
+	}
 
     bool result =
         ((MapClass::GetTotalDamage(pWeapon->Damage, pWeapon->Warhead, this->GetExt()->Shield_Armor, 0) != 0) && pWeapon->Damage) 

--- a/src/Misc/Shield.cpp
+++ b/src/Misc/Shield.cpp
@@ -70,14 +70,18 @@ int ShieldTechnoClass::ReceiveDamage(args_ReceiveDamage* args)
     }
 
     if (nDamage > 0) {
+
         this->Timer_SelfHealing.Start(int(this->GetExt()->Shield_SelfHealing_Rate * 900)); //when attacked, restart the timer
         this->ResponseAttack();
 
         auto residueDamage = nDamage - this->HP;
-        if (residueDamage >= 0) {
+        if (residueDamage >= 0 || pWHExt -> BreaksShield) {
             this->BreakShield();
-            return this->GetExt()->Shield_AbsorbOverDamage ? 0 : residueDamage;
+            return pWHExt->PenetratesShield ? *args->Damage : this->GetExt()->Shield_AbsorbOverDamage ? 0 : residueDamage;
         }
+		else if (pWHExt->PenetratesShield) {
+			return *args->Damage;
+		}
         else {
             this->WeaponNullifyAnim();
             this->HP = -residueDamage;
@@ -85,7 +89,7 @@ int ShieldTechnoClass::ReceiveDamage(args_ReceiveDamage* args)
         }
     }
     else {
-        return nDamage; //might change in future
+        return pWHExt->PenetratesShield ? *args->Damage : nDamage; //might change in future
     }
 }
 
@@ -120,6 +124,9 @@ bool ShieldTechnoClass::CanBeTargeted(WeaponTypeClass* pWeapon, TechnoClass* pSo
     auto pWHExt = WarheadTypeExt::ExtMap.Find(pWeapon->Warhead);
     UNREFERENCED_PARAMETER(pWHExt);
     
+	if (pWHExt->PenetratesShield)
+		return true;
+
     bool result =
         ((MapClass::GetTotalDamage(pWeapon->Damage, pWeapon->Warhead, this->GetExt()->Shield_Armor, 0) != 0) && pWeapon->Damage) 
         || !pWeapon->Damage; // we could check how is a warhead vs shield's armor 


### PR DESCRIPTION
Currently, this adds two new keys to warheads for interaction with shield logic, and tweaks the documentation to mention functionality that was not previously mentioned.

The new warhead keys:
  - `PenetratesShield` allows the warhead ignore the shield and always deal full damage to the TechnoType itself. It also allows targeting the TechnoType even if weapons using the warhead cannot target or damage the shield.
  - `BreaksShield` allows the warhead to always break shields of TechnoTypes, regardless of the amount of strength the shield has remaining or the damage dealt, assuming it affects the shield's armor type. Residual damage, if there is any, still respects `Shield.AbsorbOverDamage`.