### PR TITLE
Script Actions 84-91: Mission attack that use a list of possible targets

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -580,14 +580,14 @@ x=112,n
 ```
 
 
-### `74-81` New Attack Action
+### `74-81`, `84-91` New Attack Action
 
 - These Actions instruct the TeamType to use the TaskForce to approach and attack the target specified by the second parameter. Look at the tables below for the possible Actions (first parameter value) and Arguments (the second parameter value).
 
 In `aimd.ini`:
 ```ini
 [SOMESCRIPTTYPE]  ; ScriptType
-x=i,n             ; where 74 <= i <= 81
+x=i,n             ; where 74 <= i <= 81 or 84 <= i <= 91
 ```
 
 | *Action* | *Argument*   | *Repeats* | *Target Priority* | *Description*                                 |
@@ -600,8 +600,66 @@ x=i,n             ; where 74 <= i <= 81
 79         | Target Type# | No | Farther, higher threat | Ends when a team member kill the designated target |
 80         | Target Type# | No | Closer | Ends when a team member kill the designated target |
 81         | Target Type# | No | Farther | Ends when a team member kill the designated target |
+84         | [AITargetType] index# | Yes | Closer, higher threat |  |
+85         | [AITargetType] index# | Yes | Farther, higher threat |  |
+86         | [AITargetType] index# | Yes | Closer |  |
+87         | [AITargetType] index# | Yes | Farther |  |
+88         | [AITargetType] index# | No | Closer, higher threat | Ends when a team member kill the designated target |
+89         | [AITargetType] index# | No | Farther, higher threat | Ends when a team member kill the designated target |
+90         | [AITargetType] index# | No | Closer | Ends when a team member kill the designated target |
+91         | [AITargetType] index# | No | Farther | Ends when a team member kill the designated target |
 
-Note: New Attack action scripts (74, 75, 78, 79) that are focused in target threat use `TargetSpecialThreatCoefficientDefault` and `EnemyHouseThreatBonus` tags from `rulesmd.ini`.
+Note: New Attack action scripts (74, 75, 78 ,79, 84, 85, 88 & 89) that are focused in target threat use `TargetSpecialThreatCoefficientDefault` and `EnemyHouseThreatBonus` tags from `rulesmd.ini`.
 
 Note: All Aircrafts that attack other air units will end the script. This behavior is intentional because without it aircrafts had some bugs that weren't fixable at the time of developing the feature.
 
+The second parameter with a 0-based index for the *[AITargetType]* section specifies the list of possible *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* and *[BuildingTypes]* that can be evaluated. The new *[AITargetType]* section must be declared in RulesMD.ini for making this script work:
+
+In `rulesmd.ini`:
+```ini
+[AITargetType]  ; List of Technos
+0=Techno N,Techno N+1, Techno N+1,... Techno N+M
+1= ...
+2= ...
+...
+```
+
+The following values are the *Target Type#* which can be used as second parameter of the new attack script actions:
+
+| *Value* | *Target Type*     | *Description*                                 |
+| :-----: | :---------------: | :-------------------------------------------: |
+1         | Anything          |	Any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* and *[BuildingTypes]* |
+2         | Structures        |	Any enemy *[BuildingTypes]* without `Artillary=yes`, `TickTank=yes`, `ICBMLauncher=yes` or `SensorArray=yes` |
+3         | Ore Miners        |	Any enemy *[VehicleTypes]* with `Harvester=yes` or `ResourceGatherer=yes`, *[BuildingTypes]* with `ResourceGatherer=yes` |
+4         | Infantry          |	Any enemy *[InfantryTypes]* |
+5         | Vehicles          |	Any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[BuildingTypes]* with `Artillary=yes`, `TickTank=yes`, `ICBMLauncher=yes` & `SensorArray=yes` |
+6         | Factories         |	Any enemy *[BuildingTypes]* with a Factory= setting |
+7         | Base Defenses     |	Any enemy *[BuildingTypes]* with `IsBaseDefense=yes` |
+8         | House Threats     |	Any object that targets anything of the Team's House or any enemy that is near to the Team Leader |
+9         | Power Plants      |	Any enemy *[BuildingTypes]* with positive `Power=` values |
+10        | Occupied          |	Any *[BuildingTypes]* with garrisoned infantry |
+11        | Tech Buildings    |	Any *[BuildingTypes]* with `Unsellable=yes`, `Capturable=yes`, negative `TechLevel=` values or appears in `[AI]>NeutralTechBuildings=` list |
+12        |	Refinery          |	Any enemy *[BuildingTypes]* with `Refinery=yes` or `ResourceGatherer=yes`, *[VehicleTypes]* with `ResourceGatherer=yes` & `Harvester=no` (i.e. Slave Miner) |
+13        |	Mind Controller   |	Anything *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* and *[BuildingTypes]* with `MindControl=yes` in the weapons Warheads |
+14        |	Air Units         |	Any enemy *[AircraftTypes]*, flying *[VehicleTypes]* or *[InfantryTypes]* |
+15        |	Naval             |	Any enemy *[BuildingTypes]* and *[VehicleTypes]* with a `Naval=yes`, any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* in a water cell |
+16        |	Disruptors        |	Any enemy objects with positive `InhibitorRange=` values, positive `RadarJamRadius=` values, `CloakGenerator=yes` or `GapGenerator=yes` |
+17        |	Ground Vehicles   |	Any enemy *[VehicleTypes]* without `Naval=yes`, landed *[AircraftTypes]*, Deployed vehicles into *[BuildingTypes]* |
+18        |	Economy           |	Any enemy *[VehicleTypes]* with `Harvester=yes` or `ResourceGatherer=yes`, *[BuildingTypes]* with `Refinery=yes`, `ResourceGatherer=yes` or `OrePurifier=yes` |
+19        |	Infantry Factory  |	Any enemy *[BuildingTypes]* with `Factory=InfantryType` |
+20        |	Vehicle Factory   |	Any enemy *[BuildingTypes]* with `Factory=UnitType` |
+21        |	Aircraft Factory  |	Any enemy *[BuildingTypes]* with `Factory=AircraftType` |
+22        |	Radar             |	Any enemy *[BuildingTypes]* with `Radar=yes` or `SpySat=yes` |
+23        |	Tech Lab          |	Any enemy *[BuildingTypes]* in `[AI]>BuildTech=` list |
+24        |	Naval Factory     |	Any enemy *[BuildingTypes]* with `Naval=yes` and `Factory=UnitType` |
+25        |	Super Weapon      |	Any enemy *[BuildingTypes]* with `SuperWeapon=`, `SuperWeapon2=` or `SuperWeapons=` |
+26        |	Construction Yard |	Any enemy *[BuildingTypes]* with `ConstructionYard=yes` and `Factory=BuildingType` |
+27        |	Neutrals          |	Any neutral object (Civilian) |
+28        |	Generators        |	Any enemy *[BuildingTypes]* with `CloakGenerator=yes` or `GapGenerator=yes` |
+29        |	Radar Jammer      |	Any enemy objects with positive `RadarJamRadius=` values |
+30        |	Inhibitors        |	Any enemy objects with positive `InhibitorRange=` values |
+31        |	Naval Units       |	Any enemy *[VehicleTypes]* with a `Naval=yes` or any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* in a water cell |
+32        | Mobile Units      |	Anything *[VehicleTypes]*, *[AircraftTypes]* and *[InfantryTypes]* |
+33        |	Capturable        |	Any *[BuildingTypes]* with `Capturable=yes` or any *[BuildingTypes]* with `BridgeRepairHut=yes` and `Repairable=yes` |
+34         | Area Threats     |	Any enemy object that is inside of the Team Leader's Guard Area |
+Inside the Area Guard of the Team Leader

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -549,6 +549,68 @@ In `aimd.ini`:
 x=73,0
 ```
 
+### `74-81` Generic Target Type Attack Action
+
+- These Actions instruct the TeamType to use the TaskForce to approach and attack the target specified by the second parameter which is an index of a generic pre-defined group. Look at the tables below for the possible Actions (first parameter value) and Arguments (the second parameter value).
+  - For threat-based attack actions `TargetSpecialThreatCoefficientDefault` and `EnemyHouseThreatBonus` tags from `rulesmd.ini` are accounted.
+  - All Aircrafts that attack other air units will end the script. This behavior is intentional because without it aircrafts had some bugs that weren't fixable at the time of developing the feature.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=i,n             ; where 74 <= i <= 81
+```
+
+| *Action* | *Argument*   | *Repeats* | *Target Priority* | *Description*                                 |
+| :------: | :----------: | :-------: | :---------------: | :-------------------------------------------: |
+74         | Target Type# | Yes | Closer, higher threat |  |
+75         | Target Type# | Yes | Farther, higher threat |  |
+76         | Target Type# | Yes | Closer |  |
+77         | Target Type# | Yes | Farther |  |
+78         | Target Type# | No | Closer, higher threat | Ends when a team member kill the designated target |
+79         | Target Type# | No | Farther, higher threat | Ends when a team member kill the designated target |
+80         | Target Type# | No | Closer | Ends when a team member kill the designated target |
+81         | Target Type# | No | Farther | Ends when a team member kill the designated target |
+
+- The following values are the *Target Type#* which can be used as second parameter of the new attack script actions:
+
+| *Value* | *Target Type*     | *Description*                                 |
+| :-----: | :---------------: | :-------------------------------------------: |
+1         | Anything          |	Any enemy `VehicleTypes`, `AircraftTypes`, `InfantryTypes` and `BuildingTypes` |
+2         | Structures        |	Any enemy `BuildingTypes` without `Artillary=yes`, `TickTank=yes`, `ICBMLauncher=yes` or `SensorArray=yes` |
+3         | Ore Miners        |	Any enemy `VehicleTypes` with `Harvester=yes` or `ResourceGatherer=yes`, `BuildingTypes` with `ResourceGatherer=yes` |
+4         | Infantry          |	Any enemy `InfantryTypes` |
+5         | Vehicles          |	Any enemy `VehicleTypes`, `AircraftTypes`, `BuildingTypes` with `Artillary=yes`, `TickTank=yes`, `ICBMLauncher=yes` & `SensorArray=yes` |
+6         | Factories         |	Any enemy `BuildingTypes` with a Factory= setting |
+7         | Base Defenses     |	Any enemy `BuildingTypes` with `IsBaseDefense=yes` |
+8         | House Threats     |	Any object that targets anything of the Team's House or any enemy that is near to the Team Leader |
+9         | Power Plants      |	Any enemy `BuildingTypes` with positive `Power=` values |
+10        | Occupied          |	Any `BuildingTypes` with garrisoned infantry |
+11        | Tech Buildings    |	Any `BuildingTypes` with `Unsellable=yes`, `Capturable=yes`, negative `TechLevel=` values or appears in `[AI]>NeutralTechBuildings=` list |
+12        |	Refinery          |	Any enemy `BuildingTypes` with `Refinery=yes` or `ResourceGatherer=yes`, `VehicleTypes` with `ResourceGatherer=yes` & `Harvester=no` (i.e. Slave Miner) |
+13        |	Mind Controller   |	Anything `VehicleTypes`, `AircraftTypes`, `InfantryTypes` and `BuildingTypes` with `MindControl=yes` in the weapons Warheads |
+14        |	Air Units         |	Any enemy `AircraftTypes`, flying `VehicleTypes` or `InfantryTypes` |
+15        |	Naval             |	Any enemy `BuildingTypes` and `VehicleTypes` with a `Naval=yes`, any enemy `VehicleTypes`, `AircraftTypes`, `InfantryTypes` in a water cell |
+16        |	Disruptors        |	Any enemy objects with positive `InhibitorRange=` values, positive `RadarJamRadius=` values, `CloakGenerator=yes` or `GapGenerator=yes` |
+17        |	Ground Vehicles   |	Any enemy `VehicleTypes` without `Naval=yes`, landed `AircraftTypes`, Deployed vehicles into `BuildingTypes` |
+18        |	Economy           |	Any enemy `VehicleTypes` with `Harvester=yes` or `ResourceGatherer=yes`, `BuildingTypes` with `Refinery=yes`, `ResourceGatherer=yes` or `OrePurifier=yes` |
+19        |	Infantry Factory  |	Any enemy `BuildingTypes` with `Factory=InfantryType` |
+20        |	Vehicle Factory   |	Any enemy `BuildingTypes` with `Factory=UnitType` |
+21        |	Aircraft Factory  |	Any enemy `BuildingTypes` with `Factory=AircraftType` |
+22        |	Radar             |	Any enemy `BuildingTypes` with `Radar=yes` or `SpySat=yes` |
+23        |	Tech Lab          |	Any enemy `BuildingTypes` in `[AI]>BuildTech=` list |
+24        |	Naval Factory     |	Any enemy `BuildingTypes` with `Naval=yes` and `Factory=UnitType` |
+25        |	Super Weapon      |	Any enemy `BuildingTypes` with `SuperWeapon=`, `SuperWeapon2=` or `SuperWeapons=` |
+26        |	Construction Yard |	Any enemy `BuildingTypes` with `ConstructionYard=yes` and `Factory=BuildingType` |
+27        |	Neutrals          |	Any neutral object (Civilian) |
+28        |	Generators        |	Any enemy `BuildingTypes` with `CloakGenerator=yes` or `GapGenerator=yes` |
+29        |	Radar Jammer      |	Any enemy objects with positive `RadarJamRadius=` values |
+30        |	Inhibitors        |	Any enemy objects with positive `InhibitorRange=` values |
+31        |	Naval Units       |	Any enemy `VehicleTypes` with a `Naval=yes` or any enemy `VehicleTypes`, `AircraftTypes`, `InfantryTypes` in a water cell |
+32        | Mobile Units      |	Anything `VehicleTypes`, `AircraftTypes` and `InfantryTypes` |
+33        |	Capturable        |	Any `BuildingTypes` with `Capturable=yes` or any `BuildingTypes` with `BridgeRepairHut=yes` and `Repairable=yes` |
+34         | Area Threats     |	Any enemy object that is inside of the Team Leader's Guard Area |
+
 ### `82` Decrease AI Trigger Current Weight
 
 - When executed this decreases the current Weight of the AI Trigger.The current Weight will never surprass the Minimum Weight and Maximum Weight limits of the AI Trigger. Take note that all TeamTypes of the same AI Trigger will update sooner or later the AI Trigger Current Weight. The second parameter is a positive value. Take note that the original game only uses the first of the two Teams for calculating the AI Trigger Current Weight at the end of the Trigger life, this action ignores if the Team is the first or the second of the AI Trigger and the Current Weight is calculated when is executed the action.
@@ -569,6 +631,39 @@ In `aimd.ini`:
 x=83,n
 ```
 
+### `84-91` `AITargetTypes` Attack Action
+
+- These Actions instruct the TeamType to use the TaskForce to approach and attack the target specified by the second parameter which is an index of a modder-defined group from `AITargetTypess`. Look at the tables below for the possible Actions (first parameter value) and Arguments (the second parameter value).
+  - For threat-based attack actions `TargetSpecialThreatCoefficientDefault` and `EnemyHouseThreatBonus` tags from `rulesmd.ini` are accounted.
+  - All Aircrafts that attack other air units will end the script. This behavior is intentional because without it aircrafts had some bugs that weren't fixable at the time of developing the feature.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=i,n             ; where 84 <= i <= 91
+```
+
+| *Action* | *Argument*   | *Repeats* | *Target Priority* | *Description*                                 |
+| :------: | :----------: | :-------: | :---------------: | :-------------------------------------------: |
+84         | `AITargetTypes` index# | Yes | Closer, higher threat |  |
+85         | `AITargetTypes` index# | Yes | Farther, higher threat |  |
+86         | `AITargetTypes` index# | Yes | Closer |  |
+87         | `AITargetTypes` index# | Yes | Farther |  |
+88         | `AITargetTypes` index# | No | Closer, higher threat | Ends when a team member kill the designated target |
+89         | `AITargetTypes` index# | No | Farther, higher threat | Ends when a team member kill the designated target |
+90         | `AITargetTypes` index# | No | Closer | Ends when a team member kill the designated target |
+91         | `AITargetTypes` index# | No | Farther | Ends when a team member kill the designated target |
+
+- The second parameter with a 0-based index for the `AITargetTypes` section specifies the list of possible `VehicleTypes`, `AircraftTypes`, `InfantryTypes` and `BuildingTypes` that can be evaluated. The new `AITargetTypes` section must be declared in `rulesmd.ini` for making this script work:
+
+In `rulesmd.ini`:
+```ini
+[AITargetTypes]  ; List of TechnoType lists
+0=SOMETECHNOTYPE,SOMEOTHERTECHNOTYPE,SAMPLETECHNOTYPE
+1=ANOTHERTECHNOTYPE,YETANOTHERTECHNOTYPE
+; ...
+```
+
 ### `112` Regroup temporarily around the Team Leader
 
 - Puts the TaskForce into Area Guard Mode for the given amount of time around the Team Leader (this unit remains almost immobile until the action ends). The default radius around the Leader is `[General] > CloseEnough` and the units will not leave that area.
@@ -578,88 +673,3 @@ In `aimd.ini`:
 [SOMESCRIPTTYPE]  ; ScriptType
 x=112,n
 ```
-
-
-### `74-81`, `84-91` New Attack Action
-
-- These Actions instruct the TeamType to use the TaskForce to approach and attack the target specified by the second parameter. Look at the tables below for the possible Actions (first parameter value) and Arguments (the second parameter value).
-
-In `aimd.ini`:
-```ini
-[SOMESCRIPTTYPE]  ; ScriptType
-x=i,n             ; where 74 <= i <= 81 or 84 <= i <= 91
-```
-
-| *Action* | *Argument*   | *Repeats* | *Target Priority* | *Description*                                 |
-| :------: | :----------: | :-------: | :---------------: | :-------------------------------------------: |
-74         | Target Type# | Yes | Closer, higher threat |  |
-75         | Target Type# | Yes | Farther, higher threat |  |
-76         | Target Type# | Yes | Closer |  |
-77         | Target Type# | Yes | Farther |  |
-78         | Target Type# | No | Closer, higher threat | Ends when a team member kill the designated target |
-79         | Target Type# | No | Farther, higher threat | Ends when a team member kill the designated target |
-80         | Target Type# | No | Closer | Ends when a team member kill the designated target |
-81         | Target Type# | No | Farther | Ends when a team member kill the designated target |
-84         | [AITargetType] index# | Yes | Closer, higher threat |  |
-85         | [AITargetType] index# | Yes | Farther, higher threat |  |
-86         | [AITargetType] index# | Yes | Closer |  |
-87         | [AITargetType] index# | Yes | Farther |  |
-88         | [AITargetType] index# | No | Closer, higher threat | Ends when a team member kill the designated target |
-89         | [AITargetType] index# | No | Farther, higher threat | Ends when a team member kill the designated target |
-90         | [AITargetType] index# | No | Closer | Ends when a team member kill the designated target |
-91         | [AITargetType] index# | No | Farther | Ends when a team member kill the designated target |
-
-Note: New Attack action scripts (74, 75, 78 ,79, 84, 85, 88 & 89) that are focused in target threat use `TargetSpecialThreatCoefficientDefault` and `EnemyHouseThreatBonus` tags from `rulesmd.ini`.
-
-Note: All Aircrafts that attack other air units will end the script. This behavior is intentional because without it aircrafts had some bugs that weren't fixable at the time of developing the feature.
-
-The second parameter with a 0-based index for the *[AITargetType]* section specifies the list of possible *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* and *[BuildingTypes]* that can be evaluated. The new *[AITargetType]* section must be declared in RulesMD.ini for making this script work:
-
-In `rulesmd.ini`:
-```ini
-[AITargetType]  ; List of Technos
-0=Techno N,Techno N+1, Techno N+1,... Techno N+M
-1= ...
-2= ...
-...
-```
-
-The following values are the *Target Type#* which can be used as second parameter of the new attack script actions:
-
-| *Value* | *Target Type*     | *Description*                                 |
-| :-----: | :---------------: | :-------------------------------------------: |
-1         | Anything          |	Any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* and *[BuildingTypes]* |
-2         | Structures        |	Any enemy *[BuildingTypes]* without `Artillary=yes`, `TickTank=yes`, `ICBMLauncher=yes` or `SensorArray=yes` |
-3         | Ore Miners        |	Any enemy *[VehicleTypes]* with `Harvester=yes` or `ResourceGatherer=yes`, *[BuildingTypes]* with `ResourceGatherer=yes` |
-4         | Infantry          |	Any enemy *[InfantryTypes]* |
-5         | Vehicles          |	Any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[BuildingTypes]* with `Artillary=yes`, `TickTank=yes`, `ICBMLauncher=yes` & `SensorArray=yes` |
-6         | Factories         |	Any enemy *[BuildingTypes]* with a Factory= setting |
-7         | Base Defenses     |	Any enemy *[BuildingTypes]* with `IsBaseDefense=yes` |
-8         | House Threats     |	Any object that targets anything of the Team's House or any enemy that is near to the Team Leader |
-9         | Power Plants      |	Any enemy *[BuildingTypes]* with positive `Power=` values |
-10        | Occupied          |	Any *[BuildingTypes]* with garrisoned infantry |
-11        | Tech Buildings    |	Any *[BuildingTypes]* with `Unsellable=yes`, `Capturable=yes`, negative `TechLevel=` values or appears in `[AI]>NeutralTechBuildings=` list |
-12        |	Refinery          |	Any enemy *[BuildingTypes]* with `Refinery=yes` or `ResourceGatherer=yes`, *[VehicleTypes]* with `ResourceGatherer=yes` & `Harvester=no` (i.e. Slave Miner) |
-13        |	Mind Controller   |	Anything *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* and *[BuildingTypes]* with `MindControl=yes` in the weapons Warheads |
-14        |	Air Units         |	Any enemy *[AircraftTypes]*, flying *[VehicleTypes]* or *[InfantryTypes]* |
-15        |	Naval             |	Any enemy *[BuildingTypes]* and *[VehicleTypes]* with a `Naval=yes`, any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* in a water cell |
-16        |	Disruptors        |	Any enemy objects with positive `InhibitorRange=` values, positive `RadarJamRadius=` values, `CloakGenerator=yes` or `GapGenerator=yes` |
-17        |	Ground Vehicles   |	Any enemy *[VehicleTypes]* without `Naval=yes`, landed *[AircraftTypes]*, Deployed vehicles into *[BuildingTypes]* |
-18        |	Economy           |	Any enemy *[VehicleTypes]* with `Harvester=yes` or `ResourceGatherer=yes`, *[BuildingTypes]* with `Refinery=yes`, `ResourceGatherer=yes` or `OrePurifier=yes` |
-19        |	Infantry Factory  |	Any enemy *[BuildingTypes]* with `Factory=InfantryType` |
-20        |	Vehicle Factory   |	Any enemy *[BuildingTypes]* with `Factory=UnitType` |
-21        |	Aircraft Factory  |	Any enemy *[BuildingTypes]* with `Factory=AircraftType` |
-22        |	Radar             |	Any enemy *[BuildingTypes]* with `Radar=yes` or `SpySat=yes` |
-23        |	Tech Lab          |	Any enemy *[BuildingTypes]* in `[AI]>BuildTech=` list |
-24        |	Naval Factory     |	Any enemy *[BuildingTypes]* with `Naval=yes` and `Factory=UnitType` |
-25        |	Super Weapon      |	Any enemy *[BuildingTypes]* with `SuperWeapon=`, `SuperWeapon2=` or `SuperWeapons=` |
-26        |	Construction Yard |	Any enemy *[BuildingTypes]* with `ConstructionYard=yes` and `Factory=BuildingType` |
-27        |	Neutrals          |	Any neutral object (Civilian) |
-28        |	Generators        |	Any enemy *[BuildingTypes]* with `CloakGenerator=yes` or `GapGenerator=yes` |
-29        |	Radar Jammer      |	Any enemy objects with positive `RadarJamRadius=` values |
-30        |	Inhibitors        |	Any enemy objects with positive `InhibitorRange=` values |
-31        |	Naval Units       |	Any enemy *[VehicleTypes]* with a `Naval=yes` or any enemy *[VehicleTypes]*, *[AircraftTypes]*, *[InfantryTypes]* in a water cell |
-32        | Mobile Units      |	Anything *[VehicleTypes]*, *[AircraftTypes]* and *[InfantryTypes]* |
-33        |	Capturable        |	Any *[BuildingTypes]* with `Capturable=yes` or any *[BuildingTypes]* with `BridgeRepairHut=yes` and `Repairable=yes` |
-34         | Area Threats     |	Any enemy object that is inside of the Team Leader's Guard Area |
-Inside the Area Guard of the Team Leader

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -52,9 +52,9 @@ New:
 - XDrawOffset for animations (by Morton)
 - Customizable OpenTopped properties (by Otamaa)
 - Automatic Passenger Deletion (by FS-21)
-- Script Action 74 to 81 for new AI attacks (by FS-21)
+- Script Action 74 to 81 and 84 to 91 for new AI attacks (by FS-21)
 - Script Actions 82 & 83 for modifying AI Trigger Current Weight (by FS-21)
-- Script Action to regroup temporarily around the Team Leader (by FS-21)
+- Script Action 112 to regroup temporarily around the Team Leader (by FS-21)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -62,7 +62,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	if (!pData)
 		return;
 
-	const char* sectionAITargetType = "AITargetType";
+	const char* sectionAITargetTypes = "AITargetTypes";
 
 	INI_EX exINI(pINI);
 
@@ -72,27 +72,23 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
 
 	// Section AITargetType
-	int itemsCount = pINI->GetKeyCount(sectionAITargetType);
+	int itemsCount = pINI->GetKeyCount(sectionAITargetTypes);
 	for (int i = 0; i < itemsCount; ++i)
 	{
 		DynamicVectorClass<TechnoTypeClass*> objectsList;
 		char* context = nullptr;
-		pINI->ReadString(sectionAITargetType, pINI->GetKeyName(sectionAITargetType, i), "", Phobos::readBuffer);
+		pINI->ReadString(sectionAITargetTypes, pINI->GetKeyName(sectionAITargetTypes, i), "", Phobos::readBuffer);
 
 		for (char *cur = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
 		{
 			TechnoTypeClass* buffer;
 			if (Parser<TechnoTypeClass*>::TryParse(cur, &buffer))
-			{
-				//Debug::Log("DEBUG: [AITargetType][%d]: Parsed [%s]\n", AITargetTypeLists.Count, cur);
 				objectsList.AddItem(buffer);
-			}
 			else
-				Debug::Log("DEBUG: [AITargetType][%d]: Error parsing [%s]\n", AITargetTypeLists.Count, cur);
-			//if (!std::is_pointer<char*>() || !INIClass::IsBlank(cur))
-				//Debug::INIParseFailed(sectionAITargetType, (char*)(i), cur);
+				Debug::Log("DEBUG: [AITargetTypes][%d]: Error parsing [%s]\n", AITargetTypesLists.Count, cur);
 		}
-		AITargetTypeLists.AddItem(objectsList);
+
+		AITargetTypesLists.AddItem(objectsList);
 		objectsList.Clear();
 	}
 }
@@ -146,7 +142,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->MissingCameo)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
-		.Process(AITargetTypeLists)
+		.Process(this->AITargetTypesLists)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -62,12 +62,39 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	if (!pData)
 		return;
 
+	const char* sectionAITargetType = "AITargetType";
+
 	INI_EX exINI(pINI);
 
 	this->RadApplicationDelay_Building.Read(exINI, "Radiation", "RadApplicationDelay.Building");
 	this->Pips_Shield.Read(exINI, "AudioVisual", "Pips.Shield");
 	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
 	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
+
+	// Section AITargetType
+	int itemsCount = pINI->GetKeyCount(sectionAITargetType);
+	for (int i = 0; i < itemsCount; ++i)
+	{
+		DynamicVectorClass<TechnoTypeClass*> objectsList;
+		char* context = nullptr;
+		pINI->ReadString(sectionAITargetType, pINI->GetKeyName(sectionAITargetType, i), "", Phobos::readBuffer);
+
+		for (char *cur = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+		{
+			TechnoTypeClass* buffer;
+			if (Parser<TechnoTypeClass*>::TryParse(cur, &buffer))
+			{
+				//Debug::Log("DEBUG: [AITargetType][%d]: Parsed [%s]\n", AITargetTypeLists.Count, cur);
+				objectsList.AddItem(buffer);
+			}
+			else
+				Debug::Log("DEBUG: [AITargetType][%d]: Error parsing [%s]\n", AITargetTypeLists.Count, cur);
+			//if (!std::is_pointer<char*>() || !INIClass::IsBlank(cur))
+				//Debug::INIParseFailed(sectionAITargetType, (char*)(i), cur);
+		}
+		AITargetTypeLists.AddItem(objectsList);
+		objectsList.Clear();
+	}
 }
 
 // this runs between the before and after type data loading methods for rules ini
@@ -119,6 +146,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->MissingCameo)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
+		.Process(AITargetTypeLists)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -28,7 +28,7 @@ public:
 		Valueable<Vector3D<int>> Pips_Shield_Buildings;
 		Valueable<int> RadApplicationDelay_Building;
 		PhobosFixedString<32u> MissingCameo;
-		DynamicVectorClass<DynamicVectorClass<TechnoTypeClass*>> AITargetTypeLists;
+		DynamicVectorClass<DynamicVectorClass<TechnoTypeClass*>> AITargetTypesLists;
 
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -28,6 +28,7 @@ public:
 		Valueable<Vector3D<int>> Pips_Shield_Buildings;
 		Valueable<int> RadApplicationDelay_Building;
 		PhobosFixedString<32u> MissingCameo;
+		DynamicVectorClass<DynamicVectorClass<TechnoTypeClass*>> AITargetTypeLists;
 
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1118,9 +1118,9 @@ bool ScriptExt::EvaluateObjectWithMask(TechnoClass *pTechno, int mask, int attac
 	TechnoClass* pTarget = nullptr;
 
 	// Special case: validate target if is part of a technos list in [AITargetType]	section
-	if (attackAITargetType >= 0 && RulesExt::Global()->AITargetTypeLists.Count > 0)
+	if (attackAITargetType >= 0 && RulesExt::Global()->AITargetTypesLists.Count > 0)
 	{
-		DynamicVectorClass<TechnoTypeClass*> objectsList = RulesExt::Global()->AITargetTypeLists.GetItem(attackAITargetType);
+		DynamicVectorClass<TechnoTypeClass*> objectsList = RulesExt::Global()->AITargetTypesLists.GetItem(attackAITargetType);
 
 		for (int i = 0; i < objectsList.Count; i++)
 		{
@@ -1769,7 +1769,9 @@ void ScriptExt::Mission_Attack_List(TeamClass *pTeam, bool repeatAction, int cal
 	if (attackAITargetType < 0)
 		attackAITargetType = pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->idxCurrentLine].Argument;
 
-	if (RulesExt::Global()->AITargetTypeLists.Count > 0 
-		&& RulesExt::Global()->AITargetTypeLists.GetItem(attackAITargetType).Count > 0)
+	if (RulesExt::Global()->AITargetTypesLists.Count > 0
+		&& RulesExt::Global()->AITargetTypesLists.GetItem(attackAITargetType).Count > 0)
+	{
 		ScriptExt::Mission_Attack(pTeam, repeatAction, calcThreatMode, attackAITargetType, -1);
+	}
 }

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1117,7 +1117,7 @@ bool ScriptExt::EvaluateObjectWithMask(TechnoClass *pTechno, int mask, int attac
 	double distanceToTarget = 0;
 	TechnoClass* pTarget = nullptr;
 
-	// Special case: validate target if is part of a technos list in [AITargetType] section
+	// Special case: validate target if is part of a technos list in [AITargetType]	section
 	if (attackAITargetType >= 0 && RulesExt::Global()->AITargetTypeLists.Count > 0)
 	{
 		DynamicVectorClass<TechnoTypeClass*> objectsList = RulesExt::Global()->AITargetTypeLists.GetItem(attackAITargetType);

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -58,6 +58,8 @@ public:
 	static void DecreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static void IncreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 
+	static void Mission_Attack_List(TeamClass *pTeam, bool repeatAction, int calcThreatMode, int attackAITargetType);
+
 	static ExtContainer ExtMap;
 
 private:


### PR DESCRIPTION
These use a new [AITargetType] section in rulesmd.ini for finding a specific enemy target.

Backported from PR 296 and I know that this was tested by Ayylmao because some some people these actions makes the enemy selection very flexible