### PR TITLE
LimboDelivery

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -25,6 +25,8 @@
     <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />
     <ClCompile Include="src\Ext\Anim\Body.cpp" />
+    <ClCompile Include="src\Ext\SWType\FireSuperWeapon.cpp" />
+    <ClCompile Include="src\Ext\SWType\Hooks.cpp" />
     <ClCompile Include="src\Ext\TAction\Body.cpp" />
     <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
     <ClCompile Include="src\Ext\Team\Body.cpp" />

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Credits
 - **thomassneddon** - general assistance
 - **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
-- **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption
+- **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption, building LimboDelivery
 - **mevitar** - honorary shield tester *triple* award
 - **Damfoos** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -933,11 +933,11 @@ Remember that Limbo Delivered buildings don't exist physically! This means they 
 ```
 In `rulesmd.ini`:
 ```ini
-[SOMESW]                                ; Super Weapon
-LimboDelivery.Types=                    ; List of BuildingTypes
-LimboDelivery.IDs=                      ; List of numeric IDs. -1 cannot be used.
-LimboDelivery.RollChances=              ; List of percentages.
-LimboDelivery.RandomWeightsN=           ; List of integers.
-LimboKill.Affects=self                  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
-LimboKill.IDs=                          ; List of numeric IDs.
+[SOMESW]                        ; Super Weapon
+LimboDelivery.Types=            ; List of BuildingTypes
+LimboDelivery.IDs=              ; List of numeric IDs. -1 cannot be used.
+LimboDelivery.RollChances=      ; List of percentages.
+LimboDelivery.RandomWeightsN=   ; List of integers.
+LimboKill.Affects=self          ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+LimboKill.IDs=                  ; List of numeric IDs.
 ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -835,7 +835,6 @@ x=93,n            ; integer n=0
 ```
 
 ### `94` Pick A Random Script
-## Super Weapons
 
 - When executed this action picks a random Script Type and replaces the current script by the new picked. The second parameter is a 0-based index from the new section `AIScriptsList` explained below.
 
@@ -901,6 +900,9 @@ In `aimd.ini`:
 [SOMESCRIPTTYPE]  ; ScriptType
 x=i,n             ; where 500 <= i <= 519, n is made up of two parts, the low 16 bits is being used to store the variable index, the high 16 bits is being used for storing the param value.
 ```
+
+
+## Super Weapons
 
 ### LimboDelivery
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -835,6 +835,7 @@ x=93,n            ; integer n=0
 ```
 
 ### `94` Pick A Random Script
+## Super Weapons
 
 - When executed this action picks a random Script Type and replaces the current script by the new picked. The second parameter is a 0-based index from the new section `AIScriptsList` explained below.
 
@@ -899,4 +900,39 @@ In `aimd.ini`:
 ```ini
 [SOMESCRIPTTYPE]  ; ScriptType
 x=i,n             ; where 500 <= i <= 519, n is made up of two parts, the low 16 bits is being used to store the variable index, the high 16 bits is being used for storing the param value.
+```
+
+### LimboDelivery
+
+- Super Weapons can now deliver off-map buildings that act as if they were on the field.
+  - `LimboDelivery.Types` is the list of BuildingTypes that will be created when the Super Weapons fire. Super Weapon Type and coordinates do not matter.
+  - `LimboDelivery.IDs` is the list of numeric IDs that will be assigned to buildings. Necessary for LimboKill to work.
+
+- Created buildings are not affected by any on-map threats. The only way to remove them from the game is by using a Super Weapon with LimboKill set.
+  - `LimboKill.Affects` sets which houses are affected by this feature.
+  - `LimboKill.IDs` lists IDs that will be targeted. Buildings with these IDs will be removed from the game instantly.
+
+- Delivery can be made random with these optional tags. The game will randomly choose only a single building from the list for each roll chance provided.
+  - `LimboDelivery.RollChance` lits chances of each "dice roll" happening. Valid values range from 0% (never happens) to 100% (always happens). Defaults to a single sure roll.
+  - `LimboDelivery.RandomWeightsN` lists the weights for each "dice roll" that increase the probability of picking a specific building. Valid values are 0 (don't pick) and above (the higher value, the bigger the likelyhood). `RandomWeights` are a valid alias for `RandomWeights0`. If a roll attempt doesn't have weights specified, the last weights will be used.
+
+Note: This feature might not support every building flag. Flags that are confirmed to work correctly are listed below:
+  - FactoryPlant
+  - OrePurifier
+  - SpySat
+  - KeepAlive (Ares 3.0)
+  - Prerequisite, PrerequisiteOverride, Prerequisite.List# (Ares 0.1), Prerequisite.Negative (Ares 0.1), GenericPrerequisites (Ares 0.1)
+  - SuperWeapon, SuperWeapon2, SuperWeapons (Ares 0.9), SW.AuxBuildings (Ares 0.9), SW.NegBuildings (Ares 0.9)
+
+Note: Buildings delivered through LimboDelivery should never have enabled machanics that require interaction with the game world (i.e. factories, cloning vats, service depots).
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]								; Super Weapon
+LimboDelivery.Types=					; List of BuildingTypes
+LimboDelivery.IDs=						; List of numeric IDs. -1 cannot be used.
+LimboDelivery.RollChances=				; List of percentages.
+LimboDelivery.RandomWeightsN=			; List of integers.
+LimboKill.Affects=self					; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+LimboKill.IDs=							; List of numeric IDs.
 ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -933,11 +933,11 @@ Remember that Limbo Delivered buildings don't exist physically! This means they 
 ```
 In `rulesmd.ini`:
 ```ini
-[SOMESW]								; Super Weapon
-LimboDelivery.Types=					; List of BuildingTypes
-LimboDelivery.IDs=						; List of numeric IDs. -1 cannot be used.
-LimboDelivery.RollChances=				; List of percentages.
-LimboDelivery.RandomWeightsN=			; List of integers.
-LimboKill.Affects=self					; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
-LimboKill.IDs=							; List of numeric IDs.
+[SOMESW]                                ; Super Weapon
+LimboDelivery.Types=                    ; List of BuildingTypes
+LimboDelivery.IDs=                      ; List of numeric IDs. -1 cannot be used.
+LimboDelivery.RollChances=              ; List of percentages.
+LimboDelivery.RandomWeightsN=           ; List of integers.
+LimboKill.Affects=self                  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+LimboKill.IDs=                          ; List of numeric IDs.
 ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -924,8 +924,11 @@ Note: This feature might not support every building flag. Flags that are confirm
   - Prerequisite, PrerequisiteOverride, Prerequisite.List# (Ares 0.1), Prerequisite.Negative (Ares 0.1), GenericPrerequisites (Ares 0.1)
   - SuperWeapon, SuperWeapon2, SuperWeapons (Ares 0.9), SW.AuxBuildings (Ares 0.9), SW.NegBuildings (Ares 0.9)
 
-Note: Buildings delivered through LimboDelivery should never have enabled machanics that require interaction with the game world (i.e. factories, cloning vats, service depots).
+Note: In order for this feature to work with AITriggerTypes conditions ("Owning house owns ???" and "Enemy house owns ???"), `LegalTarget` must be set to true.
 
+```{warning}
+Remember that Limbo Delivered buildings don't exist physically! This means they should never have enabled machanics that require interaction with the game world (i.e. factories, cloning vats, service depots, helipads). They also **should have either `KeepAlive=yes` set or be killable with LimboKill** - otherwise the game might never end.
+```
 In `rulesmd.ini`:
 ```ini
 [SOMESW]								; Super Weapon

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -127,6 +127,7 @@ New:
 - Script Action 112 to regroup temporarily around the Team Leader (by FS-21)
 - ObjectInfo now shows current Target and AI Trigger data (by FS-21)
 - Shield absorption and passthrough customization (by Morton)
+- Limbo Delivery of buildings (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -11,6 +11,7 @@ void BuildingExt::ExtData::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->DeployedTechno)
+		.Process(this->LimboID)
 		;
 }
 

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -16,9 +16,12 @@ public:
 	{
 	public:
 		Valueable<bool> DeployedTechno;
+		Valueable<int> LimboID;
 
 		ExtData(BuildingClass* OwnerObject) : Extension<BuildingClass>(OwnerObject)
 			, DeployedTechno(false)
+			, LimboID(-1)
+
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -45,9 +45,10 @@ int HouseExt::TotalHarvesterCount(HouseClass* pThis)
 	return result;
 }
 
-int HouseExt::CountOwnedLimbo(HouseClass* pThis, BuildingTypeClass const* const pItem) {
-	// return pThis->OwnedLimboBuildingTypes.GetItemCount(pItem->ArrayIndex);
-	return 0;
+int HouseExt::CountOwnedLimbo(HouseClass* pThis, BuildingTypeClass const* const pItem)
+{
+	auto pHouseExt = HouseExt::ExtMap.Find(pThis);
+	return pHouseExt->OwnedLimboBuildingTypes.GetItemCount(pItem->ArrayIndex);
 }
 
 // Ares

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -45,6 +45,11 @@ int HouseExt::TotalHarvesterCount(HouseClass* pThis)
 	return result;
 }
 
+int HouseExt::CountOwnedLimbo(HouseClass* pThis, BuildingTypeClass const* const pItem) {
+	// return pThis->OwnedLimboBuildingTypes.GetItemCount(pItem->ArrayIndex);
+	return 0;
+}
+
 // Ares
 HouseClass* HouseExt::GetHouseKind(OwnerHouseKind const kind, bool const allowRandom, HouseClass* const pDefault, HouseClass* const pInvoker, HouseClass* const pVictim)
 {

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -17,8 +17,10 @@ public:
 	{
 	public:
 		std::map<BuildingTypeExt::ExtData*, int> BuildingCounter;
+		CounterClass OwnedLimboBuildingTypes;
 
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
+			, OwnedLimboBuildingTypes()
 		{ }
 
 		virtual ~ExtData() = default;
@@ -44,8 +46,6 @@ public:
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
 
-	//temp
-	CounterClass OwnedLimboBuildingTypes;
 	static int CountOwnedLimbo(HouseClass* pThis, BuildingTypeClass const* const pItem);
 
 	static int ActiveHarvesterCount(HouseClass* pThis);

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -44,6 +44,10 @@ public:
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
 
+	//temp
+	CounterClass OwnedLimboBuildingTypes;
+	static int CountOwnedLimbo(HouseClass* pThis, BuildingTypeClass const* const pItem);
+
 	static int ActiveHarvesterCount(HouseClass* pThis);
 	static int TotalHarvesterCount(HouseClass* pThis);
 	static HouseClass* GetHouseKind(OwnerHouseKind kind, bool allowRandom, HouseClass* pDefault, HouseClass* pInvoker = nullptr, HouseClass* pVictim = nullptr);

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -55,7 +55,8 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	}
 	ValueableVector<int> weights;
 	weights.Read(exINI, pSection, "LimboDelivery.RandomWeights");
-	this->LimboDelivery_RandomWeightsData[0] = weights;
+	if (weights.size())
+		this->LimboDelivery_RandomWeightsData[0] = weights;
 
 	this->LimboKill_Affected.Read(exINI, pSection, "LimboKill.Affected");
 	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -15,6 +15,13 @@ void SWTypeExt::ExtData::Serialize(T& Stm) {
 		.Process(this->Money_Amount)
 		.Process(this->UIDescription)
 		.Process(this->CameoPriority)
+		.Process(this->LimboDelivery_Types)
+		.Process(this->LimboDelivery_IDs)
+		.Process(this->LimboDelivery_RandomWeightsData)
+		.Process(this->LimboDelivery_RollChances)
+		.Process(this->LimboKill_Affected)
+		.Process(this->LimboKill_IDs)
+		.Process(this->RandomBuffer)
 		;
 }
 
@@ -30,6 +37,28 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->Money_Amount.Read(exINI, pSection, "Money.Amount");
 	this->UIDescription.Read(exINI, pSection, "UIDescription");
 	this->CameoPriority.Read(exINI, pSection, "CameoPriority");
+	this->LimboDelivery_Types.Read(exINI, pSection, "LimboDelivery.Types");
+	this->LimboDelivery_IDs.Read(exINI, pSection, "LimboDelivery.IDs");
+	this->LimboDelivery_RollChances.Read(exINI, pSection, "LimboDelivery.RollChances");
+
+	char tempBuffer[32];
+	for (size_t i = 0; ; ++i)
+	{
+		ValueableVector<int> weights;
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "LimboDelivery.RandomWeights%d", i);
+		weights.Read(exINI, pSection, tempBuffer);
+
+		if (!weights.size())
+			break;
+
+		this->LimboDelivery_RandomWeightsData.push_back(weights);
+	}
+	ValueableVector<int> weights;
+	weights.Read(exINI, pSection, "LimboDelivery.RandomWeights");
+	this->LimboDelivery_RandomWeightsData[0] = weights;
+
+	this->LimboKill_Affected.Read(exINI, pSection, "LimboKill.Affected");
+	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -17,12 +17,30 @@ public:
 		Valueable<int> Money_Amount;
 		Valueable<CSFText> UIDescription;
 		Valueable<int> CameoPriority;
+		ValueableVector<TechnoTypeClass*> LimboDelivery_Types;
+		ValueableVector<int> LimboDelivery_IDs;
+		ValueableVector<float> LimboDelivery_RollChances;
+		Valueable<AffectedHouse> LimboKill_Affected;
+		ValueableVector<int> LimboKill_IDs;
+		Valueable<double> RandomBuffer;
+
+		ValueableVector<ValueableVector<int>> LimboDelivery_RandomWeightsData;
 
 		ExtData(SuperWeaponTypeClass* OwnerObject) : Extension<SuperWeaponTypeClass>(OwnerObject)
 			, Money_Amount(0)
 			, UIDescription()
 			, CameoPriority(0)
+			, LimboDelivery_Types()
+			, LimboDelivery_IDs()
+			, LimboDelivery_RollChances()
+			, LimboDelivery_RandomWeightsData()
+			, LimboKill_Affected(AffectedHouse::Owner)
+			, LimboKill_IDs()
+			, RandomBuffer(0.0)
 		{ }
+
+
+		void FireSuperWeapon(SuperClass* pSW, HouseClass* pHouse, CoordStruct coords);
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		virtual ~ExtData() = default;
@@ -33,6 +51,9 @@ public:
 
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 	private:
+		void ApplyLimboDelivery(HouseClass* pHouse);
+		void ApplyLimboKill(HouseClass* pHouse);
+
 		template <typename T>
 		void Serialize(T& Stm);
 	};

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -1,0 +1,179 @@
+#include "Body.h"
+
+#include <SuperClass.h>
+#include <BuildingClass.h>
+#include <HouseClass.h>
+#include <ScenarioClass.h>
+
+#include <Utilities/EnumFunctions.h>
+#include <Utilities/GeneralUtils.h>
+#include "Ext/Building/Body.h"
+
+// Too big to be kept in ApplyLimboDelivery
+void LimboDeliver(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
+{
+	// BuildLimit check goes before creation - TODO
+	if (pType->BuildLimit >= 0)
+	{
+		int sum = pOwner->CountOwnedNow(pType);
+		// restore Ares' deployable units x build limit fix
+		if (auto const pUndeploy = pType->UndeploysInto) {
+			sum += pOwner->CountOwnedNow(pUndeploy);
+		}
+		// sum += pOwner->CountOwnedLimbo(pType);
+		if (sum > pType->BuildLimit)
+			return;
+	}
+
+	BuildingClass* pBuilding = abstract_cast<BuildingClass*>(pType->CreateObject(pOwner));
+
+	// All of these are mandatory
+	pBuilding->InLimbo = false;
+	pBuilding->IsAlive = true;
+	pBuilding->IsOnMap = true;
+	pOwner->RegisterGain(pBuilding, false);
+	pOwner->UpdatePower();
+	pOwner->RecheckTechTree = true;
+	pOwner->RecheckPower = true;
+	pOwner->RecheckRadar = true;
+	pOwner->Buildings.AddItem(pBuilding);
+
+	// Different types of building logics
+	if (pType->ConstructionYard)
+		pOwner->ConYards.AddItem(pBuilding); // why would you do that????
+
+	if (pType->SecretLab)
+		pOwner->SecretLabs.AddItem(pBuilding);
+
+	if (pType->FactoryPlant)
+	{
+		pOwner->FactoryPlants.AddItem(pBuilding);
+		pOwner->CalculateCostMultipliers();
+	}
+
+	if (pType->OrePurifier)
+		pOwner->NumOrePurifiers++;
+
+	// BuildingClass::Place is where Ares hooks secret lab expansion
+	// pTechnoBuilding->Place(false);
+	// even with it no bueno yet, plus new issues
+	// probably should just port it from Ares 0.A and be done
+
+	// LimboKill init
+	if (auto const pBuildingExt = BuildingExt::ExtMap.Find(pBuilding))
+		if (ID != -1)
+			pBuildingExt->LimboID = ID;
+}
+
+void SWTypeExt::ExtData::FireSuperWeapon(SuperClass* pSW, HouseClass* pHouse, CoordStruct coords)
+{
+
+	if (this->LimboDelivery_Types.size())
+		ApplyLimboDelivery(pHouse);
+
+	if (this->LimboKill_IDs.size())
+		ApplyLimboKill(pHouse);
+}
+
+void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
+{
+	// random mode
+	if (this->LimboDelivery_RandomWeightsData[0].size())
+	{
+		bool rollOnce = false;
+		size_t rolls = this->LimboDelivery_RollChances.size();
+		size_t weights = this->LimboDelivery_RandomWeightsData.size();
+		size_t index;
+		size_t j;
+
+		// if no RollChances are supplied, do only one roll
+		if (rolls == 0)
+		{
+			rolls = 1;
+			rollOnce = true;
+		}
+
+		for (size_t i = 0; i < rolls; i++)
+		{
+			this->RandomBuffer = ScenarioClass::Instance->Random.RandomDouble();
+			if (!rollOnce)
+				if (this->RandomBuffer > this->LimboDelivery_RollChances[i])
+					continue;
+
+			j = rolls > weights ? weights: i;
+			index = GeneralUtils::ChooseOneWeighted(this->RandomBuffer, &this->LimboDelivery_RandomWeightsData[j]);
+			// extra weight is for chance to fail
+			if (index == this->LimboDelivery_Types.size())
+				index = size_t(-1);
+			if (index != -1)
+			{
+				LimboDeliver(
+					abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[index]),
+					pHouse,
+					this->LimboDelivery_IDs[index]
+				);
+			}
+		}
+	}
+	// no randomness mode
+	else
+	{
+		for (size_t i = 0; i < this->LimboDelivery_Types.size(); i++)
+		{
+			LimboDeliver(
+				abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[i]),
+				pHouse,
+				this->LimboDelivery_IDs[i]
+			);
+		}
+	}
+}
+
+void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
+{
+	for (unsigned int i = 0; i < this->LimboKill_IDs.size(); i++)
+	{
+		for (int j = 0; j < HouseClass::Array->Count; j++)
+		{
+			HouseClass* pTargetHouse = HouseClass::Array->Items[j];
+			if (EnumFunctions::CanTargetHouse(this->LimboKill_Affected, pHouse, pTargetHouse))
+			{
+				for (const auto pBuilding : pHouse->Buildings)
+				{
+					const auto pBuildingExt = BuildingExt::ExtMap.Find(pBuilding);
+					if (pBuildingExt->LimboID == this->LimboKill_IDs[i])
+					{
+						BuildingTypeClass* pType = static_cast<BuildingTypeClass*>(pBuilding->Type);
+
+						// Mandatory
+						pBuilding->InLimbo = true;
+						pBuilding->IsAlive = false;
+						pBuilding->IsOnMap = false;
+						pTargetHouse->RegisterLoss(pBuilding, false);
+						pTargetHouse->UpdatePower();
+						pTargetHouse->RecheckTechTree = true;
+						pTargetHouse->RecheckPower = true;
+						pTargetHouse->RecheckRadar = true;
+						pTargetHouse->Buildings.Remove(pBuilding);
+
+						// Building logics
+						if (pType->ConstructionYard)
+							pTargetHouse->ConYards.Remove(pBuilding);
+						if (pType->SecretLab)
+							pTargetHouse->SecretLabs.Remove(pBuilding);
+						if (pType->FactoryPlant)
+						{
+							pTargetHouse->FactoryPlants.Remove(pBuilding);
+							pTargetHouse->CalculateCostMultipliers();
+						}
+						if (pType->OrePurifier)
+							pTargetHouse->NumOrePurifiers--;
+
+						// Remove completely
+						pBuilding->UnInit();
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -144,7 +144,8 @@ void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
 			HouseClass* pTargetHouse = HouseClass::Array->Items[j];
 			if (EnumFunctions::CanTargetHouse(this->LimboKill_Affected, pHouse, pTargetHouse))
 			{
-				for (const auto pBuilding : pHouse->Buildings)
+				auto buildings = DynamicVectorClass(pTargetHouse->Buildings);
+				for (const auto pBuilding : buildings)
 				{
 					const auto pBuildingExt = BuildingExt::ExtMap.Find(pBuilding);
 					if (pBuildingExt->LimboID == this->LimboKill_IDs[i])

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -19,10 +19,11 @@ void LimboDeliver(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 	if (pType->BuildLimit > 0)
 	{
 		int sum = pOwner->CountOwnedNow(pType);
+
 		// copy Ares' deployable units x build limit fix
-		if (auto const pUndeploy = pType->UndeploysInto) {
+		if (auto const pUndeploy = pType->UndeploysInto)
 			sum += pOwner->CountOwnedNow(pUndeploy);
-		}
+
 		if (sum >= pType->BuildLimit)
 			return;
 	}
@@ -66,14 +67,13 @@ void LimboDeliver(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 	// probably should just port it from Ares 0.A and be done
 
 	// LimboKill init
-	if (auto const pBuildingExt = BuildingExt::ExtMap.Find(pBuilding))
-		if (ID != -1)
-			pBuildingExt->LimboID = ID;
+	auto const pBuildingExt = BuildingExt::ExtMap.Find(pBuilding);
+	if (pBuildingExt && ID != -1)
+		pBuildingExt->LimboID = ID;
 }
 
 void SWTypeExt::ExtData::FireSuperWeapon(SuperClass* pSW, HouseClass* pHouse, CoordStruct coords)
 {
-
 	if (this->LimboDelivery_Types.size())
 		ApplyLimboDelivery(pHouse);
 
@@ -104,20 +104,22 @@ void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 		for (size_t i = 0; i < rolls; i++)
 		{
 			this->RandomBuffer = ScenarioClass::Instance->Random.RandomDouble();
-			if (!rollOnce)
-				if (this->RandomBuffer > this->LimboDelivery_RollChances[i])
-					continue;
+			if (!rollOnce && this->RandomBuffer > this->LimboDelivery_RollChances[i])
+				continue;
 
 			j = rolls > weights ? weights: i;
 			index = GeneralUtils::ChooseOneWeighted(this->RandomBuffer, &this->LimboDelivery_RandomWeightsData[j]);
+
 			// extra weights are bound to automatically fail
 			if (index >= this->LimboDelivery_Types.size())
 				index = size_t(-1);
+
 			if (index != -1)
 			{
 				if (index < ids)
 					id = this->LimboDelivery_IDs[index];
-				LimboDeliver( abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[index]), pHouse, id );
+
+				LimboDeliver(abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[index]), pHouse, id);
 			}
 		}
 	}
@@ -126,10 +128,12 @@ void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 	{
 		int id = -1;
 		size_t ids = this->LimboDelivery_IDs.size();
+
 		for (size_t i = 0; i < this->LimboDelivery_Types.size(); i++)
 		{
 			if (i < ids)
 				id = this->LimboDelivery_IDs[i];
+
 			LimboDeliver(abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[i]), pHouse, id);
 		}
 	}
@@ -166,13 +170,16 @@ void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
 						// Building logics
 						if (pType->ConstructionYard)
 							pTargetHouse->ConYards.Remove(pBuilding);
+
 						if (pType->SecretLab)
 							pTargetHouse->SecretLabs.Remove(pBuilding);
+
 						if (pType->FactoryPlant)
 						{
 							pTargetHouse->FactoryPlants.Remove(pBuilding);
 							pTargetHouse->CalculateCostMultipliers();
 						}
+
 						if (pType->OrePurifier)
 							pTargetHouse->NumOrePurifiers--;
 

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -78,11 +78,13 @@ void SWTypeExt::ExtData::FireSuperWeapon(SuperClass* pSW, HouseClass* pHouse, Co
 void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 {
 	// random mode
-	if (this->LimboDelivery_RandomWeightsData[0].size())
+	if (this->LimboDelivery_RandomWeightsData.size())
 	{
 		bool rollOnce = false;
+		int id = -1;
 		size_t rolls = this->LimboDelivery_RollChances.size();
 		size_t weights = this->LimboDelivery_RandomWeightsData.size();
+		size_t ids = this->LimboDelivery_IDs.size();
 		size_t index;
 		size_t j;
 
@@ -102,29 +104,27 @@ void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 
 			j = rolls > weights ? weights: i;
 			index = GeneralUtils::ChooseOneWeighted(this->RandomBuffer, &this->LimboDelivery_RandomWeightsData[j]);
-			// extra weight is for chance to fail
-			if (index == this->LimboDelivery_Types.size())
+			// extra weights are bound to automatically fail
+			if (index >= this->LimboDelivery_Types.size())
 				index = size_t(-1);
 			if (index != -1)
 			{
-				LimboDeliver(
-					abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[index]),
-					pHouse,
-					this->LimboDelivery_IDs[index]
-				);
+				if (index < ids)
+					id = this->LimboDelivery_IDs[index];
+				LimboDeliver( abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[index]), pHouse, id );
 			}
 		}
 	}
 	// no randomness mode
 	else
 	{
+		int id = -1;
+		size_t ids = this->LimboDelivery_IDs.size();
 		for (size_t i = 0; i < this->LimboDelivery_Types.size(); i++)
 		{
-			LimboDeliver(
-				abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[i]),
-				pHouse,
-				this->LimboDelivery_IDs[i]
-			);
+			if (i < ids)
+				id = this->LimboDelivery_IDs[i];
+			LimboDeliver(abstract_cast<BuildingTypeClass*>(this->LimboDelivery_Types[i]), pHouse, id);
 		}
 	}
 }

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -1,0 +1,14 @@
+#include "Body.h"
+
+#include <SuperClass.h>
+
+DEFINE_HOOK(0x6CDE40, SuperClass_Place, 0x5)
+{
+	GET(SuperClass* const, pSuper, ECX);
+	GET_STACK(CoordStruct const, coords, 0x230); // I think?
+
+	if (auto const pSWExt = SWTypeExt::ExtMap.Find(pSuper->Type))
+		pSWExt->FireSuperWeapon(pSuper, pSuper->Owner, coords);
+
+	return 0;
+}

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -60,3 +60,23 @@ const double GeneralUtils::GetWarheadVersusArmor(WarheadTypeClass* pWH, Armor Ar
 {
 	return double(MapClass::GetTotalDamage(100, pWH, ArmorType, 0)) / 100.0;
 }
+
+// Weighted random element choice (weight) - roll for one.
+// Takes a vector of integer type weights, which are then summed to calculate the chances.
+// Returns chosen index or -1 if nothing is chosen.
+int GeneralUtils::ChooseOneWeighted(const double dice, const std::vector<int>* weights)
+{
+	float sum = 0.0;
+	float sum2 = 0.0;
+
+	for (size_t i = 0; i < weights->size(); i++)
+		sum += (*weights)[i];
+	for (size_t i = 0; i < weights->size(); i++)
+	{
+		sum2 += (*weights)[i];
+		if (dice < (sum2 / sum))
+			return i;
+	}
+
+	return -1;
+}

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -71,6 +71,7 @@ int GeneralUtils::ChooseOneWeighted(const double dice, const std::vector<int>* w
 
 	for (size_t i = 0; i < weights->size(); i++)
 		sum += (*weights)[i];
+
 	for (size_t i = 0; i < weights->size(); i++)
 	{
 		sum2 += (*weights)[i];

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -24,4 +24,6 @@ public:
 	static std::vector<CellStruct> AdjacentCellsInRange(unsigned int range);
 	static const int GetRangedRandomOrSingleValue(Point2D range);
 	static const double GetWarheadVersusArmor(WarheadTypeClass* pWH, Armor ArmorType);
+
+	static int ChooseOneWeighted(const double dice, const std::vector<int>* weights);
 };


### PR DESCRIPTION
You can now, through Super Weapons, deliver BuildingTypes that will appear "in limbo" instead of the game world. These buildings will satisfy prerequisite checks, grant Super Weapons, supply or drain power, and generally act as if they existed (cannot be factories or have weapons, or generally contain any mechanics that require them to have coordinates). These buildings can be removed from "limbo" with LimboKill superweapons, that erase all buildings with matching IDs.

Documentation copy below.

### LimboDelivery

- Super Weapons can now deliver off-map buildings that act as if they were on the field.
  - `LimboDelivery.Types` is the list of BuildingTypes that will be created when the Super Weapons fire. Super Weapon Type and coordinates do not matter.
  - `LimboDelivery.IDs` is the list of numeric IDs that will be assigned to buildings. Necessary for LimboKill to work.

- Created buildings are not affected by any on-map threats. The only way to remove them from the game is by using a Super Weapon with LimboKill set.
  - `LimboKill.Affects` sets which houses are affected by this feature.
  - `LimboKill.IDs` lists IDs that will be targeted. Buildings with these IDs will be removed from the game instantly.

- Delivery can be made random with these optional tags. The game will randomly choose only a single building from the list for each roll chance provided.
  - `LimboDelivery.RollChance` lits chances of each "dice roll" happening. Valid values range from 0% (never happens) to 100% (always happens). Defaults to a single sure roll.
  - `LimboDelivery.RandomWeightsN` lists the weights for each "dice roll" that increase the probability of picking a specific building. Valid values are 0 (don't pick) and above (the higher value, the bigger the likelyhood). `RandomWeights` are a valid alias for `RandomWeights0`. If a roll attempt doesn't have weights specified, the last weights will be used.

Note: This feature might not support every building flag. Flags that are confirmed to work correctly are listed below:
  - FactoryPlant
  - OrePurifier
  - SpySat
  - KeepAlive (Ares 3.0)
  - Prerequisite, PrerequisiteOverride, Prerequisite.List# (Ares 0.1), Prerequisite.Negative (Ares 0.1), GenericPrerequisites (Ares 0.1)
  - SuperWeapon, SuperWeapon2, SuperWeapons (Ares 0.9), SW.AuxBuildings (Ares 0.9), SW.NegBuildings (Ares 0.9)

Note: Buildings delivered through LimboDelivery should never have enabled machanics that require interaction with the game world (i.e. factories, cloning vats, service depots).

In `rulesmd.ini`:
```ini
[SOMESW]                                      ; Super Weapon
LimboDelivery.Types=                          ; List of BuildingTypes
LimboDelivery.IDs=                            ; List of numeric IDs. -1 cannot be used.
LimboDelivery.RollChances=                    ; List of percentages.
LimboDelivery.RandomWeightsN=                 ; List of integers.
LimboKill.Affects=self                        ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
LimboKill.IDs=                                ; List of numeric IDs.
```