### PR TITLE
Possible fix buggy MoveToCell which uses 128 as leftovers

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -13,6 +13,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `InfiniteMindControl` with `Damage=1` can now control more than 1 unit.
 - Aircraft with `Fighter` set to false or those using strafing pattern (weapon projectile `ROT` is below 2) now take weapon's `Burst` into accord for all shots instead of just the first one.
 - `EMEffect` used for random AnimList pick is now replaced by a new tag `AnimList.PickRandom` with no side effect. (EMEffect=yes on AA inviso projectile deals no damage to units in movement)
+- Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's RA leftover)
 
 ![image](_static/images/remember-target-after-deploying-01.gif)  
 *Nod arty keeping target on attack order in [C&C: Reloaded](https://www.moddb.com/mods/cncreloaded/)*

--- a/src/Ext/Script/Hooks.cpp
+++ b/src/Ext/Script/Hooks.cpp
@@ -9,3 +9,14 @@ DEFINE_HOOK(6E9443, TeamClass_AI, 8) {
 	
 	return 0;
 }
+
+DEFINE_HOOK(6E95B7, TeamClass_AI_MoveToCell, 8)
+{
+	GET(int, nCoord, ECX);
+	REF_STACK(CellStruct, cell, STACK_OFFS(0x38, 0x28));
+
+	cell.X = static_cast<short>(nCoord % 1000);
+	cell.Y = static_cast<short>(nCoord / 1000);
+
+	return 0x6E95CD;
+}

--- a/src/Ext/Script/Hooks.cpp
+++ b/src/Ext/Script/Hooks.cpp
@@ -2,6 +2,8 @@
 
 #include "Body.h"
 
+#include <MapClass.h>
+
 DEFINE_HOOK(6E9443, TeamClass_AI, 8) {
 	GET(TeamClass *, pTeam, ESI);
 
@@ -10,13 +12,18 @@ DEFINE_HOOK(6E9443, TeamClass_AI, 8) {
 	return 0;
 }
 
-DEFINE_HOOK(6E95B7, TeamClass_AI_MoveToCell, 8)
+// Idea from E1Elite - secsome
+DEFINE_HOOK(6E95B3, TeamClass_AI_MoveToCell, 6)
 {
+	if (!R->BL())
+		return 0x6E95A4;
+
 	GET(int, nCoord, ECX);
 	REF_STACK(CellStruct, cell, STACK_OFFS(0x38, 0x28));
 
 	cell.X = static_cast<short>(nCoord % 1000);
 	cell.Y = static_cast<short>(nCoord / 1000);
 
-	return 0x6E95CD;
+	R->EAX(MapClass::Instance->GetCellAt(cell));
+	return 0x6E959C;
 }


### PR DESCRIPTION
This  possibly fix the Script Action 4 Move to cell from calculating the cell from dividing 128 to 1000.