### PR TITLE
CreateUnit improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, CreateUnit.ConsiderPathfinding
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption, building LimboDelivery
 - **mevitar** - honorary shield tester *triple* award

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, CreateUnit.ConsiderPathfinding
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, CreateUnit improvements
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption, building LimboDelivery
 - **mevitar** - honorary shield tester *triple* award

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -169,6 +169,7 @@ CreateUnit.InheritTurretFacings=no  ; boolean, inherit facing from destroyed uni
 CreateUnit.RemapAnim=no             ; boolean, whether to remap anim to owner color
 CreateUnit.Mission=Guard            ; MissionType
 CreateUnit.Owner=Victim             ; owner house kind, Invoker/Killer/Victim/Civilian/Special/Neutral/Random
+CreateUnit.ConsiderPathfinding=no   ; boolean, whether to consider if the created unit can move in the cell and look for eligible cells nearby instead.
 ```
 
 ## Buildings

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -150,7 +150,7 @@ RadSiteWarhead=RadSite          ; WarheadType
 ![image](_static/images/animToUnit.gif)  
 
 - Animations can now create (or "convert" to) units when they end.
-  - Because anims usually don't have an owner the unit will be created with civilian owner unless you use `DestroyAnim` which was modified to store owner and facing information from the destroyed unit.
+  - Because in most cases animations do not have owner, the unit will be created with civilian owner unless you use `DestroyAnim` which was modified to store owner and facing information from the destroyed unit, or animation from Warhead `AnimList` or one created through map trigger action `41 Play Anim At`.
 
 In `rulesmd.ini`:
 ```ini

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -28,6 +28,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->CreateUnit_Mission.Read(exINI, pID, "CreateUnit.Mission");
 	this->CreateUnit_Owner.Read(exINI, pID, "CreateUnit.Owner");
 	this->CreateUnit_RandomFacing.Read(exINI, pID, "CreateUnit.RandomFacing");
+	this->CreateUnit_ConsiderPathfinding.Read(exINI, pID, "CreateUnit.ConsiderPathfinding");
 	this->XDrawOffset.Read(exINI, pID, "XDrawOffset");
 	this->HideIfNoOre_Threshold.Read(exINI, pID, "HideIfNoOre.Threshold");
 }
@@ -102,6 +103,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->CreateUnit_InheritTurretFacings)
 		.Process(this->CreateUnit_Owner)
 		.Process(this->CreateUnit_RandomFacing)
+		.Process(this->CreateUnit_ConsiderPathfinding)
 		.Process(this->XDrawOffset)
 		.Process(this->HideIfNoOre_Threshold)
 		;

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -23,6 +23,7 @@ public:
 		Valueable<bool> CreateUnit_RandomFacing;
 		Valueable<Mission> CreateUnit_Mission;
 		Valueable<OwnerHouseKind> CreateUnit_Owner;
+		Valueable<bool> CreateUnit_ConsiderPathfinding;
 		Valueable<int> XDrawOffset;
 		Valueable<int> HideIfNoOre_Threshold;
 
@@ -35,6 +36,7 @@ public:
 			, CreateUnit_RemapAnim(false)
 			, CreateUnit_Mission(Mission::Guard)
 			, CreateUnit_Owner(OwnerHouseKind::Victim)
+			, CreateUnit_ConsiderPathfinding(false)
 			, XDrawOffset(0)
 			, HideIfNoOre_Threshold(0)
 		{ }

--- a/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
+++ b/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
@@ -77,6 +77,23 @@ DEFINE_HOOK(0x424932, AnimClass_Update_CreateUnit_ActualAffects, 0x6)
 
 		pThis->UnmarkAllOccupationBits(location);
 
+		if (pTypeExt->CreateUnit_ConsiderPathfinding)
+		{
+			bool allowBridges = unit->SpeedType != SpeedType::Float;
+
+			auto nCell = MapClass::Instance->Pathfinding_Find(CellClass::Coord2Cell(location),
+				unit->SpeedType, -1, unit->MovementZone, false, 1, 1, true,
+				false, false, allowBridges, CellStruct::Empty, false, false);
+
+			pCell = MapClass::Instance->TryGetCellAt(nCell);
+			location = pThis->GetCoords();
+
+			if (pCell)
+				location = pCell->GetCoordsWithBridge();
+			else
+				location.Z = MapClass::Instance->GetCellFloorHeight(location);
+		}
+
 		if (auto pTechno = static_cast<TechnoClass*>(unit->CreateObject(decidedOwner)))
 		{
 			bool success = false;

--- a/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
+++ b/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
@@ -161,14 +161,10 @@ DEFINE_HOOK(0x469C98, BulletClass_DetonateAt_DamageAnimSelected, 0x0)
 		HouseClass* pVictim = nullptr;
 
 		if (TechnoClass* Target = generic_cast<TechnoClass*>(pThis->Target))
-		{
 			pVictim = Target->Owner;
-		}
 
 		if (auto unit = pTypeExt->CreateUnit.Get())
-		{
 			AnimExt::SetAnimOwnerHouseKind(pAnim, pInvoker, pVictim, pInvoker);
-		}
 	}
 	else if (pThis->WH == RulesClass::Instance->NukeWarhead)
 	{
@@ -188,9 +184,8 @@ DEFINE_HOOK(0x6E2368, ActionClass_PlayAnimAt, 0x7)
 		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pAnim->Type);
 
 		if (auto unit = pTypeExt->CreateUnit.Get())
-		{
 			AnimExt::SetAnimOwnerHouseKind(pAnim, pHouse, pHouse, pHouse);
-		}
+
 	}
 
 	return 0;

--- a/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
+++ b/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
@@ -148,6 +148,8 @@ DEFINE_HOOK(0x424932, AnimClass_Update_CreateUnit_ActualAffects, 0x6)
 
 DEFINE_HOOK(0x469C98, BulletClass_DetonateAt_DamageAnimSelected, 0x0)
 {
+	enum { Continue = 0x469D06, NukeWarheadExtras = 0x469CAF };
+
 	GET(BulletClass*, pThis, ESI);
 	GET(AnimClass*, pAnim, EAX);
 
@@ -159,15 +161,21 @@ DEFINE_HOOK(0x469C98, BulletClass_DetonateAt_DamageAnimSelected, 0x0)
 		HouseClass* pVictim = nullptr;
 
 		if (TechnoClass* Target = generic_cast<TechnoClass*>(pThis->Target))
+		{
 			pVictim = Target->Owner;
+		}
 
 		if (auto unit = pTypeExt->CreateUnit.Get())
+		{
 			AnimExt::SetAnimOwnerHouseKind(pAnim, pInvoker, pVictim, pInvoker);
+		}
 	}
 	else if (pThis->WH == RulesClass::Instance->NukeWarhead)
-		return 0x469CAF;
+	{
+		return NukeWarheadExtras;
+	}
 
-	return 0x469D06;
+	return Continue;
 }
 
 DEFINE_HOOK(0x6E2368, ActionClass_PlayAnimAt, 0x7)
@@ -180,7 +188,9 @@ DEFINE_HOOK(0x6E2368, ActionClass_PlayAnimAt, 0x7)
 		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pAnim->Type);
 
 		if (auto unit = pTypeExt->CreateUnit.Get())
+		{
 			AnimExt::SetAnimOwnerHouseKind(pAnim, pHouse, pHouse, pHouse);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
- `CreateUnit.ConsiderPathfinding`, if set, makes game look for eligible cells around the animation's coordinates if the cell at those coordinates is not passable to the created unit, and creates the unit at the first eligible cell found instead.
- Warhead `AnimList/SplashList` animations and animations created through map trigger action `41 Play Anim At` now have owner set correctly if the animation has `CreateUnit` set.