### PR TITLE
Unit auto-death enhancement: allow peaceful removal from the game

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -782,12 +782,14 @@ InitialStrength=    ; int
 - Objects can be destroyed automatically under certaing cases:
   - No Ammo: The object will die if the remaining ammo reaches 0.
   - Countdown: The object will die if the countdown reaches 0.
+  - Peaceful: If `NoAmmo` or `Countdown` is set, the object will be directly removed from the game peacefully, without triggering deathweapon or "Unit lost" EVA.
 
 In `rulesmd.ini`:
 ```ini
 [SOMETECHNO]                       ; TechnoType
 Death.NoAmmo=no                    ; boolean
 Death.Countdown=0                  ; integer
+Death.Peaceful=no                  ; boolean, default to no
 ```
 
 ### Mind Control enhancement

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -789,7 +789,7 @@ In `rulesmd.ini`:
 [SOMETECHNO]                       ; TechnoType
 Death.NoAmmo=no                    ; boolean
 Death.Countdown=0                  ; integer
-Death.Peaceful=no                  ; boolean, default to no
+Death.Peaceful=no                  ; boolean, whether to not trigger DeathWeapon and EVA
 ```
 
 ### Mind Control enhancement

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -423,11 +423,19 @@ void TechnoExt::CheckDeathConditions(TechnoClass* pThis)
 	auto pTypeData = TechnoTypeExt::ExtMap.Find(pTypeThis);
 	auto pData = TechnoExt::ExtMap.Find(pThis);
 
+	const bool peacefulDeath = pTypeData->Death_Peaceful.Get();
 	// Death if no ammo
 	if (pTypeThis && pTypeData && pTypeData->Death_NoAmmo)
 	{
 		if (pTypeThis->Ammo > 0 && pThis->Ammo <= 0)
+		{
+			if (peacefulDeath) {
+				pThis->Limbo();
+				pThis->UnInit();
+			}else
 			pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
+		}
+			
 	}
 
 	// Death if countdown ends
@@ -443,6 +451,11 @@ void TechnoExt::CheckDeathConditions(TechnoClass* pThis)
 			{
 				// Countdown ended. Kill the unit
 				pData->Death_Countdown = -1;
+				if (peacefulDeath) {
+					pThis->Limbo();
+					pThis->UnInit();
+				}
+				else
 				pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
 			}
 		}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -429,13 +429,16 @@ void TechnoExt::CheckDeathConditions(TechnoClass* pThis)
 	{
 		if (pTypeThis->Ammo > 0 && pThis->Ammo <= 0)
 		{
-			if (peacefulDeath) {
+			if (peacefulDeath)
+			{
 				pThis->Limbo();
 				pThis->UnInit();
-			}else
-			pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
+			}
+			else
+			{
+				pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
+			}
 		}
-			
 	}
 
 	// Death if countdown ends
@@ -451,12 +454,15 @@ void TechnoExt::CheckDeathConditions(TechnoClass* pThis)
 			{
 				// Countdown ended. Kill the unit
 				pData->Death_Countdown = -1;
-				if (peacefulDeath) {
+				if (peacefulDeath)
+				{
 					pThis->Limbo();
 					pThis->UnInit();
 				}
 				else
-				pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
+				{
+					pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
+				}
 			}
 		}
 		else

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -100,6 +100,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->InitialStrength.Read(exINI, pSection, "InitialStrength");
 	this->Death_NoAmmo.Read(exINI, pSection, "Death.NoAmmo");
 	this->Death_Countdown.Read(exINI, pSection, "Death.Countdown");
+	this->Death_Peaceful.Read(exINI, pSection, "Death.Peaceful");
 	this->ShieldType.Read(exINI, pSection, "ShieldType", true);
 	this->CameoPriority.Read(exINI, pSection, "CameoPriority");
 
@@ -256,6 +257,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->InitialStrength)
 		.Process(this->Death_NoAmmo)
 		.Process(this->Death_Countdown)
+		.Process(this->Death_Peaceful)
 		.Process(this->ShieldType)
 		.Process(this->WarpOut)
 		.Process(this->WarpIn)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -50,6 +50,7 @@ public:
 		Valueable<bool> Death_NoAmmo;
 		Valueable<int> Death_Countdown;
 		Valueable<bool> Death_Peaceful;
+
 		Valueable<ShieldTypeClass*> ShieldType;
 
 		Nullable<AnimTypeClass*> WarpOut;
@@ -185,7 +186,7 @@ public:
 			, EnemyUIName {}
 			, Death_NoAmmo { false }
 			, Death_Countdown { 0 }
-			, Death_Peaceful {false}
+			, Death_Peaceful { false }
 			, ForceWeapon_Naval_Decloaked { -1 }
 			, Ammo_Shared { false }
 			, Ammo_Shared_Group { -1 }

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -49,7 +49,7 @@ public:
 		Nullable<AnimTypeClass*> PassengerDeletion_Anim;
 		Valueable<bool> Death_NoAmmo;
 		Valueable<int> Death_Countdown;
-
+		Valueable<bool> Death_Peaceful;
 		Valueable<ShieldTypeClass*> ShieldType;
 
 		Nullable<AnimTypeClass*> WarpOut;
@@ -185,6 +185,7 @@ public:
 			, EnemyUIName {}
 			, Death_NoAmmo { false }
 			, Death_Countdown { 0 }
+			, Death_Peaceful {false}
 			, ForceWeapon_Naval_Decloaked { -1 }
 			, Ammo_Shared { false }
 			, Ammo_Shared_Group { -1 }


### PR DESCRIPTION
### Unit auto removal 

- Objects can be destroyed automatically under certaing cases:
  - No Ammo: The object will die if the remaining ammo reaches 0.
  - Countdown: The object will die if the countdown reaches 0.
  - **Peaceful: If `NoAmmo` or `Countdown` is set, the object will be removed from the game peacefully, without triggering DeathWeapon or "Unit lost" EVA.**

In `rulesmd.ini`:
```ini
[SOMETECHNO]                       ; TechnoType
Death.NoAmmo=no                    ; boolean
Death.Countdown=0                  ; integer
Death.Peaceful=no                  ; boolean, default to no
```



Someone asked me how to commit a PR, I didn't remember. So, a random commit just for testing