### PR TITLE
Launch superweapons using warhead

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -157,7 +157,9 @@ This page lists all the individual contributions to the project by their author.
    - Interceptor logic prototype
    - LaserTrails prototype
    - Laser fixes prototype
-- **Trsdy** - Jumpjet facing fix
+- **Trsdy**
+   - Jumpjet facing fix
+   - Warhead superweapon launch logic
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **E1 Elite** - TileSet 255 and above bridge repair fix
 - **AutoGavy** - interceptor logic, Warhead critical hit logic

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -743,6 +743,24 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]            ; Warhead
 NotHuman.DeathSequence=  ; integer (1 to 5)
 ```
+### Launch superweapons on impact
+
+- Superweapons can now be launched when a warhead is detonated.
+  - `LaunchSW` specifies the superweapons to launch when the warhead is detonated.
+  - `LaunchSW.RealLaunch` controls whether the owner who fired the warhead must own all listed superweapons and sufficient fund to support `Money.Amout`. Otherwise they will be launched out of nowhere.
+  - `LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors` of the superweapon, otherwise only non-inhibited superweapons are launched.
+
+```{note}
+Animation weapons from _Ares_ are **not** supported. Nevertheless, animation warheads may work in certain circumstances. Also, due to the nature of some superweapon types, not all superweapons are suitable for launch.
+```
+
+In `rulesmd.ini`:
+```ini
+[SOMEWARHEAD]                 ; Warhead
+LaunchSW=                     ; list of superweapons
+LaunchSW.RealLaunch=no        ; bool
+LaunchSW.IgnoreInhibitors=no  ; bool
+```
 
 ## Weapons
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -304,6 +304,7 @@ New:
 - Building placement preview (by Otamaa)
 - Passable & buildable-upon TerrainTypes (by Starkku)
 - Toggle for passengers to automatically change owner if transport owner changes (by Starkku)
+- Superweapon launch on warhead detonation (by Trsdy)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -2732,30 +2732,29 @@ msgid ""
 "Launch superweapons on impact"
 msgstr "发射超武"
 
-#: ../New-or-Enhanced-Logics.md:565
+#: ../New-or-Enhanced-Logics.md:1199
 msgid ""
-"Superweapons can be launched when a standard warhead is detonated."
+"Superweapons can now be launched when a warhead is detonated."
 msgstr "超武在对应常规弹头所引爆的格子上发射"
 
-#: ../New-or-Enhanced-Logics.md:566
+#: ../New-or-Enhanced-Logics.md:1200
 msgid ""
 "`LaunchSW` specifies the superweapons to launch when the warhead is detonated."
 msgstr "`LaunchSW` 指定所要发射的超武"
 
-#: ../New-or-Enhanced-Logics.md:567
+#: ../New-or-Enhanced-Logics.md:1201
 msgid ""
-"`LaunchSW.RealLaunch` controls whether the owner who fired "
-"the warhead must own all listed superweapons and sufficient fund to "
-"support `Money.Amout`. Otherwise they will be launched out of nowhere."
+"`LaunchSW.RealLaunch` controls whether the owner who fired the warhead must own all listed superweapons "
+"and sufficient fund to support `Money.Amout`. Otherwise they will be launched out of nowhere."
 msgstr "`LaunchSW.RealLaunch` 真实发射指仅使用弹头所属方目前拥有的超武。否则超武将无条件发射到指定格子，即无视是否拥有，是否够钱，是否充能"
 
-#: ../New-or-Enhanced-Logics.md:568
+#: ../New-or-Enhanced-Logics.md:1202
 msgid ""
 "`LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors` of the superweapon,"
 " otherwise only non-inhibited superweapons are launched. "
 msgstr "`LaunchSW.IgnoreInhibitors` 是否忽略`SW.Inhibitors`"
 
-#: ../New-or-Enhanced-Logics.md:569
+#: ../New-or-Enhanced-Logics.md:1203
 msgid ""
 "Animation weapons from Ares are _not_ supported yet."
 "Nevertheless, animation warheads may work under certain circumstances."

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -2727,6 +2727,41 @@ msgid ""
 "sequences from `Die1` to `Die5`."
 msgstr "弹头可以触发指定的`NotHuman=yes`的步兵的死亡动画序列，值代表`Die1`到`Die5`。"
 
+#: ../New-or-Enhanced-Logics.md:1198
+msgid ""
+"Launch superweapons on impact"
+msgstr "发射超武"
+
+#: ../New-or-Enhanced-Logics.md:565
+msgid ""
+"Superweapons can be launched when a standard warhead is detonated."
+msgstr "超武在对应常规弹头所引爆的格子上发射"
+
+#: ../New-or-Enhanced-Logics.md:566
+msgid ""
+"`LaunchSW` specifies the superweapons to launch when the warhead is detonated."
+msgstr "`LaunchSW` 指定所要发射的超武"
+
+#: ../New-or-Enhanced-Logics.md:567
+msgid ""
+"`LaunchSW.RealLaunch` controls whether the owner who fired "
+"the warhead must own all listed superweapons and sufficient fund to "
+"support `Money.Amout`. Otherwise they will be launched out of nowhere."
+msgstr "`LaunchSW.RealLaunch` 真实发射指仅使用弹头所属方目前拥有的超武。否则超武将无条件发射到指定格子，即无视是否拥有，是否够钱，是否充能"
+
+#: ../New-or-Enhanced-Logics.md:568
+msgid ""
+"`LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors` of the superweapon,"
+" otherwise only non-inhibited superweapons are launched. "
+msgstr "`LaunchSW.IgnoreInhibitors` 是否忽略`SW.Inhibitors`"
+
+#: ../New-or-Enhanced-Logics.md:569
+msgid ""
+"Animation weapons from Ares are _not_ supported yet."
+"Nevertheless, animation warheads may work under certain circumstances."
+" Also, due to the nature of some superweapon types, not all superweapons are suitable for launch."
+"目前Ares中的动画武器无法生效，动画弹头不全生效。自行探索，谨慎使用，后果自负。"
+
 #: ../New-or-Enhanced-Logics.md:1205
 msgid "Weapons"
 msgstr "武器"

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -13,6 +13,8 @@ template <typename T>
 void SWTypeExt::ExtData::Serialize(T& Stm) {
 	Stm
 		.Process(this->Money_Amount)
+		.Process(this->SW_Inhibitors)
+		.Process(this->SW_AnyInhibitor)
 		.Process(this->UIDescription)
 		.Process(this->CameoPriority)
 		.Process(this->LimboDelivery_Types)
@@ -34,7 +36,12 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	}
 
 	INI_EX exINI(pINI);
+
+	// from ares
 	this->Money_Amount.Read(exINI, pSection, "Money.Amount");
+	this->SW_Inhibitors.Read(exINI, pSection, "SW.Inhibitors");
+	this->SW_AnyInhibitor.Read(exINI, pSection, "SW.AnyInhibitor");
+
 	this->UIDescription.Read(exINI, pSection, "UIDescription");
 	this->CameoPriority.Read(exINI, pSection, "CameoPriority");
 	this->LimboDelivery_Types.Read(exINI, pSection, "LimboDelivery.Types");
@@ -60,6 +67,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 
 	this->LimboKill_Affected.Read(exINI, pSection, "LimboKill.Affected");
 	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");
+	
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -14,7 +14,11 @@ public:
 	{
 	public:
 
+		//Ares 0.A
 		Valueable<int> Money_Amount;
+		ValueableVector<TechnoTypeClass*> SW_Inhibitors;
+		Valueable<bool> SW_AnyInhibitor;
+
 		Valueable<CSFText> UIDescription;
 		Valueable<int> CameoPriority;
 		ValueableVector<TechnoTypeClass*> LimboDelivery_Types;
@@ -24,10 +28,13 @@ public:
 		ValueableVector<int> LimboKill_IDs;
 		Valueable<double> RandomBuffer;
 
+
 		ValueableVector<ValueableVector<int>> LimboDelivery_RandomWeightsData;
 
 		ExtData(SuperWeaponTypeClass* OwnerObject) : Extension<SuperWeaponTypeClass>(OwnerObject)
 			, Money_Amount { 0 }
+			, SW_Inhibitors {}
+			, SW_AnyInhibitor { false }
 			, UIDescription {}
 			, CameoPriority { 0 }
 			, LimboDelivery_Types {}
@@ -68,4 +75,8 @@ public:
 	static ExtContainer ExtMap;
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
+
+	static bool IsInhibitor(SWTypeExt::ExtData* pSWType, HouseClass* pOwner, TechnoClass* pTechno);
+	static bool HasInhibitor(SWTypeExt::ExtData* pSWType, HouseClass* pOwner, const CellStruct& Coords);
+	static bool IsInhibitorEligible(SWTypeExt::ExtData* pSWType, HouseClass* pOwner, const CellStruct& Coords, TechnoClass* pTechno);
 };

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1537,7 +1537,7 @@ bool ScriptExt::EvaluateObjectWithMask(TechnoClass *pTechno, int mask, int attac
 		if (!pTechno->Owner->IsNeutral()
 			&& ((pTypeTechnoExt
 				&& (pTypeTechnoExt->RadarJamRadius > 0
-					|| pTypeTechnoExt->InhibitorRange > 0))
+					|| pTypeTechnoExt->InhibitorRange.isset()))
 				|| (pTypeBuilding && (pTypeBuilding->GapGenerator
 					|| pTypeBuilding->CloakGenerator))))
 		{
@@ -1748,7 +1748,7 @@ bool ScriptExt::EvaluateObjectWithMask(TechnoClass *pTechno, int mask, int attac
 
 		if (!pTechno->Owner->IsNeutral()
 			&& (pTypeTechnoExt 
-				&& pTypeTechnoExt->InhibitorRange > 0))
+				&& pTypeTechnoExt->InhibitorRange.isset()))
 		{
 			return true;
 		}

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -23,7 +23,7 @@ public:
 		Valueable<bool> LowSelectionPriority;
 		PhobosFixedString<0x20> GroupAs;
 		Valueable<int> RadarJamRadius;
-		Valueable<int> InhibitorRange;
+		Nullable<int> InhibitorRange;
 		Valueable<Leptons> MindControlRangeLimit;
 		Valueable<bool> Interceptor;
 		Valueable<Leptons> Interceptor_GuardRange;
@@ -131,7 +131,7 @@ public:
 			, LowSelectionPriority { false }
 			, GroupAs { NONE_STR }
 			, RadarJamRadius { 0 }
-			, InhibitorRange { 0 }
+			, InhibitorRange { }
 			, MindControlRangeLimit {}
 			, Interceptor { false }
 			, Interceptor_GuardRange {}

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -127,8 +127,10 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Shield_MinimumReplaceDelay.Read(exINI, pSection, "Shield.MinimumReplaceDelay");
 	this->Shield_AffectTypes.Read(exINI, pSection, "Shield.AffectTypes");
 
-	this->NotHuman_DeathSequence.Read(exINI, pSection, "NotHuman.DeathSequence");
-
+	this->NotHuman_DeathSequence.Read(exINI, pSection, "NotHuman.DeathSequence"); 
+	this->LaunchSW.Read(exINI, pSection, "LaunchSW");
+	this->LaunchSW_RealLaunch.Read(exINI, pSection, "LaunchSW.RealLaunch");
+	this->LaunchSW_IgnoreInhibitors.Read(exINI, pSection, "LaunchSW.IgnoreInhibitors");
 	// Ares tags
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 	this->AffectsEnemies.Read(exINI, pSection, "AffectsEnemies");
@@ -191,7 +193,9 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Shield_AffectTypes)
 
 		.Process(this->NotHuman_DeathSequence)
-
+		.Process(this->LaunchSW)
+		.Process(this->LaunchSW_RealLaunch)
+		.Process(this->LaunchSW_IgnoreInhibitors)
 		// Ares tags
 		.Process(this->AffectsEnemies)
 		.Process(this->AffectsOwner)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <WarheadTypeClass.h>
-
+#include <SuperWeaponTypeClass.h>
 #include <Helpers/Macro.h>
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
@@ -73,6 +73,10 @@ public:
 		Valueable<int> Shield_MinimumReplaceDelay;
 		ValueableVector<ShieldTypeClass*> Shield_AffectTypes;
 
+		ValueableVector<SuperWeaponTypeClass*> LaunchSW;
+		Valueable<bool> LaunchSW_RealLaunch;
+		Valueable<bool> LaunchSW_IgnoreInhibitors;
+
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 		Valueable<bool> AffectsEnemies;
@@ -143,6 +147,9 @@ public:
 
 			, AffectsEnemies { true }
 			, AffectsOwner {}
+			, LaunchSW {}
+			, LaunchSW_RealLaunch { true }
+			, LaunchSW_IgnoreInhibitors { false }
 		{ }
 
 	private:

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -7,10 +7,12 @@
 #include <AnimTypeClass.h>
 #include <AnimClass.h>
 #include <BitFont.h>
+#include <SuperClass.h>
 
 #include <Utilities/Helpers.Alex.h>
 #include <Ext/Techno/Body.h>
 #include <Ext/TechnoType/Body.h>
+#include <Ext/SWType/Body.h>
 #include <Misc/FlyingStrings.h>
 #include <Utilities/EnumFunctions.h>
 
@@ -57,6 +59,24 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 				pixelOffset.X -= (width / 2);
 
 				FlyingStrings::Add(moneyStr, displayCoord, color, pixelOffset);
+			}
+		}
+
+		for (const auto pSWType : this->LaunchSW)
+		{
+			if (const auto pSuper = pHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pSWType)))
+			{
+				const auto pSWExt = SWTypeExt::ExtMap.Find(pSWType);
+				const auto cell = CellClass::Coord2Cell(coords);
+				if ((pSWExt && pSuper->IsCharged && pHouse->CanTransactMoney(pSWExt->Money_Amount)) || !this->LaunchSW_RealLaunch)
+				{
+					if (this->LaunchSW_IgnoreInhibitors || !SWTypeExt::HasInhibitor(pSWExt, pHouse, cell))
+					{
+						pSuper->SetReadiness(true);
+						pSuper->Launch(cell, true);
+						pSuper->Reset();
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Reopened the PR for nightly builds for testers

### Launch superweapons on impact

- Superweapons can be launched when a standard warhead is detonated. This means that animation weapons from _Ares_ are **not** supported.(even when working together with Starkku's animation damage re-implementation) Nevertheless, animation warheads may works in certain circumstances. Due to the nature of some superweapon types, not all superweapons are suitable for launch. The user should not abuse this feature.
  - `LaunchSW` specifies the superweapons to launch when the warhead is detonated.
  - `LaunchSW.RealLaunch` controls whether the owner who fired the warhead must own all listed superweapons and sufficient fund to support `Money.Amout`. Otherwise they will be launched out of nowhere.
  - `LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors` of the superweapon, otherwise only non-inhibited superweapons are launched.

In `rulesmd.ini`:
```ini
[SOMEWARHEAD]                 ; Warhead
LaunchSW=                     ; list of superweapons
LaunchSW.RealLaunch=no        ; bool
LaunchSW.IgnoreInhibitors=no  ; bool