### PR TITLE
Enable and custom select box

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -82,6 +82,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->SelectBrd_PAL_Unit.Read(pINI, "AudioVisual", "SelectBrd.PAL.Unit");
 	this->SelectBrd_Frame_Unit.Read(exINI, "AudioVisual", "SelectBrd.Frame.Unit");
 	this->SelectBrd_DrawOffset_Unit.Read(exINI, "AudioVisual", "SelectBrd.DrawOffset.Unit");
+	this->SelectBrd_DefaultTranslucentLevel.Read(exINI, "AudioVisual", "SelectBrd.DefaultTranslucentLevel");
+	this->SelectBrd_DefaultShowEnemy.Read(exINI, "AudioVisual", "SelectBrd.DefaultShowEnemy");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount(sectionAITargetTypes);
@@ -186,6 +188,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->SelectBrd_PAL_Unit)
 		.Process(this->SelectBrd_Frame_Unit)
 		.Process(this->SelectBrd_DrawOffset_Unit)
+		.Process(this->SelectBrd_DefaultTranslucentLevel)
+		.Process(this->SelectBrd_DefaultShowEnemy)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -73,6 +73,16 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
 	this->JumpjetAllowLayerDeviation.Read(exINI, "JumpjetControls", "AllowLayerDeviation");
 
+	this->UseSelectBrd.Read(exINI, "AudioVisual", "UseSelectBrd");
+	this->SelectBrd_SHP_Infantry.Read(pINI, "AudioVisual", "SelectBrd.SHP.Infantry");
+	this->SelectBrd_PAL_Infantry.Read(pINI, "AudioVisual", "SelectBrd.PAL.Infantry");
+	this->SelectBrd_Frame_Infantry.Read(exINI, "AudioVisual", "SelectBrd.Frame.Infantry");
+	this->SelectBrd_DrawOffset_Infantry.Read(exINI, "AudioVisual", "SelectBrd.DrawOffset.Infantry");
+	this->SelectBrd_SHP_Unit.Read(pINI, "AudioVisual", "SelectBrd.SHP.Unit");
+	this->SelectBrd_PAL_Unit.Read(pINI, "AudioVisual", "SelectBrd.PAL.Unit");
+	this->SelectBrd_Frame_Unit.Read(exINI, "AudioVisual", "SelectBrd.Frame.Unit");
+	this->SelectBrd_DrawOffset_Unit.Read(exINI, "AudioVisual", "SelectBrd.DrawOffset.Unit");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount(sectionAITargetTypes);
 	for (int i = 0; i < itemsCount; ++i)
@@ -167,6 +177,15 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AITargetTypesLists)
 		.Process(this->AIScriptsLists)
 		.Process(this->Storage_TiberiumIndex)
+		.Process(this->UseSelectBrd)
+		.Process(this->SelectBrd_SHP_Infantry)
+		.Process(this->SelectBrd_PAL_Infantry)
+		.Process(this->SelectBrd_Frame_Infantry)
+		.Process(this->SelectBrd_DrawOffset_Infantry)
+		.Process(this->SelectBrd_SHP_Unit)
+		.Process(this->SelectBrd_PAL_Unit)
+		.Process(this->SelectBrd_Frame_Unit)
+		.Process(this->SelectBrd_DrawOffset_Unit)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -51,7 +51,7 @@ public:
 		Nullable<Vector3D<int>> SelectBrd_Frame_Unit;
 		Nullable<Vector2D<int>> SelectBrd_DrawOffset_Unit;
 		Nullable<int> SelectBrd_DefaultTranslucentLevel;
-		Nullable<int> SelectBrd_DefaultShowEnemy;
+		Valueable<bool> SelectBrd_DefaultShowEnemy;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Pips_Shield { { -1,-1,-1 } }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -70,7 +70,7 @@ public:
 			, SelectBrd_Frame_Infantry { {0,0,0} }
 			, SelectBrd_DrawOffset_Infantry { {0,0} }
 			, SelectBrd_SHP_Unit { "select.shp" }
-			, SelectBrd_PAL_Unit { "palette.shp" }
+			, SelectBrd_PAL_Unit { "palette.pal" }
 			, SelectBrd_Frame_Unit { {3,3,3} }
 			, SelectBrd_DrawOffset_Unit { {0,0} }
 		{ }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -36,6 +36,21 @@ public:
 		Valueable<bool> JumpjetAllowLayerDeviation;
 		Valueable<int> Storage_TiberiumIndex;
 
+		SHPStruct* SHP_SelectBrdSHP_INF;
+		ConvertClass* SHP_SelectBrdPAL_INF;
+		SHPStruct* SHP_SelectBrdSHP_UNIT;
+		ConvertClass* SHP_SelectBrdPAL_UNIT;
+
+		Valueable<bool> UseSelectBrd;
+		PhobosFixedString<32U> SelectBrd_SHP_Infantry;
+		PhobosFixedString<32U> SelectBrd_PAL_Infantry;
+		Nullable<Vector3D<int>> SelectBrd_Frame_Infantry;
+		Nullable<Vector2D<int>> SelectBrd_DrawOffset_Infantry;
+		PhobosFixedString<32U> SelectBrd_SHP_Unit;
+		PhobosFixedString<32U> SelectBrd_PAL_Unit;
+		Nullable<Vector3D<int>> SelectBrd_Frame_Unit;
+		Nullable<Vector2D<int>> SelectBrd_DrawOffset_Unit;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Pips_Shield { { -1,-1,-1 } }
 			, Pips_Shield_Buildings { { -1,-1,-1 } }
@@ -45,6 +60,19 @@ public:
 			, JumpjetNoWobbles { false }
 			, JumpjetAllowLayerDeviation { true }
 			, Storage_TiberiumIndex { -1 }
+			, SHP_SelectBrdSHP_INF { nullptr }
+			, SHP_SelectBrdPAL_INF { nullptr }
+			, SHP_SelectBrdSHP_UNIT { nullptr }
+			, SHP_SelectBrdPAL_UNIT { nullptr }
+			, UseSelectBrd { false }
+			, SelectBrd_SHP_Infantry { "select.shp" }
+			, SelectBrd_PAL_Infantry { "palette.pal" }
+			, SelectBrd_Frame_Infantry { {0,0,0} }
+			, SelectBrd_DrawOffset_Infantry { {0,0} }
+			, SelectBrd_SHP_Unit { "select.shp" }
+			, SelectBrd_PAL_Unit { "palette.shp" }
+			, SelectBrd_Frame_Unit { {3,3,3} }
+			, SelectBrd_DrawOffset_Unit { {0,0} }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -50,6 +50,8 @@ public:
 		PhobosFixedString<32U> SelectBrd_PAL_Unit;
 		Nullable<Vector3D<int>> SelectBrd_Frame_Unit;
 		Nullable<Vector2D<int>> SelectBrd_DrawOffset_Unit;
+		Nullable<int> SelectBrd_DefaultTranslucentLevel;
+		Nullable<int> SelectBrd_DefaultShowEnemy;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Pips_Shield { { -1,-1,-1 } }
@@ -73,6 +75,8 @@ public:
 			, SelectBrd_PAL_Unit { "palette.pal" }
 			, SelectBrd_Frame_Unit { {3,3,3} }
 			, SelectBrd_DrawOffset_Unit { {0,0} }
+			, SelectBrd_DefaultTranslucentLevel { 0 }
+			, SelectBrd_DefaultShowEnemy { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -561,32 +561,14 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 	int frame, XOffset, YOffset;
 
 	Vector3D<int> glbSelectbrdFrame = isInfantry ?
-		RulesExt::Global()->SelectBrd_Frame_Infantry :
-		RulesExt::Global()->SelectBrd_Frame_Unit;
+		RulesExt::Global()->SelectBrd_Frame_Infantry.Get() :
+		RulesExt::Global()->SelectBrd_Frame_Unit.Get();
 
 	Vector3D<int> selectbrdFrame = pTypeExt->SelectBrd_Frame.Get();
 
-	if (selectbrdFrame.X == NULL
-		|| selectbrdFrame.Y == NULL
-		|| selectbrdFrame.Z == NULL)
+	if (selectbrdFrame.X == -1)
 	{
-		if (glbSelectbrdFrame.X == NULL)
-		{
-			if (isInfantry)
-				selectbrdFrame = { 0,0,0 };
-			else
-				selectbrdFrame = { 3,3,3 };
-		}
-		else
-		{
-			if (glbSelectbrdFrame.Y == NULL
-				&& glbSelectbrdFrame.Z == NULL)
-			{
-				glbSelectbrdFrame.Y = glbSelectbrdFrame.X;
-				glbSelectbrdFrame.Z = glbSelectbrdFrame.X;
-			}
-			selectbrdFrame = glbSelectbrdFrame;
-		}
+		selectbrdFrame = glbSelectbrdFrame;
 	}
 
 	vOfs = pTypeExt->SelectBrd_DrawOffset.Get();
@@ -689,7 +671,7 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 			frame = selectbrdFrame.X;
 		else if (pThis->IsYellowHP())
 			frame = selectbrdFrame.Y;
-		else if (pThis->IsRedHP())
+		else
 			frame = selectbrdFrame.Z;
 		DSurface::Temp->DrawSHP(SelectBrdPAL, SelectBrdSHP,
 			frame, &vPos, pBound, BlitterFlags(0xE00), 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -558,17 +558,12 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 	Point2D vPos = { 0, 0 };
 	Point2D vLoc = *pLocation;
 	Point2D vOfs = { 0, 0};
-
 	int frame, XOffset, YOffset;
-
 	Vector3D<int> glbSelectbrdFrame = isInfantry ?
 		RulesExt::Global()->SelectBrd_Frame_Infantry.Get() :
 		RulesExt::Global()->SelectBrd_Frame_Unit.Get();
-
 	Vector3D<int> selectbrdFrame = pTypeExt->SelectBrd_Frame.Get();
-
 	auto const nFlag = BlitterFlags::Centered | BlitterFlags::Nonzero | BlitterFlags::MultiPass | EnumFunctions::GetTranslucentLevel(pTypeExt->SelectBrd_TranslucentLevel.Get(RulesExt::Global()->SelectBrd_DefaultTranslucentLevel.Get()));
-
 	auto const canSee = pThis->Owner->IsAlliedWith(HouseClass::Player)
 		|| HouseClass::IsPlayerObserver()
 		|| pTypeExt->SelectBrd_ShowEnemy.Get(RulesExt::Global()->SelectBrd_DefaultShowEnemy.Get());
@@ -579,18 +574,8 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 	}
 
 	vOfs = pTypeExt->SelectBrd_DrawOffset.Get();
-	if (vOfs.X == NULL || vOfs.Y == NULL)
-	{
-		if (isInfantry)
-			vOfs = RulesExt::Global()->SelectBrd_DrawOffset_Infantry.Get();
-		else
-			vOfs = RulesExt::Global()->SelectBrd_DrawOffset_Unit.Get();
-	}
-
 	XOffset = vOfs.X;
-
-	YOffset = pThis->GetTechnoType()->PixelSelectionBracketDelta;
-	YOffset += vOfs.Y;
+	YOffset = pThis->GetTechnoType()->PixelSelectionBracketDelta + vOfs.Y;
 	vLoc.Y -= 5;
 
 	if (iLength == 8)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -11,6 +11,7 @@
 
 #include <Ext/BulletType/Body.h>
 #include <Ext/WeaponType/Body.h>
+#include <Utilities/EnumFunctions.h>
 
 template<> const DWORD Extension<TechnoClass>::Canary = 0x55555555;
 TechnoExt::ExtContainer TechnoExt::ExtMap;
@@ -566,6 +567,12 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 
 	Vector3D<int> selectbrdFrame = pTypeExt->SelectBrd_Frame.Get();
 
+	auto const nFlag = BlitterFlags::Centered | BlitterFlags::Nonzero | BlitterFlags::MultiPass | EnumFunctions::GetTranslucentLevel(pTypeExt->SelectBrd_TranslucentLevel.Get(RulesExt::Global()->SelectBrd_DefaultTranslucentLevel.Get()));
+
+	auto const canSee = pThis->Owner->IsAlliedWith(HouseClass::Player)
+		|| HouseClass::IsPlayerObserver()
+		|| pTypeExt->SelectBrd_ShowEnemy.Get(RulesExt::Global()->SelectBrd_DefaultShowEnemy.Get());
+
 	if (selectbrdFrame.X == -1)
 	{
 		selectbrdFrame = glbSelectbrdFrame;
@@ -665,7 +672,7 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 	}
 	if (SelectBrdPAL == nullptr) return;
 
-	if (pThis->IsSelected)
+	if (pThis->IsSelected && canSee)
 	{
 		if (pThis->IsGreenHP())
 			frame = selectbrdFrame.X;
@@ -674,7 +681,7 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 		else
 			frame = selectbrdFrame.Z;
 		DSurface::Temp->DrawSHP(SelectBrdPAL, SelectBrdSHP,
-			frame, &vPos, pBound, BlitterFlags(0xE00), 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
+			frame, &vPos, pBound, nFlag, 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
 	}
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -558,12 +558,17 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 	Point2D vPos = { 0, 0 };
 	Point2D vLoc = *pLocation;
 	Point2D vOfs = { 0, 0};
+
 	int frame, XOffset, YOffset;
+
 	Vector3D<int> glbSelectbrdFrame = isInfantry ?
 		RulesExt::Global()->SelectBrd_Frame_Infantry.Get() :
 		RulesExt::Global()->SelectBrd_Frame_Unit.Get();
+
 	Vector3D<int> selectbrdFrame = pTypeExt->SelectBrd_Frame.Get();
+
 	auto const nFlag = BlitterFlags::Centered | BlitterFlags::Nonzero | BlitterFlags::MultiPass | EnumFunctions::GetTranslucentLevel(pTypeExt->SelectBrd_TranslucentLevel.Get(RulesExt::Global()->SelectBrd_DefaultTranslucentLevel.Get()));
+
 	auto const canSee = pThis->Owner->IsAlliedWith(HouseClass::Player)
 		|| HouseClass::IsPlayerObserver()
 		|| pTypeExt->SelectBrd_ShowEnemy.Get(RulesExt::Global()->SelectBrd_DefaultShowEnemy.Get());
@@ -574,8 +579,18 @@ void TechnoExt::DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeE
 	}
 
 	vOfs = pTypeExt->SelectBrd_DrawOffset.Get();
+	if (vOfs.X == NULL || vOfs.Y == NULL)
+	{
+		if (isInfantry)
+			vOfs = RulesExt::Global()->SelectBrd_DrawOffset_Infantry.Get();
+		else
+			vOfs = RulesExt::Global()->SelectBrd_DrawOffset_Unit.Get();
+	}
+
 	XOffset = vOfs.X;
-	YOffset = pThis->GetTechnoType()->PixelSelectionBracketDelta + vOfs.Y;
+
+	YOffset = pThis->GetTechnoType()->PixelSelectionBracketDelta;
+	YOffset += vOfs.Y;
 	vLoc.Y -= 5;
 
 	if (iLength == 8)

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -100,4 +100,5 @@ public:
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);
 	static bool CanFireNoAmmoWeapon(TechnoClass* pThis, int weaponIndex);
 	static void UpdateMindControlAnim(TechnoClass* pThis);
+	static void DrawSelectBrd(TechnoClass* pThis, TechnoTypeExt::ExtData* pTypeExt, int iLength, Point2D* pLocation, RectangleStruct* pBound, bool isInfantry);
 };

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -203,9 +203,7 @@ DEFINE_HOOK(0x6F683C, TechnoClass_DrawHealthBar_DrawOtherShieldBar, 0x7)
 	{
 		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
 
-		bool useSelectBrd = RulesExt::Global()->UseSelectBrd.Get();
-		if (useSelectBrd != pTypeExt->UseCustomSelectBrd.Get() && pTypeExt->UseCustomSelectBrd.Get() != NULL)
-			useSelectBrd = pTypeExt->UseCustomSelectBrd.Get();
+		const auto useSelectBrd = pTypeExt->UseCustomSelectBrd.Get(RulesExt::Global()->UseSelectBrd.Get());
 
 		if (useSelectBrd)
 		{

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -199,6 +199,27 @@ DEFINE_HOOK(0x6F683C, TechnoClass_DrawHealthBar_DrawOtherShieldBar, 0x7)
 		}
 	}
 
+	if (Phobos::Config::EnableSelectBrd)
+	{
+		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+		bool useSelectBrd = RulesExt::Global()->UseSelectBrd.Get();
+		if (useSelectBrd != pTypeExt->UseCustomSelectBrd.Get() && pTypeExt->UseCustomSelectBrd.Get() != NULL)
+			useSelectBrd = pTypeExt->UseCustomSelectBrd.Get();
+
+		if (useSelectBrd != pTypeExt->SelectBrd_Show)
+			useSelectBrd = pTypeExt->SelectBrd_Show;
+
+		if (useSelectBrd)
+		{
+			const int iLength = pThis->WhatAmI() == AbstractType::Infantry ? 8 : 17;
+			if (pThis->WhatAmI() == AbstractType::Infantry)
+				TechnoExt::DrawSelectBrd(pThis, pTypeExt, iLength, pLocation, pBound, true);
+			else
+				TechnoExt::DrawSelectBrd(pThis, pTypeExt, iLength, pLocation, pBound, false);
+		}
+	}
+
 	return 0;
 }
 

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -207,9 +207,6 @@ DEFINE_HOOK(0x6F683C, TechnoClass_DrawHealthBar_DrawOtherShieldBar, 0x7)
 		if (useSelectBrd != pTypeExt->UseCustomSelectBrd.Get() && pTypeExt->UseCustomSelectBrd.Get() != NULL)
 			useSelectBrd = pTypeExt->UseCustomSelectBrd.Get();
 
-		if (useSelectBrd != pTypeExt->SelectBrd_Show)
-			useSelectBrd = pTypeExt->SelectBrd_Show;
-
 		if (useSelectBrd)
 		{
 			const int iLength = pThis->WhatAmI() == AbstractType::Infantry ? 8 : 17;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -231,7 +231,6 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SelectBrd_PAL.Read(pINI, pSection, "SelectBrd.PAL");
 	this->SelectBrd_Frame.Read(exINI, pSection, "SelectBrd.Frame");
 	this->SelectBrd_DrawOffset.Read(exINI, pSection, "SelectBrd.DrawOffset");
-	this->SelectBrd_Show.Read(exINI, pSection, "SelectBrd.Show");
 }
 
 template <typename T>
@@ -313,7 +312,6 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SelectBrd_PAL)
 		.Process(this->SelectBrd_Frame)
 		.Process(this->SelectBrd_DrawOffset)
-		.Process(this->SelectBrd_Show)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -231,6 +231,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SelectBrd_PAL.Read(pINI, pSection, "SelectBrd.PAL");
 	this->SelectBrd_Frame.Read(exINI, pSection, "SelectBrd.Frame");
 	this->SelectBrd_DrawOffset.Read(exINI, pSection, "SelectBrd.DrawOffset");
+	this->SelectBrd_TranslucentLevel.Read(exINI, pSection, "SelectBrd.TranslucentLevel");
+	this->SelectBrd_ShowEnemy.Read(exINI, pSection, "SelectBrd.ShowEnemy");
 }
 
 template <typename T>
@@ -312,6 +314,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SelectBrd_PAL)
 		.Process(this->SelectBrd_Frame)
 		.Process(this->SelectBrd_DrawOffset)
+		.Process(this->SelectBrd_TranslucentLevel)
+		.Process(this->SelectBrd_ShowEnemy)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -225,6 +225,13 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ForceWeapon_Naval_Decloaked.Read(exINI, pSection, "ForceWeapon.Naval.Decloaked");
 	this->Ammo_Shared.Read(exINI, pSection, "Ammo.Shared");
 	this->Ammo_Shared_Group.Read(exINI, pSection, "Ammo.Shared.Group");
+
+	this->UseCustomSelectBrd.Read(exINI, pSection, "UseCustomSelectBrd");
+	this->SelectBrd_SHP.Read(pINI, pSection, "SelectBrd.SHP");
+	this->SelectBrd_PAL.Read(pINI, pSection, "SelectBrd.PAL");
+	this->SelectBrd_Frame.Read(exINI, pSection, "SelectBrd.Frame");
+	this->SelectBrd_DrawOffset.Read(exINI, pSection, "SelectBrd.DrawOffset");
+	this->SelectBrd_Show.Read(exINI, pSection, "SelectBrd.Show");
 }
 
 template <typename T>
@@ -301,6 +308,12 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ForceWeapon_Naval_Decloaked)
 		.Process(this->Ammo_Shared)
 		.Process(this->Ammo_Shared_Group)
+		.Process(this->UseCustomSelectBrd)
+		.Process(this->SelectBrd_SHP)
+		.Process(this->SelectBrd_PAL)
+		.Process(this->SelectBrd_Frame)
+		.Process(this->SelectBrd_DrawOffset)
+		.Process(this->SelectBrd_Show)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -127,6 +127,8 @@ public:
 		PhobosFixedString<32U> SelectBrd_PAL;
 		Nullable<Vector3D<int>> SelectBrd_Frame;
 		Nullable<Vector2D<int>> SelectBrd_DrawOffset;
+		Nullable<int> SelectBrd_TranslucentLevel;
+		Nullable<bool> SelectBrd_ShowEnemy;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -204,6 +206,8 @@ public:
 			, SelectBrd_PAL {}
 			, SelectBrd_Frame { {-1,-1,-1} }
 			, SelectBrd_DrawOffset {}
+			, SelectBrd_TranslucentLevel {}
+			, SelectBrd_ShowEnemy {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -127,7 +127,6 @@ public:
 		PhobosFixedString<32U> SelectBrd_PAL;
 		Nullable<Vector3D<int>> SelectBrd_Frame;
 		Nullable<Vector2D<int>> SelectBrd_DrawOffset;
-		Nullable<bool> SelectBrd_Show;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -202,10 +201,9 @@ public:
 			, SHP_SelectBrdPAL { nullptr }
 			, UseCustomSelectBrd {}
 			, SelectBrd_SHP {}
-			, SelectBrd_PAL { "palette.pal" }
+			, SelectBrd_PAL {}
 			, SelectBrd_Frame {}
 			, SelectBrd_DrawOffset {}
-			, SelectBrd_Show { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -202,7 +202,7 @@ public:
 			, UseCustomSelectBrd {}
 			, SelectBrd_SHP {}
 			, SelectBrd_PAL {}
-			, SelectBrd_Frame {}
+			, SelectBrd_Frame { {-1,-1} }
 			, SelectBrd_DrawOffset {}
 		{ }
 

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -119,6 +119,16 @@ public:
 		ValueableVector<LaserTrailDataEntry> LaserTrailData;
 		Valueable<CSFText> EnemyUIName;
 
+		SHPStruct* SHP_SelectBrdSHP;
+		ConvertClass* SHP_SelectBrdPAL;
+
+		Valueable<bool> UseCustomSelectBrd;
+		PhobosFixedString<32U> SelectBrd_SHP;
+		PhobosFixedString<32U> SelectBrd_PAL;
+		Nullable<Vector3D<int>> SelectBrd_Frame;
+		Nullable<Vector2D<int>> SelectBrd_DrawOffset;
+		Nullable<bool> SelectBrd_Show;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, UIDescription {}
@@ -188,6 +198,14 @@ public:
 			, ForceWeapon_Naval_Decloaked { -1 }
 			, Ammo_Shared { false }
 			, Ammo_Shared_Group { -1 }
+			, SHP_SelectBrdSHP { nullptr }
+			, SHP_SelectBrdPAL { nullptr }
+			, UseCustomSelectBrd {}
+			, SelectBrd_SHP {}
+			, SelectBrd_PAL { "palette.pal" }
+			, SelectBrd_Frame {}
+			, SelectBrd_DrawOffset {}
+			, SelectBrd_Show { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -202,7 +202,7 @@ public:
 			, UseCustomSelectBrd {}
 			, SelectBrd_SHP {}
 			, SelectBrd_PAL {}
-			, SelectBrd_Frame { {-1,-1} }
+			, SelectBrd_Frame { {-1,-1,-1} }
 			, SelectBrd_DrawOffset {}
 		{ }
 

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -122,7 +122,7 @@ public:
 		SHPStruct* SHP_SelectBrdSHP;
 		ConvertClass* SHP_SelectBrdPAL;
 
-		Valueable<bool> UseCustomSelectBrd;
+		Nullable<bool> UseCustomSelectBrd;
 		PhobosFixedString<32U> SelectBrd_SHP;
 		PhobosFixedString<32U> SelectBrd_PAL;
 		Nullable<Vector3D<int>> SelectBrd_Frame;

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -50,6 +50,7 @@ bool Phobos::Config::PrioritySelectionFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::AllowParallelAIQueues = true;
+bool Phobos::Config::EnableSelectBrd = false;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -162,6 +163,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 {
 	Phobos::Config::ToolTipDescriptions = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ToolTipDescriptions", true);
 	Phobos::Config::PrioritySelectionFiltering = CCINIClass::INI_RA2MD->ReadBool("Phobos", "PrioritySelectionFiltering", true);
+	Phobos::Config::EnableSelectBrd = CCINIClass::INI_RA2MD->ReadBool("Phobos", "EnableSelectBrd", false);
 
 	CCINIClass* pINI_UIMD = Phobos::OpenConfig("uimd.ini");
 

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -66,5 +66,6 @@ public:
 		static bool DevelopmentCommands;
 		static bool ArtImageSwap;
 		static bool AllowParallelAIQueues;
+		static bool EnableSelectBrd;
 	};
 };

--- a/src/Utilities/EnumFunctions.cpp
+++ b/src/Utilities/EnumFunctions.cpp
@@ -86,3 +86,20 @@ bool EnumFunctions::AreCellAndObjectsEligible(CellClass* const pCell, AffectedTa
 
 	return eligible;
 }
+
+BlitterFlags EnumFunctions::GetTranslucentLevel(int nInt)
+{
+	auto const nFlag_ = Math::clamp(nInt, 0, 3);
+
+	switch (nFlag_)
+	{
+	case 1:
+		return BlitterFlags::TransLucent25;
+	case 2:
+		return BlitterFlags::TransLucent50;
+	case 3:
+		return BlitterFlags::TransLucent75;
+	}
+
+	return BlitterFlags::None;
+}

--- a/src/Utilities/EnumFunctions.h
+++ b/src/Utilities/EnumFunctions.h
@@ -12,4 +12,5 @@ public:
 	static bool IsCellEligible(CellClass* const pCell, AffectedTarget allowed, bool explicitEmptyCells = false);
 	static bool IsTechnoEligible(TechnoClass* const pTechno, AffectedTarget allowed);
 	static bool AreCellAndObjectsEligible(CellClass* const pCell, AffectedTarget allowed, AffectedHouse allowedHouses, HouseClass* owner, bool explicitEmptyCells = false);
+	static BlitterFlags GetTranslucentLevel(int nInt);
 };


### PR DESCRIPTION
Now you can use and custom a select box for infantry, vehicle and aircraft. Not support on buildings.

in rulesmd.ini
[AudioVisual]
UseSelectBrd=no   (boolean)
SelectBrd.SHP.Infantry=select.shp   (filename, *including*the .shp extension)
SelectBrd.PAL.Infantry=palette.pal   (filename, *including*the .pal extension)
SelectBrd.Frame.Infantry=0,0,0   (frame, green hp, yellow hp, red hp)
SelectBrd.DrawOffset.Infantry=0,0   (X, Y, positive value is right and down)
SelectBrd.SHP.Unit=select.shp   (filename, *including*the .shp extension)
SelectBrd.PAL.Unit=palette.pal   (filename, *including*the .pal extension)
SelectBrd.Frame.Unit=3,3,3   (frame, green hp, yellow hp, red hp)
SelectBrd.DrawOffset.Unit=0,0   (X, Y, positive value is right and down)
SelectBrd.DefaultTranslucentLevel=0
SelectBrd.DefaultShowEnemy=true

Remember not for buildings!!!
[SOMETECHNO]
UseCustomSelectBrd=   (boolean, override the UseSelectBrd)
SelectBrd.SHP=   (filename, *including*the .shp extension)
SelectBrd.PAL=   (filename, *including*the .pal extension)
SelectBrd.Frame=   (frame, green hp, yellow hp, red hp)
SelectBrd.DrawOffset=   (X, Y, positive value is right and down)
SelectBrd.TranslucentLevel=
SelectBrd.ShowEnemy=

You can also set it in ra2md.ini
[Phobos]
EnableSelectBrd=false   (boolean)