### PR TITLE
Script Action 93: Team's Trigger Weight Reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Credits
 - **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix, custom ore gathering anim, TemporaryClass related crash, Retry dialog on mission failure, Default disguise for individual InfantryTypes, PowerPlant Enhancer
 - **Otamaa (Fahroni, BoredEXE)** - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass, DebrisMaximums fixes, Anim-to-Unit, NotHuman anim sequences improvements, Customizable OpenTopped Properties
 - **E1 Elite** - TileSet 255 and above bridge repair fix
-- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72, 73, 74 to 81, 92, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
+- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72, 73, 74 to 81, 92, 93, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
 - **AutoGavy** - interceptor logic, warhead critical damage system
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -674,6 +674,16 @@ In `aimd.ini`:
 x=92,n            ; integer n=0
 ```
 
+### `93` Team's Trigger Weight Reward
+
+- When executed before a new Attack ScriptType Actions like `74-81` and `84-91` the TeamType will remember that must be rewarded increasing the current Weight of the AI Trigger when the TeamType Target was killed by any of the Team members. The current Weight will never surprass the Minimum Weight and Maximum Weight limits of the AI Trigger. The second parameter is a positive value.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=93,n            ; integer n=0
+```
+
 ### `112` Regroup temporarily around the Team Leader
 
 - Puts the TaskForce into Area Guard Mode for the given amount of time around the Team Leader (this unit remains almost immobile until the action ends). The default radius around the Leader is `[General] > CloseEnough` and the units will not leave that area.
@@ -683,3 +693,4 @@ In `aimd.ini`:
 [SOMESCRIPTTYPE]  ; ScriptType
 x=112,n
 ```
+

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -55,6 +55,7 @@ New:
 - Script Action 74 to 81 and 84 to 91 for new AI attacks (by FS-21)
 - Script Actions 82 & 83 for modifying AI Trigger Current Weight (by FS-21)
 - Script Action 92 for waiting & repeat the same new AI attack if no target was found (by FS-21)
+- Script Action 93 that modifies the Team's Trigger Weight when ends the new attack action (by FS-21)
 - Script Action 112 to regroup temporarily around the Team Leader (by FS-21)
 
 Vanilla fixes:

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -83,6 +83,9 @@ void ScriptExt::ProcessAction(TeamClass* pTeam)
 	case 92:
 		ScriptExt::WaitIfNoTarget(pTeam, -1);
 		break;
+	case 93:
+		ScriptExt::TeamWeightReward(pTeam, 0);
+		break;
 	case 112:
 		ScriptExt::Mission_Gather_NearTheLeader(pTeam, -1);
 		break;
@@ -494,7 +497,10 @@ void ScriptExt::Mission_Attack(TeamClass *pTeam, bool repeatAction = true, int c
 			if (pTeamData)
 			{
 				if (pTeamData->NextSuccessWeightAward > 0)
+				{
+					IncreaseCurrentTriggerWeight(pTeam, false, pTeamData->NextSuccessWeightAward);
 					pTeamData->NextSuccessWeightAward = 0;
+				}
 			}
 
 			// Let's clean the Killer mess
@@ -1777,6 +1783,24 @@ void ScriptExt::WaitIfNoTarget(TeamClass *pTeam, int attempts = 0)
 			pTeamData->WaitNoTargetAttempts = -1; // Infinite waits if no target
 		else
 			pTeamData->WaitNoTargetAttempts = attempts;
+	}
+
+	// This action finished
+	pTeam->StepCompleted = true;
+
+	return;
+}
+
+void ScriptExt::TeamWeightReward(TeamClass *pTeam, double award = 0)
+{
+	if (award <= 0)
+		award = pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->idxCurrentLine].Argument;
+
+	auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+	if (pTeamData)
+	{
+		if (award > 0)
+			pTeamData->NextSuccessWeightAward = award;
 	}
 
 	// This action finished

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -58,6 +58,7 @@ public:
 	static void DecreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static void IncreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static void WaitIfNoTarget(TeamClass *pTeam, int attempts);
+	static void TeamWeightReward(TeamClass *pTeam, double award);
 
 	static void Mission_Attack_List(TeamClass *pTeam, bool repeatAction, int calcThreatMode, int attackAITargetType);
 


### PR DESCRIPTION
Script Action 93 backported from PR 296

When executed before a new Attack ScriptType Actions like `74-81` and `84-91` the TeamType will remember that must be rewarded increasing the current Weight of the AI Trigger when the TeamType Target was killed by any of the Team members. The current Weight will never surprass the Minimum Weight and Maximum Weight limits of the AI Trigger. The second parameter is a positive value. 

Only affects the first (new) attack script action ran after this action.

In `aimd.ini`:

[SOMESCRIPTTYPE]  ; ScriptType
x=93,n            ; integer n=0