### PR TITLE
Veterancy modifier warhead

### DIFF
--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -83,6 +83,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AnimList_PickRandom.Read(exINI, pSection, "AnimList.PickRandom");
 	this->DecloakDamagedTargets.Read(exINI, pSection, "DecloakDamagedTargets");
 	this->ShakeIsLocal.Read(exINI, pSection, "ShakeIsLocal");
+	this->VeterancyModifier.Read(exINI, pSection, "VeterancyModifier");
 
 	// Crits
 	this->Crit_Chance.Read(exINI, pSection, "Crit.Chance");
@@ -145,6 +146,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AnimList_PickRandom)
 		.Process(this->DecloakDamagedTargets)
 		.Process(this->ShakeIsLocal)
+		.Process(this->VeterancyModifier)
 
 		.Process(this->Crit_Chance)
 		.Process(this->Crit_ApplyChancePerTarget)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -25,6 +25,7 @@ public:
 		Valueable<bool> AnimList_PickRandom;
 		Valueable<bool> DecloakDamagedTargets;
 		Valueable<bool> ShakeIsLocal;
+		Nullable<double> VeterancyModifier;
 
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
@@ -90,6 +91,7 @@ public:
 			, AnimList_PickRandom { false }
 			, DecloakDamagedTargets { true }
 			, ShakeIsLocal { false }
+			, VeterancyModifier{ }
 
 			, Crit_Chance { 0.0 }
 			, Crit_ApplyChancePerTarget { false }
@@ -144,6 +146,7 @@ public:
 		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner);
 		void ApplyShieldModifiers(TechnoClass* pTarget);
+		void ApplyVeterancyModifier(TechnoClass* pTarget);
 
 	public:
 		void Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletClass* pBullet, CoordStruct coords);

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -50,7 +50,8 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 		this->Shield_Respawn_Duration > 0 ||
 		this->Shield_SelfHealing_Duration > 0 ||
 		this->Shield_AttachTypes.size() > 0 ||
-		this->Shield_RemoveTypes.size() > 0;
+		this->Shield_RemoveTypes.size() > 0 ||
+		this->VeterancyModifier.isset();
 
 	const float cellSpread = this->OwnerObject()->CellSpread;
 	if (cellSpread && isCellSpreadWarhead)
@@ -83,6 +84,16 @@ void WarheadTypeExt::ExtData::DetonateOnOneUnit(HouseClass* pHouse, TechnoClass*
 
 	if (this->Crit_Chance)
 		this->ApplyCrit(pHouse, pTarget, pOwner);
+
+	if (this->VeterancyModifier.isset())
+		this->ApplyVeterancyModifier(pTarget);
+}
+
+void WarheadTypeExt::ExtData::ApplyVeterancyModifier(TechnoClass* pTarget)
+{
+	pTarget->Veterancy.Add(
+		Math::clamp(this->VeterancyModifier.Get(0),0.-pTarget->Veterancy.Veterancy,2.0)
+	);
 }
 
 void WarheadTypeExt::ExtData::ApplyShieldModifiers(TechnoClass* pTarget)


### PR DESCRIPTION
I don't know if you have this already or not, or if this would be useful

`VeterancyModifier` can modify the veterancy of the victim. For example, `100%` to promote a rookie to a veteran, `200%` to promote a rookie to an elite, `-123%` to degrade an elite to an (almost veteran) rookie. 

in rulesmd.ini
```ini
[WarheadType]
VeterancyModifier=    ; float or percentage (positive or negative)
```
