### PR TITLE
Feature/canfire target

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -179,7 +179,7 @@ CreateUnit.Owner=Victim             ; owner house kind, Invoker/Killer/Victim/Ci
 In `rulesmd.ini`:
 ```ini
 [UPGRADENAME]       ; BuildingType
-PowersUp.Owner=Self ; list of owners (Self, Ally and/or Enemy)
+PowersUp.Owner=Self ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 PowersUp.Buildings= ; list of BuildingTypes
 ```
 
@@ -288,6 +288,16 @@ In `rulesmd.ini`:
 ```ini
 [SOMEWEAPON]    ; WeaponType
 Rad.NoOwner=no  ; boolean
+```
+
+### Weapon targeting filter
+
+- You can now specify which house this weapon can fire at.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWEAPON]        ; WeaponType
+CanTargetHouse=all  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 ```
 
 ## Warheads

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -179,7 +179,7 @@ CreateUnit.Owner=Victim             ; owner house kind, Invoker/Killer/Victim/Ci
 In `rulesmd.ini`:
 ```ini
 [UPGRADENAME]       ; BuildingType
-PowersUp.Owner=Self ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+PowersUp.Owner=Self ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 PowersUp.Buildings= ; list of BuildingTypes
 ```
 
@@ -297,7 +297,7 @@ Rad.NoOwner=no  ; boolean
 In `rulesmd.ini`:
 ```ini
 [SOMEWEAPON]        ; WeaponType
-CanTargetHouse=all  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+CanTargetHouse=all  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 ```
 
 ## Warheads

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -296,8 +296,8 @@ Rad.NoOwner=no  ; boolean
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWEAPON]        ; WeaponType
-CanTargetHouse=all  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+[SOMEWEAPON]         ; WeaponType
+CanTargetHouses=all  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 ```
 
 ## Warheads

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -39,6 +39,7 @@ New:
 - LaserTrails initial implementation (by Kerbiter, ChrisLv_CN)
 - Anim-to-Unit logic and ability to randomize DestroyAnim (by Otamaa)
 - Initial Strength for TechnoTypes (by Uranusian)
+- Weapon targeting filter (by Uranusian)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -106,36 +106,6 @@ DEFINE_HOOK(0x6F36F2, TechnoClass_WhatWeaponShouldIUse_Shield, 0x6)
 }
 */
 
-DEFINE_HOOK(0x6F36DB, TechnoClass_WhatWeaponShouldIUse_Shield, 0x8)
-{
-	GET(TechnoClass*, pThis, ESI);
-	GET(TechnoClass*, pTarget, EBP);
-	enum { Primary = 0x6F37AD, Secondary = 0x6F3745, FurtherCheck = 0x6F3754, OriginalCheck = 0x6F36E3 };
-
-	if (!pTarget)
-		return Primary;
-
-	if (const auto pExt = TechnoExt::ExtMap.Find(pTarget))
-	{
-		if (const auto pShieldData = pExt->Shield.get())
-		{
-			if (pShieldData->IsActive())
-			{
-				if (pThis->GetWeapon(1))
-				{
-					if (!pShieldData->CanBeTargeted(pThis->GetWeapon(0)->WeaponType))
-						return Secondary;
-					else
-						return FurtherCheck;
-				}
-
-				return Primary;
-			}
-		}
-	}
-	return OriginalCheck;
-}
-
 DEFINE_HOOK(0x6F9E50, TechnoClass_AI_Shield, 0x5)
 {
 	GET(TechnoClass*, pThis, ECX);

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -120,7 +120,7 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 
 	if (const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon))
 	{
-		if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouse, pThis->Owner, pTarget->Owner))
+		if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pThis->Owner, pTarget->Owner))
 			return CannotFire;
 	}
 

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -110,7 +110,7 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 	GET_STACK(AbstractClass*, pTarget, STACK_OFFS(0x20, -0x4))
 	// Checking for nullptr is not required here, since the game has already executed them before calling the hook  -- Belonit
 	const auto pWH = pWeapon->Warhead;
-	enum { CannotFire = 0x6FCB7E};
+	enum { CannotFire = 0x6FCB7E };
 
 	if (const auto pWHExt = WarheadTypeExt::ExtMap.Find(pWH))
 	{

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -102,7 +102,7 @@ DEFINE_HOOK(0x48A5B3, WarheadTypeClass_AnimList_CritAnim, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x6FC339, TechnoClass_CanFire_InsufficientFunds, 0x6)
+DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 {
 	GET(TechnoClass*, pThis, ESI);
 	GET(WeaponTypeClass*, pWeapon, EDI);

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -106,7 +106,7 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 {
 	GET(TechnoClass*, pThis, ESI);
 	GET(WeaponTypeClass*, pWeapon, EDI);
-	GET_STACK(TechnoClass*, pTarget, STACK_OFFS(0x20, -0x4))
+	GET_STACK(AbstractClass*, pTarget, STACK_OFFS(0x20, -0x4))
 	// Checking for nullptr is not required here, since the game has already executed them before calling the hook  -- Belonit
 	const auto pWH = pWeapon->Warhead;
 	enum { CannotFire = 0x6FCB7E};
@@ -120,8 +120,11 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 
 	if (const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon))
 	{
-		if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pThis->Owner, pTarget->Owner))
-			return CannotFire;
+		if (const auto pTechno = abstract_cast<TechnoClass*>(pTarget))
+		{
+			if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pThis->Owner, pTechno->Owner))
+				return CannotFire;
+		}
 	}
 
 	return 0;

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -40,7 +40,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Strafing_Shots.Read(exINI, pSection, "Strafing.Shots");
 	this->Strafing_SimulateBurst.Read(exINI, pSection, "Strafing.SimulateBurst");
-	this->CanTargetHouse.Read(exINI, pSection, "CanTargetHouse");
+	this->CanTargetHouses.Read(exINI, pSection, "CanTargetHouses");
 }
 
 template <typename T>
@@ -55,7 +55,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Bolt_Disable3)
 		.Process(this->Strafing_Shots)
 		.Process(this->Strafing_SimulateBurst)
-		.Process(this->CanTargetHouse)
+		.Process(this->CanTargetHouses)
 		.Process(this->RadType)
 		;
 };

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -40,6 +40,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Strafing_Shots.Read(exINI, pSection, "Strafing.Shots");
 	this->Strafing_SimulateBurst.Read(exINI, pSection, "Strafing.SimulateBurst");
+	this->CanTargetHouse.Read(exINI, pSection, "CanTargetHouse");
 }
 
 template <typename T>
@@ -54,6 +55,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Bolt_Disable3)
 		.Process(this->Strafing_Shots)
 		.Process(this->Strafing_SimulateBurst)
+		.Process(this->CanTargetHouse)
 		.Process(this->RadType)
 		;
 };

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -25,7 +25,7 @@ public:
 		Valueable<bool> Bolt_Disable3;
 		Valueable<int> Strafing_Shots;
 		Valueable<bool> Strafing_SimulateBurst;
-		Valueable<AffectedHouse> CanTargetHouse;
+		Valueable<AffectedHouse> CanTargetHouses;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius(38.2)
@@ -37,7 +37,7 @@ public:
 			, Bolt_Disable3(false)
 			, Strafing_Shots(5)
 			, Strafing_SimulateBurst(false)
-			, CanTargetHouse(AffectedHouse::All)
+			, CanTargetHouses(AffectedHouse::All)
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -25,17 +25,19 @@ public:
 		Valueable<bool> Bolt_Disable3;
 		Valueable<int> Strafing_Shots;
 		Valueable<bool> Strafing_SimulateBurst;
-		
+		Valueable<AffectedHouse> CanTargetHouse;
+
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
-			,DiskLaser_Radius(38.2)
-			,DiskLaser_Circumference(240)
-			,RadType()
-			,Rad_NoOwner(false)
-			,Bolt_Disable1(false)
-			,Bolt_Disable2(false)
-			,Bolt_Disable3(false)
-			,Strafing_Shots(5)
-			,Strafing_SimulateBurst(false)
+			, DiskLaser_Radius(38.2)
+			, DiskLaser_Circumference(240)
+			, RadType()
+			, Rad_NoOwner(false)
+			, Bolt_Disable1(false)
+			, Bolt_Disable2(false)
+			, Bolt_Disable3(false)
+			, Strafing_Shots(5)
+			, Strafing_SimulateBurst(false)
+			, CanTargetHouse(AffectedHouse::All)
 		{ }
 
 		virtual ~ExtData() = default;
@@ -43,7 +45,7 @@ public:
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		virtual void Initialize() override;
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override {}
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 
@@ -54,7 +56,8 @@ public:
 		void Serialize(T& Stm);
 	};
 
-	class ExtContainer final : public Container<WeaponTypeExt> {
+	class ExtContainer final : public Container<WeaponTypeExt>
+	{
 	public:
 		ExtContainer();
 		~ExtContainer();


### PR DESCRIPTION
### Weapon targeting filter

- You can now specify which house this weapon can fire at.

In `rulesmd.ini`:
```ini
[SOMEWEAPON]        ; WeaponType
CanTargetHouses=all  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
```