### PR TITLE
Jumpjet facing bugfix: Jumpjet units face towards target when firing from different directions

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -151,6 +151,7 @@ This page lists all the individual contributions to the project by their author.
    - Interceptor logic prototype
    - LaserTrails prototype
    - Laser fixes prototype
+- **Trsdy** - Jumpjet facing fix
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **E1 Elite** - TileSet 255 and above bridge repair fix
 - **AutoGavy** - interceptor logic, Warhead critical hit logic

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -20,6 +20,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - Some settings are still ignored like `PreImpactAnim` *(Ares feature)*, this might change in future.
 - Fixed the bug when occupied building's `MuzzleFlashX` is drawn on the center of the building when `X` goes past 10.
 - Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead.
+- Fixed jumpjet units cannot turn its facing to the target when firing from a different direction.
 - Fixed interaction of `UnitAbsorb` & `InfantryAbsorb` with `Grinding` buildings. The keys will now make the building only accept appropriate types of objects.
 - Fixed missing 'no enter' cursor for VehicleTypes being unable to enter a `Grinding` building.
 - Fixed Engineers being able to enter `Grinding` buildings even when they shouldn't (such as ally building at full HP).
@@ -212,6 +213,23 @@ AllowLayerDeviation=yes         ; boolean
 [SOMETECHNO]                    ; TechnoType
 JumpjetAllowLayerDeviation=yes  ; boolean
 ```
+
+### Jumpjet facing target customization 
+
+- Allows jumpjet units to face towards the target when firing from different directions. Set `[JumpjetControls] -> FacingTarget=yes` to enable it for all jumpjet locomotor units. This behavior can be overriden by setting `[UnitType] -> JumpjetFacingTarget` for specific units.
+- This behavior does not apply to `TurretSpins=yes` units for obvious reasons.
+
+In `rulesmd.ini`:
+```ini
+[JumpjetControls]
+FacingTarget=no        ; boolean
+
+[UnitType]
+JumpjetFacingTarget=   ; boolean, override the tag in JumpjetControls
+Locomotor=Jumpjet      ; Jumpjet only
+TurretSpins=no         ; It's meaningless to use that for disks obviously
+```
+
 
 ### Kill spawns on low power
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -216,18 +216,16 @@ JumpjetAllowLayerDeviation=yes  ; boolean
 
 ### Jumpjet facing target customization 
 
-- Allows jumpjet units to face towards the target when firing from different directions. Set `[JumpjetControls] -> FacingTarget=yes` to enable it for all jumpjet locomotor units. This behavior can be overriden by setting `[UnitType] -> JumpjetFacingTarget` for specific units.
+- Allows jumpjet units to face towards the target when firing from different directions. Set `[JumpjetControls] -> TurnToTarget=yes` to enable it for all jumpjet locomotor units. This behavior can be overriden by setting `[UnitType] -> JumpjetTurnToTarget` for specific units.
 - This behavior does not apply to `TurretSpins=yes` units for obvious reasons.
 
 In `rulesmd.ini`:
 ```ini
 [JumpjetControls]
-FacingTarget=no        ; boolean
+TurnToTarget=no        ; boolean
 
-[UnitType]
-JumpjetFacingTarget=   ; boolean, override the tag in JumpjetControls
-Locomotor=Jumpjet      ; Jumpjet only
-TurretSpins=no         ; It's meaningless to use that for disks obviously
+[SOMEUNITTYPE]         ; UnitType with jumpjet locomotor
+JumpjetTurnToTarget=   ; boolean, override the tag in JumpjetControls
 ```
 
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -72,7 +72,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
 	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
 	this->JumpjetAllowLayerDeviation.Read(exINI, "JumpjetControls", "AllowLayerDeviation");
-	this->JumpjetFacingTarget.Read(exINI, "JumpjetControls", "FacingTarget");
+	this->JumpjetTurnToTarget.Read(exINI, "JumpjetControls", "TurnToTarget");
 	this->PlacementGrid_TranslucentLevel.Read(exINI, "AudioVisual", "BuildingPlacementGrid.TranslucentLevel");
 	this->BuildingPlacementPreview_TranslucentLevel.Read(exINI, "AudioVisual", "BuildingPlacementPreview.DefaultTranslucentLevel");
 
@@ -167,7 +167,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->JumpjetAllowLayerDeviation)
-		.Process(this->JumpjetFacingTarget)
+		.Process(this->JumpjetTurnToTarget)
 		.Process(this->AITargetTypesLists)
 		.Process(this->AIScriptsLists)
 		.Process(this->Storage_TiberiumIndex)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -72,6 +72,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Pips_Shield_Buildings.Read(exINI, "AudioVisual", "Pips.Shield.Building");
 	this->MissingCameo.Read(pINI, "AudioVisual", "MissingCameo");
 	this->JumpjetAllowLayerDeviation.Read(exINI, "JumpjetControls", "AllowLayerDeviation");
+	this->JumpjetFacingTarget.Read(exINI, "JumpjetControls", "FacingTarget");
 	this->PlacementGrid_TranslucentLevel.Read(exINI, "AudioVisual", "BuildingPlacementGrid.TranslucentLevel");
 	this->BuildingPlacementPreview_TranslucentLevel.Read(exINI, "AudioVisual", "BuildingPlacementPreview.DefaultTranslucentLevel");
 
@@ -166,6 +167,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->JumpjetAllowLayerDeviation)
+		.Process(this->JumpjetFacingTarget)
 		.Process(this->AITargetTypesLists)
 		.Process(this->AIScriptsLists)
 		.Process(this->Storage_TiberiumIndex)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -34,7 +34,7 @@ public:
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;
 		Valueable<bool> JumpjetAllowLayerDeviation;
-		Valueable<bool> JumpjetFacingTarget;
+		Valueable<bool> JumpjetTurnToTarget;
 		Valueable<int> Storage_TiberiumIndex;
 		Valueable<int> PlacementGrid_TranslucentLevel;
 		Valueable<int> BuildingPlacementPreview_TranslucentLevel;
@@ -50,7 +50,7 @@ public:
 			, Storage_TiberiumIndex { -1 }
 			, PlacementGrid_TranslucentLevel{ 0 }
 			, BuildingPlacementPreview_TranslucentLevel { 3 }
-			, JumpjetFacingTarget { false }
+			, JumpjetTurnToTarget { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -34,6 +34,7 @@ public:
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;
 		Valueable<bool> JumpjetAllowLayerDeviation;
+		Valueable<bool> JumpjetFacingTarget;
 		Valueable<int> Storage_TiberiumIndex;
 		Valueable<int> PlacementGrid_TranslucentLevel;
 		Valueable<int> BuildingPlacementPreview_TranslucentLevel;
@@ -49,6 +50,7 @@ public:
 			, Storage_TiberiumIndex { -1 }
 			, PlacementGrid_TranslucentLevel{ 0 }
 			, BuildingPlacementPreview_TranslucentLevel { 3 }
+			, JumpjetFacingTarget { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -572,22 +572,20 @@ void TechnoExt::UpdateMindControlAnim(TechnoClass* pThis)
 	}
 }
 
-static bool __fastcall CheckIfCanFireAt(TechnoClass* pTechno, AbstractClass* pTarget)
+bool TechnoExt::CheckIfCanFireAt(TechnoClass* pThis, AbstractClass* pTarget)
 {
-	const int wpnIdx = pTechno->SelectWeapon(pTarget);
-	const FireError fErr = pTechno->GetFireError(pTarget, wpnIdx, true);
-	if (fErr != FireError::ILLEGAL
+	const int wpnIdx = pThis->SelectWeapon(pTarget);
+	const FireError fErr = pThis->GetFireError(pTarget, wpnIdx, true);
+	if (   fErr != FireError::ILLEGAL
 		&& fErr != FireError::CANT
 		&& fErr != FireError::MOVING
 		&& fErr != FireError::RANGE)
-	{
-		return pTechno->IsCloseEnough(pTarget, wpnIdx);
-	}
+		return pThis->IsCloseEnough(pTarget, wpnIdx);
 	else
 		return false;
 }
 
-void TechnoExt::JumpjetUnitFacingFix(TechnoClass* pThis)
+void TechnoExt::ForceJumpjetTurnToTarget(TechnoClass* pThis)
 {
 	const auto pType = pThis->GetTechnoType();
 	if (pType->Locomotor == LocomotionClass::CLSIDs::Jumpjet && pThis->IsInAir()
@@ -595,17 +593,19 @@ void TechnoExt::JumpjetUnitFacingFix(TechnoClass* pThis)
 	{
 		const auto pFoot = abstract_cast<UnitClass*>(pThis);
 		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-		if (pTypeExt && pTypeExt->JumpjetFacingTarget.Get(RulesExt::Global()->JumpjetFacingTarget)
+
+		if (pTypeExt && pTypeExt->JumpjetTurnToTarget.Get(RulesExt::Global()->JumpjetTurnToTarget)
 			&& pFoot && pFoot->GetCurrentSpeed() == 0)
 		{
 			if (const auto pTarget = pThis->Target)
 			{
 				const auto pLoco = static_cast<JumpjetLocomotionClass*>(pFoot->Locomotor.get());
-				if (pLoco && !pLoco->LocomotionFacing.in_motion() && CheckIfCanFireAt(pThis, pTarget))
+				if (pLoco && !pLoco->LocomotionFacing.in_motion() && TechnoExt::CheckIfCanFireAt(pThis, pTarget))
 				{
 					const CoordStruct source = pThis->Location;
 					const CoordStruct target = pTarget->GetCoords();
 					const DirStruct tgtDir = DirStruct(Math::arctanfoo(source.Y - target.Y, target.X - source.X));
+					
 					if (pThis->GetRealFacing().value32() != tgtDir.value32())
 						pLoco->LocomotionFacing.turn(tgtDir);
 				}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -580,7 +580,9 @@ bool TechnoExt::CheckIfCanFireAt(TechnoClass* pThis, AbstractClass* pTarget)
 		&& fErr != FireError::CANT
 		&& fErr != FireError::MOVING
 		&& fErr != FireError::RANGE)
+	{
 		return pThis->IsCloseEnough(pTarget, wpnIdx);
+	}
 	else
 		return false;
 }

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -8,6 +8,7 @@
 #include <SpawnManagerClass.h>
 #include <InfantryClass.h>
 #include <Unsorted.h>
+#include <JumpjetLocomotionClass.h>
 
 #include <Ext/BulletType/Body.h>
 #include <Ext/WeaponType/Body.h>
@@ -567,6 +568,48 @@ void TechnoExt::UpdateMindControlAnim(TechnoClass* pThis)
 		else if (pExt->MindControlRingAnimType)
 		{
 			pExt->MindControlRingAnimType = nullptr;
+		}
+	}
+}
+
+static bool __fastcall CheckIfCanFireAt(TechnoClass* pTechno, AbstractClass* pTarget)
+{
+	const int wpnIdx = pTechno->SelectWeapon(pTarget);
+	const FireError fErr = pTechno->GetFireError(pTarget, wpnIdx, true);
+	if (fErr != FireError::ILLEGAL
+		&& fErr != FireError::CANT
+		&& fErr != FireError::MOVING
+		&& fErr != FireError::RANGE)
+	{
+		return pTechno->IsCloseEnough(pTarget, wpnIdx);
+	}
+	else
+		return false;
+}
+
+void TechnoExt::JumpjetUnitFacingFix(TechnoClass* pThis)
+{
+	const auto pType = pThis->GetTechnoType();
+	if (pType->Locomotor == LocomotionClass::CLSIDs::Jumpjet && pThis->IsInAir()
+		&& pThis->WhatAmI() == AbstractType::Unit && !pType->TurretSpins)
+	{
+		const auto pFoot = abstract_cast<UnitClass*>(pThis);
+		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+		if (pTypeExt && pTypeExt->JumpjetFacingTarget.Get(RulesExt::Global()->JumpjetFacingTarget)
+			&& pFoot && pFoot->GetCurrentSpeed() == 0)
+		{
+			if (const auto pTarget = pThis->Target)
+			{
+				const auto pLoco = static_cast<JumpjetLocomotionClass*>(pFoot->Locomotor.get());
+				if (pLoco && !pLoco->LocomotionFacing.in_motion() && CheckIfCanFireAt(pThis, pTarget))
+				{
+					const CoordStruct source = pThis->Location;
+					const CoordStruct target = pTarget->GetCoords();
+					const DirStruct tgtDir = DirStruct(Math::arctanfoo(source.Y - target.Y, target.X - source.X));
+					if (pThis->GetRealFacing().value32() != tgtDir.value32())
+						pLoco->LocomotionFacing.turn(tgtDir);
+				}
+			}
 		}
 	}
 }

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -100,4 +100,5 @@ public:
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);
 	static bool CanFireNoAmmoWeapon(TechnoClass* pThis, int weaponIndex);
 	static void UpdateMindControlAnim(TechnoClass* pThis);
+	static void JumpjetUnitFacingFix(TechnoClass* pThis);
 };

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -100,5 +100,6 @@ public:
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);
 	static bool CanFireNoAmmoWeapon(TechnoClass* pThis, int weaponIndex);
 	static void UpdateMindControlAnim(TechnoClass* pThis);
-	static void JumpjetUnitFacingFix(TechnoClass* pThis);
+	static bool CheckIfCanFireAt(TechnoClass* pThis, AbstractClass* pTarget);
+	static void ForceJumpjetTurnToTarget(TechnoClass* pThis);
 };

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -20,6 +20,7 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	TechnoExt::CheckDeathConditions(pThis);
 	TechnoExt::EatPassengers(pThis);
 	TechnoExt::UpdateMindControlAnim(pThis);
+	TechnoExt::JumpjetUnitFacingFix(pThis);
 
 	// LaserTrails update routine is in TechnoClass::AI hook because TechnoClass::Draw
 	// doesn't run when the object is off-screen which leads to visual bugs - Kerbiter

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -20,7 +20,7 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	TechnoExt::CheckDeathConditions(pThis);
 	TechnoExt::EatPassengers(pThis);
 	TechnoExt::UpdateMindControlAnim(pThis);
-	TechnoExt::JumpjetUnitFacingFix(pThis);
+	TechnoExt::ForceJumpjetTurnToTarget(pThis);//TODO: move to locomotor processing
 
 	// LaserTrails update routine is in TechnoClass::AI hook because TechnoClass::Draw
 	// doesn't run when the object is off-screen which leads to visual bugs - Kerbiter

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -144,7 +144,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->NoSecondaryWeaponFallback.Read(exINI, pSection, "NoSecondaryWeaponFallback");
 
 	this->JumpjetAllowLayerDeviation.Read(exINI, pSection, "JumpjetAllowLayerDeviation");
-	this->JumpjetFacingTarget.Read(exINI, pSection, "JumpjetFacingTarget");
+	this->JumpjetTurnToTarget.Read(exINI, pSection, "JumpjetTurnToTarget");
 	this->DeployingAnim_AllowAnyDirection.Read(exINI, pSection, "DeployingAnim.AllowAnyDirection");
 	this->DeployingAnim_KeepUnitVisible.Read(exINI, pSection, "DeployingAnim.KeepUnitVisible");
 	this->DeployingAnim_ReverseForUndeploy.Read(exINI, pSection, "DeployingAnim.ReverseForUndeploy");
@@ -295,7 +295,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->NoAmmoWeapon)
 		.Process(this->NoAmmoAmount)
 		.Process(this->JumpjetAllowLayerDeviation)
-		.Process(this->JumpjetFacingTarget)
+		.Process(this->JumpjetTurnToTarget)
 		.Process(this->DeployingAnim_AllowAnyDirection)
 		.Process(this->DeployingAnim_KeepUnitVisible)
 		.Process(this->DeployingAnim_ReverseForUndeploy)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -144,7 +144,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->NoSecondaryWeaponFallback.Read(exINI, pSection, "NoSecondaryWeaponFallback");
 
 	this->JumpjetAllowLayerDeviation.Read(exINI, pSection, "JumpjetAllowLayerDeviation");
-
+	this->JumpjetFacingTarget.Read(exINI, pSection, "JumpjetFacingTarget");
 	this->DeployingAnim_AllowAnyDirection.Read(exINI, pSection, "DeployingAnim.AllowAnyDirection");
 	this->DeployingAnim_KeepUnitVisible.Read(exINI, pSection, "DeployingAnim.KeepUnitVisible");
 	this->DeployingAnim_ReverseForUndeploy.Read(exINI, pSection, "DeployingAnim.ReverseForUndeploy");
@@ -295,6 +295,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->NoAmmoWeapon)
 		.Process(this->NoAmmoAmount)
 		.Process(this->JumpjetAllowLayerDeviation)
+		.Process(this->JumpjetFacingTarget)
 		.Process(this->DeployingAnim_AllowAnyDirection)
 		.Process(this->DeployingAnim_KeepUnitVisible)
 		.Process(this->DeployingAnim_ReverseForUndeploy)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -102,7 +102,7 @@ public:
 
 		Valueable<bool> Ammo_Shared;
 		Valueable<int> Ammo_Shared_Group;
-		Nullable<bool> JumpjetFacingTarget;
+		Nullable<bool> JumpjetTurnToTarget;
 
 		struct LaserTrailDataEntry
 		{
@@ -180,7 +180,7 @@ public:
 			, NoAmmoWeapon { -1 }
 			, NoAmmoAmount { 0 }
 			, JumpjetAllowLayerDeviation {}
-			, JumpjetFacingTarget {}
+			, JumpjetTurnToTarget {}
 			, DeployingAnim_AllowAnyDirection { false }
 			, DeployingAnim_KeepUnitVisible { false }
 			, DeployingAnim_ReverseForUndeploy { true }

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -102,6 +102,7 @@ public:
 
 		Valueable<bool> Ammo_Shared;
 		Valueable<int> Ammo_Shared_Group;
+		Nullable<bool> JumpjetFacingTarget;
 
 		struct LaserTrailDataEntry
 		{
@@ -179,6 +180,7 @@ public:
 			, NoAmmoWeapon { -1 }
 			, NoAmmoAmount { 0 }
 			, JumpjetAllowLayerDeviation {}
+			, JumpjetFacingTarget {}
 			, DeployingAnim_AllowAnyDirection { false }
 			, DeployingAnim_KeepUnitVisible { false }
 			, DeployingAnim_ReverseForUndeploy { true }


### PR DESCRIPTION
### Jumpjet facing target customization 

- Allows jumpjet units to face towards the target when firing from different directions. Set `[JumpjetControls] -> FacingTarget=yes` to enable it for all jumpjet locomotor units. This behavior can be overriden by setting `[UnitType] -> JumpjetFacingTarget` for specific units.
- This behavior does not apply to `TurretSpins=yes` units for obvious reasons.

In `rulesmd.ini`:
```ini
[JumpjetControls]
FacingTarget=no        ; boolean

[UnitType]
JumpjetFacingTarget=   ; boolean, override the tag in JumpjetControls
Locomotor=Jumpjet      ; Jumpjet only
TurretSpins=no         ; It's meaningless to use that for disks obviously
```