### PR TITLE
Another implementation on turning jumpjet to its target

### DIFF
--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -735,50 +735,6 @@ void TechnoExt::UpdateMindControlAnim(TechnoClass* pThis)
 	}
 }
 
-bool TechnoExt::CheckIfCanFireAt(TechnoClass* pThis, AbstractClass* pTarget)
-{
-	const int wpnIdx = pThis->SelectWeapon(pTarget);
-	const FireError fErr = pThis->GetFireError(pTarget, wpnIdx, true);
-	if (   fErr != FireError::ILLEGAL
-		&& fErr != FireError::CANT
-		&& fErr != FireError::MOVING
-		&& fErr != FireError::RANGE)
-	{
-		return pThis->IsCloseEnough(pTarget, wpnIdx);
-	}
-	else
-		return false;
-}
-
-void TechnoExt::ForceJumpjetTurnToTarget(TechnoClass* pThis)
-{
-	const auto pType = pThis->GetTechnoType();
-	if (pType->Locomotor == LocomotionClass::CLSIDs::Jumpjet && pThis->IsInAir()
-		&& pThis->WhatAmI() == AbstractType::Unit && !pType->TurretSpins)
-	{
-		const auto pFoot = abstract_cast<UnitClass*>(pThis);
-		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-
-		if (pTypeExt && pTypeExt->JumpjetTurnToTarget.Get(RulesExt::Global()->JumpjetTurnToTarget)
-			&& pFoot && pFoot->GetCurrentSpeed() == 0)
-		{
-			if (const auto pTarget = pThis->Target)
-			{
-				const auto pLoco = static_cast<JumpjetLocomotionClass*>(pFoot->Locomotor.get());
-				if (pLoco && !pLoco->LocomotionFacing.in_motion() && TechnoExt::CheckIfCanFireAt(pThis, pTarget))
-				{
-					const CoordStruct source = pThis->Location;
-					const CoordStruct target = pTarget->GetCoords();
-					const DirStruct tgtDir = DirStruct(Math::arctanfoo(source.Y - target.Y, target.X - source.X));
-					
-					if (pThis->GetRealFacing().value32() != tgtDir.value32())
-						pLoco->LocomotionFacing.turn(tgtDir);
-				}
-			}
-		}
-	}
-}
-
 void TechnoExt::DisplayDamageNumberString(TechnoClass* pThis, int damage, bool isShieldDamage)
 {
 	if (!pThis || damage == 0)

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -102,8 +102,6 @@ public:
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);
 	static bool CanFireNoAmmoWeapon(TechnoClass* pThis, int weaponIndex);
 	static void UpdateMindControlAnim(TechnoClass* pThis);
-	static bool CheckIfCanFireAt(TechnoClass* pThis, AbstractClass* pTarget);
-	static void ForceJumpjetTurnToTarget(TechnoClass* pThis);
 	static void DisplayDamageNumberString(TechnoClass* pThis, int damage, bool isShieldDamage);
 	static void DrawSelfHealPips(TechnoClass* pThis, Point2D* pLocation, RectangleStruct* pBounds);
 	static void ApplyGainedSelfHeal(TechnoClass* pThis);

--- a/src/Ext/Techno/Hooks.VehicleToBuildingMCFix.cpp
+++ b/src/Ext/Techno/Hooks.VehicleToBuildingMCFix.cpp
@@ -97,7 +97,6 @@ DEFINE_HOOK(0x448460, BuildingClass_Captured_MuteSound, 0x6)
 		0x44848F : 0;
 }
 
-
 DEFINE_HOOK(0x54AEC0, JumpjetLocomotion_Process, 0x8)
 {
 	GET_STACK(ILocomotion*, iLoco, 0x4);

--- a/src/Ext/Techno/Hooks.VehicleToBuildingMCFix.cpp
+++ b/src/Ext/Techno/Hooks.VehicleToBuildingMCFix.cpp
@@ -1,7 +1,7 @@
 #include "Body.h"
 
 #include <Phobos.h>
-
+#include <JumpjetLocomotionClass.h>
 #include <HouseClass.h>
 #include <AnimClass.h>
 #include <BuildingClass.h>
@@ -95,4 +95,30 @@ DEFINE_HOOK(0x448460, BuildingClass_Captured_MuteSound, 0x6)
 {
 	return MindControlFixTemp::isMindControlBeingTransferred ?
 		0x44848F : 0;
+}
+
+
+DEFINE_HOOK(0x54AEC0, JumpjetLocomotion_Process, 0x8)
+{
+	GET_STACK(ILocomotion*, iLoco, 0x4);
+	const auto pLoco = static_cast<JumpjetLocomotionClass*>(iLoco);
+	const auto pThis = pLoco->Owner;
+	const auto pType = pThis->GetTechnoType();
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+	if (pTypeExt && pTypeExt->JumpjetTurnToTarget.Get(RulesExt::Global()->JumpjetTurnToTarget) &&
+		pThis->WhatAmI() == AbstractType::Unit && pThis->IsInAir() && !pType->TurretSpins && pLoco)
+	{
+		if (const auto pTarget = pThis->Target)
+		{
+			const CoordStruct source = pThis->Location;
+			const CoordStruct target = pTarget->GetCoords();
+			const DirStruct tgtDir = DirStruct(Math::arctanfoo(source.Y - target.Y, target.X - source.X));
+
+			if (pThis->GetRealFacing().value32() != tgtDir.value32())
+				pLoco->LocomotionFacing.turn(tgtDir);
+		}
+	}
+
+	return 0;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1,6 +1,6 @@
 #include <InfantryClass.h>
 #include <ScenarioClass.h>
-#include <JumpjetLocomotionClass.h>
+
 #include "Body.h"
 
 #include <Ext/TechnoType/Body.h>
@@ -20,7 +20,6 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	TechnoExt::CheckDeathConditions(pThis);
 	TechnoExt::EatPassengers(pThis);
 	TechnoExt::UpdateMindControlAnim(pThis);
-	//TechnoExt::ForceJumpjetTurnToTarget(pThis);//Moved to JumpjetLocomotion::Process
 
 	// LaserTrails update routine is in TechnoClass::AI hook because TechnoClass::Draw
 	// doesn't run when the object is off-screen which leads to visual bugs - Kerbiter
@@ -30,27 +29,6 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	return 0;
 }
 
-DEFINE_HOOK(0x54AEC0, JumpjetLoco_Process, 0x8)
-{
-	GET_STACK(ILocomotion*, iLoco, 0x4);
-	const auto pLoco = static_cast<JumpjetLocomotionClass*>(iLoco);
-	const auto pThis = pLoco->Owner;
-	const auto pType = pThis->GetTechnoType();
-	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-	if (pTypeExt && pTypeExt->JumpjetTurnToTarget.Get(RulesExt::Global()->JumpjetTurnToTarget) &&
-		pThis->WhatAmI() == AbstractType::Unit && pThis->IsInAir() && !pType->TurretSpins && pLoco)
-	{
-		if (const auto pTarget = pThis->Target)
-		{
-			const CoordStruct source = pThis->Location;
-			const CoordStruct target = pTarget->GetCoords();
-			const DirStruct tgtDir = DirStruct(Math::arctanfoo(source.Y - target.Y, target.X - source.X));
-			if (pThis->GetRealFacing().value32() != tgtDir.value32())
-				pLoco->LocomotionFacing.turn(tgtDir);
-		}
-	}
-	return 0;
-}
 
 DEFINE_HOOK(0x6F42F7, TechnoClass_Init_NewEntities, 0x2)
 {

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -35,7 +35,10 @@ DEFINE_HOOK(0x54AEC0, JumpjetLoco_Process, 0x8)
 	GET_STACK(ILocomotion*, iLoco, 0x4);
 	const auto pLoco = static_cast<JumpjetLocomotionClass*>(iLoco);
 	const auto pThis = pLoco->Owner;
-	if (pThis->WhatAmI() == AbstractType::Unit && pThis->IsInAir() && !pThis->GetTechnoType()->TurretSpins)
+	const auto pType = pThis->GetTechnoType();
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+	if (pTypeExt && pTypeExt->JumpjetTurnToTarget.Get(RulesExt::Global()->JumpjetTurnToTarget) &&
+		pThis->WhatAmI() == AbstractType::Unit && pThis->IsInAir() && !pType->TurretSpins && pLoco)
 	{
 		if (const auto pTarget = pThis->Target)
 		{


### PR DESCRIPTION
**This is the exact same thing as my previous "Jumpjet facing target" pull request, with a different implementation.
It won't check if the jumpjet is stationary or not.**

**Need comparison tests**

Description of the previous PR:
### Jumpjet facing target customization 

- Allows jumpjet units to face towards the target when firing from different directions. Set `[JumpjetControls] -> TurnToTarget=yes` to enable it for all jumpjet locomotor units. This behavior can be overriden by setting `[UnitType] -> JumpjetTurnToTarget` for specific units.
- This behavior does not apply to `TurretSpins=yes` units for obvious reasons.

In `rulesmd.ini`:
```ini
[JumpjetControls]
TurnToTarget=no        ; boolean

[SOMEUNITTYPE]         ; UnitType with jumpjet locomotor
JumpjetTurnToTarget=   ; boolean, override the tag in JumpjetControls
```