### PR TITLE
Replace DeployDir customization with DeployingAnim.AllowAnyDirection

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -96,18 +96,17 @@ Grinding.Weapon=           ; WeaponType
 
 ## Vehicles
 
-### Deploy direction for IsSimpleDeployer vehicles & deploy animation customization
+### IsSimpleDeployer vehicle deploy animation / direction customization
 
-- `DeployDir` can be used to set the facing the vehicle needs to turn towards before deploying if it has `DeployingAnim` set. This is works the same as Ares flag of same name other than allowing use of negative numbers to disable the direction-specific deploy and that it only applies to units on ground. If not set, it defaults to `[General] -> DeployDir`.
-- In addition there are some new options for `DeployingAnim`:
-  - `DeployingAnim.KeepUnitVisible` determines if the unit is hidden while the animation is playing.
-  - `DeployingAnim.ReverseForUndeploy` controls whether or not the animation is played in reverse for undeploying.
-  - `DeployingAnim.UseUnitDrawer` controls whether or not the animation is displayed in the unit's palette and team colours.
+- `DeployingAnim.AllowAnyDirection` if set, disables any direction constraints for deployers with `DeployingAnim` set. Only works for ground units.
+- `DeployingAnim.KeepUnitVisible` determines if the unit is hidden while the animation is playing.
+- `DeployingAnim.ReverseForUndeploy` controls whether or not the animation is played in reverse for undeploying.
+- `DeployingAnim.UseUnitDrawer` controls whether or not the animation is displayed in the unit's palette and team colours or regular animation palette, including a potential custom palette.
 
 In `rulesmd.ini`:
 ```ini
 [SOMEVEHICLE]                          ; VehicleType
-DeployDir=                             ; integer, facing or a negative number to disable direction-specific deploy
+DeployingAnim.AllowAnyDirection=false  ; boolean
 DeployingAnim.KeepUnitVisible=false    ; boolean
 DeployingAnim.ReverseForUndeploy=true  ; boolean
 DeployingAnim.UseUnitDrawer=true       ; boolean

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -144,6 +144,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->JumpjetAllowLayerDeviation.Read(exINI, pSection, "JumpjetAllowLayerDeviation");
 
+	this->DeployingAnim_AllowAnyDirection.Read(exINI, pSection, "DeployingAnim.AllowAnyDirection");
 	this->DeployingAnim_KeepUnitVisible.Read(exINI, pSection, "DeployingAnim.KeepUnitVisible");
 	this->DeployingAnim_ReverseForUndeploy.Read(exINI, pSection, "DeployingAnim.ReverseForUndeploy");
 	this->DeployingAnim_UseUnitDrawer.Read(exINI, pSection, "DeployingAnim.UseUnitDrawer");
@@ -160,9 +161,6 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// Ares 0.C
 	this->NoAmmoWeapon.Read(exINI, pSection, "NoAmmoWeapon");
 	this->NoAmmoAmount.Read(exINI, pSection, "NoAmmoAmount");
-
-	// Ares 2.0
-	this->DeployDir.Read(exINI, pSection, "DeployDir");
 
 	// Art tags
 	INI_EX exArtINI(CCINIClass::INI_Art);
@@ -291,10 +289,10 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->NoAmmoWeapon)
 		.Process(this->NoAmmoAmount)
 		.Process(this->JumpjetAllowLayerDeviation)
+		.Process(this->DeployingAnim_AllowAnyDirection)
 		.Process(this->DeployingAnim_KeepUnitVisible)
 		.Process(this->DeployingAnim_ReverseForUndeploy)
 		.Process(this->DeployingAnim_UseUnitDrawer)
-		.Process(this->DeployDir)
 		.Process(this->EnemyUIName)
 		;
 }

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -92,10 +92,10 @@ public:
 
 		Nullable<bool> JumpjetAllowLayerDeviation;
 
+		Valueable<bool> DeployingAnim_AllowAnyDirection;
 		Valueable<bool> DeployingAnim_KeepUnitVisible;
 		Valueable<bool> DeployingAnim_ReverseForUndeploy;
 		Valueable<bool> DeployingAnim_UseUnitDrawer;
-		Nullable<int> DeployDir;
 
 		struct LaserTrailDataEntry
 		{
@@ -175,10 +175,10 @@ public:
 			, NoAmmoWeapon { -1 }
 			, NoAmmoAmount { 0 }
 			, JumpjetAllowLayerDeviation {}
+			, DeployingAnim_AllowAnyDirection { false }
 			, DeployingAnim_KeepUnitVisible { false }
 			, DeployingAnim_ReverseForUndeploy { true }
 			, DeployingAnim_UseUnitDrawer { true }
-			, DeployDir {}
 			, EnemyUIName {}
 		{ }
 

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -215,10 +215,10 @@ DEFINE_HOOK(0x73CF46, UnitClass_Draw_It_KeepUnitVisible, 0x6)
 	return 0;
 }
 
-// Ares hooks in at 739B8A, this goes before it and skips & basically reimplements Ares code with some changes.
+// Ares hooks in at 739B8A, this goes before it and skips it if needed.
 DEFINE_HOOK(0x739B7C, UnitClass_Deploy_DeployDir, 0x6)
 {
-	enum { Skip = 0x739C70, Continue = 0x739B9E };
+	enum { SkipAnim = 0x739C70, PlayAnim = 0x739B9E };
 
 	GET(UnitClass*, pThis, ESI);
 
@@ -226,36 +226,16 @@ DEFINE_HOOK(0x739B7C, UnitClass_Deploy_DeployDir, 0x6)
 	{
 		if (pThis->Type->DeployingAnim)
 		{
-			int deployDir = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType())->DeployDir.Get(RulesClass::Instance->DeployDir >> 5);
+			if (TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType())->DeployingAnim_AllowAnyDirection)
+				return PlayAnim;
 
-			if (deployDir >= 0)
-			{
-				auto targetFacing = DirStruct(deployDir << 13);
-
-				if (pThis->PrimaryFacing.current() != targetFacing)
-				{
-					auto locomotor = pThis->Locomotor.get();
-
-					if (locomotor)
-					{
-						if (locomotor->Is_Moving_Now())
-							return Skip;
-
-						locomotor->Do_Turn(targetFacing);
-
-						return Skip;
-					}
-				}
-			}
-
-			return Continue;
+			return 0;
 		}
 
 		pThis->Deployed = true;
-
 	}
 
-	return Skip;
+	return SkipAnim;
 }
 
 DEFINE_HOOK_AGAIN(0x739D8B, UnitClass_DeployUndeploy_DeployAnim, 0x5)


### PR DESCRIPTION
This is to remove parsing conflicts with Ares, due to Ares treating any other facing than 0-8 as invalid when parsing INI content and thus generating warnings such as:

`[Developer warning]Failed to parse INI file content: [ATCRT]DeployDir=-1 (Expected a facing between 0 and 8)`

Besides requiring INI changes, no actual functionality should have been lost with this change. This will still only apply to ground units due to the Ares hook for jumpjet unit DeployDir being at an address that can't be hooked around.

Translated documentation will need to be adjusted to match the changes here.