### PR TITLE
Burst logic improvements / additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **mevitar** - honorary shield tester *triple* award
 - **Damfoos** - extensive and thorough testing

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -33,6 +33,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode.
 - `DeathWeapon` now will properly detonate. 
   - But still some settings are ignored like `PreImpactAnim` *(Ares feature)*, this might change in future.
+- Effects like lasers are no longer drawn from wrong firing offset on weapons that use Burst.
 
 ## Technos
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -259,7 +259,35 @@ In `rulesmd.ini`:
 InitialStrength=    ; int
 ```
 
+### Firing offsets for specific Burst shots
+
+- You can now specify separate firing offsets for each of the shots fired by weapon with `Burst` via using `(Elite)PrimaryFire|SecondaryFire|WeaponX|FLH.BurstN` keys, depending on which weapons your TechnoType makes use of. *N* in `BurstN` is zero-based burst shot index, and the values are parsed sequentially until no value for either regular or elite weapon is present, with elite weapon defaulting to regular weapon FLH if only it is missing. If no burst-index specific value is available, value from the base key (f.ex `PrimaryFireFLH`) is used.
+- Burst-index specific firing offsets are absolute firing offsets and the lateral shifting based on burst index that occurs with the base firing offsets is not applied.
+
+In `artmd.ini`:
+```ini
+[SOMETECHNO]                   ; TechnoType Image
+PrimaryFireFLH.BurstN=         ; int - forward, lateral, height
+ElitePrimaryFireFLH.BurstN=    ; int - forward, lateral, height
+SecondaryFireFLH.BurstN=       ; int - forward, lateral, height
+EliteSecondaryFireFLH.BurstN=  ; int - forward, lateral, height
+WeaponXFLH.BurstN=             ; int - forward, lateral, height
+EliteWeaponXFLH.BurstN=        ; int - forward, lateral, height
+```
+
 ## Weapons
+
+### Burst.Delays
+
+- Allows specifying weapon-specific burst shot delays. Takes precedence over the old `BurstDelayX` logic available on VehicleTypes, functions with Infantry & BuildingType weapons (AircraftTypes are not supported due to their weapon firing system being completely different) and allows every shot of `Burst` to have a separate delay instead of only first four shots.
+- If no delay is defined for a shot, it falls back to last delay value defined (f.ex `Burst=3` and `BurstDelays=10` would use 10 as delay for all shots).
+- Using -1 as delay reverts back to old logic (`BurstDelay0-3` for VehicleTypes if available or random value between 3-5 otherwise) for that shot.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWEAPON]                 ; WeaponType
+Burst.Delays=-1              ; int - burst delays (comma-separated) for shots in order from first to last.
+```
 
 ### Strafing aircraft weapon customization
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -41,10 +41,13 @@ New:
 - Initial Strength for TechnoTypes (by Uranusian)
 - Re-enable obsolete `JumpjetControls` for TechnoTypes' default Jumpjet properties (by Uranusian)
 - Weapon targeting filter (by Uranusian)
+- Burst-specific FLH's for TechnoTypes (by Starkku)
+- Burst delays for weapons (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)
 - Fixed DeathWeapon not detonating properly (by Uranusian)
+- Fixed lasers & other effects drawing from wrong offset with weapons that use Burst (by Starkku)
 
 Phobos fixes:
 - Fixed extended building upgrades logic not properly interact with Ares' BuildLimit check (by Uranusian)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -233,6 +233,36 @@ CoordStruct TechnoExt::GetFLHAbsoluteCoords(TechnoClass* pThis, CoordStruct pCoo
 	return location;
 }
 
+CoordStruct TechnoExt::GetBurstFLH(TechnoClass* pThis, int weaponIndex, bool& FLHFound)
+{
+	FLHFound = false;
+	CoordStruct FLH = CoordStruct::Empty;
+
+	if (!pThis || weaponIndex < 0)
+		return FLH;
+
+	auto pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+	if (pThis->Veterancy.IsElite())
+	{
+		if (pExt->EliteWeaponBurstFLHs[weaponIndex].Count > pThis->CurrentBurstIndex)
+		{
+			FLHFound = true;
+			FLH = pExt->EliteWeaponBurstFLHs[weaponIndex][pThis->CurrentBurstIndex];
+		}
+	}
+	else
+	{
+		if (pExt->WeaponBurstFLHs[weaponIndex].Count > pThis->CurrentBurstIndex)
+		{
+			FLHFound = true;
+			FLH = pExt->WeaponBurstFLHs[weaponIndex][pThis->CurrentBurstIndex];
+		}
+	}
+
+	return FLH;
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -66,6 +66,8 @@ public:
 
 	static void InitializeLaserTrails(TechnoClass* pThis);
 	static CoordStruct GetFLHAbsoluteCoords(TechnoClass* pThis, CoordStruct flh, bool turretFLH = false);
+	
+	static CoordStruct GetBurstFLH(TechnoClass* pThis, int weaponIndex, bool& FLHFound);
 
 	static void TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo);
 

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -3,6 +3,7 @@
 #include "Body.h"
 
 #include <Ext/TechnoType/Body.h>
+#include <Ext/WeaponType/Body.h>
 
 DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 {
@@ -55,6 +56,35 @@ DEFINE_HOOK(0x414057, TechnoClass_Init_InitialStrength, 0x6)       // AircraftCl
 		auto strength = pTypeExt->InitialStrength.Get(R->EDX<int>());
 		pThis->Health = strength;
 		pThis->EstimatedHealth = strength;
+	}
+
+	return 0;
+}
+
+// Issue #271: Separate burst delay for weapon type
+// Author: Starkku
+DEFINE_HOOK(0x6FD05E, TechnoClass_Rearm_Delay_BurstDelays, 0x7)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET(WeaponTypeClass*, pWeapon, EDI);
+
+	auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
+
+	int burstDelay = -1;
+
+	if (pWeaponExt->Burst_Delays.size() >= (unsigned)pThis->CurrentBurstIndex)
+	{
+		burstDelay = pWeaponExt->Burst_Delays[pThis->CurrentBurstIndex - 1];
+	}
+	else if (pWeaponExt->Burst_Delays.size() > 0)
+	{
+		burstDelay = pWeaponExt->Burst_Delays[pWeaponExt->Burst_Delays.size() - 1];
+	}
+
+	if (burstDelay >= 0)
+	{
+		R->EAX(burstDelay);
+		return 0x6FD099;
 	}
 
 	return 0;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -89,3 +89,35 @@ DEFINE_HOOK(0x6FD05E, TechnoClass_Rearm_Delay_BurstDelays, 0x7)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x6F3B37, TechnoClass_Transform_6F3AD0_BurstFLH_1, 0x7)
+{
+	GET(TechnoClass*, pThis, EBX);
+	GET_STACK(int, weaponIndex, STACK_OFFS(0xD8, -0x8));
+
+	bool FLHFound = false;
+	CoordStruct FLH = TechnoExt::GetBurstFLH(pThis, weaponIndex, FLHFound);
+
+	if (FLHFound)
+	{
+		R->ECX(FLH.X);
+		R->EBP(FLH.Y);
+		R->EAX(FLH.Z);
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6F3C88, TechnoClass_Transform_6F3AD0_BurstFLH_2, 0x6)
+{
+	GET(TechnoClass*, pThis, EBX);
+	GET_STACK(int, weaponIndex, STACK_OFFS(0xD8, -0x8));
+
+	bool FLHFound = false;
+	TechnoExt::GetBurstFLH(pThis, weaponIndex, FLHFound);
+
+	if (FLHFound)
+		R->EAX(0);
+
+	return 0;
+}

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -54,6 +54,9 @@ public:
 		ValueableVector<AnimTypeClass*> OreGathering_Anims;
 		ValueableVector<int> OreGathering_Tiberiums;
 		ValueableVector<int> OreGathering_FramesPerDir;
+		
+		std::vector<DynamicVectorClass<CoordStruct>> WeaponBurstFLHs;
+		std::vector<DynamicVectorClass<CoordStruct>> EliteWeaponBurstFLHs;
 
 		Valueable<bool> DestroyAnim_Random;
 

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -3,8 +3,8 @@
 template<> const DWORD Extension<WeaponTypeClass>::Canary = 0x22222222;
 WeaponTypeExt::ExtContainer WeaponTypeExt::ExtMap;
 
-void WeaponTypeExt::ExtData::Initialize() 
-{ 
+void WeaponTypeExt::ExtData::Initialize()
+{
 	this->RadType = RadTypeClass::FindOrAllocate("Radiation");
 }
 
@@ -33,14 +33,15 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// RadTypeClass
 //	if (this->OwnerObject()->RadLevel > 0) 
 //	{
-		this->RadType.Read(exINI, pSection, "RadType", true);
+	this->RadType.Read(exINI, pSection, "RadType", true);
 	//	Debug::Log("Weapon[%s] :: Has RadLevel[%d] Rad check [%s]  \n", pSection , this->OwnerObject()->RadLevel , this->RadType->Name.data());
-		this->Rad_NoOwner.Read(exINI, pSection, "Rad.NoOwner");
-//	}
+	this->Rad_NoOwner.Read(exINI, pSection, "Rad.NoOwner");
+	//	}
 
 	this->Strafing_Shots.Read(exINI, pSection, "Strafing.Shots");
 	this->Strafing_SimulateBurst.Read(exINI, pSection, "Strafing.SimulateBurst");
 	this->CanTargetHouses.Read(exINI, pSection, "CanTargetHouses");
+	this->Burst_Delays.Read(exINI, pSection, "Burst.Delays");
 }
 
 template <typename T>
@@ -57,6 +58,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Strafing_SimulateBurst)
 		.Process(this->CanTargetHouses)
 		.Process(this->RadType)
+		.Process(this->Burst_Delays)
 		;
 };
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -26,7 +26,8 @@ public:
 		Valueable<int> Strafing_Shots;
 		Valueable<bool> Strafing_SimulateBurst;
 		Valueable<AffectedHouse> CanTargetHouses;
-
+		ValueableVector<int> Burst_Delays;
+		
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius(38.2)
 			, DiskLaser_Circumference(240)
@@ -38,6 +39,7 @@ public:
 			, Strafing_Shots(5)
 			, Strafing_SimulateBurst(false)
 			, CanTargetHouses(AffectedHouse::All)
+			, Burst_Delays()
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -103,7 +103,7 @@ DEFINE_HOOK(0x702299, TechnoClass_ReceiveDamage_DebrisMaximumsFix, 0xA)
 				amountToSpawn = Math::min(amountToSpawn, totalSpawnAmount);
 				totalSpawnAmount -= amountToSpawn;
 
-				for ( ; amountToSpawn > 0; --amountToSpawn)
+				for (; amountToSpawn > 0; --amountToSpawn)
 				{
 					GameCreate<VoxelAnimClass>(pType->DebrisTypes.GetItem(currentIndex),
 						&cord, pThis->Owner);
@@ -162,6 +162,28 @@ DEFINE_HOOK(0x4FB2DE, HouseClass_PlaceObject_HotkeyFix, 0x6)
 	GET(TechnoClass*, pObject, ESI);
 
 	pObject->ClearSidebarTabObject();
+
+	return 0;
+}
+
+// Issue #46: Laser is mirrored relative to FireFLH
+// Author: Starkku
+DEFINE_HOOK(0x6FF2BE, TechnoClass_Fire_At_BurstOffsetFix_1, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	--pThis->CurrentBurstIndex;
+
+	return 0x6FF2D1;
+}
+
+DEFINE_HOOK(0x6FF660, TechnoClass_Fire_At_BurstOffsetFix_2, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET_BASE(int, weaponIndex, 0xC);
+
+	++pThis->CurrentBurstIndex;
+	pThis->CurrentBurstIndex %= pThis->GetWeapon(weaponIndex)->WeaponType->Burst;
 
 	return 0;
 }


### PR DESCRIPTION
### Firing offsets for specific Burst shots

- You can now specify separate firing offsets for each of the shots fired by weapon with `Burst` via using `(Elite)PrimaryFire|SecondaryFire|WeaponX|FLH.BurstN` keys, depending on which weapons your TechnoType makes use of. *N* in `BurstN` is zero-based burst shot index, and the values are parsed sequentially until no value for either regular or elite weapon is present, with elite weapon defaulting to regular weapon FLH if only it is missing. If no burst-index specific value is available, value from the base key (f.ex `PrimaryFireFLH`) is used.
- Burst-index specific firing offsets are absolute firing offsets and the lateral shifting based on burst index that occurs with the base firing offsets is not applied.

In `artmd.ini`:
```ini
[SOMETECHNO]                   ; TechnoType Image
PrimaryFireFLH.BurstN=         ; int - forward, lateral, height
ElitePrimaryFireFLH.BurstN=    ; int - forward, lateral, height
SecondaryFireFLH.BurstN=       ; int - forward, lateral, height
EliteSecondaryFireFLH.BurstN=  ; int - forward, lateral, height
WeaponXFLH.BurstN=             ; int - forward, lateral, height
EliteWeaponXFLH.BurstN=        ; int - forward, lateral, height
```

In addition effects like lasers are no longer drawn on wrong firing offsets with Burst.

### Burst.Delays

- Allows specifying weapon-specific burst shot delays. Takes precedence over the old `BurstDelayX` logic available on VehicleTypes, functions with Infantry & BuildingType weapons (AircraftTypes are not supported due to their weapon firing system being completely different) and allows every shot of `Burst` to have a separate delay instead of only first four shots.
- If no delay is defined for a shot, it falls back to last delay value defined (f.ex `Burst=3` and `BurstDelays=10` would use 10 as delay for all shots).
- Using -1 as delay reverts back to old logic (`BurstDelay0-3` for VehicleTypes if available or random value between 3-5 otherwise) for that shot.

In `rulesmd.ini`:
```ini
[SOMEWEAPON]                 ; WeaponType
Burst.Delays=-1              ; int - burst delays (comma-separated) for shots in order from first to last.
```

Closes #271
Closes #46