### PR TITLE
Vehicle DeployFire improvements / fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Credits
 - ChrisLv_CN - interceptor logic, general assistance
 - Xkein - general assistance, YRpp edits
 - thomassneddon - general assistance
-- Starkku - Warhead shield penetration & breaking, strafing aircraft weapon customization
+- Starkku - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements
 - SukaHati (Erzoid) - Minimum interceptor guard range
 - mevitar - honorary shield tester award
 - Damfoos - extensive and thorough testing

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -15,6 +15,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `EMEffect` used for random AnimList pick is now replaced by a new tag `AnimList.PickRandom` with no side effect. (EMEffect=yes on AA inviso projectile deals no damage to units in movement)
 - Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's RA leftover)
 - The game now can reads waypoints ranges in [0, 2147483647]. (was [0,701])
+- Vehicles using `DeployFire` will now explicitly use weapon specified by `DeployFireWeapon` for firing the deploy weapon and respect `FireOnce` setting on weapon and any stop commands issued during firing.
 
 ![image](_static/images/remember-target-after-deploying-01.gif)  
 *Nod arty keeping target on attack order in [C&C: Reloaded](https://www.moddb.com/mods/cncreloaded/)*

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -100,3 +100,25 @@ DEFINE_HOOK(6B7282, SpawnManagerClass_AI_PromoteSpawns, 5)
 
 	return 0;
 }
+
+DEFINE_HOOK(73DD12, UnitClass_Mission_Unload_DeployFire, 6)
+{
+	enum { ReturnFromFunction = 0x73DD3C };
+
+	GET(UnitClass*, pThis, ESI);
+
+	int weaponIndex = pThis->GetTechnoType()->DeployFireWeapon;
+
+	if (pThis->GetFireError(pThis->Target, weaponIndex, true) == FireError::OK)
+	{
+		pThis->Fire(pThis->Target, weaponIndex);
+		auto weapon = pThis->GetWeapon(weaponIndex);
+
+		if (weapon && weapon->WeaponType->FireOnce)
+		{
+			pThis->QueueMission(Mission::Guard, true);
+		}
+	}
+
+	return ReturnFromFunction;
+}

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -100,25 +100,3 @@ DEFINE_HOOK(6B7282, SpawnManagerClass_AI_PromoteSpawns, 5)
 
 	return 0;
 }
-
-DEFINE_HOOK(73DD12, UnitClass_Mission_Unload_DeployFire, 6)
-{
-	enum { ReturnFromFunction = 0x73DD3C };
-
-	GET(UnitClass*, pThis, ESI);
-
-	int weaponIndex = pThis->GetTechnoType()->DeployFireWeapon;
-
-	if (pThis->GetFireError(pThis->Target, weaponIndex, true) == FireError::OK)
-	{
-		pThis->Fire(pThis->Target, weaponIndex);
-		auto weapon = pThis->GetWeapon(weaponIndex);
-
-		if (weapon && weapon->WeaponType->FireOnce)
-		{
-			pThis->QueueMission(Mission::Guard, true);
-		}
-	}
-
-	return ReturnFromFunction;
-}

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -48,7 +48,7 @@ DEFINE_HOOK(4D7431, FootClass_ReceiveDamage_DyingFix, 5)
 	GET(FootClass*, pThis, ESI);
 	GET(DamageState, result, EAX);
 
-  if (result != DamageState::PostMortem && (pThis->IsSinking || (!pThis->IsAttackedByLocomotor && pThis->IsCrashing)))
+	if (result != DamageState::PostMortem && (pThis->IsSinking || (!pThis->IsAttackedByLocomotor && pThis->IsCrashing)))
     R->EAX(DamageState::PostMortem);
 
 	return 0;
@@ -65,15 +65,32 @@ DEFINE_HOOK(737D57, UnitClass_ReceiveDamage_DyingFix, 7)
 	return 0;
 }
 
+// issue #112 Make FireOnce=yes work on other TechnoTypes
+// Author: Starkku
 DEFINE_HOOK(4C7518, EventClass_Execute_StopUnitDeployFire, 9)
 {
-	GET(TechnoClass*, pThis, ESI);
+	GET(TechnoClass* const, pThis, ESI);
 
-	if (pThis->WhatAmI() == AbstractType::Unit && pThis->CurrentMission == Mission::Unload &&
-		pThis->GetTechnoType()->DeployFire && !static_cast<UnitClass*>(pThis)->Type->IsSimpleDeployer)
-	{
-		pThis->QueueMission(Mission::Guard, true);
-	}
+	auto const pUnit = abstract_cast<UnitClass*>(pThis);
+	if (pUnit && pUnit->CurrentMission == Mission::Unload && pUnit->Type->DeployFire && !pUnit->Type->IsSimpleDeployer)
+		pUnit->QueueMission(Mission::Guard, true);
 
 	return 0;
+}
+
+DEFINE_HOOK(73DD12, UnitClass_Mission_Unload_DeployFire, 6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	int weaponIndex = pThis->GetTechnoType()->DeployFireWeapon;
+
+	if (pThis->GetFireError(pThis->Target, weaponIndex, true) == FireError::OK)
+	{
+		pThis->Fire(pThis->Target, weaponIndex);
+		auto const pWeapon = pThis->GetWeapon(weaponIndex);
+		if (pWeapon && pWeapon->WeaponType->FireOnce)
+			pThis->QueueMission(Mission::Guard, true);
+	}
+
+	return 0x73DD3C;
 }

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1,10 +1,10 @@
-#include <Utilities/Macro.h>
 #include <AnimClass.h>
 #include <TechnoClass.h>
 #include <FootClass.h>
 #include <UnitClass.h>
-#include <Utilities/Debug.h>
 
+#include <Utilities/Macro.h>
+#include <Utilities/Debug.h>
 
 //Replace: checking of HasExtras = > checking of (HasExtras && Shadow)
 DEFINE_HOOK(423365, Phobos_BugFixes_SHPShadowCheck, 8)
@@ -88,6 +88,7 @@ DEFINE_HOOK(73DD12, UnitClass_Mission_Unload_DeployFire, 6)
 	{
 		pThis->Fire(pThis->Target, weaponIndex);
 		auto const pWeapon = pThis->GetWeapon(weaponIndex);
+
 		if (pWeapon && pWeapon->WeaponType->FireOnce)
 			pThis->QueueMission(Mission::Guard, true);
 	}

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3,6 +3,9 @@
 #include <TechnoClass.h>
 #include <FootClass.h>
 #include <UnitClass.h>
+#include <Utilities/Debug.h>
+
+
 //Replace: checking of HasExtras = > checking of (HasExtras && Shadow)
 DEFINE_HOOK(423365, Phobos_BugFixes_SHPShadowCheck, 8)
 {
@@ -58,6 +61,19 @@ DEFINE_HOOK(737D57, UnitClass_ReceiveDamage_DyingFix, 7)
 
 	if (result != DamageState::PostMortem && pThis->DeathFrameCounter > 0)
 		R->EAX(DamageState::PostMortem);
+
+	return 0;
+}
+
+DEFINE_HOOK(4C7518, EventClass_Execute_StopUnitDeployFire, 9)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	if (pThis->WhatAmI() == AbstractType::Unit && pThis->CurrentMission == Mission::Unload &&
+		pThis->GetTechnoType()->DeployFire && !static_cast<UnitClass*>(pThis)->Type->IsSimpleDeployer)
+	{
+		pThis->QueueMission(Mission::Guard, true);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
- Explicitly use weapon specified by `DeployFireWeapon` for firing deploy weapon.
- Respect `FireOnce` setting on the weapon.
- Respect stop commands issued during firing the deploy weapon.

If I am not mistaken this addresses #112.