### PR TITLE
Script Action 92: Wait If No Target Found

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Credits
 - **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix, custom ore gathering anim, TemporaryClass related crash, Retry dialog on mission failure, Default disguise for individual InfantryTypes, PowerPlant Enhancer
 - **Otamaa (Fahroni, BoredEXE)** - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass, DebrisMaximums fixes, Anim-to-Unit, NotHuman anim sequences improvements, Customizable OpenTopped Properties
 - **E1 Elite** - TileSet 255 and above bridge repair fix
-- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72 & 73, 74 to 81, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
+- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72, 73, 74 to 81, 92, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
 - **AutoGavy** - interceptor logic, warhead critical damage system
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -605,3 +605,12 @@ Note: New Attack action scripts (74, 75, 78, 79) that are focused in target thre
 
 Note: All Aircrafts that attack other air units will end the script. This behavior is intentional because without it aircrafts had some bugs that weren't fixable at the time of developing the feature.
 
+### `92` Wait If No Target Found
+
+- When executed before a new Attack ScriptType Actions like `74-81` and `84-91` the TeamType will remember that must wait 1 second if no target was selected. The second parameter is a positive value that specifies how much retries the Attack will do when no target was found before new Attack ScriptType Action is discarded & the script execution jumps to the next line. The value `0` means infinite retries.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=92,n            ; integer n=0
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -55,6 +55,7 @@ New:
 - Script Action 74 to 81 for new AI attacks (by FS-21)
 - Script Actions 82 & 83 for modifying AI Trigger Current Weight (by FS-21)
 - Script Action to regroup temporarily around the Team Leader (by FS-21)
+- Script Action 92 for waiting & repeat the same new AI attack if no target was found (by FS-21)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -80,6 +80,9 @@ void ScriptExt::ProcessAction(TeamClass* pTeam)
 	case 83:
 		ScriptExt::IncreaseCurrentTriggerWeight(pTeam, true, 0);
 		break;
+	case 92:
+		ScriptExt::WaitIfNoTarget(pTeam, -1);
+		break;
 	case 112:
 		ScriptExt::Mission_Gather_NearTheLeader(pTeam, -1);
 		break;
@@ -1744,4 +1747,26 @@ void ScriptExt::ModifyCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine 
 				pTriggerType->Weight_Current = pTriggerType->Weight_Minimum;
 		}
 	}
+}
+
+void ScriptExt::WaitIfNoTarget(TeamClass *pTeam, int attempts = 0)
+{
+	// This method modifies the new attack actions preventing Team's Trigger to jump to next script action
+	// attempts == number of times the Team will wait if Mission_Attack(...) can't find a new target.
+	if (attempts < 0)
+		attempts = pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->idxCurrentLine].Argument;
+
+	auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+	if (pTeamData)
+	{
+		if (attempts <= 0)
+			pTeamData->WaitNoTargetAttempts = -1; // Infinite waits if no target
+		else
+			pTeamData->WaitNoTargetAttempts = attempts;
+	}
+
+	// This action finished
+	pTeam->StepCompleted = true;
+
+	return;
 }

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -57,6 +57,7 @@ public:
 
 	static void DecreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static void IncreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
+	static void WaitIfNoTarget(TeamClass *pTeam, int attempts);
 
 	static ExtContainer ExtMap;
 


### PR DESCRIPTION
Action 92 backported from PR 296

Executed BEFORE the attack script action you wanted to affect it sets how many attempts will do the affected action before acorting the action and jump to the next script line.

If set n=0 then the Team always stays waiting for a valid target in the attack action.
The effect ends when the attack action picked a target.
Old YR AI actions can't use this feature.Action 92 backported from PR 296

In `aimd.ini`:
[SOMESCRIPTTYPE]  ; ScriptType
x=92,n            ; integer n=0