### PR TITLE
Map trigger action 125 Build at will play BuildUp animation now.

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -17,6 +17,8 @@
   <ItemGroup>
     <ClCompile Include="src\Commands\Commands.cpp" />
     <ClCompile Include="src\Commands\Dummy.h" />
+    <ClCompile Include="src\Ext\TAction\Body.cpp" />
+    <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
     <ClCompile Include="src\New\Type\RadTypeClass.cpp" />
     <ClCompile Include="src\Ext\Aircraft\Body.cpp" />
     <ClCompile Include="src\Ext\Aircraft\Hooks.cpp" />
@@ -81,6 +83,7 @@
     <ClInclude Include="src\Commands\NextIdleHarvester.h" />
     <ClInclude Include="src\Commands\ObjectInfo.h" />
     <ClInclude Include="src\Commands\Commands.h" />
+    <ClInclude Include="src\Ext\TAction\Body.h" />
     <ClInclude Include="src\New\Type\RadTypeClass.h" />
     <ClInclude Include="src\Utilities\Enumerable.h" />
     <ClInclude Include="src\ExtraHeaders\CCToolTip.h" />

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Credits
 - 4SG - help with docs
 - wiktorderelf - overhauled Unicode font
 - Thrifinesma (Uranusian) - Mind Control enhancement, custom warhead splash list, harvesters counter, promoted spawns, shields, death after dead fix, customizeable missing cameo, overhauled Unicode font, help with docs
-- SEC-SOME (secsome) - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints
+- SEC-SOME (secsome) - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix
 - Otamaa (BoredEXE) - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass
 - E1 Elite - TileSet 255 and above bridge repair fix
 - FS-21 - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72 & 73, MC deployer fixes, help with docs

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -15,6 +15,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `EMEffect` used for random AnimList pick is now replaced by a new tag `AnimList.PickRandom` with no side effect. (EMEffect=yes on AA inviso projectile deals no damage to units in movement)
 - Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's RA leftover)
 - The game now can reads waypoints ranges in [0, 2147483647]. (was [0,701])
+- Map trigger action 125 can play BuildUp anim correctly as an option
 
 ![image](_static/images/remember-target-after-deploying-01.gif)  
 *Nod arty keeping target on attack order in [C&C: Reloaded](https://www.moddb.com/mods/cncreloaded/)*

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -15,7 +15,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `EMEffect` used for random AnimList pick is now replaced by a new tag `AnimList.PickRandom` with no side effect. (EMEffect=yes on AA inviso projectile deals no damage to units in movement)
 - Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's RA leftover)
 - The game now can reads waypoints ranges in [0, 2147483647]. (was [0,701])
-- Map trigger action 125 can play BuildUp anim correctly as an option
+- Map trigger action `125 Build At` can now play buildup anim (optionally).
 
 ![image](_static/images/remember-target-after-deploying-01.gif)  
 *Nod arty keeping target on attack order in [C&C: Reloaded](https://www.moddb.com/mods/cncreloaded/)*

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -15,7 +15,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `EMEffect` used for random AnimList pick is now replaced by a new tag `AnimList.PickRandom` with no side effect. (EMEffect=yes on AA inviso projectile deals no damage to units in movement)
 - Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's RA leftover)
 - The game now can reads waypoints ranges in [0, 2147483647]. (was [0,701])
-- Map trigger action `125 Build At` can now play buildup anim optionally (needs [following changes to `fadata.ini`](https://github.com/Phobos-developers/Phobos/pull/249#issuecomment-866860866)).
+- Map trigger action `125 Build At...` can now play buildup anim optionally (needs [following changes to `fadata.ini`](https://github.com/Phobos-developers/Phobos/pull/249#issuecomment-866860866)).
 
 ![image](_static/images/remember-target-after-deploying-01.gif)  
 *Nod arty keeping target on attack order in [C&C: Reloaded](https://www.moddb.com/mods/cncreloaded/)*

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -15,7 +15,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `EMEffect` used for random AnimList pick is now replaced by a new tag `AnimList.PickRandom` with no side effect. (EMEffect=yes on AA inviso projectile deals no damage to units in movement)
 - Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's RA leftover)
 - The game now can reads waypoints ranges in [0, 2147483647]. (was [0,701])
-- Map trigger action `125 Build At` can now play buildup anim (optionally).
+- Map trigger action `125 Build At` can now play buildup anim optionally (needs [following changes to `fadata.ini`](https://github.com/Phobos-developers/Phobos/pull/249#issuecomment-866860866)).
 
 ![image](_static/images/remember-target-after-deploying-01.gif)  
 *Nod arty keeping target on attack order in [C&C: Reloaded](https://www.moddb.com/mods/cncreloaded/)*

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -50,7 +50,8 @@ Vanilla fixes:
 - Fixed the bug when units are already dead but still in map (for sinking, crashing, dying animation, etc.), they could die again (by Uranusian)
 - Fixed the bug when cloaked Desolator was unable to fire his deploy weapon (by Otamaa)
 - Fixed the bug when `InfiniteMindControl` with `Damage=1` will auto-release the victim to control new one (by Uranusian)
-- Fixed the bug that script action `Move to cell` was still using leftover from previous game (by secsome)
+- Fixed the bug that script action `Move to cell` was still using leftover cell calculations from previous games (by secsome)
+- Fixed the bug when script action `125 Build At...` didn't play buildup anim (by secsome)
 
 Phobos fixes:
 - Properly rewritten a fix for mind-controlled vehicles deploying into buildings (by FS-21)

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -1,0 +1,81 @@
+#include "Body.h"
+
+#include <Utilities/SavegameDef.h>
+
+//Static init
+template<> const DWORD Extension<TActionClass>::Canary = 0x91919191;
+TActionExt::ExtContainer TActionExt::ExtMap;
+
+// =============================
+// load / save
+
+template <typename T>
+void TActionExt::ExtData::Serialize(T& Stm)
+{
+	//Stm;
+}
+
+void TActionExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
+{
+	Extension<TActionClass>::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void TActionExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
+{
+	Extension<TActionClass>::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+// =============================
+// container
+
+TActionExt::ExtContainer::ExtContainer() : Container("TActionClass")
+{
+}
+
+TActionExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// container hooks
+
+#ifdef MAKE_GAME_SLOWER_FOR_NO_REASON
+DEFINE_HOOK(6DD176, TActionClass_CTOR, 5)
+{
+	GET(TActionClass*, pItem, ESI);
+
+	TActionExt::ExtMap.FindOrAllocate(pItem);
+	return 0;
+}
+
+DEFINE_HOOK(6E4761, TActionClass_SDDTOR, 6)
+{
+	GET(TActionClass*, pItem, ESI);
+
+	TActionExt::ExtMap.Remove(pItem);
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(6E3E30, TActionClass_SaveLoad_Prefix, 8)
+DEFINE_HOOK(6E3DB0, TActionClass_SaveLoad_Prefix, 5)
+{
+	GET_STACK(TActionClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	TActionExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(6E3E29, TActionClass_Load_Suffix, 4)
+{
+	TActionExt::ExtMap.LoadStatic();
+	return 0;
+}
+
+DEFINE_HOOK(6E3E4A, TActionClass_Save_Suffix, 3)
+{
+	TActionExt::ExtMap.SaveStatic();
+	return 0;
+}
+#endif

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -30,9 +30,7 @@ void TActionExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 // =============================
 // container
 
-TActionExt::ExtContainer::ExtContainer() : Container("TActionClass")
-{
-}
+TActionExt::ExtContainer::ExtContainer() : Container("TActionClass") { }
 
 TActionExt::ExtContainer::~ExtContainer() = default;
 

--- a/src/Ext/TAction/Body.h
+++ b/src/Ext/TAction/Body.h
@@ -22,12 +22,9 @@ public:
 
 		virtual ~ExtData() = default;
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
-		{
-		}
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
-
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 
 	private:
@@ -43,5 +40,4 @@ public:
 	};
 
 	static ExtContainer ExtMap;
-
 };

--- a/src/Ext/TAction/Body.h
+++ b/src/Ext/TAction/Body.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <Utilities/Container.h>
+#include <Utilities/Template.h>
+
+#include <Helpers/Template.h>
+
+#include <TActionClass.h>
+
+class HouseClass;
+
+class TActionExt
+{
+public:
+	using base_type = TActionClass;
+
+	class ExtData final : public Extension<TActionClass>
+	{
+	public:
+		ExtData(TActionClass* const OwnerObject) : Extension<TActionClass>(OwnerObject)
+		{ }
+
+		virtual ~ExtData() = default;
+
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
+		{
+		}
+
+		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+
+		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+	private:
+		template <typename T>
+		void Serialize(T& Stm);
+	};
+
+	class ExtContainer final : public Container<TActionExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+	};
+
+	static ExtContainer ExtMap;
+
+};

--- a/src/Ext/TAction/Hooks.cpp
+++ b/src/Ext/TAction/Hooks.cpp
@@ -5,7 +5,8 @@
 #include <HouseClass.h>
 #include <BuildingClass.h>
 
-// Bugfix : TAction 125 Build At do not display the buildups
+// Bugfix: TAction 125 Build At do not display the buildups
+// Author: secsome
 DEFINE_HOOK(6E427D, TActionClass_CreateBuildingAt, 9)
 {
 	GET(TActionClass*, pThis, ESI);
@@ -15,12 +16,12 @@ DEFINE_HOOK(6E427D, TActionClass_CreateBuildingAt, 9)
 
 	auto pBld = GameCreate<BuildingClass>(pBldType, pHouse);
 
-	if (pThis->Bounds.X) // use this one for our flag : bPlayBuildUp
+	if (pThis->Bounds.X) // use this one for our flag: bPlayBuildUp
 		pBld->QueueMission(Mission::Construction, true);
-		
+
 	if (pBld->Put(coord, Direction::North))
 		pBld->IsReadyToCommence = true;
-	else 
+	else
 		pBld->UnInit();
 
 	return 0x6E42C1;

--- a/src/Ext/TAction/Hooks.cpp
+++ b/src/Ext/TAction/Hooks.cpp
@@ -8,14 +8,19 @@
 // Bugfix : TAction 125 Build At do not display the buildups
 DEFINE_HOOK(6E427D, TActionClass_CreateBuildingAt, 9)
 {
+	GET(TActionClass*, pThis, ESI);
 	GET(BuildingTypeClass*, pBldType, ECX);
 	GET(HouseClass*, pHouse, EDI);
 	REF_STACK(CoordStruct, coord, STACK_OFFS(0x24, 0x18));
 
 	auto pBld = GameCreate<BuildingClass>(pBldType, pHouse);
 
-	pBld->QueueMission(Mission::Construction, true);
-	if (!pBld->Put(coord, Direction::North))
+	if (pThis->Bounds.X) // use this one for our flag : bPlayBuildUp
+		pBld->QueueMission(Mission::Construction, true);
+		
+	if (pBld->Put(coord, Direction::North))
+		pBld->IsReadyToCommence = true;
+	else 
 		pBld->UnInit();
 
 	return 0x6E42C1;

--- a/src/Ext/TAction/Hooks.cpp
+++ b/src/Ext/TAction/Hooks.cpp
@@ -1,0 +1,22 @@
+#include "Body.h"
+
+#include <Helpers\Macro.h>
+
+#include <HouseClass.h>
+#include <BuildingClass.h>
+
+// Bugfix : TAction 125 Build At do not display the buildups
+DEFINE_HOOK(6E427D, TActionClass_CreateBuildingAt, 9)
+{
+	GET(BuildingTypeClass*, pBldType, ECX);
+	GET(HouseClass*, pHouse, EDI);
+	REF_STACK(CoordStruct, coord, STACK_OFFS(0x24, 0x18));
+
+	auto pBld = GameCreate<BuildingClass>(pBldType, pHouse);
+
+	pBld->QueueMission(Mission::Construction, true);
+	if (!pBld->Put(coord, Direction::North))
+		pBld->UnInit();
+
+	return 0x6E42C1;
+}

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -11,6 +11,7 @@
 #include <Ext/Script/Body.h>
 #include <Ext/Side/Body.h>
 #include <Ext/SWType/Body.h>
+#include <Ext/TAction/Body.h>
 #include <Ext/Techno/Body.h>
 #include <Ext/TechnoType/Body.h>
 #include <Ext/TerrainType/Body.h>
@@ -226,6 +227,7 @@ auto MassActions = MassAction <
 	ScriptExt,
 	SideExt,
 	SWTypeExt,
+	TActionExt,
 	TechnoExt,
 	TechnoTypeExt,
 	TerrainTypeExt,


### PR DESCRIPTION
In vanilla YR, TActionClass::CreateBuildingAt's implement skipped the BuildUp animation and thus you will see buildings suddenly appear from nothing. This fix plays the animation.