### PR TITLE
Make jumpjets crash correctly if killed while pulled by Locomotor WH

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -44,6 +44,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - AITrigger can now recognize Building Upgrades as legal condition.
 - `EWGates` and `NSGates` now will link walls like `xxGateOne` and `xxGateTwo` do.
 - Fixed the bug when occupied building's `MuzzleFlashX` is drawn on the center of the building when `X` goes past 10.
+- Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead.
 
 ## Animations
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -274,6 +274,7 @@ Vanilla fixes:
 - Fixed the bug when retinting map lighting with a map action corrupted light sources (by secsome)
 - Fixed the bug that AITriggerTypes do not recognize building upgrades (by Uranusian)
 - Fixed the bug when occupied building's `MuzzleFlashX` is drawn on the center of the building when `X` goes past 10 (by Otamaa)
+- Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead (by Starkku)
 
 Phobos fixes:
 - Fixed shields being able to take damage when the parent TechnoType was under effects of a `Temporal` Warhead (by Starkku)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -71,6 +71,10 @@ DEFINE_HOOK(0x737D57, UnitClass_ReceiveDamage_DyingFix, 0x7)
 	GET(UnitClass*, pThis, ESI);
 	GET(DamageState, result, EAX);
 
+	// Immediately release locomotor warhead's hold on a crashable unit if it dies while attacked by one.
+	if (result == DamageState::NowDead && pThis->IsAttackedByLocomotor && pThis->GetTechnoType()->Crashable)
+		pThis->IsAttackedByLocomotor = false;
+
 	if (result != DamageState::PostMortem && pThis->DeathFrameCounter > 0)
 		R->EAX(DamageState::PostMortem);
 


### PR DESCRIPTION
This makes crashable jumpjet units crash if they are destroyed while affected by `Locomotor` warhead, instead of simply falling to ground (and not dying at all due to Phobos fixes to prevent units counting as dying multiple times while crashing etc).