### PR TITLE
Potential fix for shield anim + cloaked object crash

### DIFF
--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -613,7 +613,7 @@ void ShieldClass::KillAnim()
 {
 	if (this->IdleAnim)
 	{
-		GameDelete(this->IdleAnim);
+		this->IdleAnim->DetachFromObject(this->Techno, false);
 		this->IdleAnim = nullptr;
 	}
 }


### PR DESCRIPTION
Trying to remove the shield anim, usually on breaking the shield would sometimes crash if the shield was attached to a cloaked object. I was not able to pinpoint the exact root cause of this problem, but from what I could gather something went wrong trying to dispose the animation object. Replacing the direct `GameDelete` call with a call to the game function used for detaching attached anims from objects (which will, amongst other things, mark the anims for deletion, to be done on next frame in AI function) I have thus far been unable to reproduce the crash even after extensive testing.