### PR TITLE
New tag for overriding an underwater attack case

### DIFF
--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -380,3 +380,36 @@ DEFINE_HOOK(0x5F4F4E, ObjectClass_Unlimbo_LaserTrails, 0x7)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x6F3428, TechnoClass_GetWeapon_ForceWeapon, 0x6)
+{
+	GET(TechnoClass*, pTechno, ECX);
+
+	if (pTechno && pTechno->Target)
+	{
+		auto pTechnoType = pTechno->GetTechnoType();
+		if (!pTechnoType)
+			return 0;
+
+		auto pTarget = abstract_cast<TechnoClass*>(pTechno->Target);
+		if (!pTarget)
+			return 0;
+
+		auto pTargetType = pTarget->GetTechnoType();
+		if (!pTargetType)
+			return 0;
+
+		if (auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pTechnoType))
+		{
+			if (pTechnoTypeExt->ForceWeapon_Naval_Decloaked >= 0 
+				&& pTargetType->Cloakable && pTargetType->Naval 
+				&& pTarget->CloakState == CloakState::Uncloaked)
+			{
+				R->EAX(pTechnoTypeExt->ForceWeapon_Naval_Decloaked);
+				return 0x6F37AF;
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -221,6 +221,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	}
 
 	this->EnemyUIName.Read(exINI, pSection, "EnemyUIName");
+
+	this->ForceWeapon_Naval_Decloaked.Read(exINI, pSection, "ForceWeapon.Naval.Decloaked");
 }
 
 template <typename T>
@@ -294,6 +296,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DeployingAnim_ReverseForUndeploy)
 		.Process(this->DeployingAnim_UseUnitDrawer)
 		.Process(this->EnemyUIName)
+		.Process(this->ForceWeapon_Naval_Decloaked)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -97,6 +97,8 @@ public:
 		Valueable<bool> DeployingAnim_ReverseForUndeploy;
 		Valueable<bool> DeployingAnim_UseUnitDrawer;
 
+		Valueable<int> ForceWeapon_Naval_Decloaked;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -180,6 +182,7 @@ public:
 			, DeployingAnim_ReverseForUndeploy { true }
 			, DeployingAnim_UseUnitDrawer { true }
 			, EnemyUIName {}
+			, ForceWeapon_Naval_Decloaked { -1 }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
Default YR behavior with `NavalTargeting=1` is always attack underwater (and uncloaked underwater submarines) with secondary weapon and anything else with primary weapon.
This overrides a part of the vanilla YR logic for allowing naval units to use a different weapon if the underwater unit is uncloaked.
Useful if you want a unit with 1 weapon for underwater objects and another only for surface objects.

[SOMETECHNO]
ForceWeapon.Naval.Decloacked=-1   ; 0 for primary weapon, 1 for secondary weapon