### PR TITLE
implement Power Plant Enhancer #131

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -16,6 +16,7 @@
     <ClCompile Include="src\Enum\RadTypeClass.cpp" />
     <ClCompile Include="src\Ext\Aircraft\Body.cpp" />
     <ClCompile Include="src\Ext\Aircraft\Hooks.cpp" />
+    <ClCompile Include="src\Ext\BuildingType\Hooks.cpp" />
     <ClCompile Include="src\Ext\Building\Body.cpp" />
     <ClCompile Include="src\Ext\Building\Hooks.cpp" />
     <ClCompile Include="src\Ext\BulletType\Body.cpp" />
@@ -223,7 +224,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <SDLCheck>
       </SDLCheck>

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -23,6 +23,9 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 
 	this->PowersUp_Owner.Read(exINI, pSection, "PowersUp.Owner");
 	this->PowersUp_Buildings.Read(exINI, pSection, "PowersUp.Buildings");
+	this->PowerPlantEnchancer_Buildings.Read(exINI, pSection, "PowerPlantEnchancer.PowerPlants");
+	this->PowerPlantEnchancer_Amount.Read(exINI, pSection, "PowerPlantEnchancer.Amount");
+	this->PowerPlantEnchancer_Factor.Read(exINI, pSection, "PowerPlantEnchancer.Factor");
 
 	if (pThis->PowersUpBuilding[0] == NULL && this->PowersUp_Buildings.size() > 0)
 		strcpy_s(pThis->PowersUpBuilding, this->PowersUp_Buildings[0]->ID);
@@ -38,6 +41,9 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm) {
 	Stm
 		.Process(this->PowersUp_Owner)
 		.Process(this->PowersUp_Buildings)
+		.Process(this->PowerPlantEnchancer_Buildings)
+		.Process(this->PowerPlantEnchancer_Amount)
+		.Process(this->PowerPlantEnchancer_Factor)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -15,10 +15,17 @@ public:
 	public:
 		Valueable<AffectedHouse> PowersUp_Owner;
 		ValueableVector<BuildingTypeClass*> PowersUp_Buildings;
+		
+		ValueableVector<BuildingTypeClass*> PowerPlantEnchancer_Buildings;
+		Valueable<int> PowerPlantEnchancer_Amount;
+		Valueable<float> PowerPlantEnchancer_Factor;
 
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject),
 			PowersUp_Owner(AffectedHouse::Owner),
-			PowersUp_Buildings()
+			PowersUp_Buildings(),
+			PowerPlantEnchancer_Buildings(),
+			PowerPlantEnchancer_Amount(0),
+			PowerPlantEnchancer_Factor(1.0f)
 		{ }
 
 		virtual ~ExtData() = default;
@@ -51,5 +58,6 @@ public:
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
 
+	static int GetEnchancedPower(BuildingClass* pBuilding, HouseClass* pHouse);
 	static bool CanUpgrade(BuildingClass* pBuilding, BuildingTypeClass* pUpgradeType, HouseClass* pUpgradeOwner);
 };

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -1,0 +1,44 @@
+#include "Body.h"
+
+#include <BuildingClass.h>
+#include <HouseClass.h>
+
+int BuildingTypeExt::GetEnchancedPower(BuildingClass* pBuilding, HouseClass* pHouse)
+{
+	int nPower = pBuilding->GetPowerOutput();
+
+	for (const auto pBld : pHouse->Buildings)
+	{
+		const auto pSrcType = abstract_cast<BuildingTypeClass*>(pBuilding->GetType());
+		const auto pType = abstract_cast<BuildingTypeClass*>(pBld->GetType());
+		const auto pExt = BuildingTypeExt::ExtMap.Find(pType);
+
+		if (pExt->PowerPlantEnchancer_Buildings.Contains(pSrcType))
+			if (pExt->PowerPlantEnchancer_Amount > 0)
+				nPower += pExt->PowerPlantEnchancer_Amount;
+	}
+
+	for (const auto pBld : pHouse->Buildings)
+	{
+		const auto pSrcType = abstract_cast<BuildingTypeClass*>(pBuilding->GetType());
+		const auto pType = abstract_cast<BuildingTypeClass*>(pBld->GetType());
+		const auto pExt = BuildingTypeExt::ExtMap.Find(pType);
+
+		if (pExt->PowerPlantEnchancer_Buildings.Contains(pSrcType))
+			if (pExt->PowerPlantEnchancer_Factor > 0)
+				nPower = static_cast<int>(nPower * pExt->PowerPlantEnchancer_Factor);
+	}
+	
+	return nPower;
+}
+
+// Power Plant Enhancer #131
+DEFINE_HOOK(508CF2, HouseClass_Recalc_508C30_Power_Output, 7)
+{
+	GET(HouseClass*, pThis, ESI);
+	GET(BuildingClass*, pBld, EDI);
+	
+	pThis->PowerOutput += BuildingTypeExt::GetEnchancedPower(pBld, pThis);
+
+	return 0x508D07;
+}


### PR DESCRIPTION
This is a prototype of #131 , please test it if anyone is available.
```ini
[SomeBuilding]
PowerPlantEnchancer.PowerPlants=<a list of buildingtypes>
PowerPlantEnchancer.Amount=integer
PowerPlantEnchancer.Factor=float
```

NOTICE, currently this feature add all amounts and then multiply the factors, both Amount and Factor need to be a positive number.

Example 1:
You have 1 A(PowerPlantEnchancer.Amount=10), 2 B(Power=100)
your total power = (100 + 10) * 2

Example 2:
You have 2 A(PowerPlantEnchancer.Amount=10), 2 B(Power=100)
your total power = (100 + 10 * 2) * 2

Example 3:
You have 1 A(PowerPlantEnchancer.Amount=10,PowerPlantEnchancer.Factor=.1), 2 B(Power=100)
your total power = (100 + 10) * 0.1 * 2

Example 4:
You have 3 A(PowerPlantEnchancer.Amount=10), 2 B(Power=100), 2 C(,PowerPlantEnchancer.Factor=.1)
your total power = (100 + 10 * 3) * 0.1 * 0.1 * 2