### PR TITLE
Toggle for automatic passenger owner change to match transport

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -144,6 +144,7 @@ This page lists all the individual contributions to the project by their author.
   - Building-provided self-heal customization
   - AI deploy script DeploysInto fix
   - Passable & buildable-upon TerrainTypes
+  - Automatic passenger owner change toggle
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Shield.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Grinding.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Transport.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />
     <ClCompile Include="src\Ext\VoxelAnimType\Body.cpp" />

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -428,13 +428,13 @@ PassengerDeletion.Anim=                 ; animation
 
 - Transports with `Passengers.SyncOwner` set to true will have the owner of their passengers changed to match the transport if transport's owner changes.
   - On `OpenTopped=true` transports this will also disable checks that prevent target acquisition by passengers when the transport is temporarily mind controlled.
-  - `Passengers.SyncOwner.RevertOnExit`, if set to true, changes the passengers' owner back to whatever it was originally when they entered the transport when they are ejected.
+  - `Passengers.SyncOwner.RevertOnExit`, if set to true (which is the default), changes the passengers' owner back to whatever it was originally when they entered the transport when they are ejected.
 
 In `rulesmd.ini`:
 ```ini
 [SOMETECHNO]                             ; TechnoType
 Passengers.SyncOwner=false               ; boolean
-Passengers.SyncOwner.RevertOnExit=false  ; boolean
+Passengers.SyncOwner.RevertOnExit=true   ; boolean
 ```
 
 ### Automatically firing weapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -408,7 +408,7 @@ LimboKill.IDs=                  ; List of numeric IDs.
 
 ## Technos
 
-### Automatic Passenger Deletion
+### Automatic passenger deletion
 
 - Transports with these tags will erase the passengers overtime. Bigger units takes more time. Optionally this logic can work like a grinder.
  - Good combination with Ares Abductor logic.
@@ -422,6 +422,19 @@ PassengerDeletion.Soylent=no            ; boolean
 PassengerDeletion.SoylentFriendlies=no  ; boolean
 PassengerDeletion.ReportSound=          ; sound
 PassengerDeletion.Anim=                 ; animation
+```
+
+### Automatic passenger owner change to match transport owner
+
+- Transports with `Passengers.SyncOwner` set to true will have the owner of their passengers changed to match the transport if transport's owner changes.
+  - On `OpenTopped=true` transports this will also disable checks that prevent target acquisition by passengers when the transport is temporarily mind controlled.
+  - `Passengers.SyncOwner.RevertOnExit`, if set to true, changes the passengers' owner back to whatever it was originally when they entered the transport when they are ejected.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                             ; TechnoType
+Passengers.SyncOwner=false               ; boolean
+Passengers.SyncOwner.RevertOnExit=false  ; boolean
 ```
 
 ### Automatically firing weapons

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -303,6 +303,7 @@ New:
 - Building-provided self-healing customization (by Starkku)
 - Building placement preview (by Otamaa)
 - Passable & buildable-upon TerrainTypes (by Starkku)
+- Toggle for passengers to automatically change owner if transport owner changes (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -825,6 +825,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->LastWarpDistance)
 		.Process(this->Death_Countdown)
 		.Process(this->MindControlRingAnimType)
+		.Process(this->OriginalPassengerOwner)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -31,6 +31,9 @@ public:
 		int Death_Countdown;
 		AnimTypeClass* MindControlRingAnimType;
 		int DamageNumberOffset;
+
+		// Used for Passengers.SyncOwner.RevertOnExit instead of TechnoClass::InitialOwner / OriginallyOwnedByHouse,
+		// as neither is guaranteed to point to the house the TechnoClass had prior to entering transport and cannot be safely overridden.
 		HouseClass* OriginalPassengerOwner;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -31,6 +31,7 @@ public:
 		int Death_Countdown;
 		AnimTypeClass* MindControlRingAnimType;
 		int DamageNumberOffset;
+		HouseClass* OriginalPassengerOwner;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, InterceptedBullet { nullptr }
@@ -45,6 +46,7 @@ public:
 			, Death_Countdown(-1)
 			, MindControlRingAnimType { nullptr }
 			, DamageNumberOffset { INT32_MIN }
+			, OriginalPassengerOwner {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Transport.cpp
+++ b/src/Ext/Techno/Hooks.Transport.cpp
@@ -1,0 +1,140 @@
+#include "Body.h"
+
+
+DEFINE_HOOK_AGAIN(0x6FA33C, TechnoClass_ThreatEvals_OpenToppedOwner, 0x6) // TechnoClass::AI
+DEFINE_HOOK_AGAIN(0x6F89F4, TechnoClass_ThreatEvals_OpenToppedOwner, 0x6) // TechnoClass::EvaluateCell
+DEFINE_HOOK_AGAIN(0x6F7EC2, TechnoClass_ThreatEvals_OpenToppedOwner, 0x6) // TechnoClass::EvaluateObject
+DEFINE_HOOK(0x6F8FD7, TechnoClass_ThreatEvals_OpenToppedOwner, 0x5)       // TechnoClass::Greatest_Threat
+{
+	enum { SkipCheckOne = 0x6F8FDC, SkipCheckTwo = 0x6F7EDA, SkipCheckThree = 0x6F8A0F, SkipCheckFour = 0x6FA37A };
+
+	TechnoClass* pThis = nullptr;
+	auto returnAddress = SkipCheckOne;
+
+	switch (R->Origin())
+	{
+	case 0x6F8FD7:
+		pThis = R->ESI<TechnoClass*>();
+		break;
+	case 0x6F7EC2:
+		pThis = R->EDI<TechnoClass*>();
+		returnAddress = SkipCheckTwo;
+		break;
+	case 0x6F89F4:
+		pThis = R->ESI<TechnoClass*>();
+		returnAddress = SkipCheckThree;
+	case 0x6FA33C:
+		pThis = R->ESI<TechnoClass*>();
+		returnAddress = SkipCheckFour;
+	default:
+		return 0;
+	}
+
+	auto pTransport = pThis->Transporter;
+
+	if (pTransport)
+	{
+		if (auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pTransport->GetTechnoType()))
+		{
+			if (pTypeExt->Passengers_SyncOwner)
+				return returnAddress;
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x701881, TechnoClass_ChangeHouse_Passenger_SyncOwner, 0x5)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	if (auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
+	{
+		if (pTypeExt->Passengers_SyncOwner && pThis->Passengers.NumPassengers > 0)
+		{
+			FootClass* pPassenger = pThis->Passengers.GetFirstPassenger();
+
+			if (pPassenger)
+				pPassenger->SetOwningHouse(pThis->Owner, false);
+
+			while (pPassenger->NextObject)
+			{
+				pPassenger = static_cast<FootClass*>(pPassenger->NextObject);
+
+				if (pPassenger)
+					pPassenger->SetOwningHouse(pThis->Owner, false);
+			}
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x71067B, TechnoClass_EnterTransport_SyncOwner, 0x7)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET(FootClass*, pPassenger, EDI);
+
+	if (pThis && pPassenger)
+	{
+		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+		auto const pExt = TechnoExt::ExtMap.Find(pPassenger);
+
+		if (pTypeExt->Passengers_SyncOwner && pTypeExt->Passengers_SyncOwner_RevertOnExit)
+			pExt->OriginalPassengerOwner = pPassenger->Owner;
+	}
+
+	return 0;
+}
+
+
+DEFINE_HOOK(0x4DE67B, FootClass_LeaveTransport_SyncOwner, 0x8)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET(FootClass*, pPassenger, EBX);
+
+	if (pThis && pPassenger)
+	{
+		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+		auto const pExt = TechnoExt::ExtMap.Find(pPassenger);
+
+		if (pTypeExt->Passengers_SyncOwner && pTypeExt->Passengers_SyncOwner_RevertOnExit &&
+			pExt->OriginalPassengerOwner)
+		{
+			pPassenger->SetOwningHouse(pExt->OriginalPassengerOwner, false);
+		}
+	}
+
+	return 0;
+}
+
+// Has to be done here, before Ares survivor hook to take effect.
+DEFINE_HOOK(0x737F80, TechnoClass_ReceiveDamage_Cargo_SyncOwner, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	if (pThis && pThis->Passengers.NumPassengers > 0)
+	{
+		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+		if (pTypeExt->Passengers_SyncOwner && pTypeExt->Passengers_SyncOwner_RevertOnExit)
+		{
+			auto pPassenger = pThis->Passengers.GetFirstPassenger();
+			auto pExt = TechnoExt::ExtMap.Find(pPassenger);
+
+			if (pExt->OriginalPassengerOwner)
+				pPassenger->SetOwningHouse(pExt->OriginalPassengerOwner, false);
+
+			while (pPassenger->NextObject)
+			{
+				pPassenger = static_cast<FootClass*>(pPassenger->NextObject);
+				pExt = TechnoExt::ExtMap.Find(pPassenger);
+
+				if (pExt->OriginalPassengerOwner)
+					pPassenger->SetOwningHouse(pExt->OriginalPassengerOwner, false);
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -150,7 +150,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DeployingAnim_ReverseForUndeploy.Read(exINI, pSection, "DeployingAnim.ReverseForUndeploy");
 	this->DeployingAnim_UseUnitDrawer.Read(exINI, pSection, "DeployingAnim.UseUnitDrawer");
 
+	this->Ammo_Shared.Read(exINI, pSection, "Ammo.Shared");
+	this->Ammo_Shared_Group.Read(exINI, pSection, "Ammo.Shared.Group");
 	this->SelfHealGainType.Read(exINI, pSection, "SelfHealGainType");
+	this->Passengers_SyncOwner.Read(exINI, pSection, "Passengers.SyncOwner");
+	this->Passengers_SyncOwner_RevertOnExit.Read(exINI, pSection, "Passengers.SyncOwner.RevertOnExit");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -222,12 +226,6 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 			EliteWeaponBurstFLHs[i].AddItem(eliteFLH.Get());
 		}
 	}
-
-	this->EnemyUIName.Read(exINI, pSection, "EnemyUIName");
-
-	this->ForceWeapon_Naval_Decloaked.Read(exINI, pSection, "ForceWeapon.Naval.Decloaked");
-	this->Ammo_Shared.Read(exINI, pSection, "Ammo.Shared");
-	this->Ammo_Shared_Group.Read(exINI, pSection, "Ammo.Shared.Group");
 }
 
 template <typename T>
@@ -307,6 +305,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Ammo_Shared)
 		.Process(this->Ammo_Shared_Group)
 		.Process(this->SelfHealGainType)
+		.Process(this->Passengers_SyncOwner)
+		.Process(this->Passengers_SyncOwner_RevertOnExit)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -198,7 +198,7 @@ public:
 			, Ammo_Shared_Group { -1 }
 			, SelfHealGainType()
 			, Passengers_SyncOwner { false }
-			, Passengers_SyncOwner_RevertOnExit { false }
+			, Passengers_SyncOwner_RevertOnExit { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -105,6 +105,8 @@ public:
 		Nullable<bool> JumpjetTurnToTarget;
 
 		Nullable<SelfHealGainType> SelfHealGainType;
+		Valueable<bool> Passengers_SyncOwner;
+		Valueable<bool> Passengers_SyncOwner_RevertOnExit;
 
 		struct LaserTrailDataEntry
 		{
@@ -195,6 +197,8 @@ public:
 			, Ammo_Shared { false }
 			, Ammo_Shared_Group { -1 }
 			, SelfHealGainType()
+			, Passengers_SyncOwner { false }
+			, Passengers_SyncOwner_RevertOnExit { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Automatic passenger owner change to match transport owner

- Transports with `Passengers.SyncOwner` set to true will have the owner of their passengers changed to match the transport if transport's owner changes.
  - On `OpenTopped=true` transports this will also disable checks that prevent target acquisition by passengers when the transport is temporarily mind controlled.
  - `Passengers.SyncOwner.RevertOnExit`, if set to true, changes the passengers' owner back to whatever it was originally when they entered the transport when they are ejected.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                             ; TechnoType
Passengers.SyncOwner=false               ; boolean
Passengers.SyncOwner.RevertOnExit=false  ; boolean
```