### PR TITLE
Implement passable & buildable-upon TerrainTypes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -142,6 +142,7 @@ This page lists all the individual contributions to the project by their author.
   - Display damage numbers hotkey command
   - TransactMoney.Display
   - Building-provided self-heal customization
+  - Passable & buildable-upon TerrainTypes
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -75,6 +75,7 @@
     <ClCompile Include="src\Ext\Techno\Hooks.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Body.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\TerrainType\Hooks.Passable.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.DisallowMoving.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Shield.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -63,6 +63,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Self-healing pips from `InfantryGainSelfHeal` & `UnitsGainSelfHeal` now respect unit's `PixelSelectionBracketDelta` like health bar pips do.
 - Buildings using `SelfHealing` will now correctly revert to undamaged graphics if their health is restored back by self-healing.
 - Anim owner is now set for warhead AnimList/SplashList anims and Play Anim at Waypoint trigger animations.
+- Allow use of `Foundation=0x0` on TerrainTypes without crashing for similar results as for buildings.
 
 ## Animations
 
@@ -315,6 +316,19 @@ In `rulesmd.ini`:
 ```ini
 [SOMETERRAINTYPE]  ; TerrainType
 MinimapColor=      ; integer - Red,Green,Blue
+```
+
+### Passable & buildable-upon TerrainTypes
+
+- TerrainTypes can now be made passable or buildable upon by setting `IsPassable` or `CanBeBuiltOn`, respectively.
+  - Movement cursor is displayed on `IsPassable` TerrainTypes unless force-firing.
+  - `CanBeBuiltOn=true` terrain objects are removed when building is placed on them.
+
+In `rulesmd.ini`:
+```ini
+[SOMETERRAINTYPE]   ; TerrainType
+IsPassable=false    ; boolean
+CanBeBuiltOn=false  ; boolean
 ```
 
 ## Tiberiums (ores)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -302,6 +302,7 @@ New:
 - Toggleable display of TransactMoney amounts (by Starkku)
 - Building-provided self-healing customization (by Starkku)
 - Building placement preview (by Otamaa)
+- Passable & buildable-upon TerrainTypes (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)
@@ -322,6 +323,7 @@ Vanilla fixes:
 - Fixed buildings not reverting to undamaged graphics when HP was restored above `[AudioVisual]`->`ConditionYellow` via `SelfHealing` (by Starkku)
 - Fixed jumpjet units being unable to turn to the target when firing from a different direction (by trsdy)
 - Anim owner is now set for warhead AnimList/SplashList anims and Play Anim at Waypoint trigger animations (by Starkku)
+- Fixed `Foundation=0x0` causing crashes if used on TerrainTypes.
 
 Phobos fixes:
 - Fixed shields being able to take damage when the parent TechnoType was under effects of a `Temporal` Warhead (by Starkku)

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -1,6 +1,9 @@
 #include "Body.h"
 
+#include <TacticalClass.h>
+#include <TerrainClass.h>
 #include <TerrainTypeClass.h>
+
 #include <Utilities/GeneralUtils.h>
 
 template<> const DWORD Extension<TerrainTypeClass>::Canary = 0xBEE78007;
@@ -14,6 +17,18 @@ int TerrainTypeExt::ExtData::GetTiberiumGrowthStage()
 int TerrainTypeExt::ExtData::GetCellsPerAnim()
 {
 	return GeneralUtils::GetRangedRandomOrSingleValue(this->SpawnsTiberium_CellsPerAnim.Get());
+}
+
+void TerrainTypeExt::Remove(TerrainClass* pTerrain)
+{
+	if (!pTerrain)
+		return;
+
+	RectangleStruct rect = RectangleStruct {};
+	rect = *pTerrain->GetRenderDimensions(&rect);
+	TacticalClass::Instance->RegisterDirtyArea(rect, false);
+	pTerrain->Disappear(true);
+	pTerrain->UnInit();
 }
 
 // =============================
@@ -30,6 +45,8 @@ void TerrainTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DestroyAnim)
 		.Process(this->DestroySound)
 		.Process(this->MinimapColor)
+		.Process(this->IsPassable)
+		.Process(this->CanBeBuiltOn)
 		;
 }
 
@@ -51,6 +68,9 @@ void TerrainTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DestroySound.Read(exINI, pSection, "DestroySound");
 
 	this->MinimapColor.Read(exINI, pSection, "MinimapColor");
+
+	this->IsPassable.Read(exINI, pSection, "IsPassable");
+	this->CanBeBuiltOn.Read(exINI, pSection, "CanBeBuiltOn");
 
 	//Strength is already part of ObjecTypeClass::ReadIni Duh!
 	//this->TerrainStrength.Read(exINI, pSection, "Strength");

--- a/src/Ext/TerrainType/Body.h
+++ b/src/Ext/TerrainType/Body.h
@@ -21,6 +21,8 @@ public:
 		Nullable<AnimTypeClass*> DestroyAnim;
 		NullableIdx<VocClass> DestroySound;
 		Nullable<ColorStruct> MinimapColor;
+		Valueable<bool> IsPassable;
+		Valueable<bool> CanBeBuiltOn;
 
 		ExtData(TerrainTypeClass* OwnerObject) : Extension<TerrainTypeClass>(OwnerObject)
 			, SpawnsTiberium_Type { 0 }
@@ -30,6 +32,8 @@ public:
 			, DestroyAnim {}
 			, DestroySound {}
 			, MinimapColor {}
+			, IsPassable { false }
+			, CanBeBuiltOn { false }
 		{ }
 
 		virtual ~ExtData() = default;
@@ -59,4 +63,6 @@ public:
 
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
+
+	static void Remove(TerrainClass* pTerrain);
 };

--- a/src/Ext/TerrainType/Hooks.Passable.cpp
+++ b/src/Ext/TerrainType/Hooks.Passable.cpp
@@ -1,0 +1,201 @@
+#include "Body.h"
+
+#include <OverlayClass.h>
+#include <TerrainClass.h>
+
+#include <Utilities/GeneralUtils.h>
+
+// Passable TerrainTypes Hook #1 - Do not set occupy bits.
+DEFINE_HOOK(0x71C110, TerrainClass_SetOccupyBit_PassableTerrain, 0x6)
+{
+	enum { Skip = 0x71C1A0 };
+
+	GET(TerrainClass*, pThis, ECX);
+
+	if (auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type))
+	{
+		if (pTypeExt->IsPassable)
+			return Skip;
+	}
+
+	return 0;
+}
+
+// Passable TerrainTypes Hook #2 - Do not display attack cursor unless force-firing.
+DEFINE_HOOK(0x7002E9, TechnoClass_WhatAction_PassableTerrain, 0x5)
+{
+	enum { Skip = 0x70020E };
+
+	GET(ObjectClass*, pTarget, EDI);
+	GET_STACK(bool, isForceFire, STACK_OFFS(0x1C, -0x8));
+
+	if (pTarget->WhatAmI() == AbstractType::Terrain)
+	{
+		if (auto const pTypeExt = TerrainTypeExt::ExtMap.Find((abstract_cast<TerrainClass*>(pTarget))->Type))
+		{
+			if (pTypeExt->IsPassable && !isForceFire)
+			{
+				R->EBP(1);
+				return Skip;
+			}
+		}
+	}
+
+	return 0;
+}
+
+// Passable TerrainTypes Hook #3 - Count passable TerrainTypes as completely passable.
+DEFINE_HOOK(0x483D87, CellClass_CheckPassability_PassableTerrain, 0x5)
+{
+	enum { Skip = 0x483DCD, Return = 0x483E25 };
+
+	GET(CellClass*, pThis, EDI);
+	GET(ObjectClass*, pObject, ESI);
+
+	if (auto const pTerrain = abstract_cast<TerrainClass*>(pObject))
+	{
+		if (auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pTerrain->Type))
+		{
+			if (pTypeExt->IsPassable)
+			{
+				pThis->Passability = 0;
+				return Return;
+			}
+		}
+	}
+
+	return Skip;
+}
+
+// Passable TerrainTypes Hook #4 - Make passable for vehicles.
+DEFINE_HOOK(0x73FB71, UnitClass_CanEnterCell_PassableTerrain, 0x6)
+{
+	enum { Return = 0x73FD37 };
+
+	GET(AbstractClass*, pTarget, ESI);
+
+	if (auto const pTerrain = abstract_cast<TerrainClass*>(pTarget))
+	{
+		auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pTerrain->Type);
+
+		if (pTypeExt->IsPassable)
+		{
+			R->EBP(0);
+			return 0x73FD37;
+		}
+	}
+
+	return 0;
+}
+
+// Buildable-upon TerrainTypes Hook #1 - Allow placing buildings on top of them.
+DEFINE_HOOK_AGAIN(0x47C80E, CellClass_IsClearTo_Build_BuildableTerrain, 0x5)
+DEFINE_HOOK(0x47C745, CellClass_IsClearTo_Build_BuildableTerrain, 0x5)
+{
+	enum { Skip = 0x47C85F, SkipFlags = 0x47C6A0 };
+
+	GET(CellClass*, pThis, EDI);
+
+	auto pTerrain = pThis->GetTerrain(false);
+
+	if (pTerrain)
+	{
+		if (auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pTerrain->Type))
+		{
+			if (pTypeExt->CanBeBuiltOn)
+			{
+				if (pThis->OccupationFlags & 0x20 || pThis->OccupationFlags & 0x40 || pThis->OccupationFlags & 0x80 || pThis->GetInfantry(false))
+					return Skip;
+				else
+					return SkipFlags;
+			}
+		}
+	}
+
+	return 0;
+}
+
+// Buildable-upon TerrainTypes Hook #2 - Allow placing laser fences on top of them.
+DEFINE_HOOK(0x47C657, CellClass_IsClearTo_Build_BuildableTerrain_LF, 0x6)
+{
+	enum { Skip = 0x47C6A0, Return = 0x47C6D1 };
+
+	GET(CellClass*, pThis, EDI);
+
+	auto pObj = pThis->FirstObject;
+
+	if (pObj)
+	{
+		bool isEligible = true;
+
+		while (true)
+		{
+			isEligible = pObj->WhatAmI() != AbstractType::Building;
+
+			if (auto const pTerrain = abstract_cast<TerrainClass*>(pObj))
+			{
+				isEligible = false;
+				auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pTerrain->Type);
+
+				if (pTypeExt->CanBeBuiltOn)
+					isEligible = true;
+			}
+
+			if (!isEligible)
+				break;
+
+			pObj = pObj->NextObject;
+
+			if (!pObj)
+				return Skip;
+		}
+
+		return Return;
+	}
+
+	return Skip;
+}
+
+
+// Buildable-upon TerrainTypes Hook #3 - Draw laser fence placement even if they are on the way.
+DEFINE_HOOK(0x6D57C1, TacticalClass_DrawLaserFencePlacement_BuildableTerrain, 0x9)
+{
+	enum { ContinueChecks = 0x6D57D2, DontDraw = 0x6D59A6 };
+
+	GET(CellClass*, pCell, ESI);
+
+	if (auto const pTerrain = pCell->GetTerrain(false))
+	{
+		auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pTerrain->Type);
+
+		if (pTypeExt->CanBeBuiltOn)
+			return ContinueChecks;
+
+		return DontDraw;
+	}
+
+	return ContinueChecks;
+}
+
+// Buildable-upon TerrainTypes Hook #4 - Remove them when buildings are placed on them.
+DEFINE_HOOK(0x5684B1, MapClass_PlaceDown_BuildableTerrain, 0x6)
+{
+	GET(ObjectClass*, pObject, EDI);
+	GET(CellClass*, pCell, EAX);
+
+	if (pObject->WhatAmI() == AbstractType::Building)
+	{
+		if (auto const pTerrain = pCell->GetTerrain(false))
+		{
+			auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pTerrain->Type);
+
+			if (pTypeExt->CanBeBuiltOn)
+			{
+				pCell->RemoveContent(pTerrain, false);
+				TerrainTypeExt::Remove(pTerrain);
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/TerrainType/Hooks.Passable.cpp
+++ b/src/Ext/TerrainType/Hooks.Passable.cpp
@@ -81,7 +81,7 @@ DEFINE_HOOK(0x73FB71, UnitClass_CanEnterCell_PassableTerrain, 0x6)
 		if (pTypeExt->IsPassable)
 		{
 			R->EBP(0);
-			return 0x73FD37;
+			return Return;
 		}
 	}
 

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -153,3 +153,16 @@ DEFINE_HOOK(0x47C065, CellClass_CellColor_TerrainRadarColor, 0x6)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x568432, MapClass_PlaceDown_0x0TerrainTypes, 0x8)
+{
+	GET(ObjectClass*, pObject, EDI);
+
+	if (auto const pTerrain = abstract_cast<TerrainClass*>(pObject))
+	{
+		if (pTerrain->Type->Foundation == 21)
+			return 0x5687DF;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
- TerrainTypes can now be made passable or buildable upon by setting `IsPassable` or `CanBeBuiltOn`, respectively.
  - Movement cursor is displayed on `IsPassable` TerrainTypes unless force-firing.
  - `CanBeBuiltOn=true` terrain objects are removed when building is placed on them.

In `rulesmd.ini`:
```ini
[SOMETERRAINTYPE]   ; TerrainType
IsPassable=false    ; boolean
CanBeBuiltOn=false  ; boolean
```