### PR TITLE
Fix the jumpjet facing bug: Jumpjet helicopters can turn itself when firing

### DIFF
--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -100,4 +100,5 @@ public:
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);
 	static bool CanFireNoAmmoWeapon(TechnoClass* pThis, int weaponIndex);
 	static void UpdateMindControlAnim(TechnoClass* pThis);
+	static void JumpjetVehicleFacingFix(TechnoClass* pThis);
 };

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -20,6 +20,7 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	TechnoExt::CheckDeathConditions(pThis);
 	TechnoExt::EatPassengers(pThis);
 	TechnoExt::UpdateMindControlAnim(pThis);
+	TechnoExt::JumpjetVehicleFacingFix(pThis);
 
 	// LaserTrails update routine is in TechnoClass::AI hook because TechnoClass::Draw
 	// doesn't run when the object is off-screen which leads to visual bugs - Kerbiter

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -225,6 +225,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ForceWeapon_Naval_Decloaked.Read(exINI, pSection, "ForceWeapon.Naval.Decloaked");
 	this->Ammo_Shared.Read(exINI, pSection, "Ammo.Shared");
 	this->Ammo_Shared_Group.Read(exINI, pSection, "Ammo.Shared.Group");
+	this->JumpjetFacing.Read(exINI, pSection, "JumpjetFacing");
 }
 
 template <typename T>
@@ -301,6 +302,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ForceWeapon_Naval_Decloaked)
 		.Process(this->Ammo_Shared)
 		.Process(this->Ammo_Shared_Group)
+		.Process(this->JumpjetFacing)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -102,6 +102,7 @@ public:
 		Valueable<bool> Ammo_Shared;
 		Valueable<int> Ammo_Shared_Group;
 
+		Valueable<bool> JumpjetFacing;
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -188,6 +189,7 @@ public:
 			, ForceWeapon_Naval_Decloaked { -1 }
 			, Ammo_Shared { false }
 			, Ammo_Shared_Group { -1 }
+			, JumpjetFacing{false}
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
In vanilla, a jumpjet helicopter cannot turn itself when choosing a target within its range with different direction. 
This PR aims to solve this problem

In rulesmd.ini
```ini
[VehicleType]
JumpJet=yes           ; Necessary
Turret=no               ; Necessary
JumpjetFacing=no  ; Decide whether to face the target when firing.
```
If I did it correctly, the weapon would be able to not set `OmniFire=yes`.
