### PR TITLE
FlyingStrings / TransactMoney.Display / Grinding.DisplayRefund / Display damage hotkey command

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -139,6 +139,8 @@ This page lists all the individual contributions to the project by their author.
   - Mind control indicator animation cloak fix
   - Warhead / Play animation trigger animation owner fix
   - Nuke carrier & payload Bright fix
+  - Display damage numbers hotkey command
+  - TransactMoney.Display
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -161,6 +161,8 @@ This page lists all the individual contributions to the project by their author.
 - **Ares developers** - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares, unfinished RadTypes code, prototype deployer fixes
 - **tomsons26** - all-around help, assistance and guidance in reverse-engineering, YR binary mappings
 - **CCHyper** - all-around help, current project logo, assistance and guidance in reverse-engineering, YR binary mappings
+- **AlexB** - Original FlyingStrings implementation
+- **Joshy** - Original FlyingStrings implementation
 - **ZΞPHYɌUS** - win/lose themes code
 - **ayylmao** - help with docs, extensive and thorough testing
 - **SMxReaver** - help with docs, extensive and thorough testing

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="src\Utilities\Stream.cpp" />
     <ClCompile Include="src\Utilities\Swizzle.cpp" />
     <ClCompile Include="src\Phobos.cpp" />
+	<ClCompile Include="src\Misc\FlyingStrings.cpp" />
     <ClCompile Include="src\Misc\Hooks.BugFixes.cpp" />
     <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
@@ -119,6 +120,7 @@
     <ClInclude Include="src\Commands\NextTeam.h" />
     <ClInclude Include="src\Commands\ObjectInfo.h" />
     <ClInclude Include="src\Commands\Commands.h" />
+	<ClInclude Include="src\Commands\DamageDisplay.h" />
     <ClInclude Include="src\Commands\QuickSave.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
@@ -129,6 +131,7 @@
     <ClInclude Include="src\Ext\Team\Body.h" />
     <ClInclude Include="src\Ext\TEvent\Body.h" />
     <ClInclude Include="src\Misc\CaptureManager.h" />
+	<ClInclude Include="src\Misc\FlyingStrings.h" />
     <ClInclude Include="src\Misc\PhobosToolTip.h" />
     <ClInclude Include="src\New\Entity\ShieldClass.h" />
     <ClInclude Include="src\New\Type\RadTypeClass.h" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -100,7 +100,7 @@
     <ClCompile Include="src\Utilities\Stream.cpp" />
     <ClCompile Include="src\Utilities\Swizzle.cpp" />
     <ClCompile Include="src\Phobos.cpp" />
-	<ClCompile Include="src\Misc\FlyingStrings.cpp" />
+    <ClCompile Include="src\Misc\FlyingStrings.cpp" />
     <ClCompile Include="src\Misc\Hooks.BugFixes.cpp" />
     <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
@@ -120,7 +120,7 @@
     <ClInclude Include="src\Commands\NextTeam.h" />
     <ClInclude Include="src\Commands\ObjectInfo.h" />
     <ClInclude Include="src\Commands\Commands.h" />
-	<ClInclude Include="src\Commands\DamageDisplay.h" />
+    <ClInclude Include="src\Commands\DamageDisplay.h" />
     <ClInclude Include="src\Commands\QuickSave.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
@@ -131,7 +131,7 @@
     <ClInclude Include="src\Ext\Team\Body.h" />
     <ClInclude Include="src\Ext\TEvent\Body.h" />
     <ClInclude Include="src\Misc\CaptureManager.h" />
-	<ClInclude Include="src\Misc\FlyingStrings.h" />
+    <ClInclude Include="src\Misc\FlyingStrings.h" />
     <ClInclude Include="src\Misc\PhobosToolTip.h" />
     <ClInclude Include="src\New\Entity\ShieldClass.h" />
     <ClInclude Include="src\New\Type\RadTypeClass.h" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -108,16 +108,22 @@ HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage
   - `Grinding.DisallowTypes` can be used to exclude InfantryTypes or VehicleTypes from being able to enter the grinder building.
   - `Grinding.Sound` is a sound played by when object is grinded by the building. If not set, defaults to `[AudioVisual]`->`EnterGrinderSound`.
   - `Grinding.Weapon` is a weapon fired at the building & by the building when it grinds an object. Will only be fired if at least weapon's `ROF` amount of frames have passed since it was last fired.
+  - `Grinding.DisplayRefund` can be set to display the amount of credits acquired upon grinding on the building. Multiple refunded objects within a short period of time have their refund amounts coalesced into single display.
+    - `Grinding.DisplayRefund.Houses` determines which houses can see the credits display.
+    - `Grinding.DisplayRefund.Offset` is additional pixel offset for the center of the credits display, by default (0,0) at building's center.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEBUILDING]             ; BuildingType
-Grinding.AllowAllies=false ; boolean
-Grinding.AllowOwner=true   ; boolean
-Grinding.AllowTypes=       ; List of InfantryTypes / VehicleTypes
-Grinding.DisallowTypes=    ; List of InfantryTypes / VehicleTypes
-Grinding.Sound=            ; Sound
-Grinding.Weapon=           ; WeaponType
+[SOMEBUILDING]                     ; BuildingType
+Grinding.AllowAllies=false         ; boolean
+Grinding.AllowOwner=true           ; boolean
+Grinding.AllowTypes=               ; List of InfantryTypes / VehicleTypes
+Grinding.DisallowTypes=            ; List of InfantryTypes / VehicleTypes
+Grinding.Sound=                    ; Sound
+Grinding.Weapon=                   ; WeaponType
+Grinding.DisplayRefund=false       ; boolean
+Grinding.DisplayRefund.Houses=All  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+Grinding.DisplayRefund.Offset=0,0  ; X,Y, pixels relative to default
 ```
 
 ## Projectiles

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -9,13 +9,11 @@ This page describes every change in Phobos that wasn't categorized into a proper
 ![image](_static/images/objectinfo-01.png)  
 *Object info dump from [CnC: Reloaded](https://www.moddb.com/mods/cncreloaded/)*
 
-- There's a new hotkey to dump selected/hovered object info on press. Available only when the debug tag is set.
+- There's a new hotkey to dump selected/hovered object info on press. Available only if `DebugKeysEnabled` under `[GlobalControls]` is set to true in `rulesmd.ini`.
 
-In `rulesmd.ini`:
-```ini
-[GlobalControls]
-DebugKeysEnabled=yes ; boolean
-```
+### Display Damage Numbers
+
+- There's a new hotkey to show exact numbers of damage dealt on units & buildings. The numbers are shown in red (blue against shields) for damage, and for healing damage in green (cyan against shields). They are shown on the affected units and will move upwards after appearing. Available only if `DebugKeysEnabled` under `[GlobalControls]` is set to true in `rulesmd.ini`.
 
 ### Semantic locomotor aliases
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1185,11 +1185,13 @@ SplashList.PickRandom=no ; play a random animation from the list? boolean, defau
 *`TransactMoney` used in [Rise of the East](https://www.moddb.com/mods/riseoftheeast) mod*
 
 - Warheads can now give credits to its owner at impact.
+  - `TransactMoney.Display` can be set to display the amount of credits given or deducted. This is displayed on the firing object, or at the warhead detonation location if firer is not known. The number is displayed in green if given, red if deducted and will move upwards after appearing.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWARHEAD]   ; Warhead
-TransactMoney=0 ; integer - credits added or subtracted
+[SOMEWARHEAD]                ; Warhead
+TransactMoney=0              ; integer - credits added or subtracted
+TransactMoney.Display=false  ; boolean
 ```
 
 ### Remove disguise on impact

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1185,13 +1185,19 @@ SplashList.PickRandom=no ; play a random animation from the list? boolean, defau
 *`TransactMoney` used in [Rise of the East](https://www.moddb.com/mods/riseoftheeast) mod*
 
 - Warheads can now give credits to its owner at impact.
-  - `TransactMoney.Display` can be set to display the amount of credits given or deducted. This is displayed on the firing object, or at the warhead detonation location if firer is not known. The number is displayed in green if given, red if deducted and will move upwards after appearing.
+  - `TransactMoney.Display` can be set to display the amount of credits given or deducted. The number is displayed in green if given, red if deducted and will move upwards after appearing.
+    - `TransactMoney.Display.AtFirer` if set, makes the credits display appear on firer instead of target. If set and firer is not known, it will display at target regardless.
+    - `TransactMoney.Display.Houses` determines which houses can see the credits display.
+    - `TransactMoney.Display.Offset` is additional pixel offset for the center of the credits display, by default (0,0) at target's/firer's center.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWARHEAD]                ; Warhead
-TransactMoney=0              ; integer - credits added or subtracted
-TransactMoney.Display=false  ; boolean
+[SOMEWARHEAD]                        ; Warhead
+TransactMoney=0                      ; integer - credits added or subtracted
+TransactMoney.Display=false          ; boolean
+TransactMoney.Display.AtFirer=false  ; boolean
+TransactMoney.Display.Houses=All     ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+TransactMoney.Display.Offset=0,0     ; X,Y, pixels relative to default
 ```
 
 ### Remove disguise on impact

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -295,6 +295,8 @@ New:
 - Single-color weapon lasers (by Starkku)
 - Customizable projectile trajectory (by secsome)
 - Correct owner house for Warhead Anim/SplashList & Play Animation trigger animations (by Starkku)
+- Display damage numbers debug hotkey command (by Starkku)
+- Toggleable display of TransactMoney amounts (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Commands/Commands.cpp
+++ b/src/Commands/Commands.cpp
@@ -4,6 +4,7 @@
 #include "ObjectInfo.h"
 #include "NextIdleHarvester.h"
 #include "QuickSave.h"
+#include "DamageDisplay.h"
 
 DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 {
@@ -14,6 +15,7 @@ DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 	MakeCommand<ObjectInfoCommandClass>();
 	MakeCommand<NextIdleHarvesterCommandClass>();
 	MakeCommand<QuickSaveCommandClass>();
+	MakeCommand<DamageDisplayCommandClass>();
 
 	return 0;
 }

--- a/src/Commands/DamageDisplay.h
+++ b/src/Commands/DamageDisplay.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <BuildingTypeClass.h>
+#include <MessageListClass.h>
+
+#include "Commands.h"
+#include <Utilities/Debug.h>
+#include <Utilities/GeneralUtils.h>
+
+// Display damage strings command
+class DamageDisplayCommandClass : public PhobosCommandClass
+{
+public:
+	virtual const char* GetName() const override
+	{
+		return "Display Damage Numbers";
+	}
+
+	virtual const wchar_t* GetUIName() const override
+	{
+		return GeneralUtils::LoadStringUnlessMissing("TXT_DISPLAY_DAMAGE", L"Display Damage Dealt");
+	}
+
+	virtual const wchar_t* GetUICategory() const override
+	{
+		return GeneralUtils::LoadStringUnlessMissing("TXT_DEVELOPMENT", L"Development");
+	}
+
+	virtual const wchar_t* GetUIDescription() const override
+	{
+		return GeneralUtils::LoadStringUnlessMissing("TXT_DISPLAY_DAMAGE_DESC", L"Display exact number of damage dealt to units & buildings on them.");
+	}
+
+	virtual void Execute(WWKey eInput) const override
+	{
+		if (this->CheckDebugDeactivated())
+			return;
+
+		Phobos::Debug_DisplayDamageNumbers = !Phobos::Debug_DisplayDamageNumbers;
+	}
+};

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -1,4 +1,5 @@
 #include "Body.h"
+#include <Utilities/EnumFunctions.h>
 
 template<> const DWORD Extension<BuildingClass>::Canary = 0x87654321;
 BuildingExt::ExtContainer BuildingExt::ExtMap;
@@ -190,16 +191,21 @@ bool BuildingExt::CanGrindTechno(BuildingClass* pBuilding, TechnoClass* pTechno)
 
 bool BuildingExt::DoGrindingExtras(BuildingClass* pBuilding, TechnoClass* pTechno)
 {
-	if (const auto pTypeExt = BuildingTypeExt::ExtMap.Find(pBuilding->Type))
+	if (const auto pExt = BuildingExt::ExtMap.Find(pBuilding))
 	{
-		if (const auto pExt = BuildingExt::ExtMap.Find(pBuilding))
+		const auto pTypeExt = BuildingTypeExt::ExtMap.Find(pBuilding->Type);
+
+		if (pTypeExt->Grinding_DisplayRefund && pTypeExt->Grinding_DisplayRefund_Houses == AffectedHouse::All ||
+			EnumFunctions::CanTargetHouse(pTypeExt->Grinding_DisplayRefund_Houses, pBuilding->Owner, HouseClass::Player))
 		{
-			if (pTypeExt->Grinding_Weapon.isset()
-				&& Unsorted::CurrentFrame >= pExt->GrindingWeapon_LastFiredFrame + pTypeExt->Grinding_Weapon.Get()->ROF)
-			{
-				TechnoExt::FireWeaponAtSelf(pBuilding, pTypeExt->Grinding_Weapon.Get());
-				pExt->GrindingWeapon_LastFiredFrame = Unsorted::CurrentFrame;
-			}
+			pExt->AccumulatedGrindingRefund += pTechno->GetRefund();
+		}
+
+		if (pTypeExt->Grinding_Weapon.isset()
+			&& Unsorted::CurrentFrame >= pExt->GrindingWeapon_LastFiredFrame + pTypeExt->Grinding_Weapon.Get()->ROF)
+		{
+			TechnoExt::FireWeaponAtSelf(pBuilding, pTypeExt->Grinding_Weapon.Get());
+			pExt->GrindingWeapon_LastFiredFrame = Unsorted::CurrentFrame;
 		}
 
 		if (pTypeExt->Grinding_Sound.isset())
@@ -222,6 +228,8 @@ void BuildingExt::ExtData::Serialize(T& Stm)
 		.Process(this->DeployedTechno)
 		.Process(this->LimboID)
 		.Process(this->GrindingWeapon_LastFiredFrame)
+		.Process(this->CurrentAirFactory)
+		.Process(this->AccumulatedGrindingRefund)
 		;
 }
 

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -24,14 +24,15 @@ public:
 		Valueable<bool> DeployedTechno;
 		Valueable<int> LimboID;
 		Valueable<int> GrindingWeapon_LastFiredFrame;
-		Nullable<BuildingClass*> CurrentAirFactory;
+		BuildingClass* CurrentAirFactory;
+		int AccumulatedGrindingRefund;
 
 		ExtData(BuildingClass* OwnerObject) : Extension<BuildingClass>(OwnerObject)
 			, DeployedTechno { false }
 			, LimboID { -1 }
 			, GrindingWeapon_LastFiredFrame { 0 }
-			, CurrentAirFactory(nullptr)
-
+			, CurrentAirFactory { nullptr }
+			, AccumulatedGrindingRefund { 0 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -2,6 +2,8 @@
 
 #include <BulletClass.h>
 #include <UnitClass.h>
+#include <BitFont.h>
+#include <Misc/FlyingStrings.h>
 
 DEFINE_HOOK(0x7396D2, UnitClass_TryToDeploy_Transfer, 0x5)
 {
@@ -71,13 +73,47 @@ DEFINE_HOOK(0x4401BB, Factory_AI_PickWithFreeDocks, 0x6)
 	return 0;
 }
 
-
 DEFINE_HOOK(0x44D455, BuildingClass_Mission_Missile_EMPPulseBulletWeapon, 0x8)
 {
 	GET(WeaponTypeClass*, pWeapon, EBP);
 	GET_STACK(BulletClass*, pBullet, STACK_OFFS(0xF0, 0xA4));
 
 	pBullet->SetWeaponType(pWeapon);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x43FE73, BuildingClass_AI_FlyingStrings, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+
+	if (auto const pExt = BuildingExt::ExtMap.Find(pThis))
+	{
+		if (Unsorted::CurrentFrame % 15 == 0 && pExt->AccumulatedGrindingRefund)
+		{
+			auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+
+			int refundAmount = pExt->AccumulatedGrindingRefund;
+			bool isPositive = refundAmount > 0;
+			auto color = isPositive ? ColorStruct { 0, 255, 0 } : ColorStruct { 255, 0, 0 };
+			wchar_t moneyStr[0x20];
+			swprintf_s(moneyStr, L"%s$%d", isPositive ? L"+" : L"-", std::abs(refundAmount));
+
+			auto coords = CoordStruct::Empty;
+			coords = *pThis->GetCenterCoord(&coords);
+
+			int width = 0, height = 0;
+			BitFont::Instance->GetTextDimension(moneyStr, &width, &height, 120);
+
+			Point2D pixelOffset = Point2D::Empty;
+			pixelOffset += pTypeExt->Grinding_DisplayRefund_Offset;
+			pixelOffset.X -= width / 2;
+
+			FlyingStrings::Add(moneyStr, coords, color, pixelOffset);
+
+			pExt->AccumulatedGrindingRefund = 0;
+		}
+	}
 
 	return 0;
 }

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -100,6 +100,9 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Grinding_DisallowTypes.Read(exINI, pSection, "Grinding.DisallowTypes");
 	this->Grinding_Sound.Read(exINI, pSection, "Grinding.Sound");
 	this->Grinding_Weapon.Read(exINI, pSection, "Grinding.Weapon", true);
+	this->Grinding_DisplayRefund.Read(exINI, pSection, "Grinding.DisplayRefund");
+	this->Grinding_DisplayRefund_Houses.Read(exINI, pSection, "Grinding.DisplayRefund.Houses");
+	this->Grinding_DisplayRefund_Offset.Read(exINI, pSection, "Grinding.DisplayRefund.Offset");
 
 	// Ares SuperWeapons tag
 	pINI->ReadString(pSection, "SuperWeapons", "", Phobos::readBuffer);
@@ -187,7 +190,9 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Grinding_DisallowTypes)
 		.Process(this->Grinding_Sound)
 		.Process(this->Grinding_Weapon)
-
+		.Process(this->Grinding_DisplayRefund)
+		.Process(this->Grinding_DisplayRefund_Houses)
+		.Process(this->Grinding_DisplayRefund_Offset)
 		.Process(PlacementPreview_Remap)
 		.Process(PlacementPreview_Palette)
 		.Process(PlacementPreview_Offset)

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -32,6 +32,9 @@ public:
 		ValueableVector<TechnoTypeClass*> Grinding_DisallowTypes;
 		NullableIdx<VocClass> Grinding_Sound;
 		Nullable<WeaponTypeClass*> Grinding_Weapon;
+		Valueable<bool> Grinding_DisplayRefund;
+		Valueable<AffectedHouse> Grinding_DisplayRefund_Houses;
+		Valueable<Point2D> Grinding_DisplayRefund_Offset;
 
 		Nullable<bool> PlacementPreview_Show;
 		Nullable<SHPStruct*> PlacementPreview_Shape;
@@ -55,7 +58,9 @@ public:
 			, Grinding_DisallowTypes {}
 			, Grinding_Sound {}
 			, Grinding_Weapon {}
-
+			, Grinding_DisplayRefund { false }
+			, Grinding_DisplayRefund_Houses { AffectedHouse::All }
+			, Grinding_DisplayRefund_Offset {{ 0,0 }}
 			, PlacementPreview_Remap { true }
 			, PlacementPreview_Palette {}
 			, PlacementPreview_Offset{ {0,-15,1} }

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -8,10 +8,12 @@
 #include <SpawnManagerClass.h>
 #include <InfantryClass.h>
 #include <Unsorted.h>
+#include <BitFont.h>
 #include <JumpjetLocomotionClass.h>
 
 #include <Ext/BulletType/Body.h>
 #include <Ext/WeaponType/Body.h>
+#include <Misc/FlyingStrings.h>
 
 template<> const DWORD Extension<TechnoClass>::Canary = 0x55555555;
 TechnoExt::ExtContainer TechnoExt::ExtMap;
@@ -614,6 +616,33 @@ void TechnoExt::ForceJumpjetTurnToTarget(TechnoClass* pThis)
 			}
 		}
 	}
+}
+
+void TechnoExt::DisplayDamageNumberString(TechnoClass* pThis, int damage, bool isShieldDamage)
+{
+	if (!pThis || damage == 0)
+		return;
+
+	const auto pExt = TechnoExt::ExtMap.Find(pThis);
+
+	auto color = isShieldDamage ? damage > 0 ? ColorStruct { 0, 160, 255 } : ColorStruct { 0, 255, 230 } :
+		damage > 0 ? ColorStruct { 255, 0, 0 } : ColorStruct { 0, 255, 0 };
+
+	wchar_t damageStr[0x20];
+	swprintf_s(damageStr, L"%d", damage);
+	auto coords = CoordStruct::Empty;
+	coords = *pThis->GetCenterCoord(&coords);
+
+	int maxOffset = 30;
+	int width = 0, height = 0;
+	BitFont::Instance->GetTextDimension(damageStr, &width, &height, 120);
+
+	if (!pExt->DamageNumberOffset.isset() || pExt->DamageNumberOffset >= maxOffset)
+		pExt->DamageNumberOffset = -maxOffset;
+
+	FlyingStrings::Add(damageStr, coords, color, Point2D { pExt->DamageNumberOffset - (width / 2), 0 });
+
+	pExt->DamageNumberOffset = pExt->DamageNumberOffset + width;
 }
 
 // =============================

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -30,6 +30,7 @@ public:
 		Valueable<int> LastWarpDistance;
 		int Death_Countdown;
 		Valueable<AnimTypeClass*> MindControlRingAnimType;
+		Nullable<int> DamageNumberOffset;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, InterceptedBullet { nullptr }
@@ -43,6 +44,7 @@ public:
 			, LastWarpDistance {}
 			, Death_Countdown(-1)
 			, MindControlRingAnimType { nullptr }
+			, DamageNumberOffset {}
 		{ }
 
 		virtual ~ExtData() = default;
@@ -102,4 +104,5 @@ public:
 	static void UpdateMindControlAnim(TechnoClass* pThis);
 	static bool CheckIfCanFireAt(TechnoClass* pThis, AbstractClass* pTarget);
 	static void ForceJumpjetTurnToTarget(TechnoClass* pThis);
+	static void DisplayDamageNumberString(TechnoClass* pThis, int damage, bool isShieldDamage);
 };

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -6,7 +6,6 @@
 #include <Ext/TechnoType/Body.h>
 #include <Ext/WarheadType/Body.h>
 #include <Ext/WeaponType/Body.h>
-#include <Misc/FlyingStrings.h>
 #include <Utilities/EnumFunctions.h>
 
 DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
@@ -465,16 +464,11 @@ DEFINE_HOOK(0x6FD446, TechnoClass_FireLaser_IsSingleColor, 0x7)
 
 DEFINE_HOOK(0x701DFF, TechnoClass_ReceiveDamage_FlyingStrings, 0x7)
 {
-	GET(ObjectClass* const, pThis, ESI);
+	GET(TechnoClass* const, pThis, ESI);
 	GET(int* const, pDamage, EBX);
 
 	if (Phobos::Debug_DisplayDamageNumbers && *pDamage)
-	{
-		auto color = *pDamage > 0 ? ColorStruct { 255, 0, 0 } : ColorStruct { 0, 255, 0 };
-		wchar_t damageStr[0x20];
-		swprintf_s(damageStr, L"%d", *pDamage);
-		FlyingStrings::Add(damageStr, pThis->Location, color, true);
-	}
+		TechnoExt::DisplayDamageNumberString(pThis, *pDamage, false);
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -6,6 +6,7 @@
 #include <Ext/TechnoType/Body.h>
 #include <Ext/WarheadType/Body.h>
 #include <Ext/WeaponType/Body.h>
+#include <Misc/FlyingStrings.h>
 #include <Utilities/EnumFunctions.h>
 
 DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
@@ -457,6 +458,22 @@ DEFINE_HOOK(0x6FD446, TechnoClass_FireLaser_IsSingleColor, 0x7)
 	{
 		if (!pLaser->IsHouseColor && pWeaponExt->Laser_IsSingleColor)
 			pLaser->IsHouseColor = true;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x701DFF, TechnoClass_ReceiveDamage_FlyingStrings, 0x7)
+{
+	GET(ObjectClass* const, pThis, ESI);
+	GET(int* const, pDamage, EBX);
+
+	if (Phobos::Debug_DisplayDamageNumbers && *pDamage)
+	{
+		auto color = *pDamage > 0 ? ColorStruct { 255, 0, 0 } : ColorStruct { 0, 255, 0 };
+		wchar_t damageStr[0x20];
+		swprintf_s(damageStr, L"%d", *pDamage);
+		FlyingStrings::Add(damageStr, pThis->Location, color, true);
 	}
 
 	return 0;

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -77,6 +77,9 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->BigGap.Read(exINI, pSection, "BigGap");
 	this->TransactMoney.Read(exINI, pSection, "TransactMoney");
 	this->TransactMoney_Display.Read(exINI, pSection, "TransactMoney.Display");
+	this->TransactMoney_Display_Houses.Read(exINI, pSection, "TransactMoney.Display.Houses");
+	this->TransactMoney_Display_AtFirer.Read(exINI, pSection, "TransactMoney.Display.AtFirer");
+	this->TransactMoney_Display_Offset.Read(exINI, pSection, "TransactMoney.Display.Offset");
 	this->SplashList.Read(exINI, pSection, "SplashList");
 	this->SplashList_PickRandom.Read(exINI, pSection, "SplashList.PickRandom");
 	this->RemoveDisguise.Read(exINI, pSection, "RemoveDisguise");
@@ -97,11 +100,6 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Crit_AffectBelowPercent.Read(exINI, pSection, "Crit.AffectBelowPercent");
 
 	this->MindControl_Anim.Read(exINI, pSection, "MindControl.Anim");
-
-	// Ares tags
-	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
-	this->AffectsEnemies.Read(exINI, pSection, "AffectsEnemies");
-	this->AffectsOwner.Read(exINI, pSection, "AffectsOwner");
 
 	// Shields
 	this->Shield_Penetrate.Read(exINI, pSection, "Shield.Penetrate");
@@ -130,6 +128,11 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Shield_AffectTypes.Read(exINI, pSection, "Shield.AffectTypes");
 
 	this->NotHuman_DeathSequence.Read(exINI, pSection, "NotHuman.DeathSequence");
+
+	// Ares tags
+	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
+	this->AffectsEnemies.Read(exINI, pSection, "AffectsEnemies");
+	this->AffectsOwner.Read(exINI, pSection, "AffectsOwner");
 }
 
 template <typename T>
@@ -140,6 +143,9 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BigGap)
 		.Process(this->TransactMoney)
 		.Process(this->TransactMoney_Display)
+		.Process(this->TransactMoney_Display_Houses)
+		.Process(this->TransactMoney_Display_AtFirer)
+		.Process(this->TransactMoney_Display_Offset)
 		.Process(this->SplashList)
 		.Process(this->SplashList_PickRandom)
 		.Process(this->RemoveDisguise)
@@ -159,10 +165,6 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Crit_AffectBelowPercent)
 
 		.Process(this->MindControl_Anim)
-
-		// Ares tags
-		.Process(this->AffectsEnemies)
-		.Process(this->AffectsOwner)
 
 		.Process(this->Shield_Penetrate)
 		.Process(this->Shield_Break)
@@ -189,6 +191,10 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Shield_AffectTypes)
 
 		.Process(this->NotHuman_DeathSequence)
+
+		// Ares tags
+		.Process(this->AffectsEnemies)
+		.Process(this->AffectsOwner)
 		;
 }
 

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -76,6 +76,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SpySat.Read(exINI, pSection, "SpySat");
 	this->BigGap.Read(exINI, pSection, "BigGap");
 	this->TransactMoney.Read(exINI, pSection, "TransactMoney");
+	this->TransactMoney_Display.Read(exINI, pSection, "TransactMoney.Display");
 	this->SplashList.Read(exINI, pSection, "SplashList");
 	this->SplashList_PickRandom.Read(exINI, pSection, "SplashList.PickRandom");
 	this->RemoveDisguise.Read(exINI, pSection, "RemoveDisguise");
@@ -138,6 +139,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SpySat)
 		.Process(this->BigGap)
 		.Process(this->TransactMoney)
+		.Process(this->TransactMoney_Display)
 		.Process(this->SplashList)
 		.Process(this->SplashList_PickRandom)
 		.Process(this->RemoveDisguise)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -19,6 +19,9 @@ public:
 		Valueable<bool> BigGap;
 		Valueable<int> TransactMoney;
 		Valueable<bool> TransactMoney_Display;
+		Valueable<AffectedHouse> TransactMoney_Display_Houses;
+		Valueable<bool> TransactMoney_Display_AtFirer;
+		Valueable<Point2D> TransactMoney_Display_Offset;
 		ValueableVector<AnimTypeClass*> SplashList;
 		Valueable<bool> SplashList_PickRandom;
 		Valueable<bool> RemoveDisguise;
@@ -38,11 +41,6 @@ public:
 		Valueable<double> Crit_AffectBelowPercent;
 
 		Nullable<AnimTypeClass*> MindControl_Anim;
-
-		// Ares tags
-		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
-		Valueable<bool> AffectsEnemies;
-		Nullable<bool> AffectsOwner;
 
 		Valueable<bool> Shield_Penetrate;
 		Valueable<bool> Shield_Break;
@@ -75,6 +73,11 @@ public:
 		Valueable<int> Shield_MinimumReplaceDelay;
 		ValueableVector<ShieldTypeClass*> Shield_AffectTypes;
 
+		// Ares tags
+		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
+		Valueable<bool> AffectsEnemies;
+		Nullable<bool> AffectsOwner;
+
 	private:
 		Valueable<double> Shield_Respawn_Rate_InMinutes;
 		Valueable<double> Shield_SelfHealing_Rate_InMinutes;
@@ -85,6 +88,9 @@ public:
 			, BigGap { false }
 			, TransactMoney { 0 }
 			, TransactMoney_Display { false }
+			, TransactMoney_Display_Houses { AffectedHouse::All }
+			, TransactMoney_Display_AtFirer { false }
+			, TransactMoney_Display_Offset {{ 0, 0 }}
 			, SplashList {}
 			, SplashList_PickRandom { false }
 			, RemoveDisguise { false }
@@ -106,9 +112,6 @@ public:
 			, HasCrit { false }
 
 			, MindControl_Anim {}
-
-			, AffectsEnemies { true }
-			, AffectsOwner {}
 
 			, Shield_Penetrate { false }
 			, Shield_Break { false }
@@ -137,6 +140,9 @@ public:
 			, Shield_AffectTypes {}
 
 			, NotHuman_DeathSequence { -1 }
+
+			, AffectsEnemies { true }
+			, AffectsOwner {}
 		{ }
 
 	private:

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -18,6 +18,7 @@ public:
 		Valueable<bool> SpySat;
 		Valueable<bool> BigGap;
 		Valueable<int> TransactMoney;
+		Valueable<bool> TransactMoney_Display;
 		ValueableVector<AnimTypeClass*> SplashList;
 		Valueable<bool> SplashList_PickRandom;
 		Valueable<bool> RemoveDisguise;
@@ -83,6 +84,7 @@ public:
 			, SpySat { false }
 			, BigGap { false }
 			, TransactMoney { 0 }
+			, TransactMoney_Display { false }
 			, SplashList {}
 			, SplashList_PickRandom { false }
 			, RemoveDisguise { false }

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -6,6 +6,7 @@
 #include <ScenarioClass.h>
 #include <AnimTypeClass.h>
 #include <AnimClass.h>
+#include <BitFont.h>
 
 #include <Utilities/Helpers.Alex.h>
 #include <Ext/Techno/Body.h>
@@ -39,13 +40,23 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 		{
 			pHouse->TransactMoney(this->TransactMoney);
 
-			if (this->TransactMoney_Display)
+			if (this->TransactMoney_Display &&
+				(this->TransactMoney_Display_Houses == AffectedHouse::All ||
+					pOwner && EnumFunctions::CanTargetHouse(this->TransactMoney_Display_Houses, pOwner->Owner, HouseClass::Player)))
 			{
 				bool isPositive = this->TransactMoney > 0;
 				auto color = isPositive ? ColorStruct { 0, 255, 0 } : ColorStruct { 255, 0, 0 };
 				wchar_t moneyStr[0x20];
-				swprintf_s(moneyStr, L"%s$%d", isPositive ? L"" : L"-", std::abs(this->TransactMoney));
-				FlyingStrings::Add(moneyStr, pOwner ? pOwner->Location : coords, color);
+				swprintf_s(moneyStr, L"%s$%d", isPositive ? L"+" : L"-", std::abs(this->TransactMoney));
+				auto displayCoord = this->TransactMoney_Display_AtFirer ? (pOwner ? pOwner->Location : coords) : coords;
+
+				int width = 0, height = 0;
+				BitFont::Instance->GetTextDimension(moneyStr, &width, &height, 120);
+				Point2D pixelOffset = Point2D::Empty;
+				pixelOffset += this->TransactMoney_Display_Offset;
+				pixelOffset.X -= (width / 2);
+
+				FlyingStrings::Add(moneyStr, displayCoord, color, pixelOffset);
 			}
 		}
 	}

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -10,6 +10,7 @@
 #include <Utilities/Helpers.Alex.h>
 #include <Ext/Techno/Body.h>
 #include <Ext/TechnoType/Body.h>
+#include <Misc/FlyingStrings.h>
 #include <Utilities/EnumFunctions.h>
 
 void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletClass* pBullet, CoordStruct coords)
@@ -35,7 +36,18 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 			MapClass::Instance->Reveal(pHouse);
 
 		if (this->TransactMoney)
+		{
 			pHouse->TransactMoney(this->TransactMoney);
+
+			if (this->TransactMoney_Display)
+			{
+				bool isPositive = this->TransactMoney > 0;
+				auto color = isPositive ? ColorStruct { 0, 255, 0 } : ColorStruct { 255, 0, 0 };
+				wchar_t moneyStr[0x20];
+				swprintf_s(moneyStr, L"%s$%d", isPositive ? L"" : L"-", std::abs(this->TransactMoney));
+				FlyingStrings::Add(moneyStr, pOwner ? pOwner->Location : coords, color);
+			}
+		}
 	}
 
 	this->HasCrit = false;
@@ -126,7 +138,7 @@ void WarheadTypeExt::ExtData::ApplyShieldModifiers(TechnoClass* pTarget)
 
 			if (shieldType)
 			{
-				if (shieldType->Strength && (!pExt->Shield || (this->Shield_ReplaceNonRespawning && pExt->Shield->IsBrokenAndNonRespawning() && 
+				if (shieldType->Strength && (!pExt->Shield || (this->Shield_ReplaceNonRespawning && pExt->Shield->IsBrokenAndNonRespawning() &&
 					pExt->Shield->GetFramesSinceLastBroken() >= this->Shield_MinimumReplaceDelay)))
 				{
 					pExt->CurrentShieldType = shieldType;

--- a/src/Misc/FlyingStrings.cpp
+++ b/src/Misc/FlyingStrings.cpp
@@ -11,7 +11,7 @@
 std::vector<FlyingStrings::Item> FlyingStrings::Data;
 int FlyingStrings::CurrentCycleWidth = -FlyingStrings::MaxCycleWidth;
 
-bool FlyingStrings::DrawAllowed(CoordStruct &nCoords)
+bool FlyingStrings::DrawAllowed(CoordStruct& nCoords)
 {
 	if (auto const pCell = MapClass::Instance->TryGetCellAt(nCoords))
 	{
@@ -24,9 +24,9 @@ bool FlyingStrings::DrawAllowed(CoordStruct &nCoords)
 	return false;
 }
 
-void FlyingStrings::Add(const wchar_t *text, CoordStruct coords, ColorStruct color, bool isCyclic)
+void FlyingStrings::Add(const wchar_t* text, CoordStruct coords, ColorStruct color, bool isCyclic)
 {
-	Item item{};
+	Item item {};
 	item.Location = coords;
 
 	item.CreationFrame = Unsorted::CurrentFrame;
@@ -52,8 +52,10 @@ void FlyingStrings::UpdateAll()
 	if (Data.empty())
 		return;
 
-	for (auto const &dataItem : Data)
+	for (int i = Data.size() - 1; i >= 0; --i)
 	{
+		auto& dataItem = Data[i];
+
 		Point2D point;
 
 		TacticalClass::Instance->CoordsToClient(dataItem.Location, &point);
@@ -70,12 +72,8 @@ void FlyingStrings::UpdateAll()
 		{
 			DSurface::Temp->DrawText(dataItem.Text, point.X, point.Y, dataItem.Color);
 		}
+
+		if (Unsorted::CurrentFrame > dataItem.CreationFrame + Duration || Unsorted::CurrentFrame < dataItem.CreationFrame)
+			Data.erase(Data.begin() + i);
 	}
-
-	auto const it = std::remove_if(Data.begin(), Data.end(), [](Item nItem) {
-		return Unsorted::CurrentFrame > nItem.CreationFrame + Duration || Unsorted::CurrentFrame < nItem.CreationFrame;
-		});
-
-	if (it != Data.end())
-		Data.erase(it);
 }

--- a/src/Misc/FlyingStrings.cpp
+++ b/src/Misc/FlyingStrings.cpp
@@ -9,7 +9,6 @@
 #include <BitFont.h>
 
 std::vector<FlyingStrings::Item> FlyingStrings::Data;
-int FlyingStrings::CurrentCycleWidth = -FlyingStrings::MaxCycleWidth;
 
 bool FlyingStrings::DrawAllowed(CoordStruct& nCoords)
 {
@@ -24,26 +23,14 @@ bool FlyingStrings::DrawAllowed(CoordStruct& nCoords)
 	return false;
 }
 
-void FlyingStrings::Add(const wchar_t* text, CoordStruct coords, ColorStruct color, bool isCyclic)
+void FlyingStrings::Add(const wchar_t* text, CoordStruct coords, ColorStruct color, Point2D pixelOffset)
 {
 	Item item {};
 	item.Location = coords;
-
+	item.PixelOffset = pixelOffset;
 	item.CreationFrame = Unsorted::CurrentFrame;
 	item.Color = Drawing::RGB2DWORD(color);
 	PhobosCRT::wstrCopy(item.Text, text, 0x20);
-
-	if (isCyclic)
-	{
-		if (CurrentCycleWidth >= MaxCycleWidth)
-			CurrentCycleWidth = -MaxCycleWidth;
-
-		int width = 0, height = 0;
-		BitFont::Instance->GetTextDimension(item.Text, &width, &height, MaxCycleWidth);
-		item.XOffset = CurrentCycleWidth;
-		CurrentCycleWidth += (width + 2);
-	}
-
 	Data.push_back(item);
 }
 
@@ -60,8 +47,7 @@ void FlyingStrings::UpdateAll()
 
 		TacticalClass::Instance->CoordsToClient(dataItem.Location, &point);
 
-		if (dataItem.XOffset != 0)
-			point.X += dataItem.XOffset;
+		point += dataItem.PixelOffset;
 
 		if (Unsorted::CurrentFrame > dataItem.CreationFrame + Duration - 70)
 		{

--- a/src/Misc/FlyingStrings.cpp
+++ b/src/Misc/FlyingStrings.cpp
@@ -13,12 +13,7 @@ std::vector<FlyingStrings::Item> FlyingStrings::Data;
 bool FlyingStrings::DrawAllowed(CoordStruct& nCoords)
 {
 	if (auto const pCell = MapClass::Instance->TryGetCellAt(nCoords))
-	{
-		if (pCell->IsFogged() || pCell->IsShrouded())
-			return false;
-
-		return true;
-	}
+		return !(pCell->IsFogged() || pCell->IsShrouded());
 
 	return false;
 }

--- a/src/Misc/FlyingStrings.cpp
+++ b/src/Misc/FlyingStrings.cpp
@@ -1,0 +1,81 @@
+#include "FlyingStrings.h"
+
+#include <MapClass.h>
+#include <Phobos.CRT.h>
+#include <TacticalClass.h>
+#include <ColorScheme.h>
+#include <Drawing.h>
+#include <ScenarioClass.h>
+#include <BitFont.h>
+
+std::vector<FlyingStrings::Item> FlyingStrings::Data;
+int FlyingStrings::CurrentCycleWidth = -FlyingStrings::MaxCycleWidth;
+
+bool FlyingStrings::DrawAllowed(CoordStruct &nCoords)
+{
+	if (auto const pCell = MapClass::Instance->TryGetCellAt(nCoords))
+	{
+		if (pCell->IsFogged() || pCell->IsShrouded())
+			return false;
+
+		return true;
+	}
+
+	return false;
+}
+
+void FlyingStrings::Add(const wchar_t *text, CoordStruct coords, ColorStruct color, bool isCyclic)
+{
+	Item item{};
+	item.Location = coords;
+
+	item.CreationFrame = Unsorted::CurrentFrame;
+	item.Color = Drawing::RGB2DWORD(color);
+	PhobosCRT::wstrCopy(item.Text, text, 0x20);
+
+	if (isCyclic)
+	{
+		if (CurrentCycleWidth >= MaxCycleWidth)
+			CurrentCycleWidth = -MaxCycleWidth;
+
+		int width = 0, height = 0;
+		BitFont::Instance->GetTextDimension(item.Text, &width, &height, MaxCycleWidth);
+		item.XOffset = CurrentCycleWidth;
+		CurrentCycleWidth += (width + 2);
+	}
+
+	Data.push_back(item);
+}
+
+void FlyingStrings::UpdateAll()
+{
+	if (Data.empty())
+		return;
+
+	for (auto const &dataItem : Data)
+	{
+		Point2D point;
+
+		TacticalClass::Instance->CoordsToClient(dataItem.Location, &point);
+
+		if (dataItem.XOffset != 0)
+			point.X += dataItem.XOffset;
+
+		if (Unsorted::CurrentFrame > dataItem.CreationFrame + Duration - 70)
+		{
+			point.Y -= (Unsorted::CurrentFrame - dataItem.CreationFrame);
+			DSurface::Temp->DrawText(dataItem.Text, point.X, point.Y, dataItem.Color);
+		}
+		else
+		{
+			DSurface::Temp->DrawText(dataItem.Text, point.X, point.Y, dataItem.Color);
+		}
+	}
+
+	auto const it = std::remove_if(Data.begin(), Data.end(), [](Item nItem) {
+		return Unsorted::CurrentFrame > nItem.CreationFrame + Duration || Unsorted::CurrentFrame < nItem.CreationFrame;
+		});
+
+	if (it != Data.end())
+		Data.erase(it);
+}

--- a/src/Misc/FlyingStrings.h
+++ b/src/Misc/FlyingStrings.h
@@ -15,7 +15,7 @@ private:
 	struct Item
 	{
 		CoordStruct Location;
-		int XOffset;
+		Point2D PixelOffset;
 		int CreationFrame;
 		wchar_t Text[0x20];
 		COLORREF Color;
@@ -23,13 +23,11 @@ private:
 	};
 
 	static const int Duration = 75;
-	static const int MaxCycleWidth = 30;
-	static int CurrentCycleWidth;
 	static std::vector<Item> Data;
 
 	static bool DrawAllowed(CoordStruct &nCoords);
 
 public:
-	static void Add(const wchar_t *text, CoordStruct coords, ColorStruct color, bool isCyclic = false);
+	static void Add(const wchar_t *text, CoordStruct coords, ColorStruct color, Point2D pixelOffset = Point2D::Empty);
 	static void UpdateAll();
 };

--- a/src/Misc/FlyingStrings.h
+++ b/src/Misc/FlyingStrings.h
@@ -1,0 +1,35 @@
+/*FlyingStrings.h
+Useable to get out messages from units
+Used to output Bounty messages
+By AlexB and Joshy
+*/
+
+#pragma once
+#include <vector>
+#include <ColorScheme.h>
+
+class FlyingStrings
+{
+private:
+
+	struct Item
+	{
+		CoordStruct Location;
+		int XOffset;
+		int CreationFrame;
+		wchar_t Text[0x20];
+		COLORREF Color;
+
+	};
+
+	static const int Duration = 75;
+	static const int MaxCycleWidth = 30;
+	static int CurrentCycleWidth;
+	static std::vector<Item> Data;
+
+	static bool DrawAllowed(CoordStruct &nCoords);
+
+public:
+	static void Add(const wchar_t *text, CoordStruct coords, ColorStruct color, bool isCyclic = false);
+	static void UpdateAll();
+};

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -9,6 +9,7 @@
 #include <Ext/Rules/Body.h>
 #include <Ext/TechnoType/Body.h>
 #include <Ext/SWType/Body.h>
+#include <Misc/FlyingStrings.h>
 #include <Utilities/Debug.h>
 
 DEFINE_HOOK(0x777C41, UI_ApplyAppIcon, 0x9)
@@ -187,4 +188,10 @@ DEFINE_HOOK(0x6A8463, StripClass_OperatorLessThan_CameoPriority, 0x5)
 	// Restore overridden instructions
 	GET(AbstractType, rtti1, ESI);
 	return rtti1 == AbstractType::Special ? 0x6A8477 : 0x6A8468;
+}
+
+DEFINE_HOOK(0x6D4684, TacticalClass_Draw_FlyingStrings, 0x6)
+{
+	FlyingStrings::UpdateAll();
+	return 0;
 }

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -5,6 +5,7 @@
 #include <Ext/TechnoType/Body.h>
 #include <Ext/WarheadType/Body.h>
 
+#include <Misc/FlyingStrings.h>
 #include <Utilities/GeneralUtils.h>
 
 #include <AnimClass.h>
@@ -119,6 +120,14 @@ int ShieldClass::ReceiveDamage(args_ReceiveDamage* args)
 		shieldDamage = (int)((double)nDamage * absorbPercent);
 		// passthrough damage shouldn't be affected by shield armor
 		healthDamage = (int)((double)*args->Damage * passPercent);
+	}
+
+	if (Phobos::Debug_DisplayDamageNumbers && shieldDamage != 0)
+	{
+		auto color = shieldDamage > 0 ? ColorStruct { 0, 160, 255 } : ColorStruct { 0, 255, 230 };
+		wchar_t damageStr[0x20];
+		swprintf_s(damageStr, L"%d", shieldDamage);
+		FlyingStrings::Add(damageStr, this->Techno->Location, color, true);
 	}
 
 	if (shieldDamage > 0)

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -5,7 +5,6 @@
 #include <Ext/TechnoType/Body.h>
 #include <Ext/WarheadType/Body.h>
 
-#include <Misc/FlyingStrings.h>
 #include <Utilities/GeneralUtils.h>
 
 #include <AnimClass.h>
@@ -123,12 +122,7 @@ int ShieldClass::ReceiveDamage(args_ReceiveDamage* args)
 	}
 
 	if (Phobos::Debug_DisplayDamageNumbers && shieldDamage != 0)
-	{
-		auto color = shieldDamage > 0 ? ColorStruct { 0, 160, 255 } : ColorStruct { 0, 255, 230 };
-		wchar_t damageStr[0x20];
-		swprintf_s(damageStr, L"%d", shieldDamage);
-		FlyingStrings::Add(damageStr, this->Techno->Location, color, true);
-	}
+		TechnoExt::DisplayDamageNumberString(this->Techno, shieldDamage, true);
 
 	if (shieldDamage > 0)
 	{

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -22,6 +22,8 @@ const char Phobos::readDelims[4] = ",";
 
 const char* Phobos::AppIconPath = nullptr;
 
+bool Phobos::Debug_DisplayDamageNumbers = false;
+
 #ifdef STR_GIT_COMMIT
 const wchar_t* Phobos::VersionDescription = L"Phobos nightly build (" STR_GIT_COMMIT L" @ " STR_GIT_BRANCH L"). DO NOT SHIP IN MODS!";
 #elif !defined(IS_RELEASE_VER)

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -30,6 +30,8 @@ public:
 	static const char* AppIconPath;
 	static const wchar_t* VersionDescription;
 
+	static bool Debug_DisplayDamageNumbers;
+
 #ifdef DEBUG
 	static bool DetachFromDebugger();
 #endif


### PR DESCRIPTION
FlyingStrings implementation based on the original [Ares implementation](https://github.com/Ares-Developers/Ares/blob/596cb2103f9f1677ae2cb06084a4a0fbbf27c503/src/Misc/FlyingStrings.h) by AlexB & Joshy, modified by otamaa and Starkku.

`Grinding.DisplayRefund` can be set to display the amount of credits acquired upon grinding on the building. Multiple refunded objects within a short period of time have their refund amounts coalesced into single display.
  - `Grinding.DisplayRefund.Houses` determines which houses can see the credits display.
  - `Grinding.DisplayRefund.Offset` is additional pixel offset for the center of the credits display, by default (0,0) at building's center.

In `rulesmd.ini`:
```ini
[SOMEBUILDING]                     ; BuildingType
Grinding.DisplayRefund=false       ; boolean
Grinding.DisplayRefund.Houses=All  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
Grinding.DisplayRefund.Offset=0,0  ; X,Y, pixels relative to default
```
![image](https://user-images.githubusercontent.com/1392346/164781302-55bb527c-d8d6-47b8-a078-6140cc6b402e.png)


`TransactMoney.Display` can be set to display the amount of credits given or deducted. The number is displayed in green if given, red if deducted and will move upwards after appearing.
  - `TransactMoney.Display.AtFirer` if set, makes the credits display appear on firer instead of target. If set and firer is not known, it will display at target regardless.
  - `TransactMoney.Display.Houses` determines which houses can see the credits display.
  - `TransactMoney.Display.Offset` is additional pixel offset for the center of the credits display, by default (0,0) at target's/firer's center.

In `rulesmd.ini`:
```ini
[SOMEWARHEAD]                        ; Warhead
TransactMoney.Display=false          ; boolean
TransactMoney.Display.AtFirer=false  ; boolean
TransactMoney.Display.Houses=All     ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
TransactMoney.Display.Offset=0,0     ; X,Y, pixels relative to default
```
![image](https://user-images.githubusercontent.com/1392346/162961593-bd3ca7ed-517f-434c-9073-7e88ae9bbe56.png)


There's a new hotkey to show exact numbers of damage dealt on units & buildings. The numbers are shown in red (blue against shields) for damage, and for healing damage in green (cyan against shields). They are shown on the affected units and will move upwards after appearing. Available only if `DebugKeysEnabled` under `[GlobalControls]` is set to true in `rulesmd.ini`.

![image](https://user-images.githubusercontent.com/1392346/162967565-1dad97bf-e886-432d-9362-904ea23e919e.png)![image](https://user-images.githubusercontent.com/1392346/162967695-a81f14fa-5dec-4742-9836-7ca6aad82f2d.png)