### PR TITLE
Script Actions 95-98: Moving Team to techno object location

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Credits
 - **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix, custom ore gathering anim, TemporaryClass related crash, Retry dialog on mission failure, Default disguise for individual InfantryTypes, PowerPlant Enhancer
 - **Otamaa (Fahroni, BoredEXE)** - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass, DebrisMaximums fixes, Anim-to-Unit, NotHuman anim sequences improvements, Customizable OpenTopped Properties
 - **E1 Elite** - TileSet 255 and above bridge repair fix
-- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72 & 73, 74 to 81, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
+- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72 & 73, 74 to 81, 95 to 98, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
 - **AutoGavy** - interceptor logic, warhead critical damage system
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ Credits
 - **secsome (SEC-SOME)** - debug info dump hotkey, refactoring & porting of Ares helper code, introducing more Ares-derived stuff, disguise removal warhead, Mind Control removal warhead, Mind Control enhancement, shields, AnimList.PickRandom, MoveToCell fix, unlimited waypoints, Build At trigger action buildup anim fix, Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix, custom ore gathering anim, TemporaryClass related crash, Retry dialog on mission failure, Default disguise for individual InfantryTypes, PowerPlant Enhancer
 - **Otamaa (Fahroni, BoredEXE)** - help with CellSpread, ported and fixed custom RadType code, togglable ElectricBolt bolts, customizable Chrono Locomotor properties per TechnoClass, DebrisMaximums fixes, Anim-to-Unit, NotHuman anim sequences improvements, Customizable OpenTopped Properties
 - **E1 Elite** - TileSet 255 and above bridge repair fix
-- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72, 73, 74 to 81, 92, 93, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
-- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72 & 73, 74 to 81, 95 to 98, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
+- **FS-21** - Dump Object Info enhancements, Powered.KillSpawns, Spawner.LimitRange, ScriptType Actions 71, 72, 73, 74 to 81, 92, 93, 95 to 98, 112, MC deployer fixes, help with docs, Automatic Passenger Deletion
 - **AutoGavy** - interceptor logic, warhead critical damage system
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -605,3 +605,20 @@ Note: New Attack action scripts (74, 75, 78, 79) that are focused in target thre
 
 Note: All Aircrafts that attack other air units will end the script. This behavior is intentional because without it aircrafts had some bugs that weren't fixable at the time of developing the feature.
 
+### `95-98` Moving Team to techno location
+
+- These Actions instructs the TeamType to use the TaskForce to approach the target specified by the second parameter. Look at the tables below for the possible Actions (first parameter value).
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=i,n             ; where 95 <= i <= 98
+```
+
+| *Action* | *Argument*    | Target Owner | *Target Priority* | *Description*                                 |
+| :------: | :-----------: | :----------: | :---------------: | :-------------------------------------------: |
+95         | Target Type# | Enemy | Closer, higher threat |  |
+96         | Target Type# | Enemy | Farther, higher threat |  |
+97         | Target Type# | Friendly | Closer |  |
+98         | Target Type# | Friendly | Farther |  |
+

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -55,6 +55,7 @@ New:
 - Script Action 74 to 81 for new AI attacks (by FS-21)
 - Script Actions 82 & 83 for modifying AI Trigger Current Weight (by FS-21)
 - Script Action to regroup temporarily around the Team Leader (by FS-21)
+- Script Action 95 to 98 for new AI movements towards certain objects (by FS-21)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1788,20 +1788,19 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 			if (pTeamData)
 			{
 				if (pTeamData->WaitNoTargetAttempts > 0)
-				{
 					pTeamData->WaitNoTargetAttempts--;
-				}
 			}
 		}
 		else
+		{
 			return;
+		}
 	}
 
 	// This team has no units! END
 	if (!pTeam)
 	{
 		auto pTeamData = TeamExt::ExtMap.Find(pTeam);
-
 		if (pTeamData && pTeamData->CloseEnough > 0)
 		{
 			pTeamData->CloseEnough = -1;
@@ -1809,8 +1808,8 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 
 		// This action finished
 		pTeam->StepCompleted = true;
-
 		Debug::Log("DEBUG: ScripType: [%s] [%s] Jump to NEXT line: %d = %d,%d -> (Reason: No team members alive)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine, pScript->Type->ScriptActions[pScript->idxCurrentLine].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine].Argument);
+
 		return;
 	}
 
@@ -1849,15 +1848,13 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 			pTeamData->IdxSelectedObjectFromAIList = -1;
 
 			if (pTeamData->CloseEnough > 0)
-			{
 				pTeamData->CloseEnough = -1;
-			}
 		}
 
 		// This action finished
 		pTeam->StepCompleted = true;
-
 		Debug::Log("DEBUG: ScripType: [%s] [%s] Jump to NEXT line: %d = %d,%d -> (Reasons: No Leader | Aircrafts without ammo)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine, pScript->Type->ScriptActions[pScript->idxCurrentLine].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine].Argument);
+
 		return;
 	}
 
@@ -1869,16 +1866,13 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 		int targetMask = scriptArgument;
 
 		selectedTarget = FindBestObject(pLeaderUnit, targetMask, calcThreatMode, pickAllies, attackAITargetType, idxAITargetTypeItem);
-
 		if (selectedTarget)
 		{
 			pTeam->Focus = selectedTarget;
 
 			auto pTeamData = TeamExt::ExtMap.Find(pTeam);
 			if (pTeamData && pTeamData->WaitNoTargetAttempts != 0)
-			{
 				pTeamData->WaitNoTargetAttempts = 0;
-			}
 
 			for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
 			{
@@ -1905,9 +1899,7 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 
 						// Aircraft hack. I hate how this game auto-manages the aircraft missions.
 						if (pUnitType->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo > 0 && pUnit->GetHeight() <= 0)
-						{
 							pUnit->QueueMission(Mission::Move, false);
-						}
 
 						// Aircraft hack. I hate how this game auto-manages the aircraft missions.
 						if (pUnitType->WhatAmI() != AbstractType::AircraftType)
@@ -1916,9 +1908,7 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 							pUnit->ClickedAction(Action::Move, selectedTarget, false);
 
 							if (pUnit->GetCurrentMission() != Mission::Move)
-							{
 								pUnit->Mission_Move();
-							}
 						}
 					}
 				}
@@ -1930,13 +1920,12 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 			if (pTeamData)
 			{
 				if (pTeamData->IdxSelectedObjectFromAIList >= 0)
-				{
 					pTeamData->IdxSelectedObjectFromAIList = -1;
-				}
 
 				if (pTeamData->WaitNoTargetAttempts != 0)
 				{
 					pTeam->GuardAreaTimer.Start(16);
+
 					return;
 				}
 
@@ -1950,6 +1939,7 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 			// This action finished
 			pTeam->StepCompleted = true;
 			Debug::Log("DEBUG: Next script action line for [%s] (%s) will be: %d = %d,%d (Reason: New target NOT FOUND)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine + 1, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Argument);
+
 			return;
 		}
 	}
@@ -1958,11 +1948,8 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 		double closeEnough = RulesClass::Instance->CloseEnough / 256.0;
 
 		auto pTeamData = TeamExt::ExtMap.Find(pTeam);
-
 		if (pTeamData && pTeamData->CloseEnough > 0)
-		{
 			closeEnough = pTeamData->CloseEnough;
-		}
 
 		bool bForceNextAction = true;
 
@@ -2005,14 +1992,13 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 				pTeamData->IdxSelectedObjectFromAIList = -1;
 
 				if (pTeamData->CloseEnough >= 0)
-				{
 					pTeamData->CloseEnough = -1;
-				}
 			}
 
 			// This action finished
 			pTeam->StepCompleted = true;
 			Debug::Log("DEBUG: ScripType: [%s] [%s] Jump to NEXT line: %d = %d,%d -> (Reason: Reached destination)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine + 1, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Argument);
+
 			return;
 		}
 	}
@@ -2028,7 +2014,6 @@ TechnoClass* ScriptExt::FindBestObject(TechnoClass *pTechno, int method, int cal
 	if (!pickAllies && pTechno->BelongsToATeam())
 	{
 		auto pFoot = abstract_cast<FootClass*>(pTechno);
-
 		if (pFoot)
 		{
 			int enemyHouseIndex = pFoot->Team->FirstUnit->Owner->EnemyHouseIndex;
@@ -2090,6 +2075,7 @@ TechnoClass* ScriptExt::FindBestObject(TechnoClass *pTechno, int method, int cal
 				newCell.Y = (short)object->Location.Y;
 
 				bool isGoodTarget = false;
+
 				if (calcThreatMode == 0 || calcThreatMode == 1)
 				{
 					// Threat affected by distance
@@ -2163,8 +2149,8 @@ TechnoClass* ScriptExt::FindBestObject(TechnoClass *pTechno, int method, int cal
 		}
 	}
 
-	if (bestObject != nullptr) {
+	if (bestObject != nullptr)
 		return bestObject;
-	}
+
 	return nullptr;
 }

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -80,6 +80,22 @@ void ScriptExt::ProcessAction(TeamClass* pTeam)
 	case 83:
 		ScriptExt::IncreaseCurrentTriggerWeight(pTeam, true, 0);
 		break;
+	case 95:
+		// Move to the closest enemy target
+		ScriptExt::Mission_Move(pTeam, 2, false, -1, -1);
+		break;
+	case 96:
+		// Move to the farther enemy target
+		ScriptExt::Mission_Move(pTeam, 3, false, -1, -1);
+		break;
+	case 97:
+		// Move to the closest friendly target
+		ScriptExt::Mission_Move(pTeam, 2, true, -1, -1);
+		break;
+	case 98:
+		// Move to the farther friendly target
+		ScriptExt::Mission_Move(pTeam, 3, true, -1, -1);
+		break;
 	case 112:
 		ScriptExt::Mission_Gather_NearTheLeader(pTeam, -1);
 		break;
@@ -1744,4 +1760,411 @@ void ScriptExt::ModifyCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine 
 				pTriggerType->Weight_Current = pTriggerType->Weight_Minimum;
 		}
 	}
+}
+
+void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pickAllies = false, int attackAITargetType = -1, int idxAITargetTypeItem = -1)
+{
+	auto pScript = pTeam->CurrentScript;
+	int scriptArgument = pScript->Type->ScriptActions[pScript->idxCurrentLine].Argument; // This is the target type
+	TechnoClass* selectedTarget = nullptr;
+	bool noWaitLoop = false;
+	FootClass *pLeaderUnit = nullptr;
+	TechnoTypeClass* pLeaderUnitType = nullptr;
+	int bestUnitLeadershipValue = -1;
+	bool bAircraftsWithoutAmmo = false;
+	TechnoClass* pFocus = nullptr;
+
+	// When the new target wasn't found it sleeps some few frames before the new attempt. This can save cycles and cycles of unnecessary executed lines.
+	if (pTeam->GuardAreaTimer.TimeLeft != 0 || pTeam->GuardAreaTimer.InProgress())
+	{
+		pTeam->GuardAreaTimer.TimeLeft--;
+
+		if (pTeam->GuardAreaTimer.TimeLeft == 0)
+		{
+			pTeam->GuardAreaTimer.Stop(); // Needed
+			noWaitLoop = true;
+
+			auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+			if (pTeamData)
+			{
+				if (pTeamData->WaitNoTargetAttempts > 0)
+				{
+					pTeamData->WaitNoTargetAttempts--;
+				}
+			}
+		}
+		else
+			return;
+	}
+
+	// This team has no units! END
+	if (!pTeam)
+	{
+		auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+
+		if (pTeamData && pTeamData->CloseEnough > 0)
+		{
+			pTeamData->CloseEnough = -1;
+		}
+
+		// This action finished
+		pTeam->StepCompleted = true;
+
+		Debug::Log("DEBUG: ScripType: [%s] [%s] Jump to NEXT line: %d = %d,%d -> (Reason: No team members alive)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine, pScript->Type->ScriptActions[pScript->idxCurrentLine].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine].Argument);
+		return;
+	}
+
+	for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+	{
+		if (pUnit && pUnit->IsAlive && pUnit->Health > 0 && !pUnit->InLimbo)
+		{
+			auto pUnitType = pUnit->GetTechnoType();
+			if (pUnitType)
+			{
+				if (pUnitType->WhatAmI() == AbstractType::AircraftType
+					&& !pUnit->IsInAir()
+					&& abstract_cast<AircraftTypeClass*>(pUnitType)->AirportBound
+					&& pUnit->Ammo < pUnitType->Ammo)
+				{
+					bAircraftsWithoutAmmo = true;
+					pUnit->CurrentTargets.Clear();
+				}
+
+				// The Team Leader will be used for selecting targets, if there are living Team Members then always exists 1 Leader.
+				int unitLeadershipRating = pUnitType->LeadershipRating;
+				if (unitLeadershipRating > bestUnitLeadershipValue)
+				{
+					pLeaderUnit = pUnit;
+					bestUnitLeadershipValue = unitLeadershipRating;
+				}
+			}
+		}
+	}
+
+	if (!pLeaderUnit || bAircraftsWithoutAmmo)
+	{
+		auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+		if (pTeamData)
+		{
+			pTeamData->IdxSelectedObjectFromAIList = -1;
+
+			if (pTeamData->CloseEnough > 0)
+			{
+				pTeamData->CloseEnough = -1;
+			}
+		}
+
+		// This action finished
+		pTeam->StepCompleted = true;
+
+		Debug::Log("DEBUG: ScripType: [%s] [%s] Jump to NEXT line: %d = %d,%d -> (Reasons: No Leader | Aircrafts without ammo)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine, pScript->Type->ScriptActions[pScript->idxCurrentLine].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine].Argument);
+		return;
+	}
+
+	pLeaderUnitType = pLeaderUnit->GetTechnoType();
+
+	pFocus = abstract_cast<TechnoClass*>(pTeam->Focus);
+	if (!pFocus && !bAircraftsWithoutAmmo)
+	{
+		int targetMask = scriptArgument;
+
+		selectedTarget = FindBestObject(pLeaderUnit, targetMask, calcThreatMode, pickAllies, attackAITargetType, idxAITargetTypeItem);
+
+		if (selectedTarget)
+		{
+			pTeam->Focus = selectedTarget;
+
+			auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+			if (pTeamData && pTeamData->WaitNoTargetAttempts != 0)
+			{
+				pTeamData->WaitNoTargetAttempts = 0;
+			}
+
+			for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+			{
+				if (pUnit->IsAlive && pUnit->Health > 0 && !pUnit->InLimbo)
+				{
+					auto pUnitType = pUnit->GetTechnoType();
+
+					if (pUnit && pUnitType)
+					{
+						pUnit->CurrentTargets.Clear();
+
+						if (pUnitType->Underwater && pUnitType->LandTargeting == 1 && selectedTarget->GetCell()->LandType != LandType::Water) // Land not OK for the Naval unit
+						{
+							// Naval units like Submarines are unable to target ground targets except if they have anti-ground weapons. Ignore the attack
+							pUnit->CurrentTargets.Clear();
+							pUnit->SetTarget(nullptr);
+							pUnit->SetFocus(nullptr);
+							pUnit->SetDestination(nullptr, false);
+							pUnit->QueueMission(Mission::Area_Guard, true);
+							continue;
+						}
+
+						pUnit->SetDestination(selectedTarget, false);
+
+						// Aircraft hack. I hate how this game auto-manages the aircraft missions.
+						if (pUnitType->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo > 0 && pUnit->GetHeight() <= 0)
+						{
+							pUnit->QueueMission(Mission::Move, false);
+						}
+
+						// Aircraft hack. I hate how this game auto-manages the aircraft missions.
+						if (pUnitType->WhatAmI() != AbstractType::AircraftType)
+						{
+							pUnit->QueueMission(Mission::Move, false);
+							pUnit->ClickedAction(Action::Move, selectedTarget, false);
+
+							if (pUnit->GetCurrentMission() != Mission::Move)
+							{
+								pUnit->Mission_Move();
+							}
+						}
+					}
+				}
+			}
+		}
+		else
+		{
+			auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+			if (pTeamData)
+			{
+				if (pTeamData->IdxSelectedObjectFromAIList >= 0)
+				{
+					pTeamData->IdxSelectedObjectFromAIList = -1;
+				}
+
+				if (pTeamData->WaitNoTargetAttempts != 0)
+				{
+					pTeam->GuardAreaTimer.Start(16);
+					return;
+				}
+
+				if (pTeamData->CloseEnough >= 0)
+					pTeamData->CloseEnough = -1;
+			}
+
+			if (!noWaitLoop)
+				pTeam->GuardAreaTimer.Start(16);
+
+			// This action finished
+			pTeam->StepCompleted = true;
+			Debug::Log("DEBUG: Next script action line for [%s] (%s) will be: %d = %d,%d (Reason: New target NOT FOUND)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine + 1, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Argument);
+			return;
+		}
+	}
+	else
+	{
+		double closeEnough = RulesClass::Instance->CloseEnough / 256.0;
+
+		auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+
+		if (pTeamData && pTeamData->CloseEnough > 0)
+		{
+			closeEnough = pTeamData->CloseEnough;
+		}
+
+		bool bForceNextAction = true;
+
+		// Team already have a focused target
+		for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+		{
+			if (pUnit
+				&& pUnit->IsAlive
+				&& !pUnit->InLimbo)
+			{
+				if (!pUnit->Locomotor->Is_Moving_Now())
+					pUnit->SetDestination(pFocus, false);
+
+				if (pUnit->DistanceFrom(pUnit->Destination) / 256.0 > closeEnough)
+				{
+					bForceNextAction = false;
+
+					if (pUnit->GetTechnoType()->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo > 0)
+						pUnit->QueueMission(Mission::Move, false);
+
+					continue;
+				}
+				else
+				{
+					if (pUnit->GetTechnoType()->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo <= 0)
+					{
+						pUnit->QueueMission(Mission::Return, false);
+						pUnit->Mission_Enter();
+
+						continue;
+					}
+				}
+			}
+		}
+
+		if (bForceNextAction)
+		{
+			if (pTeamData)
+			{
+				pTeamData->IdxSelectedObjectFromAIList = -1;
+
+				if (pTeamData->CloseEnough >= 0)
+				{
+					pTeamData->CloseEnough = -1;
+				}
+			}
+
+			// This action finished
+			pTeam->StepCompleted = true;
+			Debug::Log("DEBUG: ScripType: [%s] [%s] Jump to NEXT line: %d = %d,%d -> (Reason: Reached destination)\n", pTeam->Type->ID, pScript->Type->ID, pScript->idxCurrentLine + 1, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Action, pScript->Type->ScriptActions[pScript->idxCurrentLine + 1].Argument);
+			return;
+		}
+	}
+}
+
+TechnoClass* ScriptExt::FindBestObject(TechnoClass *pTechno, int method, int calcThreatMode = 0, bool pickAllies = false, int attackAITargetType = -1, int idxAITargetTypeItem = -1)
+{
+	TechnoClass *bestObject = nullptr;
+	double bestVal = -1;
+	HouseClass* enemyHouse = nullptr;
+
+	// Favorite Enemy House case. If set, AI will focus against that House
+	if (!pickAllies && pTechno->BelongsToATeam())
+	{
+		auto pFoot = abstract_cast<FootClass*>(pTechno);
+
+		if (pFoot)
+		{
+			int enemyHouseIndex = pFoot->Team->FirstUnit->Owner->EnemyHouseIndex;
+
+			if (pFoot->Team->Type->OnlyTargetHouseEnemy
+				&& enemyHouseIndex >= 0)
+				enemyHouse = HouseClass::Array->GetItem(enemyHouseIndex);
+		}
+	}
+
+	// Generic method for targeting
+	for (int i = 0; i < TechnoClass::Array->Count; i++)
+	{
+		auto object = TechnoClass::Array->GetItem(i);
+		auto objectType = object->GetTechnoType();
+		auto pTechnoType = pTechno->GetTechnoType();
+
+		if (!object || !objectType || !pTechnoType)
+			continue;
+
+		if (enemyHouse && enemyHouse != object->Owner)
+			continue;
+
+		// Don't pick underground units
+		if (object->InWhichLayer() == Layer::Underground)
+			continue;
+
+		// Stealth ground unit check
+		if (object->CloakState == CloakState::Cloaked && !objectType->Naval)
+			continue;
+
+		// Submarines aren't a valid target
+		if (object->CloakState == CloakState::Cloaked
+			&& objectType->Underwater
+			&& (pTechnoType->NavalTargeting == 0
+				|| pTechnoType->NavalTargeting == 6))
+			continue;
+
+		// Land not OK for the Naval unit
+		if (objectType->Naval
+			&& pTechnoType->LandTargeting == 1
+			&& object->GetCell()->LandType != LandType::Water)
+			continue;
+
+		if (object != pTechno
+			&& object->IsAlive
+			&& !object->InLimbo
+			&& object->IsOnMap
+			&& !object->Absorbed
+			&& ((pickAllies && pTechno->Owner->IsAlliedWith(object))
+				|| (!pickAllies && !pTechno->Owner->IsAlliedWith(object))))
+		{
+			double value = 0;
+
+			if (EvaluateObjectWithMask(object, method, attackAITargetType, idxAITargetTypeItem, pTechno))
+			{
+				CellStruct newCell;
+				newCell.X = (short)object->Location.X;
+				newCell.Y = (short)object->Location.Y;
+
+				bool isGoodTarget = false;
+				if (calcThreatMode == 0 || calcThreatMode == 1)
+				{
+					// Threat affected by distance
+					double threatMultiplier = 128.0;
+					double objectThreatValue = objectType->ThreatPosed;
+
+					if (objectType->SpecialThreatValue > 0)
+					{
+						double const& TargetSpecialThreatCoefficientDefault = RulesClass::Instance->TargetSpecialThreatCoefficientDefault;
+						objectThreatValue += objectType->SpecialThreatValue * TargetSpecialThreatCoefficientDefault;
+					}
+
+					// Is Defender house targeting Attacker House? if "yes" then more Threat
+					if (pTechno->Owner == HouseClass::Array->GetItem(object->Owner->EnemyHouseIndex))
+					{
+						double const& EnemyHouseThreatBonus = RulesClass::Instance->EnemyHouseThreatBonus;
+						objectThreatValue += EnemyHouseThreatBonus;
+					}
+
+					// Extra threat based on current health. More damaged == More threat (almost destroyed objects gets more priority)
+					objectThreatValue += object->Health * (1 - object->GetHealthPercentage());
+					value = (objectThreatValue * threatMultiplier) / ((pTechno->DistanceFrom(object) / 256.0) + 1.0);
+
+					if (calcThreatMode == 0)
+					{
+						// Is this object very FAR? then LESS THREAT against pTechno.
+						// More CLOSER? MORE THREAT for pTechno.
+						if (value > bestVal || bestVal < 0)
+							isGoodTarget = true;
+					}
+					else
+					{
+						// Is this object very FAR? then MORE THREAT against pTechno.
+						// More CLOSER? LESS THREAT for pTechno.
+						if (value < bestVal || bestVal < 0)
+							isGoodTarget = true;
+					}
+				}
+				else
+				{
+					// Selection affected by distance
+					if (calcThreatMode == 2)
+					{
+						// Is this object very FAR? then LESS THREAT against pTechno.
+						// More CLOSER? MORE THREAT for pTechno.
+						value = pTechno->DistanceFrom(object); // Note: distance is in leptons (*256)
+
+						if (value < bestVal || bestVal < 0)
+							isGoodTarget = true;
+					}
+					else
+					{
+						if (calcThreatMode == 3)
+						{
+							// Is this object very FAR? then MORE THREAT against pTechno.
+							// More CLOSER? LESS THREAT for pTechno.
+							value = pTechno->DistanceFrom(object); // Note: distance is in leptons (*256)
+
+							if (value > bestVal || bestVal < 0)
+								isGoodTarget = true;
+						}
+					}
+				}
+
+				if (isGoodTarget)
+				{
+					bestObject = object;
+					bestVal = value;
+				}
+			}
+		}
+	}
+
+	if (bestObject != nullptr) {
+		return bestObject;
+	}
+	return nullptr;
 }

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -57,6 +57,8 @@ public:
 
 	static void DecreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static void IncreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
+	static void Mission_Move(TeamClass* pTeam, int calcThreatMode, bool pickAllies, int attackAITargetType, int idxAITargetTypeItem);
+	static TechnoClass* FindBestObject(TechnoClass *pTechno, int method, int calcThreatMode, bool pickAllies, int attackAITargetType, int idxAITargetTypeItem);
 
 	static ExtContainer ExtMap;
 


### PR DESCRIPTION
Script Actions backported from PR 296.

These Actions instructs the TeamType to use the TaskForce to approach the target specified by the second parameter.

; In aimd.ini:
[SOMESCRIPTTYPE]  ; ScriptType
x=i,n             ; where 95 <= i <= 98