### PR TITLE
Skip Naval check on WaterBound

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -24,6 +24,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed `DebrisMaximums` (spawned debris type amounts cannot go beyond specified maximums anymore). Only applied when `DebrisMaximums` values amount is more than 1 for compatibility reasons.
 - Fixed building and defense tab hotkeys not enabling the placement mode after `Cannot build here.` triggered and the placement mode cancelled.
 - Fixed buildings with `UndeployInto` playing `EVA_NewRallypointEstablished` on undeploying.
+- Fixed buildings with `Naval=yes` ignoring `WaterBound=no` to be forced to place onto water.
 
 ![image](_static/images/remember-target-after-deploying-01.gif)  
 *Nod arty keeping target on attack order in [C&C: Reloaded](https://www.moddb.com/mods/cncreloaded/)*

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -178,3 +178,7 @@ DEFINE_HOOK(0x44377E, BuildingClass_ActiveClickWith, 0x6)
 
 	return 0x4437AD;
 }
+
+// issue #232: Naval=yes overrides WaterBound=no and prevents move orders onto Land cells
+// Author: Uranusian
+DEFINE_LJMP(0x47CA05, 0x47CA33); // CellClass_IsClearToBuild_SkipNaval


### PR DESCRIPTION
`Naval` won't affect `WaterBound` at all
closes #232 