### PR TITLE
Extend Parallel AI Queues

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -168,3 +168,4 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
+- **Netsu-Negi** - extened parallel ai queues

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -27,6 +27,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - SHP debris shadows now respect the `Shadow` tag.
 - Allowed usage of TileSet of 255 and above without making NE-SW broken bridges unrepairable.
 - Adds a "Load Game" button to the retry dialog on mission failure.
+- Adds a "ExtendParallelAIQueues" flag to custom ai clone factory behaviour.
 
 ![image](_static/images/turretoffset-01.png)  
 *Side offset voxel turret in Breaking Blue project*

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -293,6 +293,7 @@ New:
 - TerrainType & ore minimap color customization (by Starkku)
 - Single-color weapon lasers (by Starkku)
 - Customizable projectile trajectory (by secsome)
+- Extend Parallel AI Queues (by Netsu-Negi)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -73,6 +73,16 @@ DEFINE_HOOK(0x4401BB, Factory_AI_PickWithFreeDocks, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x44D455, BuildingClass_Mission_Missile_EMPPulseBulletWeapon, 0x8)
+{
+	GET(WeaponTypeClass*, pWeapon, EBP);
+	GET_STACK(BulletClass*, pBullet, STACK_OFFS(0xF0, 0xA4));
+
+	pBullet->SetWeaponType(pWeapon);
+
+	return 0;
+}
+
 DEFINE_HOOK(0x4502F4, BuildingClass_Update_Factory, 0x6)
 {
 	GET(BuildingClass*, pBuilding, ESI);
@@ -88,9 +98,10 @@ DEFINE_HOOK(0x4502F4, BuildingClass_Update_Factory, 0x6)
 			currFactory = &pData->Factory_BuildingType;
 			break;
 		case AbstractType::UnitType:
-			currFactory = pBuilding->Type->Naval
-				? &pData->Factory_NavyType
-				: &pData->Factory_VehicleType;
+			if (!pBuilding->Type->Naval)
+				currFactory = &pData->Factory_VehicleType;
+			else
+				currFactory = &pData->Factory_NavyType;
 			break;
 		case AbstractType::InfantryType:
 			currFactory = &pData->Factory_InfantryType;
@@ -129,17 +140,6 @@ DEFINE_HOOK(0x4502F4, BuildingClass_Update_Factory, 0x6)
 				return 0x4503CA;
 		}
 	}
-
-	return 0;
-}
-
-
-DEFINE_HOOK(0x44D455, BuildingClass_Mission_Missile_EMPPulseBulletWeapon, 0x8)
-{
-	GET(WeaponTypeClass*, pWeapon, EBP);
-	GET_STACK(BulletClass*, pBullet, STACK_OFFS(0xF0, 0xA4));
-
-	pBullet->SetWeaponType(pWeapon);
 
 	return 0;
 }

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -19,8 +19,19 @@ public:
 		std::map<BuildingTypeExt::ExtData*, int> BuildingCounter;
 		CounterClass OwnedLimboBuildingTypes;
 
+		BuildingClass* Factory_BuildingType;
+		BuildingClass* Factory_InfantryType;
+		BuildingClass* Factory_VehicleType;
+		BuildingClass* Factory_NavyType;
+		BuildingClass* Factory_AircraftType;
+
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, OwnedLimboBuildingTypes {}
+			, Factory_BuildingType(nullptr)
+			, Factory_InfantryType(nullptr)
+			, Factory_VehicleType(nullptr)
+			, Factory_NavyType(nullptr)
+			, Factory_AircraftType(nullptr)
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -6,6 +6,7 @@
 #include <Unsorted.h>
 #include <Drawing.h>
 
+#include "Utilities\Parser.h"
 #include <Utilities/GeneralUtils.h>
 #include <Utilities/Debug.h>
 #include <Utilities/Patch.h>
@@ -50,6 +51,7 @@ bool Phobos::Config::PrioritySelectionFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::AllowParallelAIQueues = true;
+bool Phobos::Config::ExtendParallelAIQueues[5] = { true, true, true, true, true };
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -232,6 +234,15 @@ DEFINE_HOOK(0x66E9DF, RulesClass_Process_Phobos, 0x8)
 	// Ares tags
 	Phobos::Config::DevelopmentCommands = rulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", Phobos::Config::DevelopmentCommands);
 	Phobos::Config::AllowParallelAIQueues = rulesINI->ReadBool("GlobalControls", "AllowParallelAIQueues", Phobos::Config::AllowParallelAIQueues);
+
+	if (rulesINI->ReadString("GlobalControls", "ExtendParallelAIQueues", "", Phobos::readBuffer))
+	{
+		bool temp[5] = {};
+		int read = Parser<bool, 5>::Parse(Phobos::readBuffer, temp);
+
+		for (int i = 0; i < read; ++i)
+			Phobos::Config::ExtendParallelAIQueues[i] = temp[i];
+	}
 
 	return 0;
 }

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -66,5 +66,6 @@ public:
 		static bool DevelopmentCommands;
 		static bool ArtImageSwap;
 		static bool AllowParallelAIQueues;
+		static bool ExtendParallelAIQueues[5];
 	};
 };


### PR DESCRIPTION
In the vanilla game, you could make the AI construct multiple factories by using cloned BuildingTypes whit TechLevel=-1 and AIBuildThis=yes.
Ares can alter the vanilla game behaviour so that this cloning issue no longer occurs when the AI owns more than one of any factory. But we still can't set it for some type of factory.

Now we can set it on specified types of factories do not occurs cloning issue and others will not be affected.

To prevent conflict with Ares, this only work when AllowParallelAIQueues=yes.

code example:
in rulesmd.ini
[GlobalControls]
ExtendParallelAIQueues=yes,yes,yes,yes,yes (list of boolean, corresponding to InfantryTypes, Vehicle without Naval, Vehicle with Naval, Aircraft, Building)