### PR TITLE
Hotfix v0.2.2.1

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -282,11 +282,11 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]       ; Warhead
 Crit.Chance=0.0     ; float, chance on [0.0-1.0] scale
 Crit.ExtraDamage=0  ; integer, extra damage
-Crit.Affects=all    ; list of "affects" flags (same as SWType's)
+Crit.Affects=all    ; list of Affected Target Enumeration (none|land|water|empty|infantry|units|buildings|all)
 Crit.AnimList=      ; list of animations
 
-[SOMETECHNO]     ; TechnoType
-ImmuneToCrit=no  ; boolean
+[SOMETECHNO]        ; TechnoType
+ImmuneToCrit=no     ; boolean
 ```
 
 ### Custom 'SplashList' on Warheads

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -40,6 +40,7 @@ Phobos fixes:
 - Fixed trigger action 125 not functioning properly (by Uranusian)
 - Fixed Area Detonation not fallback to Firer House (by Otamaa)
 - RadSite hook adjustment for `FootClass` to support Ares `RadImmune`; also various fixes to radiation / desolators (by Otamaa)
+- Fixed `Crit.Affects` not functioning properly (by Uranusian)
 
 ### 0.2.2
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -39,6 +39,7 @@ Phobos fixes:
 - Fixed random crashes about CameoPriority (by Uranusian)
 - Fixed trigger action 125 not functioning properly (by Uranusian)
 - Fixed Area Detonation not fallback to Firer House (by Otamaa)
+- RadSite hook adjustment for `FootClass` to support Ares `RadImmune`; also various fixes to radiation / desolators (by Otamaa)
 
 ### 0.2.2
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -33,6 +33,12 @@ In `FAData.ini`:
 
 ## Changelog
 
+### 0.2.2.1
+
+Phobos fixes:
+- Fixed random crashes about CameoPriority (by Uranusian)
+- Fixed trigger action 125 not functioning properly (by Uranusian)
+
 ### 0.2.2
 
 New:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -38,9 +38,10 @@ In `FAData.ini`:
 Phobos fixes:
 - Fixed random crashes about CameoPriority (by Uranusian)
 - Fixed trigger action 125 not functioning properly (by Uranusian)
-- Fixed Area Detonation not fallback to Firer House (by Otamaa)
+- Fixed area warhead detonation not falling back to firer house (by Otamaa)
 - RadSite hook adjustment for `FootClass` to support Ares `RadImmune`; also various fixes to radiation / desolators (by Otamaa)
 - Fixed `Crit.Affects` not functioning properly (by Uranusian)
+- Fixed improper upgrade owner transfer which resulted in built ally / enemy building upgrades keeping the player who built them alive (by Kerbiter)
 
 ### 0.2.2
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -38,6 +38,7 @@ In `FAData.ini`:
 Phobos fixes:
 - Fixed random crashes about CameoPriority (by Uranusian)
 - Fixed trigger action 125 not functioning properly (by Uranusian)
+- Fixed Area Detonation not fallback to Firer House (by Otamaa)
 
 ### 0.2.2
 

--- a/src/Ext/Bullet/Body.cpp
+++ b/src/Ext/Bullet/Body.cpp
@@ -6,7 +6,7 @@ BulletExt::ExtContainer BulletExt::ExtMap;
 
 void BulletExt::ExtData::ApplyRadiationToCell(CellStruct Cell, int Spread, int RadLevel)
 {
-	auto pThis = this->OwnerObject();
+	auto const pThis = this->OwnerObject();
 	auto const& Instances = RadSiteExt::Array;
 	auto const pWeapon = pThis->GetWeaponType();
 	auto const pWeaponExt = WeaponTypeExt::ExtMap.FindOrAllocate(pWeapon);
@@ -29,8 +29,8 @@ void BulletExt::ExtData::ApplyRadiationToCell(CellStruct Cell, int Spread, int R
 		}
 		else
 		{
-			auto pRadExt = *it;
-			auto pRadSite = pRadExt->OwnerObject();
+			auto const pRadExt = *it;
+			auto const pRadSite = pRadExt->OwnerObject();
 
 			if (pRadSite->GetRadLevel() + RadLevel > pRadType->GetLevelMax())
 			{
@@ -38,7 +38,7 @@ void BulletExt::ExtData::ApplyRadiationToCell(CellStruct Cell, int Spread, int R
 			}
 
 			// Handle It 
-			pRadExt->Add(RadLevel);
+			RadSiteExt::Add(pRadSite, RadLevel);
 		}
 	}
 	else

--- a/src/Ext/Bullet/Hook.cpp
+++ b/src/Ext/Bullet/Hook.cpp
@@ -12,7 +12,7 @@ DEFINE_HOOK(0x4666F7, BulletClass_AI, 0x6)
 	if (pBulletExt && pBulletExt->ShouldIntercept)
 	{
 		pBullet->Detonate(pBullet->GetCoords());
-		pBullet->Remove();
+		pBullet->Limbo();
 		pBullet->UnInit();
 
 		const auto pTechno = pBullet->Owner;

--- a/src/Ext/RadSite/Body.h
+++ b/src/Ext/RadSite/Body.h
@@ -35,14 +35,14 @@ public:
 			return sizeof(*this);
 		}
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) { }
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) 
+		{
+			AnnounceInvalidPointer(RadHouse, ptr);
+		}
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
-
-		virtual void Add(int amount);
-		virtual void SetRadLevel(int amount);
-		virtual double GetRadLevelAt(CellStruct const& cell);
+		virtual void Initialize() override;
 
 	private:
 		template <typename T>
@@ -52,7 +52,10 @@ public:
 	static DynamicVectorClass<RadSiteExt::ExtData*> Array;
 
 	static void CreateInstance(CellStruct location, int spread, int amount, WeaponTypeExt::ExtData* pWeaponExt, HouseClass* const pOwner);
-	static void CreateInstance(CellStruct location, int spread, int amount, RadTypeClass* pType, HouseClass* const pOwner);
+	static void CreateLight(RadSiteClass* pThis);
+	static void Add(RadSiteClass* pThis,int amount);
+	static void SetRadLevel(RadSiteClass* pThis,int amount);
+	static const double GetRadLevelAt(RadSiteClass* pThis,CellStruct const& cell);
 	
 	class ExtContainer final : public Container<RadSiteExt>
 	{

--- a/src/Ext/RadSite/Hooks.cpp
+++ b/src/Ext/RadSite/Hooks.cpp
@@ -11,6 +11,7 @@
 #include <Ext/Rules/Body.h>
 #include <Ext/Techno/Body.h>
 
+#include <Utilities/Macro.h>
 /*
 	Custom Radiations
 	Worked out from old uncommented Ares RadSite Hook , adding some more hook
@@ -20,9 +21,7 @@
 			 Alex-B : GetRadSiteAt ,Helper that used at FootClass_AI & BuildingClass_AI
 					  Radiate , Uncommented
 			 me(Otamaa) adding some more stuffs and rewriting hook that cause crash
-	TODO : -Testings
-	// Do this Ares Hook will cause a problem ?
-	//4DA584 = FootClass_AI_RadImmune, 7
+
 */
 
 DEFINE_HOOK(0x469150, BulletClass_Detonate_ApplyRadiation, 0x5)
@@ -37,7 +36,7 @@ DEFINE_HOOK(0x469150, BulletClass_Detonate_ApplyRadiation, 0x5)
 		auto const pExt = BulletExt::ExtMap.Find(pThis);
 		auto const pWH = pThis->WH;
 		auto const cell = CellClass::Coord2Cell(*pCoords);
-		auto const spread = static_cast<int>(pWH->CellSpread);
+		auto const spread = Game::F2I(pWH->CellSpread);
 
 		pExt->ApplyRadiationToCell(cell, spread, pWeapon->RadLevel);
 	}
@@ -45,59 +44,14 @@ DEFINE_HOOK(0x469150, BulletClass_Detonate_ApplyRadiation, 0x5)
 	return 0x46920B;
 }
 
-/*
-// hack it here so we can use this globally if needed
-// *Prototype*
-//able to manually set the RadType instead rely on Weapon RadType
-//Break InfantryClass_AIDeployment_CheckRad atm , will fix later
-DEFINE_HOOK(0x46ADE0, BulletClass_ApplyRadiation, 0x5)
+//unused function , safeguard
+DEFINE_HOOK(0x46ADE0, BulletClass_ApplyRadiation_UnUsed, 0x5)
 {
-	GET_STACK(CellStruct, location, 0x4);
-	GET_STACK(int, spread, 0x8);
-	GET_STACK(int, amount, 0xC);
-
-	auto const& Instances = RadSiteExt::Array;
-	auto const pType = RadTypeClass::FindOrAllocate("Radiation");
-
-	if (Instances.Count > 0)
-	{
-		auto const it = std::find_if(Instances.begin(), Instances.end(),
-			[=](RadSiteExt::ExtData* const pSite) // Lambda
-		{// find
-			return
-				pSite->Type == pType &&
-				pSite->OwnerObject()->BaseCell == location &&
-				spread == pSite->OwnerObject()->Spread;
-		});
-
-		if (it == Instances.end())
-		{
-			RadSiteExt::CreateInstance(location, spread, amount, pType, nullptr);
-		}
-		else
-		{
-			auto pRadExt = *it;
-			auto pRadSite = pRadExt->OwnerObject();
-
-			if (pRadSite->GetRadLevel() + amount > pType->GetLevelMax())
-			{
-				amount = pType->GetLevelMax() - pRadSite->GetRadLevel();
-			}
-
-			// Handle It
-			pRadExt->Add(amount);
-		}
-	}
-	else
-	{
-		RadSiteExt::CreateInstance(location, spread, amount, pType, nullptr);
-	}
-
+	Debug::Log("[" __FUNCTION__ "] Called ! , You are not suppose to be here ! \n");
 	return 0x46AE5E;
 }
-*/
 
-// Fix for desolator unable to fire his deploy weapon when cloaked 
+// Fix for desolator 
 DEFINE_HOOK(0x5213E3, InfantryClass_AIDeployment_CheckRad, 0x4)
 {
 	GET(InfantryClass*, pInf, ESI);
@@ -110,18 +64,18 @@ DEFINE_HOOK(0x5213E3, InfantryClass_AIDeployment_CheckRad, 0x4)
 	{
 		auto const pWeaponExt = WeaponTypeExt::ExtMap.FindOrAllocate(pWeapon);
 		auto const pRadType = pWeaponExt->RadType;
-		auto const wh = pWeapon->Warhead;
+		auto const warhead = pWeapon->Warhead;
 		auto currentCoord = pInf->GetCell()->MapCoords;
 
 		auto const it = std::find_if(RadSiteExt::Array.begin(), RadSiteExt::Array.end(),
 			[=](RadSiteExt::ExtData* const pSite)
-		{
-			return
-				pSite->Type == pRadType &&
-				pSite->OwnerObject()->BaseCell == currentCoord &&
-				pSite->OwnerObject()->Spread == static_cast<int>(wh->CellSpread)
-				;
-		});
+			{
+				return
+					pSite->Type == pRadType &&
+					pSite->OwnerObject()->BaseCell == currentCoord &&
+					pSite->OwnerObject()->Spread == Game::F2I(warhead->CellSpread)
+					;
+			});
 
 		if (it != RadSiteExt::Array.end())
 		{
@@ -131,17 +85,34 @@ DEFINE_HOOK(0x5213E3, InfantryClass_AIDeployment_CheckRad, 0x4)
 		}
 	}
 
-	if (pInf->CloakState == CloakState::Cloaked)
-	{
-		pInf->Uncloak(false);
-		pInf->Cloakable = false;
-		pInf->NeedsRedraw = true;
-		auto pExt = TechnoExt::ExtMap.Find(pInf);
-		pExt->WasCloaked = true;
-	}
-
 	return (!radLevel || (radLevel < weaponRadLevel / 3)) ?
 		0x5213F4 : 0x521484;
+}
+
+// Fix for desolator unable to fire his deploy weapon when cloaked 
+DEFINE_HOOK(0x521478, InfantryClass_AIDeployment_FireNotOKCloakFix, 0x4)
+{
+	GET(InfantryClass* const, pThis, ESI);
+
+	auto const pWeapon = pThis->GetDeployWeapon()->WeaponType;
+	AbstractClass* pTarget = nullptr; //default WWP nullptr
+
+	if (pWeapon
+		&& pWeapon->DecloakToFire
+		&& (pThis->CloakState == CloakState::Cloaked || pThis->CloakState == CloakState::Cloaking))
+	{
+		// FYI this are hack to immedietely stop the Cloaking
+		// since this function is always failing to decloak and set target when cell is occupied 
+		// something is wrong somewhere  # Otamaa
+		auto nDeployFrame = pThis->Type->Sequence->GetSequence(Sequence::DeployedFire).CountFrames;
+		pThis->CloakDelayTimer.Start(nDeployFrame);
+
+		pTarget = MapClass::Instance->TryGetCellAt(pThis->GetCoords());
+	}
+
+	pThis->SetTarget(pTarget); //Here we go
+
+	return 0x521484;
 }
 
 // Too OP, be aware
@@ -149,21 +120,21 @@ DEFINE_HOOK(0x43FB23, BuildingClass_AI, 0x5)
 {
 	GET(BuildingClass* const, pBuilding, ECX);
 
-	if (pBuilding->IsIronCurtained() || pBuilding->Type->ImmuneToRadiation || pBuilding->InLimbo || pBuilding->BeingWarpedOut)
+	if (pBuilding->IsIronCurtained() || pBuilding->Type->ImmuneToRadiation || pBuilding->InLimbo || pBuilding->BeingWarpedOut || pBuilding->TemporalTargetingMe)
 		return 0;
 
 	auto const buildingCoords = pBuilding->GetMapCoords();
-	for (auto pFoundation = pBuilding->GetFoundationData(false); *pFoundation != CellStruct { 0x7FFF, 0x7FFF }; ++pFoundation)
+	for (auto pFoundation = pBuilding->GetFoundationData(false); *pFoundation != CellStruct{ 0x7FFF, 0x7FFF }; ++pFoundation)
 	{
-		CellStruct CurrentCoord = buildingCoords + *pFoundation;
+		CellStruct nCurrentCoord = buildingCoords + *pFoundation;
 
-		for (auto pRadExt : RadSiteExt::Array)
+		for (auto& pRadExt : RadSiteExt::Array)
 		{
 			RadSiteClass* pRadSite = pRadExt->OwnerObject();
 			RadTypeClass* pType = pRadExt->Type;
 
 			// Check the distance, if not in range, just skip this one
-			double orDistance = pRadSite->BaseCell.DistanceFrom(CurrentCoord);
+			double orDistance = pRadSite->BaseCell.DistanceFrom(nCurrentCoord);
 			if (pRadSite->Spread < orDistance - 0.5)
 				continue;
 
@@ -171,35 +142,37 @@ DEFINE_HOOK(0x43FB23, BuildingClass_AI, 0x5)
 			if ((delay == 0) || (Unsorted::CurrentFrame % delay != 0))
 				continue;
 
-			if (pRadExt->GetRadLevelAt(CurrentCoord) <= 0.0 || !pType->GetWarhead())
+			if (RadSiteExt::GetRadLevelAt(pRadSite, nCurrentCoord) <= 0.0 || !pType->GetWarhead())
 				continue;
 
-			auto wh = pType->GetWarhead();
-			auto absolute = wh->WallAbsoluteDestroyer;
+			auto pWarhead = pType->GetWarhead();
+			auto absolute = pWarhead->WallAbsoluteDestroyer;
 			bool ignore = pBuilding->Type->Wall && absolute;
-			auto damage = static_cast<int>((pRadExt->GetRadLevelAt(CurrentCoord) / 2) * pType->GetLevelFactor());
+			auto damage = Game::F2I((RadSiteExt::GetRadLevelAt(pRadSite, nCurrentCoord) / 2) * pType->GetLevelFactor());
 
 			if (pBuilding->IsAlive) // simple fix for previous issues
-				pBuilding->ReceiveDamage(&damage, static_cast<int>(orDistance), wh, nullptr, ignore, absolute, pRadExt->RadHouse.Get());
+				if (pBuilding->ReceiveDamage(&damage, Game::F2I(orDistance), pWarhead, nullptr, ignore, absolute, pRadExt->RadHouse.Get()) == DamageState::NowDead)
+					break; //dont continue , meaningless
 		}
 	}
 
 	return 0;
 }
 
-// be aware that this function is updated every frame 
-// putting debug log here can become mess because it gonna print bunch of debug line
-DEFINE_HOOK(0x4DA554, FootClass_AI_RadSiteClass, 0x5)
+// skip Frame % RadApplicationDelay
+DEFINE_LJMP(0x4DA554, 0x4DA56E);
+
+// Hook Adjusted to support Ares RadImmune Ability check
+DEFINE_HOOK(0x4DA59F, FootClass_AI_Radiation, 0x5)
 {
 	GET(FootClass* const, pFoot, ESI);
-	auto state = static_cast<DamageState>(R->AL());
 
-	if (!pFoot->IsIronCurtained() && !pFoot->GetTechnoType()->ImmuneToRadiation && !pFoot->InLimbo && !pFoot->IsInAir())
+	if (!pFoot->IsIronCurtained() && pFoot->IsInPlayfield && !pFoot->TemporalTargetingMe)
 	{
 		CellStruct CurrentCoord = pFoot->GetCell()->MapCoords;
 
 		// Loop for each different radiation stored in the RadSites container
-		for (auto const pRadExt : RadSiteExt::Array)
+		for (auto& pRadExt : RadSiteExt::Array)
 		{
 			RadSiteClass* pRadSite = pRadExt->OwnerObject();
 
@@ -214,26 +187,34 @@ DEFINE_HOOK(0x4DA554, FootClass_AI_RadSiteClass, 0x5)
 				continue;
 
 			// for more precise dmg calculation
-			double RadLevel = pRadExt->GetRadLevelAt(CurrentCoord);
-			if (RadLevel <= 0.0 || !pType->GetWarhead())
+			double nRadLevel = RadSiteExt::GetRadLevelAt(pRadSite, CurrentCoord);
+			if (nRadLevel <= 0.0 || !pType->GetWarhead())
 				continue;
 
-			int damage = static_cast<int>(RadLevel * pType->GetLevelFactor());
-			int distance = static_cast<int>(orDistance);
-			auto wh = pType->GetWarhead();
-			auto absolute = wh->WallAbsoluteDestroyer;
+			int damage = Game::F2I(nRadLevel * pType->GetLevelFactor());
+			int distance = Game::F2I(orDistance);
+			auto pWarhead = pType->GetWarhead();
+			auto absolute = pWarhead->WallAbsoluteDestroyer;
 
-			if (pFoot->IsAlive || !pFoot->IsSinking)// simple fix for previous issues
-				state = pFoot->ReceiveDamage(&damage, distance, wh, nullptr, false, absolute, pRadExt->RadHouse.Get());
+			if (pFoot->IsAlive || !pFoot->IsSinking)
+			{
+				if (pFoot->ReceiveDamage(&damage, distance, pWarhead, nullptr, false, absolute, pRadExt->RadHouse.Get()) == DamageState::NowDead)
+					break; //dont continue , meaningless
+			}
 		}
 	}
-
-	R->EAX<DamageState>(state);
 
 	return pFoot->IsAlive ? 0x4DA63B : 0x4DAF00;
 }
 
-DEFINE_HOOK(0x65B593, RadSiteClass_Activate_Delay, 0x6)
+#define GET_RADSITE(reg, value)\
+	GET(RadSiteClass* const, pThis, reg);\
+	RadSiteExt::ExtData* pExt = RadSiteExt::ExtMap.Find(pThis);\
+	auto output = pExt->Type->## value ##;
+
+/*
+//All part of 0x65B580 Hooks is here
+DEFINE_HOOK(65B593, RadSiteClass_Activate_Delay, 6)
 {
 	GET(RadSiteClass* const, pThis, ECX);
 	auto const pExt = RadSiteExt::ExtMap.Find(pThis);
@@ -254,12 +235,7 @@ DEFINE_HOOK(0x65B593, RadSiteClass_Activate_Delay, 0x6)
 	return 0x65B59F;
 }
 
-#define GET_RADSITE(reg, value)\
-	GET(RadSiteClass* const, pThis, reg);\
-	RadSiteExt::ExtData* pExt = RadSiteExt::ExtMap.Find(pThis);\
-	auto output = pExt->Type->## value ##;
-
-DEFINE_HOOK(0x65B5CE, RadSiteClass_Activate_Color, 0x6)
+DEFINE_HOOK(65B5CE, RadSiteClass_Activate_Color, 6)
 {
 	GET_RADSITE(ESI, GetColor());
 
@@ -298,6 +274,7 @@ DEFINE_HOOK(0x65B6F2, RadSiteClass_Activate_TintFactor, 0x6)
 
 	return R->Origin() + 6;
 }
+*/
 
 DEFINE_HOOK(0x65B843, RadSiteClass_AI_LevelDelay, 0x6)
 {
@@ -321,11 +298,10 @@ DEFINE_HOOK(0x65B8B9, RadSiteClass_AI_LightDelay, 0x6)
 DEFINE_HOOK(0x65BB67, RadSite_Deactivate, 0x6)
 {
 	GET_RADSITE(ECX, GetLevelDelay());
+	GET(int, val, EAX);
 
-	R->ESI(output);
-
-	__asm xor  edx, edx; // fixing integer overflow crash
-	__asm idiv esi;
+	R->EAX(val / output);
+	R->EDX(val % output);
 
 	return 0x65BB6D;
 }

--- a/src/Ext/TAction/Hooks.cpp
+++ b/src/Ext/TAction/Hooks.cpp
@@ -38,21 +38,23 @@ DEFINE_HOOK(0x6E427D, TActionClass_CreateBuildingAt, 0x9)
 	bool bCreated = false;
 	if (auto pBld = static_cast<BuildingClass*>(pBldType->CreateObject(pHouse)))
 	{
-		if (bPlayBuildUp)
-		{
-			pBld->BeginMode(BStateType::Construction);
-			pBld->QueueMission(Mission::Construction, false);
-		}
-		else
-		{
-			pBld->BeginMode(BStateType::Idle);
-			pBld->QueueMission(Mission::Guard, false);
-			pBld->Place(false);
-		}
 		if (!pBld->ForceCreate(coord))
+		{
 			pBld->UnInit();
+		}
 		else
 		{
+			if (bPlayBuildUp)
+			{
+				pBld->BeginMode(BStateType::Construction);
+				pBld->QueueMission(Mission::Construction, false);
+			}
+			else
+			{
+				pBld->BeginMode(BStateType::Idle);
+				pBld->QueueMission(Mission::Guard, false);
+				pBld->Place(false);
+			}
 			pBld->IsReadyToCommence = true;
 			bCreated = true;
 		}

--- a/src/Ext/TAction/Hooks.cpp
+++ b/src/Ext/TAction/Hooks.cpp
@@ -38,23 +38,26 @@ DEFINE_HOOK(0x6E427D, TActionClass_CreateBuildingAt, 0x9)
 	bool bCreated = false;
 	if (auto pBld = static_cast<BuildingClass*>(pBldType->CreateObject(pHouse)))
 	{
+		if (bPlayBuildUp)
+		{
+			pBld->BeginMode(BStateType::Construction);
+			pBld->QueueMission(Mission::Construction, false);
+		}
+		else
+		{
+			pBld->BeginMode(BStateType::Idle);
+			pBld->QueueMission(Mission::Guard, false);
+		}
+
 		if (!pBld->ForceCreate(coord))
 		{
 			pBld->UnInit();
 		}
 		else
 		{
-			if (bPlayBuildUp)
-			{
-				pBld->BeginMode(BStateType::Construction);
-				pBld->QueueMission(Mission::Construction, false);
-			}
-			else
-			{
-				pBld->BeginMode(BStateType::Idle);
-				pBld->QueueMission(Mission::Guard, false);
+			if(!bPlayBuildUp)
 				pBld->Place(false);
-			}
+			
 			pBld->IsReadyToCommence = true;
 			bCreated = true;
 		}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -123,22 +123,6 @@ void TechnoExt::ApplySpawn_LimitRange(TechnoClass* pThis)
 	}
 }
 
-// TODO: move the hook to InfantryExt::AI
-void TechnoExt::ApplyCloak_Undeployed(TechnoClass* pThis)
-{
-	if (auto pInf = static_cast<InfantryClass*>(pThis))
-	{
-		auto pTypeData = TechnoExt::ExtMap.Find(pThis);
-		if (pTypeData->WasCloaked && pInf->SequenceAnim == Sequence::Undeploy && pInf->IsDeployed())
-		{
-			pThis->Cloakable = true;
-			pThis->UpdateCloak();
-			pThis->NeedsRedraw = true;
-			pTypeData->WasCloaked = false;
-		}
-	}
-}
-
 bool TechnoExt::IsHarvesting(TechnoClass* pThis)
 {
 	if (!pThis || pThis->InLimbo)
@@ -181,7 +165,6 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 	Stm
 		.Process(this->InterceptedBullet)
 		.Process(this->Shield)
-		.Process(this->WasCloaked)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -20,11 +20,9 @@ public:
 		Valueable<BulletClass*> InterceptedBullet;
 		std::unique_ptr<ShieldClass> Shield;
 
-		Valueable<bool> WasCloaked;
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject),
 			InterceptedBullet(nullptr),
-			Shield(),
-			WasCloaked(false)
+			Shield()
 		{ }
 
 		virtual ~ExtData() = default;
@@ -65,5 +63,4 @@ public:
 	static void ApplyInterceptor(TechnoClass* pThis);
 	static void ApplyPowered_KillSpawns(TechnoClass* pThis);
 	static void ApplySpawn_LimitRange(TechnoClass* pThis);
-	static void ApplyCloak_Undeployed(TechnoClass* pThis);
 };

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -16,8 +16,6 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	TechnoExt::ApplyPowered_KillSpawns(pThis);
 	// Spawner.LimitRange & Spawner.ExtraLimitRange
 	TechnoExt::ApplySpawn_LimitRange(pThis);
-	//
-	TechnoExt::ApplyCloak_Undeployed(pThis);
 
 	return 0;
 }

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -36,7 +36,7 @@ bool WarheadTypeExt::ExtData::IsCellEligible(CellClass* const pCell, AffectedTar
 			return (allowed & AffectedTarget::Land) != AffectedTarget::None;
 	}
 
-	return true;
+	return allowed != AffectedTarget::None ? true : false;
 }
 
 bool WarheadTypeExt::ExtData::IsTechnoEligible(TechnoClass* const pTechno, AffectedTarget allowed)
@@ -63,7 +63,7 @@ bool WarheadTypeExt::ExtData::IsTechnoEligible(TechnoClass* const pTechno, Affec
 		}
 	}
 
-	return true;
+	return allowed != AffectedTarget::None ? true : false;
 }
 
 // =============================

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -31,7 +31,6 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 
 		if (this->SpySat)
 			MapClass::Instance->Reveal(pHouse);
-		
 
 		if (this->TransactMoney)
 			pHouse->TransactMoney(this->TransactMoney);

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -49,12 +49,12 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 	if (cellSpread && isCellSpreadWarhead)
 	{
 		for (auto pTarget : Helpers::Alex::getCellSpreadItems(coords, cellSpread, true))
-			this->DetonateOnOneUnit(pHouse, pTarget);
+			this->DetonateOnOneUnit(pHouse, pTarget, pOwner);
 	}
 	else if (pBullet && isCellSpreadWarhead)
 	{
 		if (auto pTarget = abstract_cast<TechnoClass*>(pBullet->Target))
-			this->DetonateOnOneUnit(pHouse, pTarget);
+			this->DetonateOnOneUnit(pHouse, pTarget, pOwner);
 	}
 }
 

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -47,7 +47,9 @@ DEFINE_HOOK(0x489286, MapClass_DamageArea, 0x6)
 			GET_BASE(TechnoClass*, pOwner, 0x08);
 			GET_BASE(HouseClass*, pHouse, 0x14);
 
-			pWHExt->Detonate(pOwner, pHouse, nullptr, *pCoords);
+			auto const pDecidedHouse = !pHouse && pOwner ? pOwner->Owner : pHouse;
+
+			pWHExt->Detonate(pOwner, pDecidedHouse, nullptr, *pCoords);
 		}	
 	}
 

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -111,8 +111,8 @@ DEFINE_HOOK(0x6A8463, StripClass_OperatorLessThan_CameoPriority, 0x5)
 	GET_STACK(int, idxRight, STACK_OFFS(0x1C, -0x10));
 	auto pLeftTechnoExt = TechnoTypeExt::ExtMap.Find(pLeft);
 	auto pRightTechnoExt = TechnoTypeExt::ExtMap.Find(pRight);
-	auto pLeftSWExt = SWTypeExt::ExtMap.Find(SuperWeaponTypeClass::Array->GetItem(idxLeft));
-	auto pRightSWExt = SWTypeExt::ExtMap.Find(SuperWeaponTypeClass::Array->GetItem(idxRight));
+	auto pLeftSWExt = pLeftTechnoExt ? SWTypeExt::ExtMap.Find(SuperWeaponTypeClass::Array->GetItem(idxLeft)) : nullptr;
+	auto pRightSWExt = pRightTechnoExt ? SWTypeExt::ExtMap.Find(SuperWeaponTypeClass::Array->GetItem(idxRight)) : nullptr;
 
 	if ((pLeftTechnoExt || pLeftSWExt) && (pRightTechnoExt || pRightSWExt))
 	{

--- a/src/Phobos.version.h
+++ b/src/Phobos.version.h
@@ -18,12 +18,12 @@
 #define VERSION_REVISION 2
 
 // Indicates Phobos-related bugfixes only
-#define VERSION_PATCH 0
+#define VERSION_PATCH 1
 
 #pragma endregion
 
 // Build number. Incremented on each released build.
-#define BUILD_NUMBER 19
+#define BUILD_NUMBER 21
 
 // Nightly defines GIT_COMMIT and GIT_BRANCH in GH Actions
 


### PR DESCRIPTION
Phobos fixes:
- Fixed random crashes about CameoPriority (by Uranusian)
- Fixed trigger action 125 not functioning properly (by Uranusian)
- Fixed area warhead detonation not falling back to firer house (by Otamaa)
- RadSite hook adjustment for `FootClass` to support Ares `RadImmune`; also various fixes to radiation / desolators (by Otamaa)
- Fixed `Crit.Affects` not functioning properly (by Uranusian)
- Fixed improper upgrade owner transfer which resulted in built ally / enemy building upgrades keeping the player who built them alive (by Kerbiter)