### PR TITLE
Re-enable obsolete [JumpjetControls]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Credits
 - **SMxReaver** - help with docs, extensive and thorough testing
 - **4SG** - help with docs
 - **wiktorderelf** - overhauled Unicode font
-- **Uranusian (Thrifinesma)** - Mind Control enhancement, custom warhead splash list, harvesters counter, promoted spawns, shields, death after dead fix, customizeable missing cameo, cameo sorting priority, placement mode responding of tab hotkeys fix, producing progress, custom ore gathering anim, NoManualMove, DeathWeapon fix, overhauled Unicode font, help with docs
+- **Uranusian (Thrifinesma)** - Mind Control enhancement, custom warhead splash list, harvesters counter, promoted spawns, shields, death after dead fix, customizeable missing cameo, cameo sorting priority, placement mode responding of tab hotkeys fix, producing progress, custom ore gathering anim, NoManualMove, DeathWeapon fix, re-enable obsolete `JumpjetControls`, overhauled Unicode font, help with docs
 - **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix, custom ore gathering anim
 - **Otamaa (Fahroni, BoredEXE)** - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass, DebrisMaximums fixes, Anim-to-Unit
 - **E1 Elite** - TileSet 255 and above bridge repair fix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -58,6 +58,22 @@ ChronoDelay=            ; integer, delay after teleport for chronosphere
 
 ```
 
+### Re-enable obsolete [JumpjetControls] 
+
+- Re-enable obsolete [JumpjetControls], the keys in it will be as the default value of jumpjet units.
+  - Moreover, added two tags for missing ones.
+
+In `rulesmd.ini`:
+```ini
+[JumpjetControls]
+Crash=5.0       ; float
+NoWabbles=no    ; bool
+```
+
+```{note}
+`CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for `JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and `Acceleration` is for `JumpjetAccel`. All other corresponding keys just simply have no Jumpjet prefix.
+```
+
 ### Customizable harvester ore gathering animation
 
 ![Ore gathering](_static/images/oregath.gif)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -39,6 +39,7 @@ New:
 - LaserTrails initial implementation (by Kerbiter, ChrisLv_CN)
 - Anim-to-Unit logic and ability to randomize DestroyAnim (by Otamaa)
 - Initial Strength for TechnoTypes (by Uranusian)
+- Re-enable obsolete `JumpjetControls` for TechnoTypes' default Jumpjet properties (by Uranusian)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -68,6 +68,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Pips_Shield.Read(exINI, "AudioVisual", "Pips.Shield");
 	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
 	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
+	this->JumpjetCrash.Read(exINI, "JumpjetControls", "Crash");
+	this->JumpjetNoWobbles.Read(exINI, "JumpjetControls", "NoWobbles");
 }
 
 // this runs between the before and after type data loading methods for rules ini
@@ -117,6 +119,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_Shield_Buildings)
 		.Process(this->RadApplicationDelay_Building)
 		.Process(this->MissingCameo)
+		.Process(this->JumpjetCrash)
+		.Process(this->JumpjetNoWobbles)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -29,11 +29,16 @@ public:
 		Valueable<int> RadApplicationDelay_Building;
 		PhobosFixedString<32u> MissingCameo;
 
+		Valueable<float> JumpjetCrash;
+		Valueable<bool> JumpjetNoWobbles;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Pips_Shield({ -1,-1,-1 })
 			, Pips_Shield_Buildings({ -1,-1,-1 })
 			, RadApplicationDelay_Building(0)
 			, MissingCameo("xxicon.shp")
+			, JumpjetCrash(5.0f)
+			, JumpjetNoWobbles(false)
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -6,6 +6,7 @@
 #include <ScenarioClass.h>
 #include <VoxelAnimClass.h>
 #include <BulletClass.h>
+#include <Ext/Rules/Body.h>
 
 #include <Utilities/Macro.h>
 #include <Utilities/Debug.h>
@@ -195,4 +196,25 @@ DEFINE_HOOK(0x70D77F, TechnoClass_FireDeathWeapon_ProjectileFix, 0x8)
 	pBullet->Explode(true);
 
 	return 0x70D787;
+}
+
+// Fix [JumpjetControls] obsolete in RA2/YR
+// Author: Uranusian
+DEFINE_HOOK(0x7115AE, TechnoTypeClass_CTOR_JumpjetControls, 0xA)
+{
+	GET(TechnoTypeClass*, pThis, ESI);
+	auto pRules = RulesClass::Instance();
+	auto pRulesExt = RulesExt::Global();
+
+	pThis->JumpjetTurnRate = pRules->TurnRate;
+	pThis->JumpjetSpeed = pRules->Speed;
+	pThis->JumpjetClimb = (float)pRules->Climb;
+	pThis->JumpjetCrash = pRulesExt->JumpjetCrash;
+	pThis->JumpjetHeight = pRules->CruiseHeight;
+	pThis->JumpjetAccel = (float)pRules->Acceleration;
+	pThis->JumpjetWobbles = (float)pRules->WobblesPerSecond;
+	pThis->JumpjetNoWobbles = pRulesExt->JumpjetNoWobbles;
+	pThis->JumpjetDeviation = pRules->WobbleDeviation;
+
+	return 0x711601;
 }


### PR DESCRIPTION
Re-enable obsolete [JumpjetControls], the keys in it will be as the default value of jumpjet units.
Moreover, added two tags for missing ones.

In `rulesmd.ini`: 
```ini
[JumpjetControls]
Crash=5.0       ; float
NoWabbles=no    ; bool
```

Note: `CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for `JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and `Acceleration` is for `JumpjetAccel`. All other corresponding keys just simply have no `Jumpjet` prefix.