### PR TITLE
Fix the bug about shield removing when garrison/enter something

### DIFF
--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -174,12 +174,9 @@ DEFINE_HOOK(6F6AC4, TechnoClass_Remove_Shield, 5)
 	GET(TechnoClass*, pThis, ECX);
 	const auto pExt = TechnoExt::ExtMap.Find(pThis);
 
-	if (pExt->Shield &&
-		!(pThis->WhatAmI() == AbstractType::Building && pThis->GetTechnoType()->UndeploysInto && pThis->CurrentMission == Mission::Selling))
-	{
-		pExt->Shield = nullptr;
-	}
-
+	if (pExt->Shield)
+		pExt->Shield->KillAnim();
+	
 	return 0;
 }
 

--- a/src/New/Entity/Shield.h
+++ b/src/New/Entity/Shield.h
@@ -17,6 +17,8 @@ public:
 	int ReceiveDamage(args_ReceiveDamage* args);
 	bool CanBeTargeted(WeaponTypeClass* pWeapon);
 
+	void KillAnim();
+
 	void AI_Temporal();
 	void AI();
 
@@ -46,7 +48,6 @@ private:
 	void RespawnShield();
 
 	void CreateAnim();
-	void KillAnim();
 
 	void WeaponNullifyAnim();
 	void ResponseAttack();


### PR DESCRIPTION
When infantry garrisoned building or unit entered transport, the shield will be removed because game called pThis->Remove(). Just removing the hook won't cause other side effect but losing anim after this action. So kill anim here