### PR TITLE
Update Laser Trails after Convert.Deploy transformation

### DIFF
--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -320,7 +320,7 @@ DEFINE_HOOK(0x702819, TechnoClass_ReceiveDamage_Decloak, 0xA)
 	return 0x702823;
 }
 
-DEFINE_HOOK(0x73DE90, UnitClass_Mi_Unload_SimpleDeployer_Phobos, 0x6)
+DEFINE_HOOK(0x73DE90, UnitClass_SimpleDeployer_TransferLaserTrails, 0x6)
 {
 	GET(UnitClass*, pUnit, ESI);
 

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -319,3 +319,28 @@ DEFINE_HOOK(0x702819, TechnoClass_ReceiveDamage_Decloak, 0xA)
 
 	return 0x702823;
 }
+
+DEFINE_HOOK(0x73DE90, UnitClass_Mi_Unload_SimpleDeployer_Phobos, 0x6)
+{
+	GET(UnitClass*, pUnit, ESI);
+
+	auto pTechnoExt = TechnoExt::ExtMap.Find(pUnit);
+	auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pUnit->GetTechnoType());
+
+	if (pTechnoExt && pTechnoTypeExt)
+	{
+		if (pTechnoExt->LaserTrails.size())
+			pTechnoExt->LaserTrails.clear();
+
+		for (auto const& entry : pTechnoTypeExt->LaserTrailData)
+		{
+			if (auto const pLaserType = LaserTrailTypeClass::Array[entry.idxType].get())
+			{
+				pTechnoExt->LaserTrails.push_back(std::make_unique<LaserTrailClass>(
+					pLaserType, pUnit->Owner, entry.FLH, entry.IsOnTurret));
+			}
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Convert.Deploy is an Ares tag so is necessary an extra check for loading the right Laser Trails when the unit is transformed.