### PR TITLE
Make Image work for InfantryTypes, VehicleTypes and AircraftTypes in artmd.ini

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -34,6 +34,7 @@
     <ClCompile Include="src\Ext\TEvent\Body.cpp" />
     <ClCompile Include="src\Ext\Trigger\Hooks.cpp" />
     <ClCompile Include="src\Misc\CaptureManager.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Image.cpp" />
     <ClCompile Include="src\Misc\TextInput.cpp" />
     <ClCompile Include="src\New\Entity\ShieldClass.cpp" />
     <ClCompile Include="src\Misc\RetryDialog.cpp" />

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Credits
 - **thomassneddon** - general assistance
 - **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
-- **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption, building LimboDelivery
+- **Morton (MortonPL)** - XDrawOffset, Shield passthrough & absorption, building LimboDelivery, fix for Image in art rules
 - **mevitar** - honorary shield tester *triple* award
 - **Damfoos** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -141,18 +141,19 @@ SpawnsTiberium.CellsPerAnim=1 ; single int / comma-sep. range
 
 - `Image` tag in art INI is no longer limited to AnimationTypes and BuildingTypes, and can be applied to all TechnoTypes (InfantryTypes, VehicleTypes, AircraftTypes, BuildingTypes).
 - The tag specifies **only** the file name (without extension) of the asset that replaces TechnoType's graphics. If the name in `Image` is also an entry in the art INI, **no tags will be read from it**.
-- **By default this feature is disabled** to remain compatible with YR. To use this feature, enable it in rules with `NoArtImageSwap=false`.
+- **By default this feature is disabled** to remain compatible with YR. To use this feature, enable it in rules with `ArtImageSwap=true`.
+- This feature supports SHP images for InfantryTypes, SHP and VXL images for VehicleTypes and VXL images for AircraftTypes.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-NoArtImageSwap=true
+ArtImageSwap=false  ; disabled by default
 ```
 
 In `artmd.ini`:
 ```ini
 [SOMETECHNO]
-Image=        ; name of the file that will be used as image, without extension
+Image=              ; name of the file that will be used as image, without extension
 ```
 
 ## Weapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -137,6 +137,24 @@ SpawnsTiberium.GrowthStage=3  ; single int / comma-sep. range
 SpawnsTiberium.CellsPerAnim=1 ; single int / comma-sep. range
 ```
 
+### Customizable unit image in art
+
+- `Image` tag in art INI is no longer limited to AnimationTypes and BuildingTypes, and can be applied to all TechnoTypes (InfantryTypes, VehicleTypes, AircraftTypes, BuildingTypes).
+- The tag specifies **only** the file name (without extension) of the asset that replaces TechnoType's graphics. If the name in `Image` is also an entry in the art INI, **no tags will be read from it**.
+- **By default this feature is disabled** to remain compatible with YR. To use this feature, enable it in rules with `NoArtImageSwap=false`.
+
+In `rulesmd.ini`:
+```ini
+[General]
+NoArtImageSwap=true
+```
+
+In `artmd.ini`:
+```ini
+[SOMETECHNO]
+Image=        ; name of the file that will be used as image, without extension
+```
+
 ## Weapons
 
 ### Customizable disk laser radius

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1015,7 +1015,7 @@ Note: This feature might not support every building flag. Flags that are confirm
 Note: In order for this feature to work with AITriggerTypes conditions ("Owning house owns ???" and "Enemy house owns ???"), `LegalTarget` must be set to true.
 
 ```{warning}
-Remember that Limbo Delivered buildings don't exist physically! This means they should never have enabled machanics that require interaction with the game world (i.e. factories, cloning vats, service depots, helipads). They also **should have either `KeepAlive=yes` set or be killable with LimboKill** - otherwise the game might never end.
+Remember that Limbo Delivered buildings don't exist physically! This means they should never have enabled machanics that require interaction with the game world (i.e. factories, cloning vats, service depots, helipads). They also **should have either `KeepAlive=no` set or be killable with LimboKill** - otherwise the game might never end.
 ```
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -242,6 +242,7 @@ New:
 - Shield absorption and passthrough customization (by Morton)
 - Limbo Delivery of buildings (by Morton)
 - Ore stage threshold for `HideIfNoOre` (by Otamaa)
+- Image reading in art rules for all TechnoTypes (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -12,14 +12,17 @@
 
 DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 {
-	GET(InfantryTypeClass*, infantryType, ESI);
-	char tempBuffer[0x19];
-	if (CCINIClass::INI_Art->ReadString(infantryType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+	if (!Phobos::Config::NoArtImageSwap)
 	{
-		Debug::Log("[Phobos] Replacing image for %s with %s\n", infantryType->ImageFile, tempBuffer);
-		char filename[260];
-		_makepath(filename, 0, 0, tempBuffer, ".SHP");
-		infantryType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);
+		GET(InfantryTypeClass*, infantryType, ESI);
+		char tempBuffer[0x19];
+		if (CCINIClass::INI_Art->ReadString(infantryType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+		{
+			Debug::Log("[Phobos] Replacing image for %s with %s\n", infantryType->ImageFile, tempBuffer);
+			char filename[260];
+			_makepath(filename, 0, 0, tempBuffer, ".SHP");
+			infantryType->Image = GameCreate<SHPReference>(filename);
+		}
 	}
 	
 	return 0;

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -47,14 +47,12 @@ DEFINE_HOOK(0x747B49, VehicleTypeClass_ReadINI, 0x6)
 				unitType->LoadVoxel();
 				strcpy(unitType->ImageFile, savedBufffer);
 			}
-			/*
 			else
 			{
 				char filename[260];
 				_makepath(filename, 0, 0, tempBuffer, ".SHP");
 				unitType->Image = GameCreate<SHPReference>(filename);
 			}
-			*/
 		}
 	}
 

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -1,0 +1,44 @@
+#include <Helpers/Macro.h>
+#include <CCINIClass.h>
+#include <RulesClass.h>
+#include <InfantryTypeClass.h>
+
+/*
+DEFINE_HOOK(0x52CA02, Init_Game, 0x6)
+{
+	
+	GET(CCINIClass*, pINI, EAX);
+
+	RulesClass::Instance->Read_InfantryTypes(pINI);
+
+	for (int i = 0; i < InfantryTypeClass::Array->Count; ++i)
+	{
+		InfantryTypeClass* infantryType = InfantryTypeClass::Array->Items[i];
+		infantryType->LoadFromINI(pINI);
+		CCINIClass::INI_Art->ReadString(infantryType->ID, "Image", infantryType->ImageFile, infantryType->ImageFile, 0x19);
+		_snprintf_s(infantryType->ImageFile, sizeof("COW"), "COW");
+		if (infantryType->ID == 0)
+		{
+			return 1;
+		}
+	}
+
+	return 0;
+}
+*/
+
+DEFINE_HOOK(0x5F9629, ObjectTypeClass_ReadINI, 0x5)
+{
+	
+	GET(ObjectTypeClass*, objectType, EBX);
+	if (objectType->WhatAmI() == AbstractType::Infantry)
+	{
+		CCINIClass::INI_Art->ReadString(objectType->ID, "Image", objectType->ImageFile, objectType->ImageFile, 0x19);
+		if (objectType->ID == 0)
+		{
+			return 1;
+		}
+	}
+	
+	return 0;
+}

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -15,6 +15,7 @@ DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 	{
 		GET(InfantryTypeClass*, infantryType, ESI);
 		char nameBuffer[0x19];
+
 		if (CCINIClass::INI_Art->ReadString(infantryType->ImageFile, "Image", 0, nameBuffer, 0x19) != 0)
 		{
 			Debug::Log("[Phobos] Replacing image for %s with %s.\n", infantryType->ImageFile, nameBuffer);
@@ -33,6 +34,7 @@ DEFINE_HOOK(0x747B49, VehicleTypeClass_ReadINI, 0x6)
 	{
 		GET(UnitTypeClass*, unitType, EDI);
 		char nameBuffer[0x19];
+
 		if (CCINIClass::INI_Art->ReadString(unitType->ImageFile, "Image", 0, nameBuffer, 0x19) != 0)
 		{
 			Debug::Log("[Phobos] Replacing image for %s with %s.\n", unitType->ImageFile, nameBuffer);
@@ -62,6 +64,7 @@ DEFINE_HOOK(0x41CD54, AircraftTypeClass_ReadINI, 0x6)
 	{
 		GET(AircraftTypeClass*, aircraftType, ESI);
 		char nameBuffer[0x19];
+
 		if (CCINIClass::INI_Art->ReadString(aircraftType->ImageFile, "Image", 0, nameBuffer, 0x19) != 0)
 		{
 			if (aircraftType->Voxel)

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -20,7 +20,7 @@ DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 		char filename[260];
 		_makepath(filename, 0, 0, tempBuffer, ".SHP");
 		infantryType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);
-	}	
+	}
 	
 	return 0;
 }

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -1,44 +1,44 @@
 #include <Helpers/Macro.h>
 #include <CCINIClass.h>
 #include <RulesClass.h>
+#include <MixFileClass.h>
 #include <InfantryTypeClass.h>
+#include <UnitTypeClass.h>
+
+DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
+{
+	GET(InfantryTypeClass*, infantryType, ESI);
+	char tempBuffer[0x19];
+	if (CCINIClass::INI_Art->ReadString(infantryType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+	{
+		char filename[260];
+		_makepath(filename, 0, 0, tempBuffer, ".SHP");
+		infantryType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);
+	}	
+	
+	return 0;
+}
 
 /*
-DEFINE_HOOK(0x52CA02, Init_Game, 0x6)
+DEFINE_HOOK(0x747B49, VehicleTypeClass_ReadINI, 0x6)
 {
-	
-	GET(CCINIClass*, pINI, EAX);
-
-	RulesClass::Instance->Read_InfantryTypes(pINI);
-
-	for (int i = 0; i < InfantryTypeClass::Array->Count; ++i)
+	GET(UnitTypeClass*, unitType, EDI);
+	char tempBuffer[0x19];
+	if (CCINIClass::INI_Art->ReadString(unitType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
 	{
-		InfantryTypeClass* infantryType = InfantryTypeClass::Array->Items[i];
-		infantryType->LoadFromINI(pINI);
-		CCINIClass::INI_Art->ReadString(infantryType->ID, "Image", infantryType->ImageFile, infantryType->ImageFile, 0x19);
-		_snprintf_s(infantryType->ImageFile, sizeof("COW"), "COW");
-		if (infantryType->ID == 0)
+		char filename[260];
+		if (!unitType->Voxel)
 		{
-			return 1;
+			_makepath(filename, 0, 0, tempBuffer, ".SHP");
+			unitType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);
+		}
+		else
+		{
+			_makepath(filename, 0, 0, tempBuffer, ".VXL");
+			unitType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);
 		}
 	}
 
 	return 0;
 }
 */
-
-DEFINE_HOOK(0x5F9629, ObjectTypeClass_ReadINI, 0x5)
-{
-	
-	GET(ObjectTypeClass*, objectType, EBX);
-	if (objectType->WhatAmI() == AbstractType::Infantry)
-	{
-		CCINIClass::INI_Art->ReadString(objectType->ID, "Image", objectType->ImageFile, objectType->ImageFile, 0x19);
-		if (objectType->ID == 0)
-		{
-			return 1;
-		}
-	}
-	
-	return 0;
-}

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -70,11 +70,14 @@ DEFINE_HOOK(0x41CD54, AircraftTypeClass_ReadINI, 0x6)
 		char savedBufffer[0x19];
 		if (CCINIClass::INI_Art->ReadString(aircraftType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
 		{
-			Debug::Log("[Phobos] Replacing image for %s with %s\n", aircraftType->ImageFile, tempBuffer);
-			strcpy(savedBufffer, aircraftType->ImageFile);
-			strcpy(aircraftType->ImageFile, tempBuffer);
-			aircraftType->LoadVoxel();
-			strcpy(aircraftType->ImageFile, savedBufffer);
+			if (aircraftType->Voxel)
+			{
+				Debug::Log("[Phobos] Replacing image for %s with %s\n", aircraftType->ImageFile, tempBuffer);
+				strcpy(savedBufffer, aircraftType->ImageFile);
+				strcpy(aircraftType->ImageFile, tempBuffer);
+				aircraftType->LoadVoxel();
+				strcpy(aircraftType->ImageFile, savedBufffer);
+			}
 		}
 	}
 

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -1,9 +1,14 @@
+#include <Phobos.h>
+
 #include <Helpers/Macro.h>
+#include <Utilities/Debug.h>
+
 #include <CCINIClass.h>
 #include <RulesClass.h>
 #include <MixFileClass.h>
 #include <InfantryTypeClass.h>
 #include <UnitTypeClass.h>
+
 
 DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 {
@@ -11,6 +16,7 @@ DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 	char tempBuffer[0x19];
 	if (CCINIClass::INI_Art->ReadString(infantryType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
 	{
+		Debug::Log("[Phobos] Replacing image for %s with %s\n", infantryType->ImageFile, tempBuffer);
 		char filename[260];
 		_makepath(filename, 0, 0, tempBuffer, ".SHP");
 		infantryType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -5,23 +5,21 @@
 
 #include <CCINIClass.h>
 #include <RulesClass.h>
-#include <MixFileClass.h>
 #include <InfantryTypeClass.h>
 #include <UnitTypeClass.h>
 #include <AircraftTypeClass.h>
 
-
 DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 {
-	if (!Phobos::Config::NoArtImageSwap)
+	if (Phobos::Config::ArtImageSwap)
 	{
 		GET(InfantryTypeClass*, infantryType, ESI);
-		char tempBuffer[0x19];
-		if (CCINIClass::INI_Art->ReadString(infantryType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+		char nameBuffer[0x19];
+		if (CCINIClass::INI_Art->ReadString(infantryType->ImageFile, "Image", 0, nameBuffer, 0x19) != 0)
 		{
-			Debug::Log("[Phobos] Replacing image for %s with %s\n", infantryType->ImageFile, tempBuffer);
+			Debug::Log("[Phobos] Replacing image for %s with %s.\n", infantryType->ImageFile, nameBuffer);
 			char filename[260];
-			_makepath(filename, 0, 0, tempBuffer, ".SHP");
+			_makepath(filename, 0, 0, nameBuffer, ".SHP");
 			infantryType->Image = GameCreate<SHPReference>(filename);
 		}
 	}
@@ -29,28 +27,27 @@ DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 	return 0;
 }
 
-
 DEFINE_HOOK(0x747B49, VehicleTypeClass_ReadINI, 0x6)
 {
-	if (!Phobos::Config::NoArtImageSwap)
+	if (Phobos::Config::ArtImageSwap)
 	{
 		GET(UnitTypeClass*, unitType, EDI);
-		char tempBuffer[0x19];
-		char savedBufffer[0x19];
-		if (CCINIClass::INI_Art->ReadString(unitType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+		char nameBuffer[0x19];
+		if (CCINIClass::INI_Art->ReadString(unitType->ImageFile, "Image", 0, nameBuffer, 0x19) != 0)
 		{
-			Debug::Log("[Phobos] Replacing image for %s with %s\n", unitType->ImageFile, tempBuffer);
+			Debug::Log("[Phobos] Replacing image for %s with %s.\n", unitType->ImageFile, nameBuffer);
 			if (unitType->Voxel)
 			{
-				strcpy(savedBufffer, unitType->ImageFile);
-				strcpy(unitType->ImageFile, tempBuffer);
+				char savedName[0x19];
+				strcpy(savedName, unitType->ImageFile);
+				strcpy(unitType->ImageFile, nameBuffer);
 				unitType->LoadVoxel();
-				strcpy(unitType->ImageFile, savedBufffer);
+				strcpy(unitType->ImageFile, savedName);
 			}
 			else
 			{
 				char filename[260];
-				_makepath(filename, 0, 0, tempBuffer, ".SHP");
+				_makepath(filename, 0, 0, nameBuffer, ".SHP");
 				unitType->Image = GameCreate<SHPReference>(filename);
 			}
 		}
@@ -61,20 +58,20 @@ DEFINE_HOOK(0x747B49, VehicleTypeClass_ReadINI, 0x6)
 
 DEFINE_HOOK(0x41CD54, AircraftTypeClass_ReadINI, 0x6)
 {
-	if (!Phobos::Config::NoArtImageSwap)
+	if (Phobos::Config::ArtImageSwap)
 	{
 		GET(AircraftTypeClass*, aircraftType, ESI);
-		char tempBuffer[0x19];
-		char savedBufffer[0x19];
-		if (CCINIClass::INI_Art->ReadString(aircraftType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+		char nameBuffer[0x19];
+		if (CCINIClass::INI_Art->ReadString(aircraftType->ImageFile, "Image", 0, nameBuffer, 0x19) != 0)
 		{
 			if (aircraftType->Voxel)
 			{
-				Debug::Log("[Phobos] Replacing image for %s with %s\n", aircraftType->ImageFile, tempBuffer);
-				strcpy(savedBufffer, aircraftType->ImageFile);
-				strcpy(aircraftType->ImageFile, tempBuffer);
+				Debug::Log("[Phobos] Replacing image for %s with %s.\n", aircraftType->ImageFile, nameBuffer);
+				char savedName[0x19];
+				strcpy(savedName, aircraftType->ImageFile);
+				strcpy(aircraftType->ImageFile, nameBuffer);
 				aircraftType->LoadVoxel();
-				strcpy(aircraftType->ImageFile, savedBufffer);
+				strcpy(aircraftType->ImageFile, savedName);
 			}
 		}
 	}

--- a/src/Misc/Hooks.Image.cpp
+++ b/src/Misc/Hooks.Image.cpp
@@ -8,6 +8,7 @@
 #include <MixFileClass.h>
 #include <InfantryTypeClass.h>
 #include <UnitTypeClass.h>
+#include <AircraftTypeClass.h>
 
 
 DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
@@ -28,26 +29,54 @@ DEFINE_HOOK(0x524734, InfantryTypeClass_ReadINI, 0x6)
 	return 0;
 }
 
-/*
+
 DEFINE_HOOK(0x747B49, VehicleTypeClass_ReadINI, 0x6)
 {
-	GET(UnitTypeClass*, unitType, EDI);
-	char tempBuffer[0x19];
-	if (CCINIClass::INI_Art->ReadString(unitType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+	if (!Phobos::Config::NoArtImageSwap)
 	{
-		char filename[260];
-		if (!unitType->Voxel)
+		GET(UnitTypeClass*, unitType, EDI);
+		char tempBuffer[0x19];
+		char savedBufffer[0x19];
+		if (CCINIClass::INI_Art->ReadString(unitType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
 		{
-			_makepath(filename, 0, 0, tempBuffer, ".SHP");
-			unitType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);
-		}
-		else
-		{
-			_makepath(filename, 0, 0, tempBuffer, ".VXL");
-			unitType->Image = (SHPStruct*)MixFileClass::Retrieve(filename, 0);
+			Debug::Log("[Phobos] Replacing image for %s with %s\n", unitType->ImageFile, tempBuffer);
+			if (unitType->Voxel)
+			{
+				strcpy(savedBufffer, unitType->ImageFile);
+				strcpy(unitType->ImageFile, tempBuffer);
+				unitType->LoadVoxel();
+				strcpy(unitType->ImageFile, savedBufffer);
+			}
+			/*
+			else
+			{
+				char filename[260];
+				_makepath(filename, 0, 0, tempBuffer, ".SHP");
+				unitType->Image = GameCreate<SHPReference>(filename);
+			}
+			*/
 		}
 	}
 
 	return 0;
 }
-*/
+
+DEFINE_HOOK(0x41CD54, AircraftTypeClass_ReadINI, 0x6)
+{
+	if (!Phobos::Config::NoArtImageSwap)
+	{
+		GET(AircraftTypeClass*, aircraftType, ESI);
+		char tempBuffer[0x19];
+		char savedBufffer[0x19];
+		if (CCINIClass::INI_Art->ReadString(aircraftType->ImageFile, "Image", NULL, tempBuffer, 0x19) != 0)
+		{
+			Debug::Log("[Phobos] Replacing image for %s with %s\n", aircraftType->ImageFile, tempBuffer);
+			strcpy(savedBufffer, aircraftType->ImageFile);
+			strcpy(aircraftType->ImageFile, tempBuffer);
+			aircraftType->LoadVoxel();
+			strcpy(aircraftType->ImageFile, savedBufffer);
+		}
+	}
+
+	return 0;
+}

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -45,6 +45,7 @@ const wchar_t* Phobos::UI::HarvesterLabel = L"";
 bool Phobos::Config::ToolTipDescriptions = true;
 bool Phobos::Config::PrioritySelectionFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
+bool Phobos::Config::NoArtImageSwap = true;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -187,6 +188,10 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 			pINI->ReadBool(SIDEBAR_SECTION, "ProducingProgress.Show", false);
 	}
 
+	Phobos::CloseConfig(pINI);
+
+	pINI = Phobos::OpenConfig("rulesmd.ini");
+	Phobos::Config::NoArtImageSwap = pINI->ReadBool("General", "NoArtImageSwap", true);
 	Phobos::CloseConfig(pINI);
 
 	return 0;

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -145,52 +145,70 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::ToolTipDescriptions = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ToolTipDescriptions", true);
 	Phobos::Config::PrioritySelectionFiltering = CCINIClass::INI_RA2MD->ReadBool("Phobos", "PrioritySelectionFiltering", true);
 
-	CCINIClass* pINI = Phobos::OpenConfig("uimd.ini");
+	//CCINIClass* pINI = Phobos::OpenConfig("uimd.ini");
 
 	// LoadingScreen
 	{
+		//Phobos::UI::DisableEmptySpawnPositions =
+		//	pINI->ReadBool("LoadingScreen", "DisableEmptySpawnPositions", false);
 		Phobos::UI::DisableEmptySpawnPositions =
-			pINI->ReadBool("LoadingScreen", "DisableEmptySpawnPositions", false);
+			CCINIClass::INI_UIMD->ReadBool("LoadingScreen", "DisableEmptySpawnPositions", false);
 	}
 
 	// ToolTips
 	{
+		//Phobos::UI::ExtendedToolTips =
+		//	pINI->ReadBool(TOOLTIPS_SECTION, "ExtendedToolTips", false);
 		Phobos::UI::ExtendedToolTips =
-			pINI->ReadBool(TOOLTIPS_SECTION, "ExtendedToolTips", false);
+			CCINIClass::INI_UIMD->ReadBool(TOOLTIPS_SECTION, "ExtendedToolTips", false);
 
+		//Phobos::UI::MaxToolTipWidth =
+		//	pINI->ReadInteger(TOOLTIPS_SECTION, "MaxWidth", 0);
 		Phobos::UI::MaxToolTipWidth =
-			pINI->ReadInteger(TOOLTIPS_SECTION, "MaxWidth", 0);
+			CCINIClass::INI_UIMD->ReadInteger(TOOLTIPS_SECTION, "MaxWidth", 0);
 
-		pINI->ReadString(TOOLTIPS_SECTION, "CostLabel", NONE_STR, Phobos::readBuffer);
+		//pINI->ReadString(TOOLTIPS_SECTION, "CostLabel", NONE_STR, Phobos::readBuffer);
+		CCINIClass::INI_UIMD->ReadString(TOOLTIPS_SECTION, "CostLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::CostLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"$");
 
-		pINI->ReadString(TOOLTIPS_SECTION, "PowerLabel", NONE_STR, Phobos::readBuffer);
+		//pINI->ReadString(TOOLTIPS_SECTION, "PowerLabel", NONE_STR, Phobos::readBuffer);
+		CCINIClass::INI_UIMD->ReadString(TOOLTIPS_SECTION, "PowerLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::PowerLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u26a1"); // ⚡
 
-		pINI->ReadString(TOOLTIPS_SECTION, "TimeLabel", NONE_STR, Phobos::readBuffer);
+		//pINI->ReadString(TOOLTIPS_SECTION, "TimeLabel", NONE_STR, Phobos::readBuffer);
+		CCINIClass::INI_UIMD->ReadString(TOOLTIPS_SECTION, "TimeLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::TimeLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u231a"); // ⌚
 	}
 
 	// Sidebar
 	{
+		//Phobos::UI::ShowHarvesterCounter =
+		//	pINI->ReadBool(SIDEBAR_SECTION, "HarvesterCounter.Show", false);
 		Phobos::UI::ShowHarvesterCounter =
-			pINI->ReadBool(SIDEBAR_SECTION, "HarvesterCounter.Show", false);
+			CCINIClass::INI_UIMD->ReadBool(SIDEBAR_SECTION, "HarvesterCounter.Show", false);
 
-		pINI->ReadString(SIDEBAR_SECTION, "HarvesterCounter.Label", NONE_STR, Phobos::readBuffer);
+		//pINI->ReadString(SIDEBAR_SECTION, "HarvesterCounter.Label", NONE_STR, Phobos::readBuffer);
+		CCINIClass::INI_UIMD->ReadString(SIDEBAR_SECTION, "HarvesterCounter.Label", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::HarvesterLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u26cf"); // ⛏
 
-		Phobos::UI::HarvesterCounter_ConditionYellow = 
-			pINI->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionYellow", Phobos::UI::HarvesterCounter_ConditionYellow);
+		//Phobos::UI::HarvesterCounter_ConditionYellow = 
+		//	pINI->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionYellow", Phobos::UI::HarvesterCounter_ConditionYellow);
+		Phobos::UI::HarvesterCounter_ConditionYellow =
+			CCINIClass::INI_UIMD->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionYellow", Phobos::UI::HarvesterCounter_ConditionYellow);
+		//Phobos::UI::HarvesterCounter_ConditionRed =
+		//	pINI->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionRed", Phobos::UI::HarvesterCounter_ConditionRed);
 		Phobos::UI::HarvesterCounter_ConditionRed = 
-			pINI->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionRed", Phobos::UI::HarvesterCounter_ConditionRed);
+			CCINIClass::INI_UIMD->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionRed", Phobos::UI::HarvesterCounter_ConditionRed);
 
+		//Phobos::UI::ShowProducingProgress =
+		//	pINI->ReadBool(SIDEBAR_SECTION, "ProducingProgress.Show", false);
 		Phobos::UI::ShowProducingProgress =
-			pINI->ReadBool(SIDEBAR_SECTION, "ProducingProgress.Show", false);
+			CCINIClass::INI_UIMD->ReadBool(SIDEBAR_SECTION, "ProducingProgress.Show", false);
 	}
 
-	Phobos::CloseConfig(pINI);
+	//Phobos::CloseConfig(pINI);
 
-	pINI = Phobos::OpenConfig("rulesmd.ini");
+	CCINIClass* pINI = Phobos::OpenConfig((const char*)0x826260);
 	Phobos::Config::NoArtImageSwap = pINI->ReadBool("General", "NoArtImageSwap", true);
 	Phobos::CloseConfig(pINI);
 

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -45,7 +45,7 @@ const wchar_t* Phobos::UI::HarvesterLabel = L"";
 bool Phobos::Config::ToolTipDescriptions = true;
 bool Phobos::Config::PrioritySelectionFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
-bool Phobos::Config::NoArtImageSwap = true;
+bool Phobos::Config::ArtImageSwap = false;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -145,71 +145,50 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::ToolTipDescriptions = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ToolTipDescriptions", true);
 	Phobos::Config::PrioritySelectionFiltering = CCINIClass::INI_RA2MD->ReadBool("Phobos", "PrioritySelectionFiltering", true);
 
-	//CCINIClass* pINI = Phobos::OpenConfig("uimd.ini");
-
 	// LoadingScreen
 	{
-		//Phobos::UI::DisableEmptySpawnPositions =
-		//	pINI->ReadBool("LoadingScreen", "DisableEmptySpawnPositions", false);
 		Phobos::UI::DisableEmptySpawnPositions =
 			CCINIClass::INI_UIMD->ReadBool("LoadingScreen", "DisableEmptySpawnPositions", false);
 	}
 
 	// ToolTips
 	{
-		//Phobos::UI::ExtendedToolTips =
-		//	pINI->ReadBool(TOOLTIPS_SECTION, "ExtendedToolTips", false);
 		Phobos::UI::ExtendedToolTips =
 			CCINIClass::INI_UIMD->ReadBool(TOOLTIPS_SECTION, "ExtendedToolTips", false);
 
-		//Phobos::UI::MaxToolTipWidth =
-		//	pINI->ReadInteger(TOOLTIPS_SECTION, "MaxWidth", 0);
 		Phobos::UI::MaxToolTipWidth =
 			CCINIClass::INI_UIMD->ReadInteger(TOOLTIPS_SECTION, "MaxWidth", 0);
 
-		//pINI->ReadString(TOOLTIPS_SECTION, "CostLabel", NONE_STR, Phobos::readBuffer);
 		CCINIClass::INI_UIMD->ReadString(TOOLTIPS_SECTION, "CostLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::CostLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"$");
 
-		//pINI->ReadString(TOOLTIPS_SECTION, "PowerLabel", NONE_STR, Phobos::readBuffer);
 		CCINIClass::INI_UIMD->ReadString(TOOLTIPS_SECTION, "PowerLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::PowerLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u26a1"); // ⚡
 
-		//pINI->ReadString(TOOLTIPS_SECTION, "TimeLabel", NONE_STR, Phobos::readBuffer);
 		CCINIClass::INI_UIMD->ReadString(TOOLTIPS_SECTION, "TimeLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::TimeLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u231a"); // ⌚
 	}
 
 	// Sidebar
 	{
-		//Phobos::UI::ShowHarvesterCounter =
-		//	pINI->ReadBool(SIDEBAR_SECTION, "HarvesterCounter.Show", false);
 		Phobos::UI::ShowHarvesterCounter =
 			CCINIClass::INI_UIMD->ReadBool(SIDEBAR_SECTION, "HarvesterCounter.Show", false);
 
-		//pINI->ReadString(SIDEBAR_SECTION, "HarvesterCounter.Label", NONE_STR, Phobos::readBuffer);
 		CCINIClass::INI_UIMD->ReadString(SIDEBAR_SECTION, "HarvesterCounter.Label", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::HarvesterLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u26cf"); // ⛏
 
-		//Phobos::UI::HarvesterCounter_ConditionYellow = 
-		//	pINI->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionYellow", Phobos::UI::HarvesterCounter_ConditionYellow);
 		Phobos::UI::HarvesterCounter_ConditionYellow =
 			CCINIClass::INI_UIMD->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionYellow", Phobos::UI::HarvesterCounter_ConditionYellow);
-		//Phobos::UI::HarvesterCounter_ConditionRed =
-		//	pINI->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionRed", Phobos::UI::HarvesterCounter_ConditionRed);
+
 		Phobos::UI::HarvesterCounter_ConditionRed = 
 			CCINIClass::INI_UIMD->ReadDouble(SIDEBAR_SECTION, "HarvesterCounter.ConditionRed", Phobos::UI::HarvesterCounter_ConditionRed);
 
-		//Phobos::UI::ShowProducingProgress =
-		//	pINI->ReadBool(SIDEBAR_SECTION, "ProducingProgress.Show", false);
 		Phobos::UI::ShowProducingProgress =
 			CCINIClass::INI_UIMD->ReadBool(SIDEBAR_SECTION, "ProducingProgress.Show", false);
 	}
 
-	//Phobos::CloseConfig(pINI);
-
 	CCINIClass* pINI = Phobos::OpenConfig((const char*)0x826260);
-	Phobos::Config::NoArtImageSwap = pINI->ReadBool("General", "NoArtImageSwap", true);
+	Phobos::Config::ArtImageSwap = pINI->ReadBool("General", "ArtImageSwap", false);
 	Phobos::CloseConfig(pINI);
 
 	return 0;

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -9,6 +9,7 @@ constexpr auto NONE_STR = "<none>";
 constexpr auto NONE_STR2 = "none";
 constexpr auto TOOLTIPS_SECTION = "ToolTips";
 constexpr auto SIDEBAR_SECTION = "Sidebar";
+constexpr auto GENERAL_SECTION = "General";
 
 class Phobos
 {

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -57,5 +57,6 @@ public:
 		static bool ToolTipDescriptions;
 		static bool PrioritySelectionFiltering;
 		static bool DevelopmentCommands;
+		static bool NoArtImageSwap;
 	};
 };

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -58,6 +58,6 @@ public:
 		static bool ToolTipDescriptions;
 		static bool PrioritySelectionFiltering;
 		static bool DevelopmentCommands;
-		static bool NoArtImageSwap;
+		static bool ArtImageSwap;
 	};
 };


### PR DESCRIPTION
`Image` tag in artmd.ini previously was available only for BuildingTypes and AnimationTypes. Now it is possible to use it for InfantryTypes, VXL & SHP VehicleTypes and AircraftTypes. Usage is the same as with BuildingTypes/AnimationTypes.

**By default this feature is disabled to remain compatible with YR. To use this feature, enable it in rules with `ArtImageSwap=true`.

In `rulesmd.ini`:
```ini
[General]
NoArtImageSwap=false   ; default to false, original logic
```

In `artmd.ini`:
```ini
[SOMETECHNO]
Image=                 ; name of the file that will be used as image, without extension
```