### PR TITLE
Secondary weapon fallback customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Credits
 - AutoGavy - interceptor logic, warhead critical damage system
 - Xkein - general assistance, YRpp edits
 - thomassneddon - general assistance
-- Starkku - Warhead shield penetration & breaking, strafing aircraft weapon customization
+- Starkku - Warhead shield penetration & breaking, strafing aircraft weapon customization, NoSecondaryWeaponFallback
 - SukaHati (Erzoid) - Minimum interceptor guard range
 
 Thanks to everyone who uses Phobos, tests changes and reports bugs! You can show your appreciation and help project by displaying the logo (monochrome version can be found [here](https://github.com/Phobos-developers/Phobos/logo-mono.png)) in your client/launcher, contributing or donating to us via links on the right and the `Sponsor` button on top of the repo.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -120,6 +120,23 @@ PenetratesShield=false         ; boolean
 BreaksShield=false             ; boolean
 ```
 
+### Disabling fallback to (Elite)Secondary weapon
+- It is possible to disable the fallback to `(Elite)Secondary` weapon from `(Elite)Primary` weapon if it cannot fire at the chosen target by setting `NoSecondaryWeaponFallback` to true (defaults to false). This does not apply to special cases where `(Elite)Secondary` weapon is always chosen, including but not necessarily limited to the following:
+  - `OpenTransportWeapon=1` on an unit firing from inside `OpenTopped=true` transport.
+  - `NoAmmoWeapon=1` on an unit with  `Ammo` value higher than 0 and current ammo count lower or  equal to `NoAmmoAmount`.
+  - Deployed `IsSimpleDeployer=true` units with`DeployFireWeapon=1` set or omitted.
+  - `DrainWeapon=true` weapons against enemy `Drainable=yes` buildings.
+  - Units with `IsLocomotor=true` set on `Warhead` of `(Elite)Primary` weapon against buildings.
+  - Weapons with `ElectricAssault=true` set on `Warhead` against `Overpowerable=true` buildings belonging to owner or allies.
+  - `Overpowerable=true` buildings that are currently overpowered.
+  - Any system using `(Elite)WeaponX`, f.ex `Gunner=true` or `IsGattling=true` is also wholly exempt from effects of this.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                      ; TechnoType
+NoSecondaryWeaponFallback=false   ; boolean
+```
+
 ## Weapons
 
 ### Strafing aircraft weapon customization
@@ -133,7 +150,7 @@ BreaksShield=false             ; boolean
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWEAPON]        ; WeaponType
+[SOMEWEAPON]                 ; WeaponType
 Strafing.Shots=5             ; integer
 Strafing.SimulateBurst=false ; bool
 ```

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -105,6 +105,8 @@ DEFINE_HOOK(6F36F2, TechnoClass_WhatWeaponShouldIUse_Shield, 6)
 }
 */
 
+// Moved to Hooks.cpp due to other features requiring hooking at this specific location.
+/*
 DEFINE_HOOK(6F36DB, TechnoClass_WhatWeaponShouldIUse_Shield, 8)
 {
     GET(TechnoClass*, pThis, ESI);
@@ -121,7 +123,7 @@ DEFINE_HOOK(6F36DB, TechnoClass_WhatWeaponShouldIUse_Shield, 8)
             {
                 if (pThis->GetWeapon(1))
                 {
-                    if (!pShieldData->CanBeTargeted(pThis->GetWeapon(0)->WeaponType/*, pThis*/))
+                    if (!pShieldData->CanBeTargeted(pThis->GetWeapon(0)->WeaponType))
                         return 0x6F3745; //Primary cannot attack, always use Secondary
 
                     return 0x6F3754; //Further check in vanilla function
@@ -132,7 +134,7 @@ DEFINE_HOOK(6F36DB, TechnoClass_WhatWeaponShouldIUse_Shield, 8)
         }
     }
     return 0x6F36E3; //Target doesn't have a shield, back
-}
+}*/
 
 DEFINE_HOOK(6F9E50, TechnoClass_AI_Shield, 5)
 {

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -3,21 +3,79 @@
 #include "Body.h"
 
 #include "../TechnoType/Body.h"
+#include "../../Utilities/GeneralUtils.h"
 
 DEFINE_HOOK(6F9E50, TechnoClass_AI, 5)
 {
-	GET(TechnoClass*, pThis, ECX);
+    GET(TechnoClass*, pThis, ECX);
 
-	// MindControlRangeLimit
-	TechnoExt::ApplyMindControlRangeLimit(pThis);
-	// Interceptor
-	TechnoExt::ApplyInterceptor(pThis);
-	// Powered.KillSpawns
-	TechnoExt::ApplyPowered_KillSpawns(pThis);
-	// Spawner.LimitRange & Spawner.ExtraLimitRange
-	TechnoExt::ApplySpawn_LimitRange(pThis);
+    // MindControlRangeLimit
+    TechnoExt::ApplyMindControlRangeLimit(pThis);
+    // Interceptor
+    TechnoExt::ApplyInterceptor(pThis);
+    // Powered.KillSpawns
+    TechnoExt::ApplyPowered_KillSpawns(pThis);
+    // Spawner.LimitRange & Spawner.ExtraLimitRange
+    TechnoExt::ApplySpawn_LimitRange(pThis);
     //
     TechnoExt::ApplyCloak_Undeployed(pThis);
 
-	return 0;
+    return 0;
+}
+
+DEFINE_HOOK(6F36DB, TechnoClass_WhatWeaponShouldIUse, 8)
+{
+    enum { UsePrimary = 0x6F37AD, UseSecondary = 0x6F3745, ReturnToBeginning = 0x6F36E3, ContinueWithVanillaChecks = 0x6F3754 };
+
+    GET(TechnoClass*, pThis, ESI);
+    GET(TechnoClass*, pTarget, EBP);
+
+    if (!pTarget)
+        return UsePrimary;
+
+    if (auto pExtTarget = TechnoExt::ExtMap.Find(pTarget))
+    {
+        auto pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+        auto pWeaponPrimary = pThis->GetWeapon(0)->WeaponType;
+        auto pWeaponSecondary = pThis->GetWeapon(1)->WeaponType;
+
+        // Shield checks.
+        if (auto pShieldData = pExtTarget->ShieldData.get())
+        {
+            if (pShieldData->Available() && pShieldData->GetShieldHP())
+            {
+                if (pWeaponSecondary)
+                {
+                    if (!pShieldData->CanBeTargeted(pWeaponPrimary) && !pExt->NoSecondaryWeaponFallback)
+                    {
+                        return UseSecondary;
+                    }
+                }
+
+                return UsePrimary;
+            }
+        }
+
+        // No secondary weapon fallback checks.
+        if (pExt->NoSecondaryWeaponFallback)
+        {
+            // Make an exception for NoAmmoWeapon set explicitly to secondary.
+            if (pThis->GetTechnoType()->Ammo > 0 && pThis->Ammo <= pExt->NoAmmoAmount && pExt->NoAmmoWeapon == 1)
+            {
+                return UseSecondary;
+            }
+
+            bool canSecondaryTarget = pWeaponSecondary ? GeneralUtils::GetWarheadVersusArmor(pWeaponSecondary->Warhead,
+                static_cast<int>(pTarget->GetTechnoType()->Armor)) != 0.0 : false;
+
+            if (canSecondaryTarget)
+            {
+                return UsePrimary;
+            }
+
+            return ContinueWithVanillaChecks;
+        }
+    }
+
+    return ReturnToBeginning;
 }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -129,9 +129,14 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ChronoRangeMinimum.Read(exINI, pSection, "ChronoRangeMinimum");
 	this->ChronoDelay.Read(exINI, pSection, "ChronoDelay");
 
+    this->NoSecondaryWeaponFallback.Read(exINI, pSection, "NoSecondaryWeaponFallback");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
+
+    // Ares 0.C
+    this->NoAmmoWeapon.Read(exINI, pSection, "NoAmmoWeapon");
+    this->NoAmmoAmount.Read(exINI, pSection, "NoAmmoAmount");
 
 	//Art tags
 	INI_EX exArtINI(CCINIClass::INI_Art);
@@ -181,6 +186,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ChronoMinimumDelay)
 		.Process(this->ChronoRangeMinimum)
 		.Process(this->ChronoDelay)
+        .Process(this->NoSecondaryWeaponFallback)
+        .Process(this->NoAmmoWeapon)
+        .Process(this->NoAmmoAmount)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -56,6 +56,10 @@ public:
 		Nullable<int> ChronoRangeMinimum;
 		Nullable<int> ChronoDelay;
 
+        Valueable<bool> NoSecondaryWeaponFallback;
+        Valueable<int> NoAmmoWeapon;
+        Valueable<int> NoAmmoAmount;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			HealthBar_Hide(false),
 			UIDescription(),
@@ -95,7 +99,10 @@ public:
 			ChronoDistanceFactor(),
 			ChronoMinimumDelay(),
 			ChronoRangeMinimum(),
-			ChronoDelay()
+			ChronoDelay(),
+            NoSecondaryWeaponFallback(false),
+            NoAmmoWeapon(-1),
+            NoAmmoAmount(0)
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
Primary use cases would likely be certain kinds of `Overpowerable=true` buildings, `IsSimpleDeployer=true` units or `NoAmmoWeapon` configurations.

From documentation:

- It is possible to disable the fallback to `(Elite)Secondary` weapon from `(Elite)Primary` weapon if it cannot fire at the chosen target by setting `NoSecondaryWeaponFallback` to true (defaults to false). This does not apply to special cases where `(Elite)Secondary` weapon is always chosen, including but not necessarily limited to the following:
  - `OpenTransportWeapon=1` on an unit firing from inside `OpenTopped=true` transport.
  - `NoAmmoWeapon=1` on an unit with  `Ammo` value higher than 0 and current ammo count lower or  equal to `NoAmmoAmount`.
  - Deployed `IsSimpleDeployer=true` units with`DeployFireWeapon=1` set or omitted.
  - `DrainWeapon=true` weapons against enemy `Drainable=yes` buildings.
  - Units with `IsLocomotor=true` set on `Warhead` of `(Elite)Primary` weapon against buildings.
  - Weapons with `ElectricAssault=true` set on `Warhead` against `Overpowerable=true` buildings belonging to owner or allies.
  - `Overpowerable=true` buildings that are currently overpowered.
  - Any system using `(Elite)WeaponX`, f.ex `Gunner=true` or `IsGattling=true` is also wholly exempt from effects of this.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                      ; TechnoType
NoSecondaryWeaponFallback=false   ; boolean
```