### PR TITLE
Cusomizable Harvester Oregath Animation

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="src\Commands\Dummy.h" />
     <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />
+    <ClCompile Include="src\Ext\AnimType\Body.cpp" />
     <ClCompile Include="src\Ext\TAction\Body.cpp" />
     <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
     <ClCompile Include="src\Misc\CaptureManager.cpp" />
@@ -90,6 +91,7 @@
     <ClInclude Include="src\Commands\NextIdleHarvester.h" />
     <ClInclude Include="src\Commands\ObjectInfo.h" />
     <ClInclude Include="src\Commands\Commands.h" />
+    <ClInclude Include="src\Ext\AnimType\Body.h" />
     <ClInclude Include="src\Ext\Sidebar\Body.h" />
     <ClInclude Include="src\Ext\TAction\Body.h" />
     <ClInclude Include="src\Misc\CaptureManager.h" />

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Credits
 - **SMxReaver** - help with docs, extensive and thorough testing
 - **4SG** - help with docs
 - **wiktorderelf** - overhauled Unicode font
-- **Uranusian (Thrifinesma)** - Mind Control enhancement, custom warhead splash list, harvesters counter, promoted spawns, shields, death after dead fix, customizeable missing cameo, cameo sorting priority, placement mode responding of tab hotkeys fix, producing progress, overhauled Unicode font, help with docs
-- **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix
+- **Uranusian (Thrifinesma)** - Mind Control enhancement, custom warhead splash list, harvesters counter, promoted spawns, shields, death after dead fix, customizeable missing cameo, cameo sorting priority, placement mode responding of tab hotkeys fix, producing progress, custom ore gathering anim, overhauled Unicode font, help with docs
+- **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix, custom ore gathering anim
 - **Otamaa (Fahroni, BoredEXE)** - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass, DebrisMaximums fixes
 - **E1 Elite** - TileSet 255 and above bridge repair fix
 - **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72 & 73, MC deployer fixes, help with docs

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -54,16 +54,16 @@ ChronoDelay=            ; integer, delay after teleport for chronosphere
 
 ```
 
-### Cusomizable Harvester Ore Gather Animation
+### Customizable harvester ore gathering animation
 
-- You can now specify which anim should be drawn when harvester gathering each type of ores.
+- You can now specify which anim should be drawn when a harvester of specified type is gathering specified type of ore.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEHARVESTER]             ; Harvester
-OreGath.Anims=              ; list of animations
-OreGath.FramesPerDir=15     ; list of integers
-OreGath.TiberiumTypes=      ; list of TiberiumType IDs, if not set, always display the first
+[SOMETECHNO]                     ; TechnoType
+OreGathering.Anims=              ; list of animations
+OreGathering.FramesPerDir=15     ; list of integers
+OreGathering.Tiberiums=0         ; list of Tiberium IDs
 ```
 
 ### Kill spawns on low power

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -54,32 +54,17 @@ ChronoDelay=            ; integer, delay after teleport for chronosphere
 
 ```
 
-### Cusomizable Harvester Oregath Animation
+### Cusomizable Harvester Ore Gather Animation
 
-- You can now specify which anim should be drawn when harvester gathering different ores
-
+- You can now specify which anim should be drawn when harvester gathering each type of ores.
 
 In `rulesmd.ini`:
 ```ini
 [SOMEHARVESTER]             ; Harvester
-Oregath.Anims=              ; Anims
-Oregath.FramesPerDir=       ; Integer
-Oregath.OverlayTypes=       ; Overlay ID
+OreGath.Anims=              ; list of animations
+OreGath.FramesPerDir=15     ; list of integers
+OreGath.TiberiumTypes=      ; list of TiberiumType IDs, if not set, always display the first
 ```
-
-For example:
-```ini
-[CMIN]
-...
-Oregath.Anims=NUKEANIM,OREGATH
-Oregath.OverlayTypes=112,30
-Oregath.FramesPerDir=5,15
-...
-```
-
-`NUKEANIM` will be played while the chrono miner is gathering normal golds
-`OREGATH(the default anim)` will be played while the chrono miner is gathering gems
-
 
 ### Kill spawns on low power
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -54,6 +54,33 @@ ChronoDelay=            ; integer, delay after teleport for chronosphere
 
 ```
 
+### Cusomizable Harvester Oregath Animation
+
+- You can now specify which anim should be drawn when harvester gathering different ores
+
+
+In `rulesmd.ini`:
+```ini
+[SOMEHARVESTER]             ; Harvester
+Oregath.Anims=              ; Anims
+Oregath.FramesPerDir=       ; Integer
+Oregath.OverlayTypes=       ; Overlay ID
+```
+
+For example:
+```ini
+[CMIN]
+...
+Oregath.Anims=NUKEANIM,OREGATH
+Oregath.OverlayTypes=112,30
+Oregath.FramesPerDir=5,15
+...
+```
+
+`NUKEANIM` will be played while the chrono miner is gathering normal golds
+`OREGATH(the default anim)` will be played while the chrono miner is gathering gems
+
+
 ### Kill spawns on low power
 
 - `Powered=yes` structures that spawns aircraft like Aircrafts Carriers will stop targeting the enemy if low power.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -37,6 +37,8 @@ In `FAData.ini`:
 
 New:
 - Customizable producing progress "bars" like CnC:Remastered did (by Uranusian)
+- Customizable cameo sorting priority (by Uranusian)
+- Customizable harvester ore gathering animation (by secsome, Uranusian)
 
 Vanilla fixes:
 - TBD

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -1,0 +1,104 @@
+#include "Body.h"
+#include "../House/Body.h"
+#include <Phobos.h>
+#include <Utilities/TemplateDef.h>
+#include <AnimClass.h>
+#include <HouseTypeClass.h>
+#include <HouseClass.h>
+#include <ScenarioClass.h>
+
+template<> const DWORD Extension<AnimTypeClass>::Canary = 0xEEEEEEEE;
+AnimTypeExt::ExtContainer AnimTypeExt::ExtMap;
+
+void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
+{
+	const char* pID = this->OwnerObject()->ID;
+
+	INI_EX exINI(pINI);
+
+	this->Palette.LoadFromINI(pINI, pID, "CustomPalette");
+}
+
+// =============================
+// container
+
+AnimTypeExt::ExtContainer::ExtContainer() : Container("AnimTypeClass")
+{
+}
+
+AnimTypeExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// load / save
+
+template <typename T>
+void AnimTypeExt::ExtData::Serialize(T & Stm)
+{
+	Stm
+		.Process(this->Palette);
+}
+
+void AnimTypeExt::ExtData::LoadFromStream(PhobosStreamReader & Stm)
+{
+	Extension<AnimTypeClass>::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void AnimTypeExt::ExtData::SaveToStream(PhobosStreamWriter & Stm)
+{
+	Extension<AnimTypeClass>::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+// =============================
+// container hooks
+
+DEFINE_HOOK(42784B, AnimTypeClass_CTOR, 5)
+{
+	GET(AnimTypeClass*, pItem, EAX);
+
+	AnimTypeExt::ExtMap.FindOrAllocate(pItem);
+	return 0;
+}
+
+DEFINE_HOOK(428EA8, AnimTypeClass_SDDTOR, 5)
+{
+	GET(AnimTypeClass*, pItem, ECX);
+
+	AnimTypeExt::ExtMap.Remove(pItem);
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(428970, AnimTypeClass_SaveLoad_Prefix, 8)
+DEFINE_HOOK(428800, AnimTypeClass_SaveLoad_Prefix, A)
+{
+	GET_STACK(AnimTypeClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	AnimTypeExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(42892C, AnimTypeClass_Load_Suffix, 6)
+DEFINE_HOOK(428958, AnimTypeClass_Load_Suffix, 6)
+{
+	AnimTypeExt::ExtMap.LoadStatic();
+	return 0;
+}
+
+DEFINE_HOOK(42898A, AnimTypeClass_Save_Suffix, 3)
+{
+	AnimTypeExt::ExtMap.SaveStatic();
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(4287E9, AnimTypeClass_LoadFromINI, A)
+DEFINE_HOOK(4287DC, AnimTypeClass_LoadFromINI, A)
+{
+	GET(AnimTypeClass*, pItem, ESI);
+	GET_STACK(CCINIClass*, pINI, 0xBC);
+
+	AnimTypeExt::ExtMap.LoadFromINI(pItem, pINI);
+	return 0;
+}

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -1,6 +1,6 @@
 #include "Body.h"
-#include "../House/Body.h"
 #include <Phobos.h>
+#include <Helpers/Macro.h>
 #include <Utilities/TemplateDef.h>
 #include <AnimClass.h>
 #include <HouseTypeClass.h>

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -53,7 +53,7 @@ void AnimTypeExt::ExtData::SaveToStream(PhobosStreamWriter & Stm)
 // =============================
 // container hooks
 
-DEFINE_HOOK(42784B, AnimTypeClass_CTOR, 5)
+DEFINE_HOOK(0x42784B, AnimTypeClass_CTOR, 0x5)
 {
 	GET(AnimTypeClass*, pItem, EAX);
 
@@ -61,7 +61,7 @@ DEFINE_HOOK(42784B, AnimTypeClass_CTOR, 5)
 	return 0;
 }
 
-DEFINE_HOOK(428EA8, AnimTypeClass_SDDTOR, 5)
+DEFINE_HOOK(0x428EA8, AnimTypeClass_SDDTOR, 0x5)
 {
 	GET(AnimTypeClass*, pItem, ECX);
 
@@ -69,8 +69,8 @@ DEFINE_HOOK(428EA8, AnimTypeClass_SDDTOR, 5)
 	return 0;
 }
 
-DEFINE_HOOK_AGAIN(428970, AnimTypeClass_SaveLoad_Prefix, 8)
-DEFINE_HOOK(428800, AnimTypeClass_SaveLoad_Prefix, A)
+DEFINE_HOOK_AGAIN(0x428970, AnimTypeClass_SaveLoad_Prefix, 0x8)
+DEFINE_HOOK(0x428800, AnimTypeClass_SaveLoad_Prefix, 0xA)
 {
 	GET_STACK(AnimTypeClass*, pItem, 0x4);
 	GET_STACK(IStream*, pStm, 0x8);
@@ -80,21 +80,21 @@ DEFINE_HOOK(428800, AnimTypeClass_SaveLoad_Prefix, A)
 	return 0;
 }
 
-DEFINE_HOOK_AGAIN(42892C, AnimTypeClass_Load_Suffix, 6)
-DEFINE_HOOK(428958, AnimTypeClass_Load_Suffix, 6)
+DEFINE_HOOK_AGAIN(0x42892C, AnimTypeClass_Load_Suffix, 0x6)
+DEFINE_HOOK(0x428958, AnimTypeClass_Load_Suffix, 0x6)
 {
 	AnimTypeExt::ExtMap.LoadStatic();
 	return 0;
 }
 
-DEFINE_HOOK(42898A, AnimTypeClass_Save_Suffix, 3)
+DEFINE_HOOK(0x42898A, AnimTypeClass_Save_Suffix, 0x3)
 {
 	AnimTypeExt::ExtMap.SaveStatic();
 	return 0;
 }
 
-DEFINE_HOOK_AGAIN(4287E9, AnimTypeClass_LoadFromINI, A)
-DEFINE_HOOK(4287DC, AnimTypeClass_LoadFromINI, A)
+DEFINE_HOOK_AGAIN(0x4287E9, AnimTypeClass_LoadFromINI, 0xA)
+DEFINE_HOOK(0x4287DC, AnimTypeClass_LoadFromINI, 0xA)
 {
 	GET(AnimTypeClass*, pItem, ESI);
 	GET_STACK(CCINIClass*, pINI, 0xBC);

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -22,9 +22,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 // =============================
 // container
 
-AnimTypeExt::ExtContainer::ExtContainer() : Container("AnimTypeClass")
-{
-}
+AnimTypeExt::ExtContainer::ExtContainer() : Container("AnimTypeClass") { }
 
 AnimTypeExt::ExtContainer::~ExtContainer() = default;
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <AnimTypeClass.h>
+
+#include <Utilities/Container.h>
+#include <Utilities/Enum.h>
+#include <Utilities/Constructs.h>
+#include <Utilities/Template.h>
+
+class AnimClass;
+
+class AnimTypeExt
+{
+public:
+	using base_type = AnimTypeClass;
+
+	class ExtData final : public Extension<AnimTypeClass>
+	{
+	public:
+		CustomPalette Palette;
+
+		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject),
+			Palette(CustomPalette::PaletteMode::Temperate)
+		{
+		}
+
+		virtual ~ExtData() = default;
+
+		virtual void LoadFromINIFile(CCINIClass* pINI) override;
+
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
+		{
+		}
+
+		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+
+		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+	private:
+		template <typename T>
+		void Serialize(T& Stm);
+	};
+
+	class ExtContainer final : public Container<AnimTypeExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+	};
+
+	static ExtContainer ExtMap;
+};

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -27,8 +27,7 @@ public:
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override 
-		{ }
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -21,19 +21,16 @@ public:
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject),
 			Palette(CustomPalette::PaletteMode::Temperate)
-		{
-		}
+		{ }
 
 		virtual ~ExtData() = default;
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
-		{
-		}
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override 
+		{ }
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
-
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 
 	private:

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -108,6 +108,9 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ChronoMinimumDelay.Read(exINI, pSection, "ChronoMinimumDelay");
 	this->ChronoRangeMinimum.Read(exINI, pSection, "ChronoRangeMinimum");
 	this->ChronoDelay.Read(exINI, pSection, "ChronoDelay");
+	this->OregatherAnims.Read(exINI, pSection, "Oregath.Anims");
+	this->OregatherTypes.Read(exINI, pSection, "Oregath.OverlayTypes");
+	this->OregatherFramesPerDir.Read(exINI, pSection, "Oregath.FramesPerDir");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -150,6 +153,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ChronoMinimumDelay)
 		.Process(this->ChronoRangeMinimum)
 		.Process(this->ChronoDelay)
+		.Process(this->OregatherAnims)
+		.Process(this->OregatherTypes)
+		.Process(this->OregatherFramesPerDir)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -108,9 +108,9 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ChronoMinimumDelay.Read(exINI, pSection, "ChronoMinimumDelay");
 	this->ChronoRangeMinimum.Read(exINI, pSection, "ChronoRangeMinimum");
 	this->ChronoDelay.Read(exINI, pSection, "ChronoDelay");
-	this->OreGath_Anims.Read(exINI, pSection, "OreGath.Anims");
-	this->OreGath_TiberiumTypes.Read(exINI, pSection, "OreGath.TiberiumTypes");
-	this->OreGath_FramesPerDir.Read(exINI, pSection, "OreGath.FramesPerDir");
+	this->OreGathering_Anims.Read(exINI, pSection, "OreGathering.Anims");
+	this->OreGathering_Tiberiums.Read(exINI, pSection, "OreGathering.Tiberiums");
+	this->OreGathering_FramesPerDir.Read(exINI, pSection, "OreGathering.FramesPerDir");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -153,9 +153,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ChronoMinimumDelay)
 		.Process(this->ChronoRangeMinimum)
 		.Process(this->ChronoDelay)
-		.Process(this->OreGath_Anims)
-		.Process(this->OreGath_TiberiumTypes)
-		.Process(this->OreGath_FramesPerDir)
+		.Process(this->OreGathering_Anims)
+		.Process(this->OreGathering_Tiberiums)
+		.Process(this->OreGathering_FramesPerDir)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -108,9 +108,9 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ChronoMinimumDelay.Read(exINI, pSection, "ChronoMinimumDelay");
 	this->ChronoRangeMinimum.Read(exINI, pSection, "ChronoRangeMinimum");
 	this->ChronoDelay.Read(exINI, pSection, "ChronoDelay");
-	this->OregatherAnims.Read(exINI, pSection, "Oregath.Anims");
-	this->OregatherTypes.Read(exINI, pSection, "Oregath.TiberiumTypes");
-	this->OregatherFramesPerDir.Read(exINI, pSection, "Oregath.FramesPerDir");
+	this->OreGath_Anims.Read(exINI, pSection, "OreGath.Anims");
+	this->OreGath_TiberiumTypes.Read(exINI, pSection, "OreGath.TiberiumTypes");
+	this->OreGath_FramesPerDir.Read(exINI, pSection, "OreGath.FramesPerDir");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -153,9 +153,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ChronoMinimumDelay)
 		.Process(this->ChronoRangeMinimum)
 		.Process(this->ChronoDelay)
-		.Process(this->OregatherAnims)
-		.Process(this->OregatherTypes)
-		.Process(this->OregatherFramesPerDir)
+		.Process(this->OreGath_Anims)
+		.Process(this->OreGath_TiberiumTypes)
+		.Process(this->OreGath_FramesPerDir)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -109,7 +109,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ChronoRangeMinimum.Read(exINI, pSection, "ChronoRangeMinimum");
 	this->ChronoDelay.Read(exINI, pSection, "ChronoDelay");
 	this->OregatherAnims.Read(exINI, pSection, "Oregath.Anims");
-	this->OregatherTypes.Read(exINI, pSection, "Oregath.OverlayTypes");
+	this->OregatherTypes.Read(exINI, pSection, "Oregath.TiberiumTypes");
 	this->OregatherFramesPerDir.Read(exINI, pSection, "Oregath.FramesPerDir");
 
 	// Ares 0.A

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -48,6 +48,10 @@ public:
 		Nullable<int> ChronoRangeMinimum;
 		Nullable<int> ChronoDelay;
 
+		ValueableVector<AnimTypeClass*> OregatherAnims;
+		ValueableVector<int> OregatherTypes;
+		ValueableVector<int> OregatherFramesPerDir;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			HealthBar_Hide(false),
 			UIDescription(),
@@ -76,7 +80,10 @@ public:
 			ChronoDistanceFactor(),
 			ChronoMinimumDelay(),
 			ChronoRangeMinimum(),
-			ChronoDelay()
+			ChronoDelay(),
+			OregatherAnims(),
+			OregatherTypes(),
+			OregatherFramesPerDir()
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -48,9 +48,9 @@ public:
 		Nullable<int> ChronoRangeMinimum;
 		Nullable<int> ChronoDelay;
 
-		ValueableVector<AnimTypeClass*> OregatherAnims;
-		ValueableVector<int> OregatherTypes;
-		ValueableVector<int> OregatherFramesPerDir;
+		ValueableVector<AnimTypeClass*> OreGath_Anims;
+		ValueableVector<int> OreGath_TiberiumTypes;
+		ValueableVector<int> OreGath_FramesPerDir;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			HealthBar_Hide(false),
@@ -81,9 +81,9 @@ public:
 			ChronoMinimumDelay(),
 			ChronoRangeMinimum(),
 			ChronoDelay(),
-			OregatherAnims(),
-			OregatherTypes(),
-			OregatherFramesPerDir()
+			OreGath_Anims(),
+			OreGath_TiberiumTypes(),
+			OreGath_FramesPerDir()
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -48,9 +48,9 @@ public:
 		Nullable<int> ChronoRangeMinimum;
 		Nullable<int> ChronoDelay;
 
-		ValueableVector<AnimTypeClass*> OreGath_Anims;
-		ValueableVector<int> OreGath_TiberiumTypes;
-		ValueableVector<int> OreGath_FramesPerDir;
+		ValueableVector<AnimTypeClass*> OreGathering_Anims;
+		ValueableVector<int> OreGathering_Tiberiums;
+		ValueableVector<int> OreGathering_FramesPerDir;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject),
 			HealthBar_Hide(false),
@@ -81,9 +81,9 @@ public:
 			ChronoMinimumDelay(),
 			ChronoRangeMinimum(),
 			ChronoDelay(),
-			OreGath_Anims(),
-			OreGath_TiberiumTypes(),
-			OreGath_FramesPerDir()
+			OreGathering_Anims(),
+			OreGathering_Tiberiums(),
+			OreGathering_FramesPerDir()
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -6,6 +6,7 @@
 #include <BulletClass.h>
 
 #include "Body.h"
+#include <Ext/AnimType/Body.h>
 #include <Ext/BulletType/Body.h>
 #include <Ext/Techno/Body.h>
 
@@ -111,7 +112,8 @@ DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
 	auto const pType = pThis->GetTechnoType();
 	auto const pData = TechnoTypeExt::ExtMap.Find(pType);
 
-	SHPStruct* pSHP;
+	ConvertClass* pDrawer = FileSystem::ANIM_PAL;
+	SHPStruct* pSHP = FileSystem::OREGATH_SHP;
 	int nFrame;
 
 	auto nOverlayIdx = pThis->GetCell()->OverlayTypeIndex;
@@ -120,17 +122,20 @@ DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
 	{
 		auto const pAnimType = pData->OregatherAnims[nIndexInArray];
 		auto const nFramePerFacing = pData->OregatherFramesPerDir[nIndexInArray];
-		pSHP = pAnimType ? pAnimType->GetImage() : FileSystem::OREGATH_SHP;
+		auto const pAnimExt = AnimTypeExt::ExtMap.Find(pAnimType);
+		if (pAnimType)
+		{
+			pSHP = pAnimType->GetImage();
+			if (auto const pPalette = pAnimExt->Palette.GetConvert())
+				pDrawer = pPalette;
+		}
 		nFrame = nFramePerFacing * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % nFramePerFacing;
 	}
 	else
-	{
-		pSHP = FileSystem::OREGATH_SHP;
 		nFrame = 15 * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % 15;
-	}
 
 	DSurface::Temp->DrawSHP(
-		FileSystem::ANIM_PAL, pSHP, nFrame, pLocation, pBounds,
+		pDrawer, pSHP, nFrame, pLocation, pBounds,
 		BlitterFlags::Flat | BlitterFlags::Alpha | BlitterFlags::Centered,
 		0, pThis->GetZAdjustment() - 2, ZGradientDescIndex::Flat, Brightness,
 		0, nullptr, 0, 0, 0

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -117,11 +117,11 @@ DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
 	int idxFrame;
 
 	auto idxTiberium = pThis->GetCell()->GetContainedTiberiumIndex();
-	auto idxArray = pData->OregatherTypes.IndexOf(idxTiberium);
+	auto idxArray = pData->OreGath_TiberiumTypes.size() > 0 ? pData->OreGath_TiberiumTypes.IndexOf(idxTiberium) : 0;
 	if (idxTiberium != -1 && idxArray != -1)
 	{
-		auto const pAnimType = pData->OregatherAnims[idxArray];
-		auto const nFramesPerFacing = pData->OregatherFramesPerDir[idxArray];
+		auto const pAnimType = pData->OreGath_Anims[idxArray];
+		auto const nFramesPerFacing = pData->OreGath_FramesPerDir.size() > 0 ? pData->OreGath_FramesPerDir[idxArray] : 15;
 		auto const pAnimExt = AnimTypeExt::ExtMap.Find(pAnimType);
 		if (pAnimType)
 		{
@@ -132,7 +132,9 @@ DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
 		idxFrame = nFramesPerFacing * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % nFramesPerFacing;
 	}
 	else
+	{
 		idxFrame = 15 * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % 15;
+	}
 
 	DSurface::Temp->DrawSHP(
 		pDrawer, pSHP, idxFrame, pLocation, pBounds,

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -107,7 +107,7 @@ DEFINE_HOOK(0x73D223, UnitClass_DrawIt_OreGath, 0x6)
 	GET(int, nFacing, EDI);
 	GET_STACK(RectangleStruct*, pBounds, STACK_OFFS(0x50, -0x8));
 	LEA_STACK(Point2D*, pLocation, STACK_OFFS(0x50, 0x18));
-	GET_STACK(int, Brightness, STACK_OFFS(0x50, -0x4));
+	GET_STACK(int, nBrightness, STACK_OFFS(0x50, -0x4));
 
 	auto const pType = pThis->GetTechnoType();
 	auto const pData = TechnoTypeExt::ExtMap.Find(pType);
@@ -117,11 +117,11 @@ DEFINE_HOOK(0x73D223, UnitClass_DrawIt_OreGath, 0x6)
 	int idxFrame;
 
 	auto idxTiberium = pThis->GetCell()->GetContainedTiberiumIndex();
-	auto idxArray = pData->OreGath_TiberiumTypes.size() > 0 ? pData->OreGath_TiberiumTypes.IndexOf(idxTiberium) : 0;
+	auto idxArray = pData->OreGathering_Tiberiums.size() > 0 ? pData->OreGathering_Tiberiums.IndexOf(idxTiberium) : 0;
 	if (idxTiberium != -1 && idxArray != -1)
 	{
-		auto const pAnimType = pData->OreGath_Anims.size() > 0 ? pData->OreGath_Anims[idxArray] : nullptr;
-		auto const nFramesPerFacing = pData->OreGath_FramesPerDir.size() > 0 ? pData->OreGath_FramesPerDir[idxArray] : 15;
+		auto const pAnimType = pData->OreGathering_Anims.size() > 0 ? pData->OreGathering_Anims[idxArray] : nullptr;
+		auto const nFramesPerFacing = pData->OreGathering_FramesPerDir.size() > 0 ? pData->OreGathering_FramesPerDir[idxArray] : 15;
 		auto const pAnimExt = AnimTypeExt::ExtMap.Find(pAnimType);
 		if (pAnimType)
 		{
@@ -139,11 +139,11 @@ DEFINE_HOOK(0x73D223, UnitClass_DrawIt_OreGath, 0x6)
 	DSurface::Temp->DrawSHP(
 		pDrawer, pSHP, idxFrame, pLocation, pBounds,
 		BlitterFlags::Flat | BlitterFlags::Alpha | BlitterFlags::Centered,
-		0, pThis->GetZAdjustment() - 2, ZGradientDescIndex::Flat, Brightness,
+		0, pThis->GetZAdjustment() - 2, ZGradientDescIndex::Flat, nBrightness,
 		0, nullptr, 0, 0, 0
 	);
 
-	R->EBP(Brightness);
+	R->EBP(nBrightness);
 	R->EBX(pBounds);
 
 	return 0x73D28C;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -120,7 +120,7 @@ DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
 	auto idxArray = pData->OreGath_TiberiumTypes.size() > 0 ? pData->OreGath_TiberiumTypes.IndexOf(idxTiberium) : 0;
 	if (idxTiberium != -1 && idxArray != -1)
 	{
-		auto const pAnimType = pData->OreGath_Anims[idxArray];
+		auto const pAnimType = pData->OreGath_Anims.size() > 0 ? pData->OreGath_Anims[idxArray] : nullptr;
 		auto const nFramesPerFacing = pData->OreGath_FramesPerDir.size() > 0 ? pData->OreGath_FramesPerDir[idxArray] : 15;
 		auto const pAnimExt = AnimTypeExt::ExtMap.Find(pAnimType);
 		if (pAnimType)

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -114,14 +114,14 @@ DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
 
 	ConvertClass* pDrawer = FileSystem::ANIM_PAL;
 	SHPStruct* pSHP = FileSystem::OREGATH_SHP;
-	int nFrame;
+	int idxFrame;
 
-	auto nOverlayIdx = pThis->GetCell()->OverlayTypeIndex;
-	auto nIndexInArray = pData->OregatherTypes.IndexOf(nOverlayIdx);
-	if (nOverlayIdx != -1 && nIndexInArray != -1)
+	auto idxTiberium = pThis->GetCell()->GetContainedTiberiumIndex();
+	auto idxArray = pData->OregatherTypes.IndexOf(idxTiberium);
+	if (idxTiberium != -1 && idxArray != -1)
 	{
-		auto const pAnimType = pData->OregatherAnims[nIndexInArray];
-		auto const nFramePerFacing = pData->OregatherFramesPerDir[nIndexInArray];
+		auto const pAnimType = pData->OregatherAnims[idxArray];
+		auto const nFramesPerFacing = pData->OregatherFramesPerDir[idxArray];
 		auto const pAnimExt = AnimTypeExt::ExtMap.Find(pAnimType);
 		if (pAnimType)
 		{
@@ -129,13 +129,13 @@ DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
 			if (auto const pPalette = pAnimExt->Palette.GetConvert())
 				pDrawer = pPalette;
 		}
-		nFrame = nFramePerFacing * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % nFramePerFacing;
+		idxFrame = nFramesPerFacing * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % nFramesPerFacing;
 	}
 	else
-		nFrame = 15 * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % 15;
+		idxFrame = 15 * nFacing + (Unsorted::CurrentFrame + pThis->WalkedFramesSoFar) % 15;
 
 	DSurface::Temp->DrawSHP(
-		pDrawer, pSHP, nFrame, pLocation, pBounds,
+		pDrawer, pSHP, idxFrame, pLocation, pBounds,
 		BlitterFlags::Flat | BlitterFlags::Alpha | BlitterFlags::Centered,
 		0, pThis->GetZAdjustment() - 2, ZGradientDescIndex::Flat, Brightness,
 		0, nullptr, 0, 0, 0

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -101,7 +101,7 @@ DEFINE_HOOK(0x6B7282, SpawnManagerClass_AI_PromoteSpawns, 0x5)
 	return 0;
 }
 
-DEFINE_HOOK(73D223, UnitClass_DrawIt_OreGath, 6)
+DEFINE_HOOK(0x73D223, UnitClass_DrawIt_OreGath, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 	GET(int, nFacing, EDI);

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -1,5 +1,7 @@
 #include <Phobos.h>
 
+#include <Ext/Aircraft/Body.h>
+#include <Ext/AnimType/Body.h>
 #include <Ext/Building/Body.h>
 #include <Ext/BuildingType/Body.h>
 #include <Ext/Bullet/Body.h>
@@ -216,6 +218,8 @@ private:
 // Add more class names as you like
 auto MassActions = MassAction <
 	// Ext classes
+	AircraftExt,
+	AnimTypeExt,
 	BuildingExt,
 	BuildingTypeExt,
 	BulletExt,


### PR DESCRIPTION
- You can now specify which anim should be drawn when harvester gathering each type of ores.

In `rulesmd.ini`:
```ini
[SOMEHARVESTER]             ; Harvester
OreGath.Anims=              ; list of animations
OreGath.FramesPerDir=15     ; list of integers
OreGath.TiberiumTypes=      ; list of TiberiumType IDs, if not set, always display the first
```

For example:
```ini
[CMIN]
...
OreGath.Anims=NUKEANIM,OREGATH
OreGath.TiberiumTypes=112,30
OreGath.FramesPerDir=1,2
...
```

`NUKEANIM` will be played while the chrono miner is gathering normal golds
`OREGATH(the default anim)` will be played while the chrono miner is gathering gems