### PR TITLE
Shield animation & pip customizations

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -165,8 +165,9 @@ Shield.InheritStateOnReplace=false   ; boolean
   - If you want shield recovers/respawns 1 HP per time, currently you need to set tag value to any number between 1 and 2, like `1.1`.
 - `SelfHealing.Rate` and `Respawn.Rate` respect the following settings: 0.0 instantly recovers the shield, other values determine the frequency of shield recovers/respawns in ingame minutes.
 - `IdleAnim`, if set, will be played while the shield is intact. This animation is automatically set to loop indefinitely.
-  - `IdleAnim.ConditionYellow` and `IdleAnim.ConditionRed` can be used to set different animations for when shield health is at or below the percentage defined in `[AudioVisual]`->`ConditionYellow`/`ConditionRed`, respectively. If not set, `IdleAnim` is used.
-  - `IdleAnimDamaged`, `IdleAnimDamaged.ConditionYellow` and `IdleAnimDamaged.ConditionRed` are used in an identical manner, but only when health of the object the shield is attached to is at or below `[AudioVisual]`->`ConditionYellow`. If none are set, then regular `IdleAnim` or variants are used.
+  - `IdleAnim.ConditionYellow` and `IdleAnim.ConditionRed` can be used to set different animations for when shield health is at or below the percentage defined in `[AudioVisual]`->`ConditionYellow`/`ConditionRed`, respectively. If `IdleAnim.ConditionRed` is not set it falls back to `IdleAnim.ConditionYellow`, which in turn falls back to `IdleAnim`.
+  - `IdleAnimDamaged`, `IdleAnimDamaged.ConditionYellow` and `IdleAnimDamaged.ConditionRed` are used in an identical manner, but only when health of the object the shield is attached to is at or below `[AudioVisual]`->`ConditionYellow`. Follows similar fallback sequence to regular `IdleAnim` variants and if none are set, falls back to the regular `IdleAnim` or variants thereof.
+  - `Bouncer=true` and `IsMeteor=true` animations can exhibit irregular behaviour when used as `IdleAnim` and should be avoided.
 - `IdleAnim.OfflineAction` indicates what happens to the animation when the shield is in a low power state.
 - `IdleAnim.TemporalAction` indicates what happens to the animation when the shield is attacked by temporal weapons.
 - `BreakAnim`, if set, will be played when the shield has been broken.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -105,6 +105,11 @@ Respawn=0.0                          ; double, percents or absolute
 Respawn.Rate=0.0                     ; double, ingame minutes
 BracketDelta=0                       ; integer - pixels
 IdleAnim=                            ; animation
+IdleAnim.ConditionYellow=            ; animation
+IdleAnim.ConditionRed=               ; animation
+IdleAnimDamaged=                     ; animation
+IdleAnimDamaged.ConditionYellow=     ; animation
+IdleAnimDamaged.ConditionRed=        ; animation
 IdleAnim.OfflineAction=Hides         ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
 IdleAnim.TemporalAction=Hides        ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
 BreakAnim=                           ; animation
@@ -154,7 +159,8 @@ Shield.InheritStateOnReplace=false   ; boolean
   - If you want shield recovers/respawns 1 HP per time, currently you need to set tag value to any number between 1 and 2, like `1.1`.
 - `SelfHealing.Rate` and `Respawn.Rate` respect the following settings: 0.0 instantly recovers the shield, other values determine the frequency of shield recovers/respawns in ingame minutes.
 - `IdleAnim`, if set, will be played while the shield is intact. This animation is automatically set to loop indefinitely.
-  - `Bouncer=yes` animations are not supported at the moment.
+  - `IdleAnim.ConditionYellow` and `IdleAnim.ConditionRed` can be used to set different animations for when shield health is at or below the percentage defined in ``[AudioVisual]`->`ConditionYellow`/`ConditionRed`, respectively.` If not set, `IdleAnim` is used.
+  - `IdleAnimDamaged`, `IdleAnimDamaged.ConditionYellow` and `IdleAnimDamaged.ConditionRed` are used in an identical manner, but only when health of the object the shield is attached to is at or below``[AudioVisual]`->`ConditionYellow`. If none are set, then regular `IdleAnim` or variants are used.
 - `IdleAnim.OfflineAction` indicates what happens to the animation when the shield is in a low power state.
 - `IdleAnim.TemporalAction` indicates what happens to the animation when the shield is attacked by temporal weapons.
 - `BreakAnim`, if set, will be played when the shield has been broken.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -87,8 +87,10 @@ LaserTrail.Types=SOMETRAIL  ; list of LaserTrailTypes
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
-Pips.Shield=-1,-1,-1           ; int, frames of pips.shp for Green, Yellow, Red
-Pips.Shield.Building=-1,-1,-1  ; int, frames of pips.shp for Green, Yellow, Red
+Pips.Shield=-1,-1,-1               ; int, frames of pips.shp (zero-based) for Green, Yellow, Red
+Pips.Shield.Building=-1,-1,-1      ; int, frames of pips.shp (zero-based) for Green, Yellow, Red
+Pips.Shield.Background=PIPBRD.SHP  ; filename - including the .shp/.pcx extension
+Pips.Shield.Building.Empty=0       ; int, frame of pips.shp (zero-based) for empty building pip
 
 [ShieldTypes]
 0=SOMESHIELDTYPE
@@ -104,6 +106,10 @@ SelfHealing.Rate=0.0                 ; double, ingame minutes
 Respawn=0.0                          ; double, percents or absolute
 Respawn.Rate=0.0                     ; double, ingame minutes
 BracketDelta=0                       ; integer - pixels
+Pips=-1,-1,-1                        ; int, frames of pips.shp (zero-based) for Green, Yellow, Red
+Pips.Building=-1,-1,-1               ; int, frames of pips.shp (zero-based) for Green, Yellow, Red
+Pips.Background=                     ; filename - including the .shp/.pcx extension
+Pips.Building.Empty=                 ; int, frame of pips.shp (zero-based) for empty building pip
 IdleAnim=                            ; animation
 IdleAnim.ConditionYellow=            ; animation
 IdleAnim.ConditionRed=               ; animation
@@ -159,8 +165,8 @@ Shield.InheritStateOnReplace=false   ; boolean
   - If you want shield recovers/respawns 1 HP per time, currently you need to set tag value to any number between 1 and 2, like `1.1`.
 - `SelfHealing.Rate` and `Respawn.Rate` respect the following settings: 0.0 instantly recovers the shield, other values determine the frequency of shield recovers/respawns in ingame minutes.
 - `IdleAnim`, if set, will be played while the shield is intact. This animation is automatically set to loop indefinitely.
-  - `IdleAnim.ConditionYellow` and `IdleAnim.ConditionRed` can be used to set different animations for when shield health is at or below the percentage defined in ``[AudioVisual]`->`ConditionYellow`/`ConditionRed`, respectively.` If not set, `IdleAnim` is used.
-  - `IdleAnimDamaged`, `IdleAnimDamaged.ConditionYellow` and `IdleAnimDamaged.ConditionRed` are used in an identical manner, but only when health of the object the shield is attached to is at or below``[AudioVisual]`->`ConditionYellow`. If none are set, then regular `IdleAnim` or variants are used.
+  - `IdleAnim.ConditionYellow` and `IdleAnim.ConditionRed` can be used to set different animations for when shield health is at or below the percentage defined in `[AudioVisual]`->`ConditionYellow`/`ConditionRed`, respectively. If not set, `IdleAnim` is used.
+  - `IdleAnimDamaged`, `IdleAnimDamaged.ConditionYellow` and `IdleAnimDamaged.ConditionRed` are used in an identical manner, but only when health of the object the shield is attached to is at or below `[AudioVisual]`->`ConditionYellow`. If none are set, then regular `IdleAnim` or variants are used.
 - `IdleAnim.OfflineAction` indicates what happens to the animation when the shield is in a low power state.
 - `IdleAnim.TemporalAction` indicates what happens to the animation when the shield is attacked by temporal weapons.
 - `BreakAnim`, if set, will be played when the shield has been broken.
@@ -169,10 +175,13 @@ Shield.InheritStateOnReplace=false   ; boolean
 - `AbsorbPercent` controls the percentage of damage that will be absorbed by the shield. Defaults to 1.0, meaning full damage absorption.
 - `PassPercent` controls the percentage of damage that will *not* be absorbed by the shield, and will be dealt to the unit directly even if the shield is active. Defaults to 0.0 - no penetration.
 - `AllowTransfer` controls whether or not the shield can be transferred if the TechnoType changes (such as `(Un)DeploysInto` or Ares type conversion). If not set, defaults to true if shield was attached via `Shield.AttachTypes`, otherwise false.
-- A TechnoType with a shield will show its shield Strength. An empty shield strength bar will be left after destroyed if it is respawnable.
-  - Buildings now use the 5th frame of `pips.shp` to display the shield strength while other units uses the 16th frame by default.
-  - `Pips.Shield` can be used to specify which pip frame should be used as shield strength. If only 1 digit set, then it will always display it, or if 3 digits set, it will respect `ConditionYellow` and `ConditionRed`. `Pips.Shield.Building` is used for BuildingTypes.
-  - `pipbrd.shp` will use its 4th frame to display an infantry's shield strength and the 3th frame for other units if `pipbrd.shp` has extra 2 frames. And `BracketDelta` can be used as additional `PixelSelectionBracketDelta` for shield strength.
+- A TechnoType with a shield will show its shield Strength. An empty shield strength bar will be left after destroyed if it is respawnable. Several customizations are available for the shield strength pips.
+  - By default, buildings use the 6th frame of `pips.shp` to display the shield strength while others use the 17th frame.
+  - `Pips.Shield` can be used to specify which pip frame should be used as shield strength. If only 1 digit is set, then it will always display that frame, or if 3 digits are set, it will use those if shield's current strength is at or below `ConditionYellow` and `ConditionRed`, respectively. `Pips.Shield.Building` is used for BuildingTypes. -1 as value will use the default frame, whether it is fallback to first value or the aforementioned hardcoded defaults.
+  - `Pips.Shield.Background` can be used to set the background or 'frame' for non-building pips, which defaults to `pipbrd.shp`. 4th frame is used to display an infantry's shield strength and the 3th frame for other units, or 2nd and 1st respectively if not enough frames are available.
+  - `Pips.Shield.Building.Empty` can be used to set the frame of `pips.shp` displayed for empty building strength pips, defaults to 1st frame of `pips.shp`.
+  - The above customizations are also available on per ShieldType basis, e.g `[ShieldType]`->`Pips` instead of `[AudioVisual]`->`Pips.Shield` and so on. ShieldType settings take precedence over the global ones, but will fall back to them if not set.
+  - `BracketDelta` can be used as additional vertical offset (negative shifts it up) for shield strength bar. Much like `PixelSelectionBracketDelta`, it is not applied on buildings.
 - Warheads have new options that interact with shields.
   - `Shield.Penetrate` allows the warhead ignore the shield and always deal full damage to the TechnoType itself. It also allows targeting the TechnoType as if shield doesn't exist.
   - `Shield.Break` allows the warhead to always break shields of TechnoTypes. This is done before damage is dealt.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -323,6 +323,7 @@ Phobos fixes:
 - Fixed critical hit animation playing even if no critical hits were dealt due to `Crit.Affects` or `ImmuneToCrit` settings (by Starkku)
 - Fixed `RemoveDisguise` not working on `PermaDisguise` infantry (by Starkku)
 - Fixed single-color laser (IsHouseColor, IsSingleColor, LaserTrails) glow falloff to match the vanilla appearance (by Starkku)
+- Fixed a potential cause of crashes concerning shield animations (such in conjunction with cloaking) (by Starkku)
 </details>
 
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -67,14 +67,24 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	INI_EX exINI(pINI);
 
 	this->Storage_TiberiumIndex.Read(exINI, GENERAL_SECTION, "Storage.TiberiumIndex");
-	this->RadApplicationDelay_Building.Read(exINI, "Radiation", "RadApplicationDelay.Building");
-	this->Pips_Shield.Read(exINI, "AudioVisual", "Pips.Shield");
-	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
-	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
 	this->JumpjetAllowLayerDeviation.Read(exINI, "JumpjetControls", "AllowLayerDeviation");
+	this->RadApplicationDelay_Building.Read(exINI, "Radiation", "RadApplicationDelay.Building");
+	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
 	this->JumpjetTurnToTarget.Read(exINI, "JumpjetControls", "TurnToTarget");
 	this->PlacementGrid_TranslucentLevel.Read(exINI, "AudioVisual", "BuildingPlacementGrid.TranslucentLevel");
 	this->BuildingPlacementPreview_TranslucentLevel.Read(exINI, "AudioVisual", "BuildingPlacementPreview.DefaultTranslucentLevel");
+	this->Pips_Shield.Read(exINI, "AudioVisual", "Pips.Shield");
+	this->Pips_Shield_Background_Filename.Read(pINI, "AudioVisual", "Pips.Shield.Background");
+	this->Pips_Shield_Building.Read(exINI, "AudioVisual", "Pips.Shield.Building");
+	this->Pips_Shield_Building_Empty.Read(exINI, "AudioVisual", "Pips.Shield.Building.Empty");
+
+	if (this->Pips_Shield_Background_Filename)
+	{
+		char filename[0x20];
+		strcpy(filename, this->Pips_Shield_Background_Filename);
+		_strlwr_s(filename);
+		this->Pips_Shield_Background_SHP = FileSystem::LoadSHPFile(filename);
+	}
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount(sectionAITargetTypes);
@@ -84,7 +94,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		char* context = nullptr;
 		pINI->ReadString(sectionAITargetTypes, pINI->GetKeyName(sectionAITargetTypes, i), "", Phobos::readBuffer);
 
-		for (char *cur = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+		for (char* cur = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
 		{
 			TechnoTypeClass* buffer;
 			if (Parser<TechnoTypeClass*>::TryParse(cur, &buffer))
@@ -106,7 +116,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		char* context = nullptr;
 		pINI->ReadString(sectionAIScriptsList, pINI->GetKeyName(sectionAIScriptsList, i), "", Phobos::readBuffer);
 
-		for (char *cur = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+		for (char* cur = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
 		{
 			ScriptTypeClass* pNewScript = GameCreate<ScriptTypeClass>(cur);
 			objectsList.AddItem(pNewScript);
@@ -160,19 +170,21 @@ template <typename T>
 void RulesExt::ExtData::Serialize(T& Stm)
 {
 	Stm
-		.Process(this->Pips_Shield)
-		.Process(this->Pips_Shield_Buildings)
+		.Process(this->AITargetTypesLists)
+		.Process(this->AIScriptsLists)
+		.Process(this->Storage_TiberiumIndex)
 		.Process(this->RadApplicationDelay_Building)
-		.Process(this->MissingCameo)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->JumpjetAllowLayerDeviation)
 		.Process(this->JumpjetTurnToTarget)
-		.Process(this->AITargetTypesLists)
-		.Process(this->AIScriptsLists)
-		.Process(this->Storage_TiberiumIndex)
 		.Process(this->PlacementGrid_TranslucentLevel)
 		.Process(this->BuildingPlacementPreview_TranslucentLevel)
+		.Process(this->Pips_Shield)
+		.Process(this->Pips_Shield_Background_Filename)
+		.Process(this->Pips_Shield_Background_SHP)
+		.Process(this->Pips_Shield_Building)
+		.Process(this->Pips_Shield_Building_Empty)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -24,33 +24,38 @@ public:
 	class ExtData final : public Extension<RulesClass>
 	{
 	public:
-		Valueable<Vector3D<int>> Pips_Shield;
-		Valueable<Vector3D<int>> Pips_Shield_Buildings;
-		Valueable<int> RadApplicationDelay_Building;
-		PhobosFixedString<32u> MissingCameo;
 		DynamicVectorClass<DynamicVectorClass<TechnoTypeClass*>> AITargetTypesLists;
 		DynamicVectorClass<DynamicVectorClass<ScriptTypeClass*>> AIScriptsLists;
 
+		Valueable<int> Storage_TiberiumIndex;
+		Valueable<int> RadApplicationDelay_Building;
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;
 		Valueable<bool> JumpjetAllowLayerDeviation;
 		Valueable<bool> JumpjetTurnToTarget;
-		Valueable<int> Storage_TiberiumIndex;
+		PhobosFixedString<32u> MissingCameo;
 		Valueable<int> PlacementGrid_TranslucentLevel;
 		Valueable<int> BuildingPlacementPreview_TranslucentLevel;
+		Valueable<Vector3D<int>> Pips_Shield;
+		PhobosFixedString<32u> Pips_Shield_Background_Filename;
+		SHPStruct* Pips_Shield_Background_SHP;
+		Valueable<Vector3D<int>> Pips_Shield_Building;
+		Nullable<int> Pips_Shield_Building_Empty;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
-			, Pips_Shield { { -1,-1,-1 } }
-			, Pips_Shield_Buildings { { -1,-1,-1 } }
+			, Storage_TiberiumIndex { -1 }
 			, RadApplicationDelay_Building { 0 }
-			, MissingCameo { "xxicon.shp" }
 			, JumpjetCrash { 5.0 }
 			, JumpjetNoWobbles { false }
 			, JumpjetAllowLayerDeviation { true }
-			, Storage_TiberiumIndex { -1 }
+			, JumpjetTurnToTarget { false }
+			, MissingCameo { "xxicon.shp" }
 			, PlacementGrid_TranslucentLevel{ 0 }
 			, BuildingPlacementPreview_TranslucentLevel { 3 }
-			, JumpjetTurnToTarget { false }
+			, Pips_Shield_Background_Filename {}
+			, Pips_Shield_Background_SHP {}
+			, Pips_Shield_Building { { -1,-1,-1 } }
+			, Pips_Shield_Building_Empty {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -321,7 +321,7 @@ void ShieldClass::CloakCheck()
 	this->Cloak = cloakState == CloakState::Cloaked || cloakState == CloakState::Cloaking;
 
 	if (this->Cloak)
-		this->IdleAnim = nullptr;
+		KillAnim();
 }
 
 void ShieldClass::OnlineCheck()

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -59,6 +59,8 @@ bool ShieldClass::Serialize(T& Stm)
 		.Process(this->SelfHealing_Rate_Warhead)
 		.Process(this->Respawn_Warhead)
 		.Process(this->Respawn_Rate_Warhead)
+		.Process(this->LastBreakFrame)
+		.Process(this->LastTechnoHealthRatio)
 		.Success();
 }
 
@@ -300,8 +302,15 @@ void ShieldClass::AI()
 	this->RespawnShield();
 	this->SelfHealing();
 
+	double ratio = this->Techno->GetHealthPercentage();
+
+	if (GeneralUtils::HasHealthRatioThresholdChanged(LastTechnoHealthRatio, ratio))
+		UpdateIdleAnim();
+
 	if (!this->Cloak && !this->Temporal && this->Online && (this->HP > 0 && this->Techno->Health > 0))
 		this->CreateAnim();
+
+	LastTechnoHealthRatio = ratio;
 }
 
 // The animation is automatically destroyed when the associated unit receives the isCloak statute.
@@ -763,7 +772,7 @@ void ShieldClass::DrawShieldBar_Other(int iLength, Point2D* pLocation, Rectangle
 int ShieldClass::DrawShieldBar_Pip(const bool isBuilding)
 {
 	const auto strength = this->Type->Strength;
-	const auto pips_Shield = isBuilding ? this->Type->Pips_Building.Get() :this->Type->Pips.Get();
+	const auto pips_Shield = isBuilding ? this->Type->Pips_Building.Get() : this->Type->Pips.Get();
 	const auto pips_Global = isBuilding ? RulesExt::Global()->Pips_Shield_Building.Get() : RulesExt::Global()->Pips_Shield.Get();
 
 	auto shieldPip = pips_Global;

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -57,6 +57,8 @@ private:
 	void RespawnShield();
 
 	void CreateAnim();
+	void UpdateIdleAnim();
+	AnimTypeClass* GetIdleAnimType();
 
 	void WeaponNullifyAnim(AnimTypeClass* pHitAnim = nullptr);
 	void ResponseAttack();

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -90,6 +90,7 @@ private:
 	int Respawn_Rate_Warhead;
 
 	int LastBreakFrame;
+	double LastTechnoHealthRatio;
 
 	ShieldTypeClass* Type;
 

--- a/src/New/Type/ShieldTypeClass.cpp
+++ b/src/New/Type/ShieldTypeClass.cpp
@@ -55,6 +55,19 @@ void ShieldTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->PassPercent.Read(exINI, pSection, "PassPercent");
 
 	this->AllowTransfer.Read(exINI, pSection, "AllowTransfer");
+
+	this->Pips.Read(exINI, pSection, "Pips");
+	this->Pips_Background_Filename.Read(pINI, pSection, "Pips.Background");
+	this->Pips_Building.Read(exINI, pSection, "Pips.Building");
+	this->Pips_Building_Empty.Read(exINI, pSection, "Pips.Building.Empty");
+
+	if (this->Pips_Background_Filename)
+	{
+		char filename[0x20];
+		strcpy(filename, this->Pips_Background_Filename);
+		_strlwr_s(filename);
+		this->Pips_Background_SHP = FileSystem::LoadSHPFile(filename);
+	}
 }
 
 template <typename T>
@@ -80,6 +93,11 @@ void ShieldTypeClass::Serialize(T& Stm)
 		.Process(this->AbsorbPercent)
 		.Process(this->PassPercent)
 		.Process(this->AllowTransfer)
+		.Process(this->Pips)
+		.Process(this->Pips_Background_Filename)
+		.Process(this->Pips_Background_SHP)
+		.Process(this->Pips_Building)
+		.Process(this->Pips_Building_Empty)
 		;
 }
 

--- a/src/New/Type/ShieldTypeClass.cpp
+++ b/src/New/Type/ShieldTypeClass.cpp
@@ -7,6 +7,16 @@ const char* Enumerable<ShieldTypeClass>::GetMainSection()
 	return "ShieldTypes";
 }
 
+AnimTypeClass* ShieldTypeClass::GetIdleAnimType(bool isDamaged, double healthRatio)
+{
+	auto damagedAnim = this->IdleAnimDamaged.Get(healthRatio);
+
+	if (isDamaged && damagedAnim)
+		return damagedAnim;
+	else
+		return this->IdleAnim.Get(healthRatio);
+}
+
 void ShieldTypeClass::LoadFromINI(CCINIClass* pINI)
 {
 	const char* pSection = this->Name;
@@ -34,12 +44,8 @@ void ShieldTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->IdleAnim_OfflineAction.Read(exINI, pSection, "IdleAnim.OfflineAction");
 	this->IdleAnim_TemporalAction.Read(exINI, pSection, "IdleAnim.TemporalAction");
 
-	this->IdleAnim.Read(exINI, pSection, "IdleAnim");
-	if (this->IdleAnim.Get() && this->IdleAnim->Bouncer)
-	{
-		Debug::Log("[Developer Warning]ShieldTypes don't support Bouncer=yes anims: [%s]IdleAnim=%s\r\n", pSection, this->IdleAnim->get_ID());
-		this->IdleAnim.Reset();
-	}
+	this->IdleAnim.Read(exINI, pSection, "IdleAnim.%s");
+	this->IdleAnimDamaged.Read(exINI, pSection, "IdleAnimDamaged.%s");
 
 	this->BreakAnim.Read(exINI, pSection, "BreakAnim");
 	this->HitAnim.Read(exINI, pSection, "HitAnim");

--- a/src/New/Type/ShieldTypeClass.h
+++ b/src/New/Type/ShieldTypeClass.h
@@ -31,6 +31,13 @@ public:
 	Valueable<double> PassPercent;
 
 	Nullable<bool> AllowTransfer;
+
+	Valueable<Vector3D<int>> Pips;
+	PhobosFixedString<32u> Pips_Background_Filename;
+	SHPStruct* Pips_Background_SHP;
+	Valueable<Vector3D<int>> Pips_Building;
+	Nullable<int> Pips_Building_Empty;
+
 private:
 	Valueable<double> Respawn_Rate__InMinutes;
 	Valueable<double> SelfHealing_Rate__InMinutes;
@@ -59,6 +66,11 @@ public:
 		, Respawn_Rate__InMinutes(0.0)
 		, SelfHealing_Rate__InMinutes(0.0)
 		, AllowTransfer()
+		, Pips {{ - 1,-1,-1 }}
+		, Pips_Background_Filename {}
+		, Pips_Background_SHP {}
+		, Pips_Building {{ -1,-1,-1 }}
+		, Pips_Building_Empty {}
 	{};
 
 	virtual ~ShieldTypeClass() override = default;

--- a/src/New/Type/ShieldTypeClass.h
+++ b/src/New/Type/ShieldTypeClass.h
@@ -22,7 +22,8 @@ public:
 	Valueable<int> BracketDelta;
 	Valueable<AttachedAnimFlag> IdleAnim_OfflineAction;
 	Valueable<AttachedAnimFlag> IdleAnim_TemporalAction;
-	Nullable<AnimTypeClass*> IdleAnim;
+	Damageable<AnimTypeClass*> IdleAnim;
+	Damageable<AnimTypeClass*> IdleAnimDamaged;
 	Nullable<AnimTypeClass*> BreakAnim;
 	Nullable<AnimTypeClass*> HitAnim;
 	Nullable<WeaponTypeClass*> BreakWeapon;
@@ -49,6 +50,7 @@ public:
 		, IdleAnim_OfflineAction(AttachedAnimFlag::Hides)
 		, IdleAnim_TemporalAction(AttachedAnimFlag::Hides)
 		, IdleAnim()
+		, IdleAnimDamaged()
 		, BreakAnim()
 		, HitAnim()
 		, BreakWeapon()
@@ -64,6 +66,8 @@ public:
 	virtual void LoadFromINI(CCINIClass* pINI) override;
 	virtual void LoadFromStream(PhobosStreamReader& Stm);
 	virtual void SaveToStream(PhobosStreamWriter& Stm);
+
+	AnimTypeClass* GetIdleAnimType(bool isDamaged, double healthRatio);
 
 private:
 	template <typename T>

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -95,3 +95,26 @@ double GeneralUtils::FastPow(double x, double n)
 
 	return r;
 }
+
+// Checks if health ratio has changed threshold (Healthy/ConditionYellow/Red).
+bool GeneralUtils::HasHealthRatioThresholdChanged(double oldRatio, double newRatio)
+{
+	if (oldRatio == newRatio)
+		return false;
+
+	if (oldRatio > RulesClass::Instance->ConditionYellow && newRatio <= RulesClass::Instance->ConditionYellow)
+	{
+		return true;
+	}
+	else if (oldRatio <= RulesClass::Instance->ConditionYellow && oldRatio > RulesClass::Instance->ConditionRed &&
+		(newRatio <= RulesClass::Instance->ConditionRed || newRatio > RulesClass::Instance->ConditionYellow))
+	{
+		return true;
+	}
+	else if (oldRatio <= RulesClass::Instance->ConditionRed && newRatio > RulesClass::Instance->ConditionRed) 
+	{
+		return true;
+	}
+
+	return false;
+}

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -26,4 +26,5 @@ public:
 	static const double GetWarheadVersusArmor(WarheadTypeClass* pWH, Armor ArmorType);
 	static int ChooseOneWeighted(const double dice, const std::vector<int>* weights);
 	static double FastPow(double x, double n);
+	static bool HasHealthRatioThresholdChanged(double oldRatio, double newRatio);
 };

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -341,3 +341,69 @@ class NullableIdxVector : public NullableVector<int> {
 public:
 	inline void Read(INI_EX& parser, const char* pSection, const char* pKey);
 };
+
+/*
+ * This template is for something that varies depending on Technos damage state (or arbitrary 'health' ratio provided).
+ * Damageable<AnimClass*> TestAnims; // class def
+ * TestAnims(); // ctor init-list
+ * TestAnims->Read(..., "Base%s"); // load from ini
+ * TestAnims->Get(Techno); // usage
+ * TestAnims->Get(healthRatio); // alternate usage
+ * 
+ * Use %s format specifier, exactly once. If pSingleFlag is null, pBaseFlag will
+ * be used. For the single flag name, a trailing dot (after replacing %s) will
+ * be removed. I.e. "Test.%s" will be converted to "Test".
+ */
+template<typename T>
+class Damageable
+{
+public:
+	T BaseValue {};
+	T ConditionYellow {};
+	T ConditionRed {};
+
+	Damageable() = default;
+	explicit Damageable(T const& all) noexcept(noexcept(T { all })) : BaseValue(all), ConditionYellow(all), ConditionRed(all) { }
+
+	void SetAll(const T& val)
+	{
+		this->ConditionRed = this->ConditionYellow = this->BaseValue = val;
+	}
+
+	inline void Read(INI_EX& parser, const char* pSection, const char* pBaseFlag, const char* pSingleFlag = nullptr);
+
+	const T* GetEx(TechnoClass* pTechno) const noexcept
+	{
+		return &this->Get(pTechno);
+	}
+
+	const T& Get(TechnoClass* pTechno) const noexcept
+	{
+		double healthPercentage = pTechno->GetHealthPercentage();
+		if (healthPercentage > RulesClass::Instance->ConditionYellow)
+			return this->BaseValue;
+		else if (healthPercentage > RulesClass::Instance->ConditionRed)
+			return this->ConditionYellow;
+
+		return this->ConditionRed;
+	}
+
+	const T* GetEx(double ratio) const noexcept
+	{
+		return &this->Get(ratio);
+	}
+
+	const T& Get(double ratio) const noexcept
+	{
+		if (ratio > RulesClass::Instance->ConditionYellow)
+			return this->BaseValue;
+		else if (ratio > RulesClass::Instance->ConditionRed)
+			return this->ConditionYellow;
+
+		return this->ConditionRed;
+	}
+
+	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
+
+	inline bool Save(PhobosStreamWriter& Stm) const;
+};

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -357,18 +357,16 @@ public:
 template<typename T>
 class Damageable
 {
+protected:
+	bool conditionYellowAvailable { false };
+	bool conditionRedAvailable { false };
 public:
 	T BaseValue {};
 	T ConditionYellow {};
 	T ConditionRed {};
 
 	Damageable() = default;
-	explicit Damageable(T const& all) noexcept(noexcept(T { all })) : BaseValue(all), ConditionYellow(all), ConditionRed(all) { }
-
-	void SetAll(const T& val)
-	{
-		this->ConditionRed = this->ConditionYellow = this->BaseValue = val;
-	}
+	explicit Damageable(T const& all) noexcept(noexcept(T { all })) : BaseValue(all), ConditionYellow(all), ConditionRed(all), conditionYellowAvailable(true), conditionRedAvailable(true) { }
 
 	inline void Read(INI_EX& parser, const char* pSection, const char* pBaseFlag, const char* pSingleFlag = nullptr);
 
@@ -379,13 +377,7 @@ public:
 
 	const T& Get(TechnoClass* pTechno) const noexcept
 	{
-		double healthPercentage = pTechno->GetHealthPercentage();
-		if (healthPercentage > RulesClass::Instance->ConditionYellow)
-			return this->BaseValue;
-		else if (healthPercentage > RulesClass::Instance->ConditionRed)
-			return this->ConditionYellow;
-
-		return this->ConditionRed;
+		return Get(pTechno->GetHealthPercentage());
 	}
 
 	const T* GetEx(double ratio) const noexcept
@@ -395,12 +387,12 @@ public:
 
 	const T& Get(double ratio) const noexcept
 	{
-		if (ratio > RulesClass::Instance->ConditionYellow)
-			return this->BaseValue;
-		else if (ratio > RulesClass::Instance->ConditionRed)
+		if (conditionRedAvailable && ratio <= RulesClass::Instance->ConditionRed)
+			return this->ConditionRed;
+		else if (conditionYellowAvailable && ratio <= RulesClass::Instance->ConditionYellow)
 			return this->ConditionYellow;
 
-		return this->ConditionRed;
+		return this->BaseValue;
 	}
 
 	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1016,15 +1016,13 @@ void __declspec(noinline) NullableIdxVector<Lookuper>::Read(INI_EX& parser, cons
 template <typename T>
 void __declspec(noinline) Damageable<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, const char* const pSingleFlag)
 {
-
 	// read the common flag, with the trailing dot being stripped
 	char flagName[0x40];
 	auto const pSingleFormat = pSingleFlag ? pSingleFlag : pBaseFlag;
 	auto res = _snprintf_s(flagName, _TRUNCATE, pSingleFormat, "");
+
 	if (res > 0 && flagName[res - 1] == '.')
-	{
 		flagName[res - 1] = '\0';
-	}
 	
 	detail::read(this->BaseValue, parser, pSection, flagName);
 

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -50,19 +50,24 @@
 #include <VoxClass.h>
 #include <ArmorType.h>
 
-namespace detail {
+namespace detail
+{
 	template <typename T>
-	inline bool read(T& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate = false) {
-		if (parser.ReadString(pSection, pKey)) {
+	inline bool read(T& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate = false)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
 			using base_type = std::remove_pointer_t<T>;
 
 			auto const pValue = parser.value();
 			auto const parsed = (allocate ? base_type::FindOrAllocate : base_type::Find)(pValue);
-			if (parsed || INIClass::IsBlank(pValue)) {
+			if (parsed || INIClass::IsBlank(pValue))
+			{
 				value = parsed;
 				return true;
 			}
-			else {
+			else
+			{
 				Debug::INIParseFailed(pSection, pKey, pValue);
 			}
 		}
@@ -70,26 +75,32 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<bool>(bool& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<bool>(bool& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		bool buffer;
-		if (parser.ReadBool(pSection, pKey, &buffer)) {
+		if (parser.ReadBool(pSection, pKey, &buffer))
+		{
 			value = buffer;
 			return true;
 		}
-		else if (!parser.empty()) {
+		else if (!parser.empty())
+		{
 			Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid boolean value [1, true, yes, 0, false, no]");
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<int>(int& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<int>(int& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		int buffer;
-		if (parser.ReadInteger(pSection, pKey, &buffer)) {
+		if (parser.ReadInteger(pSection, pKey, &buffer))
+		{
 			value = buffer;
 			return true;
 		}
-		else if (!parser.empty()) {
+		else if (!parser.empty())
+		{
 			Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid number");
 		}
 		return false;
@@ -111,9 +122,11 @@ namespace detail {
 	*/
 
 	template <>
-	inline bool read<unsigned short>(unsigned short& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<unsigned short>(unsigned short& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		int buffer;
-		if (parser.ReadInteger(pSection, pKey, &buffer)) {
+		if (parser.ReadInteger(pSection, pKey, &buffer))
+		{
 			value = static_cast<unsigned short>(buffer);
 			return true;
 		}
@@ -121,81 +134,101 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<BYTE>(BYTE& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<BYTE>(BYTE& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		int buffer;
-		if (parser.ReadInteger(pSection, pKey, &buffer)) {
-			if (buffer <= 255 && buffer >= 0) {
+		if (parser.ReadInteger(pSection, pKey, &buffer))
+		{
+			if (buffer <= 255 && buffer >= 0)
+			{
 				value = static_cast<BYTE>(buffer); // shut up shut up shut up C4244
 				return true;
 			}
-			else {
+			else
+			{
 				Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid number between 0 and 255 inclusive.");
 			}
 		}
-		else if (!parser.empty()) {
+		else if (!parser.empty())
+		{
 			Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid number");
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<float>(float& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<float>(float& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		double buffer;
-		if (parser.ReadDouble(pSection, pKey, &buffer)) {
+		if (parser.ReadDouble(pSection, pKey, &buffer))
+		{
 			value = static_cast<float>(buffer);
 			return true;
 		}
-		else if (!parser.empty()) {
+		else if (!parser.empty())
+		{
 			Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid floating point number");
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<double>(double& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<double>(double& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		double buffer;
-		if (parser.ReadDouble(pSection, pKey, &buffer)) {
+		if (parser.ReadDouble(pSection, pKey, &buffer))
+		{
 			value = buffer;
 			return true;
 		}
-		else if (!parser.empty()) {
+		else if (!parser.empty())
+		{
 			Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid floating point number");
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<Point2D>(Point2D& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.Read2Integers(pSection, pKey, (int*)&value)) {
+	inline bool read<Point2D>(Point2D& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.Read2Integers(pSection, pKey, (int*)&value))
+		{
 			return true;
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<CoordStruct>(CoordStruct& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.Read3Integers(pSection, pKey, (int*)&value)) {
+	inline bool read<CoordStruct>(CoordStruct& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.Read3Integers(pSection, pKey, (int*)&value))
+		{
 			return true;
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<ColorStruct>(ColorStruct& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<ColorStruct>(ColorStruct& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		ColorStruct buffer;
-		if (parser.Read3Bytes(pSection, pKey, reinterpret_cast<byte*>(&buffer))) {
+		if (parser.Read3Bytes(pSection, pKey, reinterpret_cast<byte*>(&buffer)))
+		{
 			value = buffer;
 			return true;
 		}
-		else if (!parser.empty()) {
+		else if (!parser.empty())
+		{
 			Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid R,G,B color");
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<CSFText>(CSFText& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.ReadString(pSection, pKey)) {
+	inline bool read<CSFText>(CSFText& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
 			value = parser.value();
 			return true;
 		}
@@ -203,21 +236,26 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<SHPStruct*>(SHPStruct*& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.ReadString(pSection, pKey)) {
+	inline bool read<SHPStruct*>(SHPStruct*& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
 
 			auto const pValue = parser.value();
 			std::string Result = pValue;
 
-			if (!strstr(pValue, ".shp")) {
+			if (!strstr(pValue, ".shp"))
+			{
 				Result += ".shp";
 			}
 
-			if (auto const pImage = FileSystem::LoadSHPFile(Result.c_str())) {
+			if (auto const pImage = FileSystem::LoadSHPFile(Result.c_str()))
+			{
 				value = pImage;
 				return true;
 			}
-			else {
+			else
+			{
 				Debug::Log("Failed to find file %s referenced by [%s]%s=%s\n", Result.c_str(), pSection, pKey, pValue);
 			}
 		}
@@ -225,32 +263,41 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<MouseCursor>(MouseCursor& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<MouseCursor>(MouseCursor& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		auto ret = false;
 
 		// compact way to define the cursor in one go
-		if (parser.ReadString(pSection, pKey)) {
+		if (parser.ReadString(pSection, pKey))
+		{
 			auto const buffer = parser.value();
 			char* context = nullptr;
-			if (auto const pFrame = strtok_s(buffer, Phobos::readDelims, &context)) {
+			if (auto const pFrame = strtok_s(buffer, Phobos::readDelims, &context))
+			{
 				Parser<int>::Parse(pFrame, &value.Frame);
 			}
-			if (auto const pCount = strtok_s(nullptr, Phobos::readDelims, &context)) {
+			if (auto const pCount = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
 				Parser<int>::Parse(pCount, &value.Count);
 			}
-			if (auto const pInterval = strtok_s(nullptr, Phobos::readDelims, &context)) {
+			if (auto const pInterval = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
 				Parser<int>::Parse(pInterval, &value.Interval);
 			}
-			if (auto const pFrame = strtok_s(nullptr, Phobos::readDelims, &context)) {
+			if (auto const pFrame = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
 				Parser<int>::Parse(pFrame, &value.MiniFrame);
 			}
-			if (auto const pCount = strtok_s(nullptr, Phobos::readDelims, &context)) {
+			if (auto const pCount = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
 				Parser<int>::Parse(pCount, &value.MiniCount);
 			}
-			if (auto const pHotX = strtok_s(nullptr, Phobos::readDelims, &context)) {
+			if (auto const pHotX = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
 				MouseCursorHotSpotX::Parse(pHotX, &value.HotX);
 			}
-			if (auto const pHotY = strtok_s(nullptr, Phobos::readDelims, &context)) {
+			if (auto const pHotY = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
 				MouseCursorHotSpotY::Parse(pHotY, &value.HotY);
 			}
 
@@ -274,13 +321,15 @@ namespace detail {
 		ret |= read(value.MiniCount, parser, pSection, pFlagName);
 
 		_snprintf_s(pFlagName, 31, "%s.HotSpot", pKey);
-		if (parser.ReadString(pSection, pFlagName)) {
+		if (parser.ReadString(pSection, pFlagName))
+		{
 			auto const pValue = parser.value();
 			char* context = nullptr;
 			auto const pHotX = strtok_s(pValue, ",", &context);
 			MouseCursorHotSpotX::Parse(pHotX, &value.HotX);
 
-			if (auto const pHotY = strtok_s(nullptr, ",", &context)) {
+			if (auto const pHotY = strtok_s(nullptr, ",", &context))
+			{
 				MouseCursorHotSpotY::Parse(pHotY, &value.HotY);
 			}
 
@@ -291,7 +340,8 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<RocketStruct>(RocketStruct& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<RocketStruct>(RocketStruct& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		auto ret = false;
 
 		char pFlagName[0x40];
@@ -313,7 +363,8 @@ namespace detail {
 		// sic! integer read like a float.
 		_snprintf_s(pFlagName, 0x3F, "%s.RaiseRate", pKey);
 		float buffer;
-		if (read(buffer, parser, pSection, pFlagName)) {
+		if (read(buffer, parser, pSection, pFlagName))
+		{
 			value.RaiseRate = Game::F2I(buffer);
 			ret = true;
 		}
@@ -343,46 +394,60 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<Leptons>(Leptons& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
+	inline bool read<Leptons>(Leptons& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
 		double buffer;
-		if (parser.ReadDouble(pSection, pKey, &buffer)) {
+		if (parser.ReadDouble(pSection, pKey, &buffer))
+		{
 			value = Leptons(Game::F2I(buffer * 256.0));
 			return true;
 		}
-		else if (!parser.empty()) {
+		else if (!parser.empty())
+		{
 			Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a valid floating point number");
 		}
 		return false;
 	}
 
 	template <>
-	inline bool read<OwnerHouseKind>(OwnerHouseKind& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.ReadString(pSection, pKey)) {
-			if (_strcmpi(parser.value(), "default") == 0) {
+	inline bool read<OwnerHouseKind>(OwnerHouseKind& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			if (_strcmpi(parser.value(), "default") == 0)
+			{
 				value = OwnerHouseKind::Default;
 			}
-			else if (_strcmpi(parser.value(), "invoker") == 0) {
+			else if (_strcmpi(parser.value(), "invoker") == 0)
+			{
 				value = OwnerHouseKind::Invoker;
 			}
-			else if (_strcmpi(parser.value(), "killer") == 0) {
+			else if (_strcmpi(parser.value(), "killer") == 0)
+			{
 				value = OwnerHouseKind::Killer;
 			}
-			else if (_strcmpi(parser.value(), "victim") == 0) {
+			else if (_strcmpi(parser.value(), "victim") == 0)
+			{
 				value = OwnerHouseKind::Victim;
 			}
-			else if (_strcmpi(parser.value(), "civilian") == 0) {
+			else if (_strcmpi(parser.value(), "civilian") == 0)
+			{
 				value = OwnerHouseKind::Civilian;
 			}
-			else if (_strcmpi(parser.value(), "special") == 0) {
+			else if (_strcmpi(parser.value(), "special") == 0)
+			{
 				value = OwnerHouseKind::Special;
 			}
-			else if (_strcmpi(parser.value(), "neutral") == 0) {
+			else if (_strcmpi(parser.value(), "neutral") == 0)
+			{
 				value = OwnerHouseKind::Neutral;
 			}
-			else if (_strcmpi(parser.value(), "random") == 0) {
+			else if (_strcmpi(parser.value(), "random") == 0)
+			{
 				value = OwnerHouseKind::Random;
 			}
-			else {
+			else
+			{
 				Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a owner house kind");
 				return false;
 			}
@@ -392,14 +457,18 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<Mission>(Mission& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.ReadString(pSection, pKey)) {
+	inline bool read<Mission>(Mission& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
 			auto const mission = MissionControlClass::FindIndex(parser.value());
-			if (mission != Mission::None) {
+			if (mission != Mission::None)
+			{
 				value = mission;
 				return true;
 			}
-			else if (!parser.empty()) {
+			else if (!parser.empty())
+			{
 				Debug::INIParseFailed(pSection, pKey, parser.value(), "Invalid Mission name");
 			}
 		}
@@ -407,16 +476,20 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<SuperWeaponAITargetingMode>(SuperWeaponAITargetingMode& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.ReadString(pSection, pKey)) {
+	inline bool read<SuperWeaponAITargetingMode>(SuperWeaponAITargetingMode& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
 			static const auto Modes = {
 				"none", "nuke", "lightningstorm", "psychicdominator", "paradrop",
 				"geneticmutator", "forceshield", "notarget", "offensive", "stealth",
 				"self", "base", "multimissile", "hunterseeker", "enemybase" };
 
 			auto it = Modes.begin();
-			for (auto i = 0u; i < Modes.size(); ++i) {
-				if (_strcmpi(parser.value(), *it++) == 0) {
+			for (auto i = 0u; i < Modes.size(); ++i)
+			{
+				if (_strcmpi(parser.value(), *it++) == 0)
+				{
 					value = static_cast<SuperWeaponAITargetingMode>(i);
 					return true;
 				}
@@ -428,35 +501,46 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<AffectedTarget>(AffectedTarget& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.ReadString(pSection, pKey)) {
+	inline bool read<AffectedTarget>(AffectedTarget& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
 			auto parsed = AffectedTarget::None;
 
 			auto str = parser.value();
 			char* context = nullptr;
-			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context)) {
-				if (!_strcmpi(cur, "land")) {
+			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
+				if (!_strcmpi(cur, "land"))
+				{
 					parsed |= AffectedTarget::Land;
 				}
-				else if (!_strcmpi(cur, "water")) {
+				else if (!_strcmpi(cur, "water"))
+				{
 					parsed |= AffectedTarget::Water;
 				}
-				else if (!_strcmpi(cur, "empty")) {
+				else if (!_strcmpi(cur, "empty"))
+				{
 					parsed |= AffectedTarget::NoContent;
 				}
-				else if (!_strcmpi(cur, "infantry")) {
+				else if (!_strcmpi(cur, "infantry"))
+				{
 					parsed |= AffectedTarget::Infantry;
 				}
-				else if (!_strcmpi(cur, "units")) {
+				else if (!_strcmpi(cur, "units"))
+				{
 					parsed |= AffectedTarget::Unit;
 				}
-				else if (!_strcmpi(cur, "buildings")) {
+				else if (!_strcmpi(cur, "buildings"))
+				{
 					parsed |= AffectedTarget::Building;
 				}
-				else if (!_strcmpi(cur, "all")) {
+				else if (!_strcmpi(cur, "all"))
+				{
 					parsed |= AffectedTarget::All;
 				}
-				else if (_strcmpi(cur, "none")) {
+				else if (_strcmpi(cur, "none"))
+				{
 					Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a super weapon target");
 					return false;
 				}
@@ -468,32 +552,42 @@ namespace detail {
 	}
 
 	template <>
-	inline bool read<AffectedHouse>(AffectedHouse& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate) {
-		if (parser.ReadString(pSection, pKey)) {
+	inline bool read<AffectedHouse>(AffectedHouse& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
 			auto parsed = AffectedHouse::None;
 
 			auto str = parser.value();
 			char* context = nullptr;
-			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context)) {
-				if (!_strcmpi(cur, "owner") || !_strcmpi(cur, "self")) {
+			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
+				if (!_strcmpi(cur, "owner") || !_strcmpi(cur, "self"))
+				{
 					parsed |= AffectedHouse::Owner;
 				}
-				else if (!_strcmpi(cur, "allies") || !_strcmpi(cur, "ally")) {
+				else if (!_strcmpi(cur, "allies") || !_strcmpi(cur, "ally"))
+				{
 					parsed |= AffectedHouse::Allies;
 				}
-				else if (!_strcmpi(cur, "enemies") || !_strcmpi(cur, "enemy")) {
+				else if (!_strcmpi(cur, "enemies") || !_strcmpi(cur, "enemy"))
+				{
 					parsed |= AffectedHouse::Enemies;
 				}
-				else if (!_strcmpi(cur, "team")) {
+				else if (!_strcmpi(cur, "team"))
+				{
 					parsed |= AffectedHouse::Team;
 				}
-				else if (!_strcmpi(cur, "others")) {
+				else if (!_strcmpi(cur, "others"))
+				{
 					parsed |= AffectedHouse::NotOwner;
 				}
-				else if (!_strcmpi(cur, "all")) {
+				else if (!_strcmpi(cur, "all"))
+				{
 					parsed |= AffectedHouse::All;
 				}
-				else if (_strcmpi(cur, "none")) {
+				else if (_strcmpi(cur, "none"))
+				{
 					Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a super weapon affected house");
 					return false;
 				}
@@ -603,28 +697,36 @@ namespace detail {
 	}
 
 	template <typename T>
-	void parse_values(std::vector<T>& vector, INI_EX& parser, const char* pSection, const char* pKey) {
+	void parse_values(std::vector<T>& vector, INI_EX& parser, const char* pSection, const char* pKey)
+	{
 		char* context = nullptr;
-		for (auto pCur = strtok_s(parser.value(), Phobos::readDelims, &context); pCur; pCur = strtok_s(nullptr, Phobos::readDelims, &context)) {
+		for (auto pCur = strtok_s(parser.value(), Phobos::readDelims, &context); pCur; pCur = strtok_s(nullptr, Phobos::readDelims, &context))
+		{
 			T buffer = T();
-			if (Parser<T>::Parse(pCur, &buffer)) {
+			if (Parser<T>::Parse(pCur, &buffer))
+			{
 				vector.push_back(buffer);
 			}
-			else if (!INIClass::IsBlank(pCur)) {
+			else if (!INIClass::IsBlank(pCur))
+			{
 				Debug::INIParseFailed(pSection, pKey, pCur);
 			}
 		}
 	}
 
 	template <typename Lookuper, typename T>
-	void parse_indexes(std::vector<T>& vector, INI_EX& parser, const char* pSection, const char* pKey) {
+	void parse_indexes(std::vector<T>& vector, INI_EX& parser, const char* pSection, const char* pKey)
+	{
 		char* context = nullptr;
-		for (auto pCur = strtok_s(parser.value(), Phobos::readDelims, &context); pCur; pCur = strtok_s(nullptr, Phobos::readDelims, &context)) {
+		for (auto pCur = strtok_s(parser.value(), Phobos::readDelims, &context); pCur; pCur = strtok_s(nullptr, Phobos::readDelims, &context))
+		{
 			int idx = Lookuper::FindIndex(pCur);
-			if (idx != -1) {
+			if (idx != -1)
+			{
 				vector.push_back(idx);
 			}
-			else if (!INIClass::IsBlank(pCur)) {
+			else if (!INIClass::IsBlank(pCur))
+			{
 				Debug::INIParseFailed(pSection, pKey, pCur);
 			}
 		}
@@ -635,17 +737,20 @@ namespace detail {
 // Valueable
 
 template <typename T>
-void __declspec(noinline) Valueable<T>::Read(INI_EX& parser, const char* pSection, const char* pKey, bool Allocate) {
+void __declspec(noinline) Valueable<T>::Read(INI_EX& parser, const char* pSection, const char* pKey, bool Allocate)
+{
 	detail::read(this->Value, parser, pSection, pKey, Allocate);
 }
 
 template <typename T>
-bool Valueable<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange) {
+bool Valueable<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
 	return Savegame::ReadPhobosStream(Stm, this->Value, RegisterForChange);
 }
 
 template <typename T>
-bool Valueable<T>::Save(PhobosStreamWriter& Stm) const {
+bool Valueable<T>::Save(PhobosStreamWriter& Stm) const
+{
 	return Savegame::WritePhobosStream(Stm, this->Value);
 }
 
@@ -653,14 +758,18 @@ bool Valueable<T>::Save(PhobosStreamWriter& Stm) const {
 // ValueableIdx
 
 template <typename Lookuper>
-void __declspec(noinline) ValueableIdx<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey) {
-	if (parser.ReadString(pSection, pKey)) {
+void __declspec(noinline) ValueableIdx<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey)
+{
+	if (parser.ReadString(pSection, pKey))
+	{
 		const char* val = parser.value();
 		int idx = Lookuper::FindIndex(val);
-		if (idx != -1 || INIClass::IsBlank(val)) {
+		if (idx != -1 || INIClass::IsBlank(val))
+		{
 			this->Value = idx;
 		}
-		else {
+		else
+		{
 			Debug::INIParseFailed(pSection, pKey, val);
 		}
 	}
@@ -670,26 +779,32 @@ void __declspec(noinline) ValueableIdx<Lookuper>::Read(INI_EX& parser, const cha
 // Nullable
 
 template <typename T>
-void __declspec(noinline) Nullable<T>::Read(INI_EX& parser, const char* pSection, const char* pKey, bool Allocate) {
-	if (detail::read(this->Value, parser, pSection, pKey, Allocate)) {
+void __declspec(noinline) Nullable<T>::Read(INI_EX& parser, const char* pSection, const char* pKey, bool Allocate)
+{
+	if (detail::read(this->Value, parser, pSection, pKey, Allocate))
+	{
 		this->HasValue = true;
 	}
 }
 
 template <typename T>
-bool Nullable<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange) {
+bool Nullable<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
 	this->Reset();
 	auto ret = Savegame::ReadPhobosStream(Stm, this->HasValue);
-	if (ret && this->HasValue) {
+	if (ret && this->HasValue)
+	{
 		ret = Savegame::ReadPhobosStream(Stm, this->Value, RegisterForChange);
 	}
 	return ret;
 }
 
 template <typename T>
-bool Nullable<T>::Save(PhobosStreamWriter& Stm) const {
+bool Nullable<T>::Save(PhobosStreamWriter& Stm) const
+{
 	auto ret = Savegame::WritePhobosStream(Stm, this->HasValue);
-	if (this->HasValue) {
+	if (this->HasValue)
+	{
 		ret = Savegame::WritePhobosStream(Stm, this->Value);
 	}
 	return ret;
@@ -699,15 +814,19 @@ bool Nullable<T>::Save(PhobosStreamWriter& Stm) const {
 // NullableIdx
 
 template <typename Lookuper>
-void __declspec(noinline) NullableIdx<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey) {
-	if (parser.ReadString(pSection, pKey)) {
+void __declspec(noinline) NullableIdx<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey)
+{
+	if (parser.ReadString(pSection, pKey))
+	{
 		const char* val = parser.value();
 		int idx = Lookuper::FindIndex(val);
-		if (idx != -1 || INIClass::IsBlank(val)) {
+		if (idx != -1 || INIClass::IsBlank(val))
+		{
 			this->Value = idx;
 			this->HasValue = true;
 		}
-		else {
+		else
+		{
 			Debug::INIParseFailed(pSection, pKey, val);
 		}
 	}
@@ -717,18 +836,21 @@ void __declspec(noinline) NullableIdx<Lookuper>::Read(INI_EX& parser, const char
 // Promotable
 
 template <typename T>
-void __declspec(noinline) Promotable<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, const char* const pSingleFlag) {
+void __declspec(noinline) Promotable<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, const char* const pSingleFlag)
+{
 
 	// read the common flag, with the trailing dot being stripped
 	char flagName[0x40];
 	auto const pSingleFormat = pSingleFlag ? pSingleFlag : pBaseFlag;
 	auto res = _snprintf_s(flagName, _TRUNCATE, pSingleFormat, "");
-	if (res > 0 && flagName[res - 1] == '.') {
+	if (res > 0 && flagName[res - 1] == '.')
+	{
 		flagName[res - 1] = '\0';
 	}
 
 	T placeholder;
-	if (detail::read(placeholder, parser, pSection, flagName)) {
+	if (detail::read(placeholder, parser, pSection, flagName))
+	{
 		this->SetAll(placeholder);
 	}
 
@@ -744,14 +866,16 @@ void __declspec(noinline) Promotable<T>::Read(INI_EX& parser, const char* const 
 };
 
 template <typename T>
-bool Promotable<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange) {
+bool Promotable<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
 	return Savegame::ReadPhobosStream(Stm, this->Rookie, RegisterForChange)
 		&& Savegame::ReadPhobosStream(Stm, this->Veteran, RegisterForChange)
 		&& Savegame::ReadPhobosStream(Stm, this->Elite, RegisterForChange);
 }
 
 template <typename T>
-bool Promotable<T>::Save(PhobosStreamWriter& Stm) const {
+bool Promotable<T>::Save(PhobosStreamWriter& Stm) const
+{
 	return Savegame::WritePhobosStream(Stm, this->Rookie)
 		&& Savegame::WritePhobosStream(Stm, this->Veteran)
 		&& Savegame::WritePhobosStream(Stm, this->Elite);
@@ -761,26 +885,32 @@ bool Promotable<T>::Save(PhobosStreamWriter& Stm) const {
 // ValueableVector
 
 template <typename T>
-void __declspec(noinline) ValueableVector<T>::Read(INI_EX& parser, const char* pSection, const char* pKey) {
-	if (parser.ReadString(pSection, pKey)) {
+void __declspec(noinline) ValueableVector<T>::Read(INI_EX& parser, const char* pSection, const char* pKey)
+{
+	if (parser.ReadString(pSection, pKey))
+	{
 		this->clear();
 		detail::parse_values<T>(*this, parser, pSection, pKey);
 	}
 }
 
 template <typename T>
-bool ValueableVector<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange) {
+bool ValueableVector<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
 	size_t size = 0;
-	if (Savegame::ReadPhobosStream(Stm, size, RegisterForChange)) {
+	if (Savegame::ReadPhobosStream(Stm, size, RegisterForChange))
+	{
 		this->clear();
 		this->reserve(size);
 
-		for (size_t i = 0; i < size; ++i) {
+		for (size_t i = 0; i < size; ++i)
+		{
 			value_type buffer = value_type();
 			Savegame::ReadPhobosStream(Stm, buffer, false);
 			this->push_back(std::move(buffer));
 
-			if (RegisterForChange) {
+			if (RegisterForChange)
+			{
 				Swizzle swizzle(this->back());
 			}
 		}
@@ -790,11 +920,15 @@ bool ValueableVector<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange) {
 }
 
 template <typename T>
-bool ValueableVector<T>::Save(PhobosStreamWriter& Stm) const {
+bool ValueableVector<T>::Save(PhobosStreamWriter& Stm) const
+{
 	auto size = this->size();
-	if (Savegame::WritePhobosStream(Stm, size)) {
-		for (auto const& item : *this) {
-			if (!Savegame::WritePhobosStream(Stm, item)) {
+	if (Savegame::WritePhobosStream(Stm, size))
+	{
+		for (auto const& item : *this)
+		{
+			if (!Savegame::WritePhobosStream(Stm, item))
+			{
 				return false;
 			}
 		}
@@ -807,31 +941,38 @@ bool ValueableVector<T>::Save(PhobosStreamWriter& Stm) const {
 // NullableVector
 
 template <typename T>
-void __declspec(noinline) NullableVector<T>::Read(INI_EX& parser, const char* pSection, const char* pKey) {
-	if (parser.ReadString(pSection, pKey)) {
+void __declspec(noinline) NullableVector<T>::Read(INI_EX& parser, const char* pSection, const char* pKey)
+{
+	if (parser.ReadString(pSection, pKey))
+	{
 		this->clear();
 
 		auto const non_default = _strcmpi(parser.value(), "<default>") != 0;
 		this->hasValue = non_default;
 
-		if (non_default) {
+		if (non_default)
+		{
 			detail::parse_values<T>(*this, parser, pSection, pKey);
 		}
 	}
 }
 
 template <typename T>
-bool NullableVector<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange) {
+bool NullableVector<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
 	this->clear();
-	if (Savegame::ReadPhobosStream(Stm, this->hasValue, RegisterForChange)) {
+	if (Savegame::ReadPhobosStream(Stm, this->hasValue, RegisterForChange))
+	{
 		return !this->hasValue || ValueableVector<T>::Load(Stm, RegisterForChange);
 	}
 	return false;
 }
 
 template <typename T>
-bool NullableVector<T>::Save(PhobosStreamWriter& Stm) const {
-	if (Savegame::WritePhobosStream(Stm, this->hasValue)) {
+bool NullableVector<T>::Save(PhobosStreamWriter& Stm) const
+{
+	if (Savegame::WritePhobosStream(Stm, this->hasValue))
+	{
 		return !this->hasValue || ValueableVector<T>::Save(Stm);
 	}
 	return false;
@@ -841,8 +982,10 @@ bool NullableVector<T>::Save(PhobosStreamWriter& Stm) const {
 // ValueableIdxVector
 
 template <typename Lookuper>
-void __declspec(noinline) ValueableIdxVector<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey) {
-	if (parser.ReadString(pSection, pKey)) {
+void __declspec(noinline) ValueableIdxVector<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey)
+{
+	if (parser.ReadString(pSection, pKey))
+	{
 		this->clear();
 		detail::parse_indexes<Lookuper>(*this, parser, pSection, pKey);
 	}
@@ -852,14 +995,17 @@ void __declspec(noinline) ValueableIdxVector<Lookuper>::Read(INI_EX& parser, con
 // NullableIdxVector
 
 template <typename Lookuper>
-void __declspec(noinline) NullableIdxVector<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey) {
-	if (parser.ReadString(pSection, pKey)) {
+void __declspec(noinline) NullableIdxVector<Lookuper>::Read(INI_EX& parser, const char* pSection, const char* pKey)
+{
+	if (parser.ReadString(pSection, pKey))
+	{
 		this->clear();
 
 		auto const non_default = _strcmpi(parser.value(), "<default>") != 0;
 		this->hasValue = non_default;
 
-		if (non_default) {
+		if (non_default)
+		{
 			detail::parse_indexes<Lookuper>(*this, parser, pSection, pKey);
 		}
 	}
@@ -879,16 +1025,14 @@ void __declspec(noinline) Damageable<T>::Read(INI_EX& parser, const char* const 
 	{
 		flagName[res - 1] = '\0';
 	}
-
-	T placeholder;
-	if (detail::read(placeholder, parser, pSection, flagName))
-		this->SetAll(placeholder);
+	
+	detail::read(this->BaseValue, parser, pSection, flagName);
 
 	_snprintf_s(flagName, _TRUNCATE, pBaseFlag, "ConditionYellow");
-	detail::read(this->ConditionYellow, parser, pSection, flagName);
+	conditionYellowAvailable = detail::read(this->ConditionYellow, parser, pSection, flagName) || conditionYellowAvailable;
 
 	_snprintf_s(flagName, _TRUNCATE, pBaseFlag, "ConditionRed");
-	detail::read(this->ConditionRed, parser, pSection, flagName);
+	conditionRedAvailable = detail::read(this->ConditionRed, parser, pSection, flagName) || conditionRedAvailable;
 };
 
 template <typename T>

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -864,3 +864,45 @@ void __declspec(noinline) NullableIdxVector<Lookuper>::Read(INI_EX& parser, cons
 		}
 	}
 }
+
+// Damageable
+
+template <typename T>
+void __declspec(noinline) Damageable<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, const char* const pSingleFlag)
+{
+
+	// read the common flag, with the trailing dot being stripped
+	char flagName[0x40];
+	auto const pSingleFormat = pSingleFlag ? pSingleFlag : pBaseFlag;
+	auto res = _snprintf_s(flagName, _TRUNCATE, pSingleFormat, "");
+	if (res > 0 && flagName[res - 1] == '.')
+	{
+		flagName[res - 1] = '\0';
+	}
+
+	T placeholder;
+	if (detail::read(placeholder, parser, pSection, flagName))
+		this->SetAll(placeholder);
+
+	_snprintf_s(flagName, _TRUNCATE, pBaseFlag, "ConditionYellow");
+	detail::read(this->ConditionYellow, parser, pSection, flagName);
+
+	_snprintf_s(flagName, _TRUNCATE, pBaseFlag, "ConditionRed");
+	detail::read(this->ConditionRed, parser, pSection, flagName);
+};
+
+template <typename T>
+bool Damageable<T>::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
+	return Savegame::ReadPhobosStream(Stm, this->BaseValue, RegisterForChange)
+		&& Savegame::ReadPhobosStream(Stm, this->ConditionYellow, RegisterForChange)
+		&& Savegame::ReadPhobosStream(Stm, this->ConditionRed, RegisterForChange);
+}
+
+template <typename T>
+bool Damageable<T>::Save(PhobosStreamWriter& Stm) const
+{
+	return Savegame::WritePhobosStream(Stm, this->BaseValue)
+		&& Savegame::WritePhobosStream(Stm, this->ConditionYellow)
+		&& Savegame::WritePhobosStream(Stm, this->ConditionRed);
+}


### PR DESCRIPTION
Added damage-state specific shield idle animations.

In `rulesmd.ini`: (Only new keys shown)
```ini
[SOMESHIELDTYPE]                   ; ShieldType name
IdleAnim.ConditionYellow=          ; animation
IdleAnim.ConditionRed=             ; animation
IdleAnimDamaged=                   ; animation
IdleAnimDamaged.ConditionYellow=   ; animation
IdleAnimDamaged.ConditionRed=      ; animation
```
An excerpt from adjusted documentation for shield idle animations:
- `IdleAnim`, if set, will be played while the shield is intact. This animation is automatically set to loop indefinitely.
  - `IdleAnim.ConditionYellow` and `IdleAnim.ConditionRed` can be used to set different animations for when shield health is at or below the percentage defined in `[AudioVisual]`->`ConditionYellow`/`ConditionRed`, respectively. If not set, `IdleAnim` is used.
  - `IdleAnimDamaged`, `IdleAnimDamaged.ConditionYellow` and `IdleAnimDamaged.ConditionRed` are used in an identical manner, but only when health of the object the shield is attached to is at or below `[AudioVisual]`->`ConditionYellow`. If none are set, then regular `IdleAnim` or variants are used.

There are also additional customizations for shield pips:

In `rulesmd.ini`: (Only new keys shown)
```ini
[AudioVisual]
Pips.Shield.Background=PIPBRD.SHP  ; filename - including the .shp/.pcx extension
Pips.Shield.Building.Empty=0       ; int, frame of pips.shp (zero-based) for empty building pip

[SOMESHIELDTYPE]                   ; ShieldType name
Pips=                              ; int, frames of pips.shp (zero-based) for Green, Yellow, Red
Pips.Building=                     ; int, frames of pips.shp (zero-based) for Green, Yellow, Red
Pips.Background=                   ; filename - including the .shp/.pcx extension
Pips.Building.Empty=               ; int, frame of pips.shp (zero-based) for empty building pip
```
An excerpt from adjusted documentation for shield pips:
- A TechnoType with a shield will show its shield Strength. An empty shield strength bar will be left after destroyed if it is respawnable. Several customizations are available for the shield strength pips.
  - By default, buildings use the 6th frame of `pips.shp` to display the shield strength while others use the 17th frame.
  - `Pips.Shield` can be used to specify which pip frame should be used as shield strength. If only 1 digit is set, then it will always display that frame, or if 3 digits are set, it will use those if shield's current strength is at or below `ConditionYellow` and `ConditionRed`, respectively. `Pips.Shield.Building` is used for BuildingTypes.
  - `Pips.Shield.Background` can be used to set the background or 'frame' for non-building pips, which defaults to `pipbrd.shp`. 4th frame is used to display an infantry's shield strength and the 3th frame for other units, or 2nd and 1st respectively if not enough frames are available.
  - `Pips.Shield.Building.Empty` can be used to set the frame of `pips.shp` displayed for empty building strength pips, defaults to 1st frame of `pips.shp`.
  - The above customizations are also available on per ShieldType basis, e.g `[ShieldType]`->`Pips` instead of `[AudioVisual]`->`Pips.Shield` and so on. ShieldType settings take precedence over the global ones, but will fall back to them if not set.
  - `BracketDelta` can be used as additional vertical offset (negative shifts it up) for shield strength bar. Much like `PixelSelectionBracketDelta`, it is not applied on buildings.


Additionally fixed an issue that caused crashes with shield idle animations under certain circumstances. This should hopefully fix the crashes some people were having with shield animations and cloaked units.