### PR TITLE
Fix mind control indicator animations not reappearing on uncloak

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -137,6 +137,7 @@ This page lists all the individual contributions to the project by their author.
   - Feedback weapon
   - TerrainType & ore minimap color customization
   - Laser fixes & improvements
+  - Mind control indicator animation cloak fix
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -60,6 +60,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Both voxel and SHP vehicle units should now correctly respect custom palette set through `Palette`.
 - Weapons fired by EMPulse superweapons without `EMPulse.TargetSelf=true` *(Ares feature)* can now create radiation.
 - Setting `RadarInvisible` to true on TerrainTypes now hides them from minimap display.
+- Mind control indicator animations will now correctly restore on mind controlled objects when uncloaked.
 
 ## Animations
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -307,6 +307,7 @@ Vanilla fixes:
 - Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead (by Starkku)
 - Fixed aircraft & jumpjet units not being affected by speed modifiers (by Starkku)
 - Fixed vehicles (both voxel & SHP) to fully respect `Palette` (by Starkku)
+- Fixed mind control indicator animations not reappearing on mind controlled objects that are cloaked and then uncloaked (by Starkku)
 
 Phobos fixes:
 - Fixed shields being able to take damage when the parent TechnoType was under effects of a `Temporal` Warhead (by Starkku)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -487,7 +487,8 @@ void TechnoExt::UpdateSharedAmmo(TechnoClass* pThis)
 						}
 
 						passenger = static_cast<FootClass*>(passenger->NextObject);
-					} while (passenger);
+					}
+					while (passenger);
 				}
 			}
 		}
@@ -509,6 +510,48 @@ double TechnoExt::GetCurrentSpeedMultiplier(FootClass* pThis)
 		(pThis->HasAbility(Ability::Faster) ? RulesClass::Instance->VeteranSpeed : 1.0);
 }
 
+void TechnoExt::UpdateMindControlAnim(TechnoClass* pThis)
+{
+	if (const auto pExt = TechnoExt::ExtMap.Find(pThis))
+	{
+		if (pThis->IsMindControlled())
+		{
+			if (pThis->MindControlRingAnim && !pExt->MindControlRingAnimType)
+			{
+				pExt->MindControlRingAnimType = pThis->MindControlRingAnim->Type;
+			}
+			else if (!pThis->MindControlRingAnim && pExt->MindControlRingAnimType &&
+				pThis->CloakState == CloakState::Uncloaked && !pThis->InLimbo && pThis->IsAlive)
+			{
+				auto coords = CoordStruct::Empty;
+				coords = *pThis->GetCoords(&coords);
+				int offset = 0;
+
+				if (const auto pBuilding = specific_cast<BuildingClass*>(pThis))
+					offset = 104 * pBuilding->Type->Height;
+				else
+					offset = pThis->GetTechnoType()->MindControlRingOffset;
+
+				coords.Z += offset;
+				auto anim = GameCreate<AnimClass>(pExt->MindControlRingAnimType, coords, 0, 1);
+
+				if (anim)
+				{
+					pThis->MindControlRingAnim = anim;
+					pThis->MindControlRingAnim->SetOwnerObject(pThis);
+
+					if (pThis->WhatAmI() == AbstractType::Building)
+						pThis->MindControlRingAnim->ZAdjust = -1024;
+				}
+			}
+		}
+		else if (pExt->MindControlRingAnimType)
+		{
+			pExt->MindControlRingAnimType = nullptr;
+		}
+	}
+}
+
 // =============================
 // load / save
 
@@ -525,6 +568,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->CurrentShieldType)
 		.Process(this->LastWarpDistance)
 		.Process(this->Death_Countdown)
+		.Process(this->MindControlRingAnimType)
 		;
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -528,7 +528,7 @@ void TechnoExt::UpdateMindControlAnim(TechnoClass* pThis)
 				int offset = 0;
 
 				if (const auto pBuilding = specific_cast<BuildingClass*>(pThis))
-					offset = 104 * pBuilding->Type->Height;
+					offset = Unsorted::LevelHeight * pBuilding->Type->Height;
 				else
 					offset = pThis->GetTechnoType()->MindControlRingOffset;
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -29,6 +29,7 @@ public:
 		Valueable<ShieldTypeClass*> CurrentShieldType;
 		Valueable<int> LastWarpDistance;
 		int Death_Countdown;
+		Valueable<AnimTypeClass*> MindControlRingAnimType;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, InterceptedBullet { nullptr }
@@ -38,9 +39,10 @@ public:
 			, LastKillWasTeamTarget { false }
 			, PassengerDeletionTimer {}
 			, PassengerDeletionCountDown { -1 }
-			, CurrentShieldType {}
+			, CurrentShieldType { nullptr }
 			, LastWarpDistance {}
 			, Death_Countdown(-1)
+			, MindControlRingAnimType { nullptr }
 		{ }
 
 		virtual ~ExtData() = default;
@@ -97,4 +99,5 @@ public:
 	static void UpdateSharedAmmo(TechnoClass* pThis);
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);
 	static bool CanFireNoAmmoWeapon(TechnoClass* pThis, int weaponIndex);
+	static void UpdateMindControlAnim(TechnoClass* pThis);
 };

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -19,6 +19,7 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	TechnoExt::ApplySpawn_LimitRange(pThis);
 	TechnoExt::CheckDeathConditions(pThis);
 	TechnoExt::EatPassengers(pThis);
+	TechnoExt::UpdateMindControlAnim(pThis);
 
 	// LaserTrails update routine is in TechnoClass::AI hook because TechnoClass::Draw
 	// doesn't run when the object is off-screen which leads to visual bugs - Kerbiter


### PR DESCRIPTION
Game deletes mind control animations when cloaking objects, but doesn't restore them on uncloak. This fixes that, and should function with any types of mind control animation (regular, Dominator and Ares PermaControl warheads).