### PR TITLE
Animation & Jumpjet unit layer customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, Attached animation layer customization
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption, building LimboDelivery
 - **mevitar** - honorary shield tester *triple* award

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, Attached animation layer customization
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, Attached animation & jumpjet unit layer customization
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **Morton (MortonPL)** - XDrawOffset, Shield Passthrough & Absorption, building LimboDelivery
 - **mevitar** - honorary shield tester *triple* award

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -52,6 +52,16 @@ In `artmd.ini`:
 HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage
 ```
 
+### Layer on animations attached to objects
+
+- You can now customize whether or not animations attached to objects follow the object's layer or respect their own `Layer` setting.
+
+In `artmd.ini`:
+```ini
+[SOMEANIM]                 ; AnimationType
+Layer.UseObjectLayer=true  ; boolean
+```
+
 ## Technos
 
 ### Customizable Teleport/Chrono Locomotor settings per TechnoType

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -94,11 +94,24 @@ In `rulesmd.ini`:
 ```ini
 [JumpjetControls]
 Crash=5.0       ; float
-NoWobbles=no    ; bool
+NoWobbles=no    ; boolean
 ```
 
 ```{note}
 `CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for `JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and `Acceleration` is for `JumpjetAccel`. All other corresponding keys just simply have no Jumpjet prefix.
+```
+
+### Jumpjet unit layer deviation customization
+
+- Allows turning on or off jumpjet unit behaviour where they fluctuate between `air` and `top` layers based on whether or not their current altitude is equal / below or above `JumpjetHeight` or `[JumpjetControls] -> CruiseHeight` if former is not set on TechnoType. If disabled, airborne jumpjet units exist only in `air` layer. `JumpjetAllowLayerDeviation` defaults to value of `[JumpjetControls] -> AllowLayerDeviation` if not specified.
+
+In `rulesmd.ini`:
+```ini
+[JumpjetControls]
+AllowLayerDeviation=yes         ; boolean
+
+[SOMETECHNO]                    ; TechnoType
+JumpjetAllowLayerDeviation=yes  ; boolean
 ```
 
 ### Customizable harvester ore gathering animation

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -54,12 +54,12 @@ HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage
 
 ### Layer on animations attached to objects
 
-- You can now customize whether or not animations attached to objects follow the object's layer or respect their own `Layer` setting.
+- You can now customize whether or not animations attached to objects follow the object's layer or respect their own `Layer` setting. If this is unset, attached animations use `ground` layer.
 
 In `artmd.ini`:
 ```ini
 [SOMEANIM]                 ; AnimationType
-Layer.UseObjectLayer=true  ; boolean
+Layer.UseObjectLayer=      ; boolean
 ```
 
 ## Technos

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -6,6 +6,7 @@ This page lists the history of changes across stable Phobos releases and also al
 
 ### From vanilla
 
+- Animations attached to objects (like parachutes or Ares' AttachEffect) now follow the object's layer instead of being hardcoded to `ground` layer. `Layer.UseObjectLayer` can be set to no to disable this behaviour, in which case it falls back to the animation's own `Layer` setting which defaults to `air` if not specified.
 - SHP debris hardcoded shadows now respect `Shadow=no` tag value, and due to it being the default value they wouldn't have hardcoded shadows anymore by default. Override this by specifying `Shadow=yes` for SHP debris.
 - Radiation now has owner by default, which means that radiation kills will affect score and radiation field will respect `Affects...` entries. You can override that with `rulesmd.ini->[SOMEWEAPONTYPE]->Rad.NoOwner=yes` entry.
 
@@ -242,6 +243,7 @@ New:
 - Shield absorption and passthrough customization (by Morton)
 - Limbo Delivery of buildings (by Morton)
 - Ore stage threshold for `HideIfNoOre` (by Otamaa)
+- Attached animation layer customization (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -6,7 +6,6 @@ This page lists the history of changes across stable Phobos releases and also al
 
 ### From vanilla
 
-- Animations attached to objects (like parachutes or Ares' AttachEffect) now follow the object's layer instead of being hardcoded to `ground` layer. `Layer.UseObjectLayer` can be set to no to disable this behaviour, in which case it falls back to the animation's own `Layer` setting which defaults to `air` if not specified.
 - SHP debris hardcoded shadows now respect `Shadow=no` tag value, and due to it being the default value they wouldn't have hardcoded shadows anymore by default. Override this by specifying `Shadow=yes` for SHP debris.
 - Radiation now has owner by default, which means that radiation kills will affect score and radiation field will respect `Affects...` entries. You can override that with `rulesmd.ini->[SOMEWEAPONTYPE]->Rad.NoOwner=yes` entry.
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -244,6 +244,7 @@ New:
 - Limbo Delivery of buildings (by Morton)
 - Ore stage threshold for `HideIfNoOre` (by Otamaa)
 - Attached animation layer customization (by Starkku)
+- Jumpjet unit layer deviation customization (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -30,6 +30,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->CreateUnit_RandomFacing.Read(exINI, pID, "CreateUnit.RandomFacing");
 	this->XDrawOffset.Read(exINI, pID, "XDrawOffset");
 	this->HideIfNoOre_Threshold.Read(exINI, pID, "HideIfNoOre.Threshold");
+	this->Layer_UseObjectLayer .Read(exINI, pID, "Layer.UseObjectLayer");
 }
 
 const void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)
@@ -104,6 +105,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->CreateUnit_RandomFacing)
 		.Process(this->XDrawOffset)
 		.Process(this->HideIfNoOre_Threshold)
+		.Process(this->Layer_UseObjectLayer)
 		;
 }
 

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -30,7 +30,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->CreateUnit_RandomFacing.Read(exINI, pID, "CreateUnit.RandomFacing");
 	this->XDrawOffset.Read(exINI, pID, "XDrawOffset");
 	this->HideIfNoOre_Threshold.Read(exINI, pID, "HideIfNoOre.Threshold");
-	this->Layer_UseObjectLayer .Read(exINI, pID, "Layer.UseObjectLayer");
+	this->Layer_UseObjectLayer.Read(exINI, pID, "Layer.UseObjectLayer");
 }
 
 const void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -25,7 +25,7 @@ public:
 		Valueable<OwnerHouseKind> CreateUnit_Owner;
 		Valueable<int> XDrawOffset;
 		Valueable<int> HideIfNoOre_Threshold;
-		Valueable<bool> Layer_UseObjectLayer;
+		Nullable<bool> Layer_UseObjectLayer;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette(CustomPalette::PaletteMode::Temperate)
@@ -38,7 +38,7 @@ public:
 			, CreateUnit_Owner(OwnerHouseKind::Victim)
 			, XDrawOffset(0)
 			, HideIfNoOre_Threshold(0)
-			, Layer_UseObjectLayer(true)
+			, Layer_UseObjectLayer()
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -25,6 +25,7 @@ public:
 		Valueable<OwnerHouseKind> CreateUnit_Owner;
 		Valueable<int> XDrawOffset;
 		Valueable<int> HideIfNoOre_Threshold;
+		Valueable<bool> Layer_UseObjectLayer;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette(CustomPalette::PaletteMode::Temperate)
@@ -37,6 +38,7 @@ public:
 			, CreateUnit_Owner(OwnerHouseKind::Victim)
 			, XDrawOffset(0)
 			, HideIfNoOre_Threshold(0)
+			, Layer_UseObjectLayer(true)
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -45,6 +45,7 @@ DEFINE_HOOK(0x424CB0, AnimClass_In_Which_Layer_AttachedObjectLayer, 0x6)
 			layer = pThis->OwnerObject->InWhichLayer();
 
 		R->EAX(layer);
+		
 		return ReturnValue;
 	}
 

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -28,3 +28,25 @@ DEFINE_HOOK(0x423B95, AnimClass_AI_HideIfNoOre_Threshold, 0x8)
 
 	return 0x423BBF;
 }
+
+DEFINE_HOOK(0x424CB0, AnimClass_In_Which_Layer_AttachedObjectLayer, 0x6)
+{
+	enum { ReturnValue = 0x424CBF, Continue = 0x424CC0 };
+
+	GET(AnimClass*, pThis, ECX);
+
+	auto pExt = AnimTypeExt::ExtMap.Find(pThis->Type);
+
+	if (pThis->OwnerObject)
+	{
+		Layer layer = pThis->Type->Layer;
+
+		if (pExt->Layer_UseObjectLayer)
+			layer = pThis->OwnerObject->InWhichLayer();
+
+		R->EAX(layer);
+		return ReturnValue;
+	}
+
+	return Continue;
+}

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -37,11 +37,11 @@ DEFINE_HOOK(0x424CB0, AnimClass_In_Which_Layer_AttachedObjectLayer, 0x6)
 
 	auto pExt = AnimTypeExt::ExtMap.Find(pThis->Type);
 
-	if (pThis->OwnerObject)
+	if (pThis->OwnerObject && pExt->Layer_UseObjectLayer.isset())
 	{
 		Layer layer = pThis->Type->Layer;
 
-		if (pExt->Layer_UseObjectLayer)
+		if (pExt->Layer_UseObjectLayer.Get())
 			layer = pThis->OwnerObject->InWhichLayer();
 
 		R->EAX(layer);

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -71,6 +71,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Pips_Shield.Read(exINI, "AudioVisual", "Pips.Shield");
 	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
 	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
+	this->JumpjetAllowLayerDeviation.Read(exINI, "JumpjetControls", "AllowLayerDeviation");
 
 	// Section AITargetType
 	int itemsCount = pINI->GetKeyCount(sectionAITargetTypes);
@@ -162,6 +163,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->MissingCameo)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
+		.Process(this->JumpjetAllowLayerDeviation)
 		.Process(this->AITargetTypesLists)
 		.Process(this->AIScriptsLists)
 		;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -33,6 +33,7 @@ public:
 
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;
+		Valueable<bool> JumpjetAllowLayerDeviation;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Pips_Shield({ -1,-1,-1 })
@@ -41,6 +42,7 @@ public:
 			, MissingCameo("xxicon.shp")
 			, JumpjetCrash(5.0)
 			, JumpjetNoWobbles(false)
+			, JumpjetAllowLayerDeviation(true)
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -134,6 +134,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->NoSecondaryWeaponFallback.Read(exINI, pSection, "NoSecondaryWeaponFallback");
 
+	this->JumpjetAllowLayerDeviation.Read(exINI, pSection, "JumpjetAllowLayerDeviation");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -264,6 +266,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->NoSecondaryWeaponFallback)
 		.Process(this->NoAmmoWeapon)
 		.Process(this->NoAmmoAmount)
+		.Process(this->JumpjetAllowLayerDeviation)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -82,6 +82,8 @@ public:
 		Valueable<int> NoAmmoWeapon;
 		Valueable<int> NoAmmoAmount;
 
+		Nullable<bool> JumpjetAllowLayerDeviation;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -111,7 +113,7 @@ public:
 			Interceptor_MinimumGuardRange(),
 			Interceptor_EliteGuardRange(),
 			Interceptor_EliteMinimumGuardRange(),
-			TurretOffset({0, 0, 0}),
+			TurretOffset({ 0, 0, 0 }),
 			Powered_KillSpawns(false),
 			Spawn_LimitedRange(false),
 			Spawn_LimitedExtraRange(0),
@@ -150,7 +152,8 @@ public:
 			AutoFire_TargetSelf(false),
 			NoSecondaryWeaponFallback(false),
 			NoAmmoWeapon(-1),
-			NoAmmoAmount(0)
+			NoAmmoAmount(0),
+			JumpjetAllowLayerDeviation()
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -187,12 +187,15 @@ DEFINE_HOOK(0x54B8E9, JumpjetLocomotionClass_In_Which_Layer_Deviation, 0x6)
 {
 	GET(TechnoClass*, pThis, EAX);
 
-	if (auto const pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
+	if (pThis->IsInAir())
 	{
-		if (!pExt->JumpjetAllowLayerDeviation.Get(RulesExt::Global()->JumpjetAllowLayerDeviation.Get()))
+		if (auto const pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
 		{
-			R->EDX(INT32_MAX); // Override JumpjetHeight / CruiseHeight check so it always results in 3 / Layer::Air.
-			return 0x54B96B;
+			if (!pExt->JumpjetAllowLayerDeviation.Get(RulesExt::Global()->JumpjetAllowLayerDeviation.Get()))
+			{
+				R->EDX(INT32_MAX); // Override JumpjetHeight / CruiseHeight check so it always results in 3 / Layer::Air.
+				return 0x54B96B;
+			}
 		}
 	}
 

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -1,3 +1,4 @@
+#include <AnimClass.h>
 #include <UnitClass.h>
 #include <InfantryClass.h>
 #include <BuildingClass.h>
@@ -178,6 +179,22 @@ DEFINE_HOOK(0x6F421C, TechnoClass_DefaultDisguise, 0x6) // TechnoClass_DefaultDi
 	}
 
 	pThis->Disguised = false;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x54B8E9, JumpjetLocomotionClass_In_Which_Layer_Deviation, 0x6)
+{
+	GET(TechnoClass*, pThis, EAX);
+
+	if (auto const pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
+	{
+		if (!pExt->JumpjetAllowLayerDeviation.Get(RulesExt::Global()->JumpjetAllowLayerDeviation.Get()))
+		{
+			R->EDX(INT32_MAX); // Override JumpjetHeight / CruiseHeight check so it always results in 3 / Layer::Air.
+			return 0x54B96B;
+		}
+	}
 
 	return 0;
 }


### PR DESCRIPTION
- You can now customize whether or not animations attached to objects follow the object's layer or respect their own `Layer` setting. If this is unset, attached animations use `ground` layer.

In `artmd.ini`:
```ini
[SOMEANIM]                 ; AnimationType
Layer.UseObjectLayer=      ; boolean
```

Allows turning on or off jumpjet unit behaviour where they fluctuate between `air` and `top` layers based on whether or not their current altitude is equal / below or above `JumpjetHeight` or `[JumpjetControls] -> CruiseHeight` if former is not set on TechnoType. If disabled, airborne jumpjet units exists only in `air` layer. `JumpjetAllowLayerDeviation` defaults to value of `[JumpjetControls] -> AllowLayerDeviation` if not specified.

In `rulesmd.ini`:
```ini
[JumpjetControls]
AllowLayerDeviation=yes         ; boolean

[SOMETECHNO]                    ; TechnoType
JumpjetAllowLayerDeviation=yes  ; boolean
```

Together these can work as a sort of a fix for the issue where animations, especially attached ones like shields or AttachEffect don't show up on top of airborne jumpjet units. For some reason I was not quite able to decipher, things that normally fudge the rendering order or depth-related drawing stuff (namely `YSortAdjust` & `ZAdjust`) cease to matter when both objects are on `top` layer, at least in case of jumpjet units vs animations - hence the need to potentially constrain jumpjets to `air` layer. Disabling layer deviation may only be desirable on wobbling jumpjets, as that is where it comes into play most often. It also causes other visual changes, namely with how grouped up bunch of wobbling jumpjet units looks (normally which ones would get drawn in front of others would keep shifting, creating a sort of 'blinking' effect, but disabling the layer fluctuation will also stop this from happening which might not be desirable, but considering this doesn't happen with non-wobbling jumpjets it might not be a big deal).