### PR TITLE
Make WarpOut, WarpIn, and WarpAway Anim support facings

### DIFF
--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -49,9 +49,9 @@ public:
 
 		Valueable<ShieldTypeClass*> ShieldType;
 
-		Nullable<AnimTypeClass*> WarpOut;
-		Nullable<AnimTypeClass*> WarpIn;
-		Nullable<AnimTypeClass*> WarpAway;
+		ValueableVector<AnimTypeClass*> WarpOut;
+		ValueableVector<AnimTypeClass*> WarpIn;
+		ValueableVector<AnimTypeClass*> WarpAway;
 		Nullable<bool> ChronoTrigger;
 		Nullable<int> ChronoDistanceFactor;
 		Nullable<int> ChronoMinimumDelay;


### PR DESCRIPTION
Close #437 

Will pick this up automatically and use the largest power of 2 equal to or larger than 8 to select the best animation from for each firing direction.

Fewer than 8 defined animations will result in only the first animation being used.
Default to Rules->WarpOut Anim if empty.

```Rules.ini
[SOMETECHNO]
WarpIn=          ;Vector AnimType
WarpOut=       ;Vector AnimType
WarpAway=     ;Vector AnimType
```