### PR TITLE
Script Action 94: Pick Random Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Credits
 - **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix, custom ore gathering anim, TemporaryClass related crash, Retry dialog on mission failure, Default disguise for individual InfantryTypes, PowerPlant Enhancer
 - **Otamaa (Fahroni, BoredEXE)** - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass, DebrisMaximums fixes, Anim-to-Unit, NotHuman anim sequences improvements, Customizable OpenTopped Properties
 - **E1 Elite** - TileSet 255 and above bridge repair fix
-- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72, 73, 74 to 81, 92, 93, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
+- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72, 73, 74 to 81, 92, 93, 94, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
 - **AutoGavy** - interceptor logic, warhead critical damage system
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -684,6 +684,26 @@ In `aimd.ini`:
 x=93,n            ; integer n=0
 ```
 
+### `94` Pick A Random Script
+
+- When executed this action picks a random Script Type and replaces the current script by the new picked. The second parameter is a 0-based index from the new section `AIScriptsList` explained below.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=94,n
+```
+
+The second parameter is a 0-based index for the `AIScriptsList` section that specifies the list of possible `ScriptTypes` that can be evaluated. The new `AIScriptsList` section must be declared in `rulesmd.ini` for making this script work:
+
+In `rulesmd.ini`:
+```ini
+[AIScriptsList]  ; List of ScriptType lists
+0=SOMESCRIPTTYPE,SOMEOTHERSCRIPTTYPE,SAMPLESCRIPTTYPE
+1=ANOTHERSCRIPTTYPE,YETANOTHERSCRIPTTYPE
+; ...
+```
+
 ### `112` Regroup temporarily around the Team Leader
 
 - Puts the TaskForce into Area Guard Mode for the given amount of time around the Team Leader (this unit remains almost immobile until the action ends). The default radius around the Leader is `[General] > CloseEnough` and the units will not leave that area.
@@ -693,4 +713,3 @@ In `aimd.ini`:
 [SOMESCRIPTTYPE]  ; ScriptType
 x=112,n
 ```
-

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -56,6 +56,7 @@ New:
 - Script Actions 82 & 83 for modifying AI Trigger Current Weight (by FS-21)
 - Script Action 92 for waiting & repeat the same new AI attack if no target was found (by FS-21)
 - Script Action 93 that modifies the Team's Trigger Weight when ends the new attack action (by FS-21)
+- Script Action 94 for picking a random script from a list (by FS-21)
 - Script Action 112 to regroup temporarily around the Team Leader (by FS-21)
 
 Vanilla fixes:

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -66,6 +66,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	INI_EX exINI(pINI);
 
+	const char* sectionAIScriptsList = "AIScriptsList";
+
 	this->RadApplicationDelay_Building.Read(exINI, "Radiation", "RadApplicationDelay.Building");
 	this->Pips_Shield.Read(exINI, "AudioVisual", "Pips.Shield");
 	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
@@ -89,6 +91,25 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		}
 
 		AITargetTypesLists.AddItem(objectsList);
+		objectsList.Clear();
+	}
+
+	// Section AIScriptsList
+	int scriptitemsCount = pINI->GetKeyCount(sectionAIScriptsList);
+	for (int i = 0; i < scriptitemsCount; ++i)
+	{
+		DynamicVectorClass<ScriptTypeClass*> objectsList;
+
+		char* context = nullptr;
+		pINI->ReadString(sectionAIScriptsList, pINI->GetKeyName(sectionAIScriptsList, i), "", Phobos::readBuffer);
+
+		for (char *cur = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+		{
+			ScriptTypeClass* pNewScript = new ScriptTypeClass(cur);
+			objectsList.AddItem(pNewScript);
+		}
+
+		AIScriptsLists.AddItem(objectsList);
 		objectsList.Clear();
 	}
 }
@@ -143,6 +164,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->AITargetTypesLists)
+		.Process(this->AIScriptsLists)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -29,6 +29,7 @@ public:
 		Valueable<int> RadApplicationDelay_Building;
 		PhobosFixedString<32u> MissingCameo;
 		DynamicVectorClass<DynamicVectorClass<TechnoTypeClass*>> AITargetTypesLists;
+		DynamicVectorClass<DynamicVectorClass<ScriptTypeClass*>> AIScriptsLists;
 
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1809,6 +1809,55 @@ void ScriptExt::TeamWeightReward(TeamClass *pTeam, double award = 0)
 	return;
 }
 
+void ScriptExt::PickRandomScript(TeamClass* pTeam, int idxScriptsList = -1)
+{
+	if (idxScriptsList <= 0)
+		idxScriptsList = pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->idxCurrentLine].Argument;
+
+	bool changeFailed = true;
+
+	if (idxScriptsList >= 0)
+	{
+		if (idxScriptsList < RulesExt::Global()->AIScriptsLists.Count)
+		{
+			DynamicVectorClass<ScriptTypeClass*> objectsList = RulesExt::Global()->AIScriptsLists.GetItem(idxScriptsList);
+
+			if (objectsList.Count > 0)
+			{
+				int IdxSelectedObject = ScenarioClass::Instance->Random.RandomRanged(0, objectsList.Count - 1);
+
+				ScriptTypeClass* pNewScript = objectsList.GetItem(IdxSelectedObject);
+				if (pNewScript->ActionsCount > 0)
+				{
+					changeFailed = false;
+					pTeam->CurrentScript = nullptr;
+					pTeam->CurrentScript = new ScriptClass(pNewScript);
+
+					// Ready for jumping to the first line of the new script
+					pTeam->CurrentScript->idxCurrentLine = -1;
+					pTeam->StepCompleted = true;
+
+					return;
+				}
+				else
+				{
+					pTeam->StepCompleted = true;
+					Debug::Log("DEBUG: [%s] Aborting Script change because [%s] has 0 Action scripts!\n", pTeam->Type->ID, pNewScript->ID);
+
+					return;
+				}
+			}
+		}
+	}
+
+	// This action finished
+	if (changeFailed)
+	{
+		pTeam->StepCompleted = true;
+		Debug::Log("DEBUG: [%s] [%s] Failed to change the Team Script with a random one!\n", pTeam->Type->ID, pTeam->CurrentScript->Type->ID);
+	}
+}
+
 void ScriptExt::Mission_Attack_List(TeamClass *pTeam, bool repeatAction, int calcThreatMode, int attackAITargetType)
 {
 	auto pTeamData = TeamExt::ExtMap.Find(pTeam);

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -59,6 +59,7 @@ public:
 	static void IncreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static void WaitIfNoTarget(TeamClass *pTeam, int attempts);
 	static void TeamWeightReward(TeamClass *pTeam, double award);
+	static void PickRandomScript(TeamClass * pTeam, int idxScriptsList);
 
 	static void Mission_Attack_List(TeamClass *pTeam, bool repeatAction, int calcThreatMode, int attackAITargetType);
 


### PR DESCRIPTION
Script Action 94 Backported from PR 296.

When executed it picks a random Script Type and replaces the current script by the new picked.

The second parameter is a 0-based index for the [AIScriptsList] section that specifies the list of possible [ScriptTypes] that can be evaluated. The new [AIScriptsList] section must be declared in RulesMD.ini for making this script work:

[AIScriptsList] ; List of ScriptTypes
0=ScriptType N,ScriptType N+1, ScriptType N+1,... ScriptType N+M
1= ...
2= ...
...