### PR TITLE
Allow centering attached anims on object center

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Credits
 - **ChrisLv_CN** - interceptor logic, LaserTrails, laser fixes, general assistance (work relicensed under [following permission](images/ChrisLv-relicense.png))
 - **Xkein** - general assistance, YRpp edits
 - **thomassneddon** - general assistance
-- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, CreateUnit improvements, Attached animation & jumpjet unit layer customization, IsSimpleDeployer improvements, Shield modification warheads, Warhead decloaking toggle, Warp(In/Out)Weapon, Grinder improvements / additions
+- **Starkku** - Warhead shield penetration & breaking, strafing aircraft weapon customization, vehicle DeployFire fixes/improvements, stationary VehicleTypes, Burst logic improvements, TechnoType auto-firing weapons, Secondary weapon fallback customization, weapon target type filtering, AreaFire targeting customization, CreateUnit improvements, Attached animation & jumpjet unit layer customization, IsSimpleDeployer improvements, Shield modification warheads, Warhead decloaking toggle, Warp(In/Out)Weapon, Grinder improvements / additions, Attached animation position customization
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **Morton (MortonPL)** - XDrawOffset, Shield passthrough & absorption, building LimboDelivery, fix for Image in art rules, power delta counter
 - **mevitar** - honorary shield tester *triple* award

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -67,8 +67,18 @@ HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage
 
 In `artmd.ini`:
 ```ini
-[SOMEANIM]                 ; AnimationType
-Layer.UseObjectLayer=      ; boolean
+[SOMEANIM]             ; AnimationType
+Layer.UseObjectLayer=  ; boolean
+```
+
+### Attached animation position customization
+
+- You can now customize whether or not animations attached to objects are centered at the object's actual center rather than the bottom of their top-leftmost cell (cell #0).
+
+In `artmd.ini`:
+```ini
+[SOMEANIM]                       ; AnimationType
+UseCenterCoordsIfAttached=false  ; boolean
 ```
 
 ## Buildings

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -267,6 +267,7 @@ New:
 - Weapons fired on warping in / out (by Starkku)
 - `Storage.TiberiumIndex` for customizing resource storage in structures (by FS-21)
 - Grinder improvements & customizations (by Starkku)
+- Attached animation position customization (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -32,6 +32,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->XDrawOffset.Read(exINI, pID, "XDrawOffset");
 	this->HideIfNoOre_Threshold.Read(exINI, pID, "HideIfNoOre.Threshold");
 	this->Layer_UseObjectLayer.Read(exINI, pID, "Layer.UseObjectLayer");
+	this->UseCenterCoordsIfAttached.Read(exINI, pID, "UseCenterCoordsIfAttached");
 }
 
 const void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)
@@ -108,6 +109,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->XDrawOffset)
 		.Process(this->HideIfNoOre_Threshold)
 		.Process(this->Layer_UseObjectLayer)
+		.Process(this->UseCenterCoordsIfAttached)
 		;
 }
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -27,6 +27,7 @@ public:
 		Valueable<int> XDrawOffset;
 		Valueable<int> HideIfNoOre_Threshold;
 		Nullable<bool> Layer_UseObjectLayer;
+		Valueable<bool> UseCenterCoordsIfAttached;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -41,6 +42,7 @@ public:
 			, XDrawOffset { 0 }
 			, HideIfNoOre_Threshold { 0 }
 			, Layer_UseObjectLayer {}
+			, UseCenterCoordsIfAttached { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -51,3 +51,21 @@ DEFINE_HOOK(0x424CB0, AnimClass_In_Which_Layer_AttachedObjectLayer, 0x6)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x424C49, AnimClass_AttachTo_BuildingCoords, 0x5)
+{
+	GET(AnimClass*, pThis, ESI);
+	GET(ObjectClass*, pObject, EDI);
+	GET(CoordStruct*, pCoords, EAX);
+
+	auto pExt = AnimTypeExt::ExtMap.Find(pThis->Type);
+
+	if (pExt->UseCenterCoordsIfAttached)
+	{
+		pCoords = pObject->GetCenterCoord(pCoords);
+		pCoords->X += 128;
+		pCoords->Y += 128;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
### Attached animation position customization

- You can now customize whether or not animations attached to objects are centered at the object's actual center rather than the bottom of their top-leftmost cell (cell #0).

In `artmd.ini`:
```ini
[SOMEANIM]                       ; AnimationType
UseCenterCoordsIfAttached=false  ; boolean
```

The effect is most noticeable on buildings larger than 1x1, but even on 1x1 buildings and units it will shift the animation up half a cell (15 pixels or so).
![animcenter](https://user-images.githubusercontent.com/1392346/154852569-f7a6dd98-ecec-47f2-83c5-95fa99f12df9.png)

