### PR TITLE
Weapon targeting filter improvements

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -420,6 +420,7 @@ Rad.NoOwner=no  ; boolean
 ### Weapon targeting filter
 
 - You can now specify which targets or houses a weapon can fire at. This also affects weapon selection, other than certain special cases where the selection is fixed.
+  - Note that `CanTarget` explicitly requires either `all` or `empty` to be listed for the weapon to be able to fire at cells containing no TechnoTypes.
 
 In `rulesmd.ini`:
 ```ini
@@ -432,7 +433,7 @@ CanTargetHouses=all  ; list of Affected House Enumeration (none|owner/self|allie
 
 - You can now specify how AreaFire weapon picks its target. By default it targets the base cell the firer is currently on, but this can now be changed to fire on the firer itself or at a random cell within the radius of the weapon's `Range` by setting `AreaFire.Target` to `self` or `random` respectively.
 - `AreaFire.Target=self` respects normal targeting rules (Warhead Verses etc.) against the firer itself.
-- `AreaFire.Target=random` ignores cells that are ineligible or contain ineligible objects based on listed values in weapon's `CanTarget`.
+- `AreaFire.Target=random` ignores cells that are ineligible or contain ineligible objects based on listed values in weapon's `CanTarget` & `CanTargetHouses`.
 
 In `rulesmd.ini`:
 ```ini

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -237,7 +237,7 @@ DEFINE_HOOK(0x7098B9, TechnoClass_TargetSomethingNearby_AutoFire, 0x6)
 
 DEFINE_HOOK(0x6FE19A, TechnoClass_FireAt_AreaFire, 0x6)
 {
-	enum { DoNotFire = 0x6FE4E7, SkipSetTarget = 0x6FE1D8 };
+	enum { DoNotFire = 0x6FE4E7, SkipSetTarget = 0x6FE1D5 };
 
 	GET(TechnoClass* const, pThis, ESI);
 	GET(CellClass* const, pCell, EAX);
@@ -259,7 +259,7 @@ DEFINE_HOOK(0x6FE19A, TechnoClass_FireAt_AreaFire, 0x6)
 				CellStruct tgtPos = pCell->MapCoords + adjacentCells[cellIndex];
 				CellClass* tgtCell = MapClass::Instance->GetCellAt(tgtPos);
 
-				if (EnumFunctions::AreCellAndObjectsEligible(tgtCell, pExt->CanTarget))
+				if (EnumFunctions::AreCellAndObjectsEligible(tgtCell, pExt->CanTarget, pExt->CanTargetHouses, pThis->Owner, true))
 				{
 					R->EAX(tgtCell);
 					return 0;
@@ -270,14 +270,14 @@ DEFINE_HOOK(0x6FE19A, TechnoClass_FireAt_AreaFire, 0x6)
 		}
 		else if (pExt->AreaFire_Target == AreaFireTarget::Self)
 		{
-			if (!EnumFunctions::AreCellAndObjectsEligible(pThis->GetCell(), pExt->CanTarget))
+			if (!EnumFunctions::AreCellAndObjectsEligible(pThis->GetCell(), pExt->CanTarget, pExt->CanTargetHouses, nullptr, false))
 				return DoNotFire;
 
-			pThis->Target = pThis;
+			R->EAX(pThis);
 			return SkipSetTarget;
 		}
 
-		if (!EnumFunctions::AreCellAndObjectsEligible(pCell, pExt->CanTarget))
+		if (!EnumFunctions::AreCellAndObjectsEligible(pCell, pExt->CanTarget, pExt->CanTargetHouses, nullptr, false))
 			return DoNotFire;
 	}
 

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -132,7 +132,7 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 
 		if (targetCell)
 		{
-			if (!EnumFunctions::IsCellEligible(targetCell, pWeaponExt->CanTarget))
+			if (!EnumFunctions::IsCellEligible(targetCell, pWeaponExt->CanTarget, true))
 				return CannotFire;
 		}
 
@@ -160,7 +160,7 @@ DEFINE_HOOK(0x6F33CD, TechnoClass_WhatWeaponShouldIUse_ForceFire, 0x6)
 	{
 		if (const auto pPrimaryExt = WeaponTypeExt::ExtMap.Find(pThis->GetWeapon(0)->WeaponType))
 		{
-			if (pThis->GetWeapon(1)->WeaponType && !EnumFunctions::IsCellEligible(pCell, pPrimaryExt->CanTarget))
+			if (pThis->GetWeapon(1)->WeaponType && !EnumFunctions::IsCellEligible(pCell, pPrimaryExt->CanTarget, true))
 				return Secondary;
 		}
 	}
@@ -176,9 +176,6 @@ DEFINE_HOOK(0x6F36DB, TechnoClass_WhatWeaponShouldIUse, 0x8)
 
 	enum { Primary = 0x6F37AD, Secondary = 0x6F3745, FurtherCheck = 0x6F3754, OriginalCheck = 0x6F36E3 };
 
-	if (!pTargetTechno)
-		return Primary;
-
 	CellClass* targetCell = nullptr;
 
 	if (const auto pCell = abstract_cast<CellClass*>(pTarget))
@@ -192,9 +189,9 @@ DEFINE_HOOK(0x6F36DB, TechnoClass_WhatWeaponShouldIUse, 0x8)
 		{
 			if (const auto pSecondaryExt = WeaponTypeExt::ExtMap.Find(pSecondary->WeaponType))
 			{
-				if ((targetCell && !EnumFunctions::IsCellEligible(targetCell, pSecondaryExt->CanTarget)) ||
-					!EnumFunctions::IsTechnoEligible(pTargetTechno, pSecondaryExt->CanTarget) ||
-					!EnumFunctions::CanTargetHouse(pSecondaryExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner))
+				if ((targetCell && !EnumFunctions::IsCellEligible(targetCell, pSecondaryExt->CanTarget, true)) ||
+					(pTargetTechno && (!EnumFunctions::IsTechnoEligible(pTargetTechno, pSecondaryExt->CanTarget) ||
+					!EnumFunctions::CanTargetHouse(pSecondaryExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner))))
 				{
 					return Primary;
 				}
@@ -204,15 +201,18 @@ DEFINE_HOOK(0x6F36DB, TechnoClass_WhatWeaponShouldIUse, 0x8)
 					if (pTypeExt->NoSecondaryWeaponFallback && !TechnoExt::CanFireNoAmmoWeapon(pThis, 1))
 						return Primary;
 
-					if ((targetCell && !EnumFunctions::IsCellEligible(targetCell, pPrimaryExt->CanTarget)) ||
-						!EnumFunctions::IsTechnoEligible(pTargetTechno, pPrimaryExt->CanTarget) ||
-						!EnumFunctions::CanTargetHouse(pPrimaryExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner))
+					if ((targetCell && !EnumFunctions::IsCellEligible(targetCell, pPrimaryExt->CanTarget, true)) ||
+						(pTargetTechno && (!EnumFunctions::IsTechnoEligible(pTargetTechno, pPrimaryExt->CanTarget) ||
+						!EnumFunctions::CanTargetHouse(pPrimaryExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner))))
 					{
 						return Secondary;
 					}
 				}
 			}
 		}
+
+		if (!pTargetTechno)
+			return Primary;
 
 		if (const auto pTargetExt = TechnoExt::ExtMap.Find(pTargetTechno))
 		{

--- a/src/Utilities/EnumFunctions.cpp
+++ b/src/Utilities/EnumFunctions.cpp
@@ -7,8 +7,16 @@ bool EnumFunctions::CanTargetHouse(AffectedHouse flags, HouseClass* ownerHouse, 
 		(flags & AffectedHouse::Enemies) && ownerHouse != targetHouse && !ownerHouse->IsAlliedWith(targetHouse);
 }
 
-bool EnumFunctions::IsCellEligible(CellClass* const pCell, AffectedTarget allowed)
+bool EnumFunctions::IsCellEligible(CellClass* const pCell, AffectedTarget allowed, bool explicitEmptyCells)
 {
+	if (explicitEmptyCells)
+	{
+		auto pTechno = pCell->FirstObject ? abstract_cast<TechnoClass*>(pCell->FirstObject) : nullptr;
+
+		if (!pTechno && !(allowed & AffectedTarget::NoContent))
+			return false;
+	}
+
 	if (allowed & AffectedTarget::AllCells)
 	{
 		if (pCell->LandType == LandType::Water) // check whether it supports water
@@ -47,13 +55,13 @@ bool EnumFunctions::IsTechnoEligible(TechnoClass* const pTechno, AffectedTarget 
 	return allowed != AffectedTarget::None ? true : false;
 }
 
-bool EnumFunctions::AreCellAndObjectsEligible(CellClass* const pCell, AffectedTarget allowed)
+bool EnumFunctions::AreCellAndObjectsEligible(CellClass* const pCell, AffectedTarget allowed, AffectedHouse allowedHouses, HouseClass* owner, bool explicitEmptyCells)
 {
 	if (!pCell)
 		return false;
 
 	auto object = pCell->FirstObject;
-	bool eligible = EnumFunctions::IsCellEligible(pCell, allowed);
+	bool eligible = EnumFunctions::IsCellEligible(pCell, allowed, explicitEmptyCells);
 
 	while (true)
 	{
@@ -61,7 +69,17 @@ bool EnumFunctions::AreCellAndObjectsEligible(CellClass* const pCell, AffectedTa
 			break;
 
 		if (auto pTechno = abstract_cast<TechnoClass*>(object))
+		{
+			if (owner)
+			{
+				eligible = EnumFunctions::CanTargetHouse(allowedHouses, owner, pTechno->Owner);
+
+				if (!eligible)
+					break;
+			}
+
 			eligible = EnumFunctions::IsTechnoEligible(pTechno, allowed);
+		}
 
 		object = object->NextObject;
 	}

--- a/src/Utilities/EnumFunctions.h
+++ b/src/Utilities/EnumFunctions.h
@@ -9,7 +9,7 @@ class EnumFunctions
 {
 public:
 	static bool CanTargetHouse(AffectedHouse flags, HouseClass* ownerHouse, HouseClass* targetHouse);
-	static bool IsCellEligible(CellClass* const pCell, AffectedTarget allowed);
+	static bool IsCellEligible(CellClass* const pCell, AffectedTarget allowed, bool explicitEmptyCells = false);
 	static bool IsTechnoEligible(TechnoClass* const pTechno, AffectedTarget allowed);
-	static bool AreCellAndObjectsEligible(CellClass* const pCell, AffectedTarget allowed);
+	static bool AreCellAndObjectsEligible(CellClass* const pCell, AffectedTarget allowed, AffectedHouse allowedHouses, HouseClass* owner, bool explicitEmptyCells = false);
 };


### PR DESCRIPTION
- `CanTarget` now explicitly requires `all` or `empty` to be listed to be able to fire at cells containing no TechnoTypes.
  - `AreaFire.Target=base` & `AreaFire.Target=self` (when firing the weapon, not for targeting or weapons selection) weapons are exempt from this.
- `AreaFire.Target=random` now respects `CanTargetHouses`.
- Fixed an issue where `AreaFire.Target=self` would override the firing techno's current target with itself.

Uses cases include changing force-fire weapon from Primary to Secondary (which can even be done conditionally based on whether cell is land or water) and allowing `AreaFire.Target=random` weapons to home into (specific) objects (owned by specific houses) instead of always allowing empty cells to be targeted.