### PR TITLE
Reimplemented animation damage / weapon /w improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -150,6 +150,7 @@ This page lists all the individual contributions to the project by their author.
   - OpenTopped transport rangefinding & deactivated state customizations
   - Animation damage / weapon improvements
   - Warhead self-damaging toggle
+  - Trailer animation owner inheritance
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -149,6 +149,7 @@ This page lists all the individual contributions to the project by their author.
   - Automatic passenger owner change toggle
   - Interceptor improvements
   - OpenTopped transport rangefinding & deactivated state customizations
+  - Animation damage / weapon improvements
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -134,7 +134,6 @@ This page lists all the individual contributions to the project by their author.
   - Aircraft & jumpjet speed modifiers fix
   - Local warhead screen shaking
   - Vehicle custom palette fix
-  - Weapon owner detachment
   - Feedback weapon
   - TerrainType & ore minimap color customization
   - Laser fixes & improvements
@@ -150,6 +149,7 @@ This page lists all the individual contributions to the project by their author.
   - Interceptor improvements
   - OpenTopped transport rangefinding & deactivated state customizations
   - Animation damage / weapon improvements
+  - Warhead self-damaging toggle
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -387,6 +387,17 @@ DeployingAnim.UseUnitDrawer=true       ; boolean
 
 ## Warheads
 
+### Allowing damage dealt to firer
+
+- You can now allow warhead to deal damage (and apply damage-adjacent effects such as `KillDriver` and `DisableWeapons/Sonar/Flash.Duration` *(Ares features)*) on the object that is considered as the firer of the Warhead even if it does not have `DamageSelf=true`.
+  - Note that effect of `Psychedelic=true`, despite being tied to damage will still fail to apply on the firer as it does not affect any objects belonging to same house as the firer, including itself.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWARHEAD]            ; WarheadType
+AllowDamageOnSelf=false  ; boolean
+```
+
 ### Customizing decloak on damaging targets
 
 - You can now specify whether or not the warhead decloaks objects that are damaged by the warhead.
@@ -419,18 +430,6 @@ In `rulesmd.ini`:
 [SOMEWEAPON]          ; WeaponType
 DiskLaser.Radius=38.2 ; floating point value
                       ; 38.2 is roughly the default saucer disk radius
-```
-
-### Detaching weapon from owner TechnoType
-
-- You can now control if weapon is detached from the TechnoType that fired it. This results in the weapon / warhead being able to damage the TechnoType itself even if it does not have `DamageSelf=true` set, but also treats it as if owned by no house or object, meaning any ownership-based checks like `AffectsAllies` do not function as expected and no experience is awarded.
-  - The effect of this is inherited through `AirburstWeapon` and `ShrapnelWeapon`.
-  - This does not affect projectile image or functionality or `FirersPalette` on initially fired weapon, but `FirersPalette` will not function for any weapons inheriting the effect.
-
-In `rulesmd.ini`:
-```ini
-[SOMEWEAPONTYPE]         ; WeaponType
-DetachedFromOwner=false  ; boolean
 ```
 
 ### Single-color lasers

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -66,6 +66,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allow use of `Foundation=0x0` on TerrainTypes without crashing for similar results as for buildings.
 - Projectiles now remember the house of the firer even if the firer is destroyed before the projectile detonates. Does not currently apply to some Ares-introduced Warhead effects like EMP.
 - `OpenTopped` transports now take `OpenTransportWeapon` setting of passengers into consideration when determining weapon range used for threat scanning and approaching targets.
+- Trailer animations now inherit the owner of the object they are attached to.
 
 ## Animations
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -74,18 +74,20 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 
 - `Weapon` can be set to a WeaponType, to create a projectile and immediately detonate it instead of simply dealing `Damage` by `Warhead`. This allows weapon effects to be applied.
 - `Damage.Delay` determines delay between two applications of `Damage`. Requires `Damage` to be set to 1.0 or above. Value of 0 disables the delay. Keep in mind that this is measured in animation frames, not game frames. Depending on `Rate`, animation may or may not advance animation frames on every game frame.
-- `Damage.DealtByOwner`, if set to true, makes any `Damage` dealt to be considered as coming from the animation's owner. Owner in this case is the firer of the weapon if it is Warhead `AnimList/SplashList` animation, the destroyed vehicle if it is `DestroyAnim` animation or the object the animation is attached to. Does not affect which house the `Damage` dealt by `Warhead` is dealt by.
+- `Damage.DealtByInvoker`, if set to true, makes any `Damage` dealt to be considered as coming from the animation's invoker (f.ex, firer of the weapon if it is Warhead `AnimList/SplashList` animation, the destroyed vehicle if it is `DestroyAnim` animation or the object the animation is attached to). Does not affect which house the `Damage` dealt by `Warhead` is dealt by.
 - `Damage.ApplyOnce`, if set to true, makes `Damage` be dealt only once per animation loop instead of on every frame or intervals defined by `Damage.Delay`. The frame on which it is dealt is determined by `Damage.Delay`, defaulting to after the first animation frame.
-
-*`Weapon` and `Damage.Delay`, beyond the other additions, should function similarly to the equivalent features introduced by Ares and take precedence over them if Phobos is used together with Ares.*
 
 In `artmd.ini`:
 ```ini
-[SOMEANIM]                 ; AnimationType
-Weapon=                    ; WeaponType
-Damage.Delay=0             ; integer, animation frames
-Damage.DealtByOwner=false  ; boolean
-Damage.ApplyOnce=false     ; boolean
+[SOMEANIM]                   ; AnimationType
+Weapon=                      ; WeaponType
+Damage.Delay=0               ; integer, animation frames
+Damage.DealtByInvoker=false  ; boolean
+Damage.ApplyOnce=false       ; boolean
+```
+
+```{note}
+`Weapon` and `Damage.Delay`, beyond the other additions, should function similarly to the equivalent features introduced by Ares and take precedence over them if Phobos is used together with Ares.
 ```
 
 ### Attached animation position customization

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -74,6 +74,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `Weapon` can be set to a WeaponType, to create a projectile and immediately detonate it instead of simply dealing `Damage` by `Warhead`. This allows weapon effects to be applied.
 - `Damage.Delay` determines delay between two applications of `Damage`. Requires `Damage` to be set to 1.0 or above. Value of 0 disables the delay. Keep in mind that this is measured in animation frames, not game frames. Depending on `Rate`, animation may or may not advance animation frames on every game frame.
 - `Damage.DealtByOwner`, if set to true, makes any `Damage` dealt to be considered as coming from the animation's owner. Owner in this case is the firer of the weapon if it is Warhead `AnimList/SplashList` animation, the destroyed vehicle if it is `DestroyAnim` animation or the object the animation is attached to. Does not affect which house the `Damage` dealt by `Warhead` is dealt by.
+- `Damage.ApplyOnce`, if set to true, makes `Damage` be dealt only once per animation loop instead of on every frame or intervals defined by `Damage.Delay`. The frame on which it is dealt is determined by `Damage.Delay`, defaulting to after the first animation frame.
 
 *`Weapon` and `Damage.Delay`, beyond the other additions, should function similarly to the equivalent features introduced by Ares and take precedence over them if Phobos is used together with Ares.*
 
@@ -83,6 +84,7 @@ In `artmd.ini`:
 Weapon=                    ; WeaponType
 Damage.Delay=0             ; integer, animation frames
 Damage.DealtByOwner=false  ; boolean
+Damage.ApplyOnce=false     ; boolean
 ```
 
 ### Attached animation position customization

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -69,6 +69,22 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 
 ## Animations
 
+### Animation weapon and damage settings
+
+- `Weapon` can be set to a WeaponType, to create a projectile and immediately detonate it instead of simply dealing `Damage` by `Warhead`. This allows weapon effects to be applied.
+- `Damage.Delay` determines delay between two applications of `Damage`. Requires `Damage` to be set to 1.0 or above. Value of 0 disables the delay. Keep in mind that this is measured in animation frames, not game frames. Depending on `Rate`, animation may or may not advance animation frames on every game frame.
+- `Damage.DealtByOwner`, if set to true, makes any `Damage` dealt to be considered as coming from the animation's owner. Owner in this case is the firer of the weapon if it is Warhead `AnimList/SplashList` animation, the destroyed vehicle if it is `DestroyAnim` animation or the object the animation is attached to. Does not affect which house the `Damage` dealt by `Warhead` is dealt by.
+
+*`Weapon` and `Damage.Delay`, beyond the other additions, should function similarly to the equivalent features introduced by Ares and take precedence over them if Phobos is used together with Ares.*
+
+In `artmd.ini`:
+```ini
+[SOMEANIM]                 ; AnimationType
+Weapon=                    ; WeaponType
+Damage.Delay=0             ; integer, animation frames
+Damage.DealtByOwner=false  ; boolean
+```
+
 ### Attached animation position customization
 
 - You can now customize whether or not animations attached to objects are centered at the object's actual center rather than the bottom of their top-leftmost cell (cell #0).

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -66,7 +66,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allow use of `Foundation=0x0` on TerrainTypes without crashing for similar results as for buildings.
 - Projectiles now remember the house of the firer even if the firer is destroyed before the projectile detonates. Does not currently apply to some Ares-introduced Warhead effects like EMP.
 - `OpenTopped` transports now take `OpenTransportWeapon` setting of passengers into consideration when determining weapon range used for threat scanning and approaching targets.
-- Trailer animations now inherit the owner of the object they are attached to.
+- Trailer animations now inherit the owner of the object (animation, projectile or aircraft) they are attached to.
 
 ## Animations
 
@@ -75,15 +75,15 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `Weapon` can be set to a WeaponType, to create a projectile and immediately detonate it instead of simply dealing `Damage` by `Warhead`. This allows weapon effects to be applied.
 - `Damage.Delay` determines delay between two applications of `Damage`. Requires `Damage` to be set to 1.0 or above. Value of 0 disables the delay. Keep in mind that this is measured in animation frames, not game frames. Depending on `Rate`, animation may or may not advance animation frames on every game frame.
 - `Damage.DealtByInvoker`, if set to true, makes any `Damage` dealt to be considered as coming from the animation's invoker (f.ex, firer of the weapon if it is Warhead `AnimList/SplashList` animation, the destroyed vehicle if it is `DestroyAnim` animation or the object the animation is attached to). Does not affect which house the `Damage` dealt by `Warhead` is dealt by.
-- `Damage.ApplyOnce`, if set to true, makes `Damage` be dealt only once per animation loop instead of on every frame or intervals defined by `Damage.Delay`. The frame on which it is dealt is determined by `Damage.Delay`, defaulting to after the first animation frame.
+- `Damage.ApplyOncePerLoop`, if set to true, makes `Damage` be dealt only once per animation loop (on single loop animations, only once, period) instead of on every frame or intervals defined by `Damage.Delay`. The frame on which it is dealt is determined by `Damage.Delay`, defaulting to after the first animation frame.
 
 In `artmd.ini`:
 ```ini
-[SOMEANIM]                   ; AnimationType
-Weapon=                      ; WeaponType
-Damage.Delay=0               ; integer, animation frames
-Damage.DealtByInvoker=false  ; boolean
-Damage.ApplyOnce=false       ; boolean
+[SOMEANIM]                     ; AnimationType
+Weapon=                        ; WeaponType
+Damage.Delay=0                 ; integer, animation frames
+Damage.DealtByInvoker=false    ; boolean
+Damage.ApplyOncePerLoop=false  ; boolean
 ```
 
 ```{note}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -293,7 +293,6 @@ New:
 - Additional critical hit logic customizations (by Starkku)
 - Laser trails for VoxelAnims (by Otamaa)
 - Local warhead screen shaking (by Starkku)
-- Weapon owner detachment (by Starkku)
 - Feedback weapon (by Starkku)
 - TerrainType & ore minimap color customization (by Starkku)
 - Single-color weapon lasers (by Starkku)
@@ -311,6 +310,7 @@ New:
 - Initial Strength for Cloned Infantry (by FS-21)
 - OpenTopped transport rangefinding & deactivated state customizations (by Starkku)
 - Animation damage / weapon improvements (by Starkku)
+- Warhead self-damaging toggle (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -311,6 +311,7 @@ New:
 - OpenTopped transport rangefinding & deactivated state customizations (by Starkku)
 - Animation damage / weapon improvements (by Starkku)
 - Warhead self-damaging toggle (by Starkku)
+- Trailer animations inheriting owner (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -310,6 +310,7 @@ New:
 - Enhanced projectile interception logic, including projectile strength & armor types (by Starkku)
 - Initial Strength for Cloned Infantry (by FS-21)
 - OpenTopped transport rangefinding & deactivated state customizations (by Starkku)
+- Animation damage / weapon improvements (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -2,6 +2,7 @@
 #include <Utilities/Macro.h>
 #include <Utilities/Enum.h>
 #include <Ext/Aircraft/Body.h>
+#include <Ext/Anim/Body.h>
 #include <Ext/WeaponType/Body.h>
 
 DEFINE_HOOK(0x417FF1, AircraftClass_Mission_Attack_StrafeShots, 0x6)
@@ -83,4 +84,21 @@ DEFINE_HOOK(0x418B1F, AircraftClass_Mission_Attack_FireAtTarget5Strafe_BurstFix,
 	AircraftExt::FireBurst(pThis, pThis->Target, 4);
 
 	return 0x418B40;
+}
+
+DEFINE_HOOK(0x414F47, AircraftClass_AI_TrailerInheritOwner, 0x6)
+{
+	GET(AircraftClass*, pThis, ESI);
+	GET(AnimClass*, pAnim, EAX);
+
+	if (pThis)
+	{
+		if (auto const pAnimExt = AnimExt::ExtMap.Find(pAnim))
+		{
+			pAnim->Owner = pThis->Owner;
+			pAnimExt->Invoker = pThis;
+		}
+	}
+
+	return 0;
 }

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -34,6 +34,7 @@ void AnimExt::ExtData::Serialize(T& Stm)
 		.Process(this->FromDeathUnit)
 		.Process(this->DeathUnitTurretFacing)
 		.Process(this->DeathUnitHasTurret)
+		.Process(this->Invoker)
 		;
 }
 

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -29,7 +29,10 @@ public:
 
 		virtual ~ExtData() = default;
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override 
+		{ 
+			AnnounceInvalidPointer(Invoker, ptr);
+		}
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
@@ -44,6 +47,21 @@ public:
 	public:
 		ExtContainer();
 		~ExtContainer();
+
+		virtual bool InvalidateExtDataIgnorable(void* const ptr) const override
+		{
+			auto const abs = static_cast<AbstractClass*>(ptr)->WhatAmI();
+			switch (abs)
+			{
+			case AbstractType::Aircraft:
+			case AbstractType::Building:
+			case AbstractType::Infantry:
+			case AbstractType::Unit:
+				return false;
+			default:
+				return true;
+			}
+		}
 	};
 
 	static ExtContainer ExtMap;

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -17,12 +17,14 @@ public:
 		DirStruct DeathUnitTurretFacing;
 		bool FromDeathUnit;
 		bool DeathUnitHasTurret;
+		TechnoClass* Invoker;
 
 		ExtData(AnimClass* OwnerObject) : Extension<AnimClass>(OwnerObject)
 			, DeathUnitFacing { 0 }
 			, DeathUnitTurretFacing {}
 			, FromDeathUnit { false }
 			, DeathUnitHasTurret { false }
+			, Invoker {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -35,7 +35,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->UseCenterCoordsIfAttached.Read(exINI, pID, "UseCenterCoordsIfAttached");
 	this->Weapon.Read(exINI, pID, "Weapon", true);
 	this->Damage_Delay.Read(exINI, pID, "Damage.Delay");
-	this->Damage_DealtByOwner.Read(exINI, pID, "Damage.DealtByOwner");
+	this->Damage_DealtByInvoker.Read(exINI, pID, "Damage.DealtByInvoker");
 	this->Damage_ApplyOnce.Read(exINI, pID, "Damage.ApplyOnce");
 }
 
@@ -124,7 +124,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->UseCenterCoordsIfAttached)
 		.Process(this->Weapon)
 		.Process(this->Damage_Delay)
-		.Process(this->Damage_DealtByOwner)
+		.Process(this->Damage_DealtByInvoker)
 		.Process(this->Damage_ApplyOnce)
 		;
 }

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -33,6 +33,9 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->HideIfNoOre_Threshold.Read(exINI, pID, "HideIfNoOre.Threshold");
 	this->Layer_UseObjectLayer.Read(exINI, pID, "Layer.UseObjectLayer");
 	this->UseCenterCoordsIfAttached.Read(exINI, pID, "UseCenterCoordsIfAttached");
+	this->Weapon.Read(exINI, pID, "Weapon", true);
+	this->Damage_Delay.Read(exINI, pID, "Damage.Delay");
+	this->Damage_DealtByOwner.Read(exINI, pID, "Damage.DealtByOwner");
 }
 
 const void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)
@@ -81,6 +84,7 @@ const void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKill
 
 				AnimExt::SetAnimOwnerHouseKind(pAnim, pInvoker, pThis->Owner);
 
+				pAnimExt->Invoker = pThis;
 				pAnimExt->FromDeathUnit = true;
 
 				if (pAnimTypeExt->CreateUnit_InheritDeathFacings.Get())
@@ -117,6 +121,9 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->HideIfNoOre_Threshold)
 		.Process(this->Layer_UseObjectLayer)
 		.Process(this->UseCenterCoordsIfAttached)
+		.Process(this->Weapon)
+		.Process(this->Damage_Delay)
+		.Process(this->Damage_DealtByOwner)
 		;
 }
 

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -36,6 +36,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Weapon.Read(exINI, pID, "Weapon", true);
 	this->Damage_Delay.Read(exINI, pID, "Damage.Delay");
 	this->Damage_DealtByOwner.Read(exINI, pID, "Damage.DealtByOwner");
+	this->Damage_ApplyOnce.Read(exINI, pID, "Damage.ApplyOnce");
 }
 
 const void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)
@@ -124,6 +125,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Weapon)
 		.Process(this->Damage_Delay)
 		.Process(this->Damage_DealtByOwner)
+		.Process(this->Damage_ApplyOnce)
 		;
 }
 

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -36,7 +36,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Weapon.Read(exINI, pID, "Weapon", true);
 	this->Damage_Delay.Read(exINI, pID, "Damage.Delay");
 	this->Damage_DealtByInvoker.Read(exINI, pID, "Damage.DealtByInvoker");
-	this->Damage_ApplyOnce.Read(exINI, pID, "Damage.ApplyOnce");
+	this->Damage_ApplyOncePerLoop.Read(exINI, pID, "Damage.ApplyOncePerLoop");
 }
 
 const void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)
@@ -125,7 +125,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Weapon)
 		.Process(this->Damage_Delay)
 		.Process(this->Damage_DealtByInvoker)
-		.Process(this->Damage_ApplyOnce)
+		.Process(this->Damage_ApplyOncePerLoop)
 		;
 }
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -30,7 +30,7 @@ public:
 		Valueable<bool> UseCenterCoordsIfAttached;
 		Nullable<WeaponTypeClass*> Weapon;
 		Valueable<int> Damage_Delay;
-		Valueable<bool> Damage_DealtByOwner;
+		Valueable<bool> Damage_DealtByInvoker;
 		Valueable<bool> Damage_ApplyOnce;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
@@ -49,7 +49,7 @@ public:
 			, UseCenterCoordsIfAttached { false }
 			, Weapon {}
 			, Damage_Delay { 0 }
-			, Damage_DealtByOwner { false }
+			, Damage_DealtByInvoker { false }
 			, Damage_ApplyOnce { false }
 		{ }
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -31,7 +31,7 @@ public:
 		Nullable<WeaponTypeClass*> Weapon;
 		Valueable<int> Damage_Delay;
 		Valueable<bool> Damage_DealtByInvoker;
-		Valueable<bool> Damage_ApplyOnce;
+		Valueable<bool> Damage_ApplyOncePerLoop;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -50,7 +50,7 @@ public:
 			, Weapon {}
 			, Damage_Delay { 0 }
 			, Damage_DealtByInvoker { false }
-			, Damage_ApplyOnce { false }
+			, Damage_ApplyOncePerLoop { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -28,6 +28,9 @@ public:
 		Valueable<int> HideIfNoOre_Threshold;
 		Nullable<bool> Layer_UseObjectLayer;
 		Valueable<bool> UseCenterCoordsIfAttached;
+		Nullable<WeaponTypeClass*> Weapon;
+		Valueable<int> Damage_Delay;
+		Valueable<bool> Damage_DealtByOwner;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -43,6 +46,9 @@ public:
 			, HideIfNoOre_Threshold { 0 }
 			, Layer_UseObjectLayer {}
 			, UseCenterCoordsIfAttached { false }
+			, Weapon {}
+			, Damage_Delay { 0 }
+			, Damage_DealtByOwner { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -31,6 +31,7 @@ public:
 		Nullable<WeaponTypeClass*> Weapon;
 		Valueable<int> Damage_Delay;
 		Valueable<bool> Damage_DealtByOwner;
+		Valueable<bool> Damage_ApplyOnce;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -49,6 +50,7 @@ public:
 			, Weapon {}
 			, Damage_Delay { 0 }
 			, Damage_DealtByOwner { false }
+			, Damage_ApplyOnce { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
+++ b/src/Ext/AnimType/Hooks.AnimCreateUnit.cpp
@@ -168,10 +168,16 @@ DEFINE_HOOK(0x469C98, BulletClass_DetonateAt_DamageAnimSelected, 0x0)
 		{
 			AnimExt::SetAnimOwnerHouseKind(pAnim, pInvoker, pVictim, pInvoker);
 		}
-		else if (!pAnim->Owner && pThis->Owner)
+		else if (!pAnim->Owner) 
 		{
 			auto const pExt = BulletExt::ExtMap.Find(pThis);
 			pAnim->Owner = pThis->Owner ? pThis->Owner->Owner : pExt->FirerHouse;
+		}
+
+		if (pThis->Owner)
+		{
+			auto pExt = AnimExt::ExtMap.Find(pAnim);
+			pExt->Invoker = pThis->Owner;
 		}
 	}
 	else if (pThis->WH == RulesClass::Instance->NukeWarhead)

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -137,7 +137,7 @@ DEFINE_HOOK(0x424513, AnimClass_AI_Damage, 0x6)
 	auto const pExt = AnimExt::ExtMap.Find(pThis);
 	TechnoClass* pInvoker = nullptr;
 
-	if (pTypeExt->Damage_DealtByOwner)
+	if (pTypeExt->Damage_DealtByInvoker)
 		pInvoker = pExt->Invoker ? pExt->Invoker : pThis->OwnerObject ? abstract_cast<TechnoClass*>(pThis->OwnerObject) : nullptr;
 
 	if (pTypeExt->Weapon.isset())

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -93,7 +93,7 @@ DEFINE_HOOK(0x424513, AnimClass_AI_Damage, 0x6)
 	double damage = 0;
 	int appliedDamage = 0;
 
-	if (pTypeExt->Damage_ApplyOnce) // If damage is to be applied only once per animation loop
+	if (pTypeExt->Damage_ApplyOncePerLoop) // If damage is to be applied only once per animation loop
 	{
 		if (pThis->Animation.Value == std::max(delay - 1, 1))
 			appliedDamage = static_cast<int>(std::round(pThis->Type->Damage)) * damageMultiplier;

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -93,7 +93,14 @@ DEFINE_HOOK(0x424513, AnimClass_AI_Damage, 0x6)
 	double damage = 0;
 	int appliedDamage = 0;
 
-	if (delay <= 0 || pThis->Type->Damage < 1.0) // If Damage.Delay is less than 1 or Damage is a fraction.
+	if (pTypeExt->Damage_ApplyOnce) // If damage is to be applied only once per animation loop
+	{
+		if (pThis->Animation.Value == std::max(delay - 1, 1))
+			appliedDamage = static_cast<int>(std::round(pThis->Type->Damage)) * damageMultiplier;
+		else
+			return SkipDamage;
+	}
+	else if (delay <= 0 || pThis->Type->Damage < 1.0) // If Damage.Delay is less than 1 or Damage is a fraction.
 	{
 		adjustAccum = true;
 		damage = damageMultiplier * pThis->Type->Damage + pThis->Accum;

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -157,3 +157,20 @@ DEFINE_HOOK(0x424513, AnimClass_AI_Damage, 0x6)
 
 	return Continue;
 }
+
+DEFINE_HOOK(0x424322, AnimClass_AI_TrailerInheritOwner, 0x6)
+{
+	GET(AnimClass*, pThis, ESI);
+	GET(AnimClass*, pTrailerAnim, EAX);
+
+	if (auto const pExt = AnimExt::ExtMap.Find(pThis))
+	{
+		if (auto const pTrailerAnimExt = AnimExt::ExtMap.Find(pTrailerAnim))
+		{
+			pTrailerAnim->Owner = pThis->Owner;
+			pTrailerAnimExt->Invoker = pExt->Invoker;
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/AnimType/Hooks.cpp
+++ b/src/Ext/AnimType/Hooks.cpp
@@ -138,7 +138,12 @@ DEFINE_HOOK(0x424513, AnimClass_AI_Damage, 0x6)
 	TechnoClass* pInvoker = nullptr;
 
 	if (pTypeExt->Damage_DealtByInvoker)
-		pInvoker = pExt->Invoker ? pExt->Invoker : pThis->OwnerObject ? abstract_cast<TechnoClass*>(pThis->OwnerObject) : nullptr;
+	{
+		pInvoker = pExt->Invoker;
+
+		if (!pInvoker)
+			pInvoker = pThis->OwnerObject ? abstract_cast<TechnoClass*>(pThis->OwnerObject) : nullptr;
+	}
 
 	if (pTypeExt->Weapon.isset())
 	{
@@ -146,11 +151,15 @@ DEFINE_HOOK(0x424513, AnimClass_AI_Damage, 0x6)
 	}
 	else
 	{
-		auto pWarhead = pThis->Type->Warhead ? pThis->Type->Warhead :
-			strcmp(pThis->Type->get_ID(), "INVISO") ? RulesClass::Instance->FlameDamage2 : RulesClass::Instance->C4Warhead;
+		auto pWarhead = pThis->Type->Warhead;
 
-		auto pOwner = pInvoker ? pInvoker->Owner : pThis->Owner ? pThis->Owner :
-			pThis->OwnerObject ? pThis->OwnerObject->GetOwningHouse() : nullptr;
+		if (!pWarhead)
+			pWarhead = strcmp(pThis->Type->get_ID(), "INVISO") ? RulesClass::Instance->FlameDamage2 : RulesClass::Instance->C4Warhead;
+
+		auto pOwner = pInvoker ? pInvoker->Owner : nullptr;
+		
+		if (!pOwner)
+			pOwner = pThis->OwnerObject ? pThis->OwnerObject->GetOwningHouse() : nullptr;
 
 		MapClass::DamageArea(pThis->GetCoords(), appliedDamage, pInvoker, pWarhead, true, pOwner);
 	}

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -5,6 +5,8 @@
 #include <BitFont.h>
 #include <Misc/FlyingStrings.h>
 
+#include <Ext/WarheadType/Body.h>
+
 DEFINE_HOOK(0x7396D2, UnitClass_TryToDeploy_Transfer, 0x5)
 {
 	GET(UnitClass*, pUnit, EBP);
@@ -113,6 +115,21 @@ DEFINE_HOOK(0x43FE73, BuildingClass_AI_FlyingStrings, 0x6)
 
 			pExt->AccumulatedGrindingRefund = 0;
 		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x44224F, BuildingClass_ReceiveDamage_DamageSelf, 0x5)
+{
+	enum { SkipCheck = 0x442268 };
+
+	REF_STACK(args_ReceiveDamage const, receiveDamageArgs, STACK_OFFS(0x9C, -0x4));
+
+	if (auto const pWHExt = WarheadTypeExt::ExtMap.Find(receiveDamageArgs.WH))
+	{
+		if (pWHExt->AllowDamageOnSelf)
+			return SkipCheck;
 	}
 
 	return 0;

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -196,21 +196,6 @@ DEFINE_HOOK(0x4690D4, BulletClass_Logics_ScreenShake, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x4690C1, BulletClass_Logics_DetachFromOwner, 0x8)
-{
-	GET(BulletClass*, pThis, ESI);
-
-	if (pThis->Owner && pThis->WeaponType)
-	{
-		auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pThis->WeaponType);
-
-		if (pWeaponExt->DetachedFromOwner)
-			pThis->Owner = nullptr;
-	}
-
-	return 0;
-}
-
 DEFINE_HOOK(0x469A75, BulletClass_Logics_DamageHouse, 0x7)
 {
 	GET(BulletClass*, pThis, ESI);

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -1,4 +1,5 @@
 #include "Body.h"
+#include <Ext/Anim/Body.h>
 #include <Ext/WeaponType/Body.h>
 #include <Ext/WarheadType/Body.h>
 #include <Ext/BulletType/Body.h>
@@ -82,6 +83,23 @@ DEFINE_HOOK(0x4666F7, BulletClass_AI, 0x6)
 			trail->Update(drawnCoords);
 		}
 
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x4668BD, BulletClass_AI_TrailerInheritOwner, 0x6)
+{
+	GET(BulletClass*, pThis, EBP);
+	GET(AnimClass*, pAnim, EAX);
+
+	if (auto const pExt = BulletExt::ExtMap.Find(pThis))
+	{
+		if (auto const pAnimExt = AnimExt::ExtMap.Find(pAnim))
+		{
+			pAnim->Owner = pThis->Owner ? pThis->Owner->Owner : pExt->FirerHouse;
+			pAnimExt->Invoker = pThis->Owner;
+		}
 	}
 
 	return 0;

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -132,6 +132,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->LaunchSW.Read(exINI, pSection, "LaunchSW");
 	this->LaunchSW_RealLaunch.Read(exINI, pSection, "LaunchSW.RealLaunch");
 	this->LaunchSW_IgnoreInhibitors.Read(exINI, pSection, "LaunchSW.IgnoreInhibitors");
+	this->AllowDamageOnSelf.Read(exINI, pSection, "AllowDamageOnSelf");
+
 	// Ares tags
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 	this->AffectsEnemies.Read(exINI, pSection, "AffectsEnemies");
@@ -198,6 +200,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->LaunchSW)
 		.Process(this->LaunchSW_RealLaunch)
 		.Process(this->LaunchSW_IgnoreInhibitors)
+		.Process(this->AllowDamageOnSelf)
+		
 		// Ares tags
 		.Process(this->AffectsEnemies)
 		.Process(this->AffectsOwner)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -49,11 +49,6 @@ public:
 		Nullable<AnimTypeClass*> Shield_HitAnim;
 		Nullable<WeaponTypeClass*> Shield_BreakWeapon;
 
-		double RandomBuffer;
-		bool HasCrit;
-
-		Valueable<int> NotHuman_DeathSequence;
-
 		Nullable<double> Shield_AbsorbPercent;
 		Nullable<double> Shield_PassPercent;
 
@@ -74,14 +69,19 @@ public:
 		Valueable<int> Shield_MinimumReplaceDelay;
 		ValueableVector<ShieldTypeClass*> Shield_AffectTypes;
 
+		Valueable<int> NotHuman_DeathSequence;
 		ValueableVector<SuperWeaponTypeClass*> LaunchSW;
 		Valueable<bool> LaunchSW_RealLaunch;
 		Valueable<bool> LaunchSW_IgnoreInhibitors;
+		Valueable<bool> AllowDamageOnSelf;
 
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 		Valueable<bool> AffectsEnemies;
 		Nullable<bool> AffectsOwner;
+
+		double RandomBuffer;
+		bool HasCrit;
 
 	private:
 		Valueable<double> Shield_Respawn_Rate_InMinutes;
@@ -146,12 +146,13 @@ public:
 			, Shield_AffectTypes {}
 
 			, NotHuman_DeathSequence { -1 }
-
-			, AffectsEnemies { true }
-			, AffectsOwner {}
 			, LaunchSW {}
 			, LaunchSW_RealLaunch { true }
 			, LaunchSW_IgnoreInhibitors { false }
+			, AllowDamageOnSelf { false }
+
+			, AffectsEnemies { true }
+			, AffectsOwner {}
 		{ }
 
 	private:

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -106,3 +106,19 @@ DEFINE_HOOK(0x48A5B3, WarheadTypeClass_AnimList_CritAnim, 0x6)
 
 	return 0;
 }
+
+
+DEFINE_HOOK(0x4896EC, Explosion_Damage_DamageSelf, 0x6)
+{
+	enum { SkipCheck = 0x489702 };
+
+	GET_BASE(WarheadTypeClass*, pWarhead, 0xC);
+
+	if (auto const pWHExt = WarheadTypeExt::ExtMap.Find(pWarhead))
+	{
+		if (pWHExt->AllowDamageOnSelf)
+			return SkipCheck;
+	}
+
+	return 0;
+}

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -44,7 +44,6 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->CanTargetHouses.Read(exINI, pSection, "CanTargetHouses");
 	this->Burst_Delays.Read(exINI, pSection, "Burst.Delays");
 	this->AreaFire_Target.Read(exINI, pSection, "AreaFire.Target");
-	this->DetachedFromOwner.Read(exINI, pSection, "DetachedFromOwner");
 	this->FeedbackWeapon.Read(exINI, pSection, "FeedbackWeapon", true);
 	this->Laser_IsSingleColor.Read(exINI, pSection, "IsSingleColor");
 	this->Trajectory_Speed.Read(exINI, pSection, "Trajectory.Speed");
@@ -67,7 +66,6 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->RadType)
 		.Process(this->Burst_Delays)
 		.Process(this->AreaFire_Target)
-		.Process(this->DetachedFromOwner)
 		.Process(this->FeedbackWeapon)
 		.Process(this->Laser_IsSingleColor)
 		.Process(this->Trajectory_Speed)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -30,7 +30,6 @@ public:
 		Valueable<AffectedHouse> CanTargetHouses;
 		ValueableVector<int> Burst_Delays;
 		Valueable<AreaFireTarget> AreaFire_Target;
-		Valueable<bool> DetachedFromOwner;
 		Nullable<WeaponTypeClass*> FeedbackWeapon;
 		Valueable<bool> Laser_IsSingleColor;
 		Valueable<double> Trajectory_Speed;
@@ -49,7 +48,6 @@ public:
 			, CanTargetHouses { AffectedHouse::All }
 			, Burst_Delays {}
 			, AreaFire_Target { AreaFireTarget::Base }
-			, DetachedFromOwner { false }
 			, FeedbackWeapon {}
 			, Laser_IsSingleColor { false }
 			, Trajectory_Speed { 100.0 }


### PR DESCRIPTION
This reimplements animation `Weapon` and `Damage.Delay` from Ares and adds ability to customize whether or not the Damage is dealt by the owner or invoker of the animation (does not affect which House is used to deal damage if `Warhead` is used, but does affect experience gain). `Weapon` is also automatically allocated and does not require explicit listing on `[WeaponTypes]`.

---------------------------

### Animation weapon and damage settings

- `Weapon` can be set to a WeaponType, to create a projectile and immediately detonate it instead of simply dealing `Damage` by `Warhead`. This allows weapon effects to be applied.
- `Damage.Delay` determines delay between two applications of `Damage`. Requires `Damage` to be set to 1.0 or above. Value of 0 disables the delay. Keep in mind that this is measured in animation frames, not game frames. Depending on `Rate`, animation may or may not advance animation frames on every game frame.
- `Damage.DealtByInvoker`, if set to true, makes any `Damage` dealt to be considered as coming from the animation's invoker (f.ex, firer of the weapon if it is Warhead `AnimList/SplashList` animation, the destroyed vehicle if it is `DestroyAnim` animation or the object the animation is attached to). Does not affect which house the `Damage` dealt by `Warhead` is dealt by.
- `Damage.ApplyOnce`, if set to true, makes `Damage` be dealt only once per animation loop instead of on every frame or intervals defined by `Damage.Delay`. The frame on which it is dealt is determined by `Damage.Delay`, defaulting to after the first animation frame.

In `artmd.ini`:
```ini
[SOMEANIM]                   ; AnimationType
Weapon=                      ; WeaponType
Damage.Delay=0               ; integer, animation frames
Damage.DealtByInvoker=false  ; boolean
Damage.ApplyOnce=false       ; boolean
```

*`Weapon` and `Damage.Delay`, beyond the other additions, should function similarly to the equivalent features introduced by Ares and take precedence over them if Phobos is used together with Ares.*

--------

**NOTE:** *Following replaces `DetachedFromOwner` on WeaponTypes which has now been **deprecated**.*

### Allowing damage dealt to firer

- You can now allow warhead to deal damage (and apply damage-adjacent effects such as `KillDriver` and `DisableWeapons/Sonar/Flash.Duration` *(Ares features)*) on the object that is considered as the firer of the Warhead even if it does not have `DamageSelf=true`.
  - Note that effect of `Psychedelic=true`, despite being tied to damage will still fail to apply on the firer as it does not affect any objects belonging to same house as the firer, including itself (**NOTE:** *This is because Ares replaces the game check in its entirety, otherwise would have also made this customizable.*)

In `rulesmd.ini`:
```ini
[SOMEWARHEAD]            ; WarheadType
AllowDamageOnSelf=false  ; boolean
```