### PR TITLE
Stationary vehicles (pseudo-IsSimpleDeployer)

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -52,6 +52,7 @@
     <ClCompile Include="src\Ext\Techno\Hooks.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Body.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.DisallowMoving.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Shield.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Body.cpp" />

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, general assistance
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **mevitar** - honorary shield tester *triple* award
 - **Damfoos** - extensive and thorough testing

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -20,6 +20,12 @@ PowersUp.Owner=Self ; list of owners (Self, Ally and/or Enemy)
 PowersUp.Buildings= ; list of BuildingTypes
 ```
 
+## Vehicles
+
+### Stationary vehicles
+
+Setting VehicleType `Speed` to 0 now makes game treat them as stationary, behaving in very similar manner to deployed vehicles with `IsSimpleDeployer` set to true. Should not be used on buildable vehicles, as they won't be able to exit factories.
+
 ## Technos
 
 ### Mind Control enhancement

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -36,7 +36,7 @@ In `FAData.ini`:
 ### TBD
 
 New:
-- TBD
+- Setting VehicleType `Speed` to 0 now makes game treat them as stationary (by Starkku)
 
 Vanilla fixes:
 - Fixed the bug when after a failed placement the building/defence tab hotkeys won't trigger placement mode again (by Uranusian)

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -1,0 +1,83 @@
+// Issue #5 Permanently stationary units
+// Author: Starkku
+
+#include "UnitClass.h"
+
+#include <Utilities/GeneralUtils.h>
+#include <Ext/TechnoType/Body.h>
+
+DEFINE_HOOK(0x740A91, UnitClass_Mission_Move_DisallowMoving, 0x8)
+{
+	GET(UnitClass*, pThis, ECX);
+
+	return pThis->Type->Speed == 0 ? 0x740AEF : 0;
+}
+
+DEFINE_HOOK(0x741AA7, UnitClass_Assign_Destination_DisallowMoving, 0x6)
+{
+	GET(UnitClass*, pThis, EBP);
+
+	return pThis->Type->Speed == 0 ? 0x743173 : 0;
+}
+
+DEFINE_HOOK(0x743B4B, UnitClass_Scatter_DisallowMoving, 0x6)
+{
+	GET(UnitClass*, pThis, EBP);
+
+	return pThis->Type->Speed == 0 ? 0x74408E : 0;
+}
+
+DEFINE_HOOK(0x74038F, UnitClass_What_Action_ObjectClass_DisallowMoving_1, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	return pThis->Type->Speed == 0 ? 0x7403A3 : 0;
+}
+
+DEFINE_HOOK(0x7403B7, UnitClass_What_Action_ObjectClass_DisallowMoving_2, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	return pThis->Type->Speed == 0 ? 0x7403C1 : 0;
+}
+
+DEFINE_HOOK(0x740709, UnitClass_What_Action_DisallowMoving_1, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	return pThis->Type->Speed == 0 ? 0x740727 : 0;
+}
+
+DEFINE_HOOK(0x740744, UnitClass_What_Action_DisallowMoving_2, 0x6)
+{
+	enum { AllowAttack = 0x74078E, ReturnNoMove = 0x740769, ReturnResult = 0x740801 };
+
+	GET(UnitClass*, pThis, ESI);
+	GET_STACK(Action, result, 0x30);
+
+	if (pThis->Type->Speed == 0)
+	{
+		if (result == Action::Move)
+			return ReturnNoMove;
+		if (result != Action::Attack)
+			return ReturnResult;
+
+		return AllowAttack;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x736B60, UnitClass_Rotation_AI_DisallowMoving, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	return pThis->Type->Speed == 0 ? 0x736AFB : 0;
+}
+
+DEFINE_HOOK(0x73891D, UnitClass_Active_Click_With_DisallowMoving, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	return pThis->Type->Speed == 0 ? 0x738927 : 0;
+}


### PR DESCRIPTION
Makes `Speed=0` vehicles stationary (basically behave like deployed `IsSimpleDeployer=true` vehicles). Shouldn't be used on buildable vehicles, as they won't be able to exit factories.

Closes #5.
