### PR TITLE
Implement AutoFire for TechnoTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption
 - **mevitar** - honorary shield tester *triple* award

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -344,6 +344,17 @@ WeaponXFLH.BurstN=             ; int - forward, lateral, height
 EliteWeaponXFLH.BurstN=        ; int - forward, lateral, height
 ```
 
+### Automatically firing weapons
+
+- You can now make TechnoType automatically fire its weapon(s) without having to scan for suitable targets by setting `AutoFire`, on either its base cell (in which case the weapon that is used for force-firing is used) or itself (in which case normal targeting and weapon selection rules and are respected) depending on if `AutoFire.TargetSelf` is set or not.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]            ; TechnoType
+AutoFire=no             ; boolean
+AutoFire.TargetSelf=no  ; boolean
+```
+
 ## Weapons
 
 ### Burst.Delays

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -102,6 +102,7 @@ New:
 - Weapon targeting filter (by Uranusian)
 - Burst-specific FLHs for TechnoTypes (by Starkku)
 - Burst delays for weapons (by Starkku)
+- Auto-firing TechnoType weapons (by Starkku)
 - PowerPlant Enhancer (by secsome)
 - Unlimited Global / Local Variables (by secsome)
 - Adds a "Load Game" button to the retry dialog on mission failure (by secsome)

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -173,7 +173,7 @@ DEFINE_HOOK(0x6F72D2, TechnoClass_IsCloseEnoughToTarget_OpenTopped_RangeBonus, 0
 DEFINE_HOOK(0x6FE43B, TechnoClass_Fire_OpenTopped_DmgMult, 0x8)
 {
 	enum { ApplyDamageMult = 0x6FE45A, ContinueCheck = 0x6FE460 };
-	
+
 	GET(TechnoClass* const, pThis, ESI);
 
 	//replacing whole check due to `fild`
@@ -208,6 +208,26 @@ DEFINE_HOOK(0x71A82C, TemporalClass_AI_Opentopped_WarpDistance, 0xC)
 		{
 			R->EDX(pExt->OpenTopped_WarpDistance.Get(RulesClass::Instance->OpenToppedWarpDistance));
 			return 0x71A838;
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7098B9, TechnoClass_TargetSomethingNearby_AutoFire, 0x6)
+{
+	GET(TechnoClass* const, pThis, ESI);
+
+	if (auto pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
+	{
+		if (pExt->AutoFire)
+		{
+			if (pExt->AutoFire_TargetSelf)
+				pThis->Target = pThis;
+			else
+				pThis->Target = pThis->GetCell();
+
+			return 0x7099B8;
 		}
 	}
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -129,6 +129,9 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->OpenTopped_DamageMultiplier.Read(exINI, pSection, "OpenTopped.DamageMultiplier");
 	this->OpenTopped_WarpDistance.Read(exINI, pSection, "OpenTopped.WarpDistance");
 
+	this->AutoFire.Read(exINI, pSection, "AutoFire");
+	this->AutoFire_TargetSelf.Read(exINI, pSection, "AutoFire.TargetSelf");
+
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
 
@@ -250,6 +253,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->OpenTopped_RangeBonus)
 		.Process(this->OpenTopped_DamageMultiplier)
 		.Process(this->OpenTopped_WarpDistance)
+		.Process(this->AutoFire)
+		.Process(this->AutoFire_TargetSelf)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -74,6 +74,9 @@ public:
 		Nullable<float> OpenTopped_DamageMultiplier;
 		Nullable<int> OpenTopped_WarpDistance;
 
+		Valueable<bool> AutoFire;
+		Valueable<bool> AutoFire_TargetSelf;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -137,7 +140,9 @@ public:
 			DefaultDisguise(),
 			OpenTopped_RangeBonus(),
 			OpenTopped_DamageMultiplier(),
-			OpenTopped_WarpDistance()
+			OpenTopped_WarpDistance(),
+			AutoFire(false),
+			AutoFire_TargetSelf(false)
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- You can now make TechnoType automatically fire its weapon(s) without having to scan for suitable targets by setting `AutoFire`, on either its base cell (in which case the weapon that is used for force-firing is used) or itself (in which case normal targeting and weapon selection rules and are respected) depending on if `AutoFire.TargetSelf` is set or not.

In `rulesmd.ini`:
```ini
[SOMETECHNO]            ; TechnoType
AutoFire=no             ; boolean
AutoFire.TargetSelf=no  ; boolean
```

Primary use-case is passive things like shield /  cloak generators, some dummy object weapons etc. that don't need an actual target. Full-map threat scanning is potentially *very* detrimental to performance if map is large and filled to brim with objects, hence the need to find alternate solutions. As a bonus, setting `AutoFire.TargetSelf` to true allows the weapons to snap on to the firer instead of just being fired on the base cell, which can allow for properly centered area effects.