### PR TITLE
Allow to customize missing cameo

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -96,6 +96,16 @@ Sidebar.GDIPositions= ; boolean
                       ; no for others
 ```
 
+### Custom Missing Cameo (`XXICON.SHP`)
+
+- You can now specify any SHP/PCX file as XXICON.SHP for missing cameo.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+MissingCameo=XXICON.SHP    ; filename - including the .shp/.pcx extension 
+```
+
 ### Harvester counter
 
 ![image](_static/images/harvestercounter-01.gif)  

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -60,6 +60,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->RadApplicationDelay_Building.Read(exINI, "Radiation", "RadApplicationDelay.Building");
 	this->Pips_Shield.Read(exINI, "AudioVisual", "Pips.Shield");
 	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
+	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
 }
 
 // this runs between the before and after type data loading methods for rules ini
@@ -108,6 +109,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_Shield)
 		.Process(this->Pips_Shield_Buildings)
 		.Process(this->RadApplicationDelay_Building)
+		.Process(this->MissingCameo)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -27,11 +27,13 @@ public:
 		Valueable<Vector3D<int>> Pips_Shield;
 		Valueable<Vector3D<int>> Pips_Shield_Buildings;
 		Valueable<int> RadApplicationDelay_Building;
+		PhobosFixedString<32u> MissingCameo;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Pips_Shield({ -1,-1,-1 })
 			, Pips_Shield_Buildings({ -1,-1,-1 })
 			, RadApplicationDelay_Building(0)
+			, MissingCameo("xxicon.shp")
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.PCX.cpp
+++ b/src/Misc/Hooks.PCX.cpp
@@ -52,20 +52,21 @@ DEFINE_HOOK(6A99F3, StripClass_Draw_DrawMissing, 6)
 		_strlwr_s(pFilename);
 
 		if (!_stricmp(pCameoRef->Filename, "xxicon.shp")
-			&& _stricmp(pCameoRef->Filename, pFilename))
+			&& _stricmp(pCameoRef->Filename, pFilename)
+			&& strstr(pFilename, ".pcx"))
 		{
-			if (strstr(pFilename, ".pcx"))
+			PCX::Instance->LoadFile(pFilename);
+			if (auto CameoPCX = PCX::Instance->GetSurface(pFilename))
 			{
-				if (auto CameoPCX = PCX::Instance->GetSurface(pFilename))
-				{
-					GET(int, TLX, ESI);
-					GET(int, TLY, EBP);
-					RectangleStruct bounds = { TLX, TLY, 60, 48 };
-					PCX::Instance->BlitToSurface(&bounds, DSurface::Sidebar, CameoPCX);
+				GET(int, TLX, ESI);
+				GET(int, TLY, EBP);
 
-					return 0x6A9A43; //skip drawing shp cameo
-				}
+				RectangleStruct bounds = { TLX, TLY, 60, 48 };
+				PCX::Instance->BlitToSurface(&bounds, DSurface::Sidebar, CameoPCX);
+
+				return 0x6A9A43; //skip drawing shp cameo
 			}
+
 		}
 	}
 

--- a/src/Misc/Hooks.PCX.cpp
+++ b/src/Misc/Hooks.PCX.cpp
@@ -52,16 +52,15 @@ DEFINE_HOOK(6A99F3, StripClass_Draw_DrawMissing, 6)
 		_strlwr_s(pFilename);
 
 		if (!_stricmp(pCameoRef->Filename, "xxicon.shp")
-			&& _stricmp(pCameoRef->Filename, pFilename)
 			&& strstr(pFilename, ".pcx"))
 		{
 			PCX::Instance->LoadFile(pFilename);
 			if (auto CameoPCX = PCX::Instance->GetSurface(pFilename))
 			{
-				GET(int, TLX, ESI);
-				GET(int, TLY, EBP);
+				GET(int, destX, ESI);
+				GET(int, destY, EBP);
 
-				RectangleStruct bounds = { TLX, TLY, 60, 48 };
+				RectangleStruct bounds = { destX, destY, 60, 48 };
 				PCX::Instance->BlitToSurface(&bounds, DSurface::Sidebar, CameoPCX);
 
 				return 0x6A9A43; //skip drawing shp cameo

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -10,7 +10,8 @@
 
 DEFINE_HOOK(777C41, UI_ApplyAppIcon, 9)
 {
-	if (Phobos::AppIconPath != nullptr) {
+	if (Phobos::AppIconPath != nullptr)
+	{
 		Debug::Log("Applying AppIcon from \"%s\"\n", Phobos::AppIconPath);
 
 		R->EAX(LoadImage(NULL, Phobos::AppIconPath, IMAGE_ICON, 0, 0, LR_LOADFROMFILE));
@@ -23,7 +24,8 @@ DEFINE_HOOK(777C41, UI_ApplyAppIcon, 9)
 DEFINE_HOOK(640B8D, LoadingScreen_DisableEmptySpawnPositions, 6)
 {
 	GET(bool, esi, ESI);
-	if (Phobos::UI::DisableEmptySpawnPositions || !esi) {
+	if (Phobos::UI::DisableEmptySpawnPositions || !esi)
+	{
 		return 0x640CE2;
 	}
 	return 0x640B93;
@@ -38,7 +40,8 @@ DEFINE_HOOK(640B8D, LoadingScreen_DisableEmptySpawnPositions, 6)
 DEFINE_HOOK(641B41, LoadingScreen_SkipPreview, 8)
 {
 	GET(RectangleStruct*, pRect, EAX);
-	if (pRect->Width > 0 && pRect->Height > 0) {
+	if (pRect->Width > 0 && pRect->Height > 0)
+	{
 		return 0;
 	}
 	return 0x641D4E;
@@ -46,7 +49,8 @@ DEFINE_HOOK(641B41, LoadingScreen_SkipPreview, 8)
 
 DEFINE_HOOK(4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 7)
 {
-	if (Phobos::UI::ShowHarvesterCounter) {
+	if (Phobos::UI::ShowHarvesterCounter)
+	{
 		auto pPlayer = HouseClass::Player;
 		auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->GetItem(HouseClass::Player->SideIndex));
 		wchar_t counter[0x20];
@@ -59,7 +63,7 @@ DEFINE_HOOK(4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 7)
 			? pSideExt->Sidebar_HarvesterCounter_Yellow : pSideExt->Sidebar_HarvesterCounter_Red;
 
 		swprintf_s(counter, L"%ls%d/%d", Phobos::UI::HarvesterLabel, nActive, nTotal);
-		
+
 		Point2D vPos = {
 			DSurface::Sidebar->GetWidth() / 2 + 50 + pSideExt->Sidebar_HarvesterCounter_Offset.Get().X,
 			2 + pSideExt->Sidebar_HarvesterCounter_Offset.Get().Y
@@ -70,6 +74,28 @@ DEFINE_HOOK(4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 7)
 
 		DSurface::Sidebar->DrawTextA(counter, &vRect, &vPos,
 			Drawing::RGB2DWORD(clrToolTip), 0, 0x4108);
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(6CE8AA, Replace_XXICON_With_New, 7)   //SWTypeClass::Load
+DEFINE_HOOK_AGAIN(6CEE31, Replace_XXICON_With_New, 7)   //SWTypeClass::ReadINI
+DEFINE_HOOK_AGAIN(716D13, Replace_XXICON_With_New, 7)   //TechnoTypeClass::Load
+DEFINE_HOOK(715A4D, Replace_XXICON_With_New, 7)         //TechnoTypeClass::ReadINI
+{
+	char pFilename[0x20];
+	strcpy_s(pFilename, RulesExt::Global()->MissingCameo.data());
+	_strlwr_s(pFilename);
+
+	if (_stricmp(pFilename, "xxicon.shp")
+		&& strstr(pFilename, ".shp"))
+	{
+		if (auto pFile = FileSystem::LoadFile(RulesExt::Global()->MissingCameo, false))
+		{
+			R->EAX(pFile);
+			return R->Origin() + 0xC;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
This feature allows to custom missing cameo with any shp/pcx file. When using a PCX as XXICON, we don't need to change `cameo.pal` to extend colors for the cameo anymore. This feature is standalone, i.e. don't need Ares to work
```ini
[AudioVisual]
MissingCameo=XXICON.SHP   ; filename
```