### PR TITLE
Correct a Mistake in Doc

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -108,7 +108,7 @@ ShowBuildingPlacementPreview=no  ; boolean
 ### `[ ]` Quicksave
 
 - Save the current singleplayer game.
-- If need localization, just add `TXT_QUICKGAME`, `TXT_QUICKGAME_DESC`, `TXT_QUICKSAVE_SUFFIX` and `MSG:NotAvailableInMultiplayer` into your `.csf` file.
+- If need localization, just add `TXT_QUICKSAVE`, `TXT_QUICKSAVE_DESC`, `TXT_QUICKSAVE_SUFFIX` and `MSG:NotAvailableInMultiplayer` into your `.csf` file.
     - These vanilla CSF entries will be used: `TXT_SAVING_GAME`, `TXT_GAME_WAS_SAVED` and `TXT_ERROR_SAVING_GAME`.
     - The save should be looks like `Allied Mission 25: Esther's Money - QuickSaved`
 

--- a/docs/locale/zh_CN/LC_MESSAGES/User-Interface.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/User-Interface.po
@@ -104,10 +104,10 @@ msgstr "保存当前单人游戏。"
 
 #: ../User-Interface.md:31
 msgid ""
-"If need localization, just add `TXT_QUICKGAME`, `TXT_QUICKGAME_DESC`, "
+"If need localization, just add `TXT_QUICKSAVE`, `TXT_QUICKSAVE_DESC`, "
 "`TXT_QUICKSAVE_SUFFIX` and `MSG:NotAvailableInMultiplayer` into your "
 "`.csf` file."
-msgstr "如果需要本地化，只需要在`.csf`文件中增加`TXT_QUICKGAME`，`TXT_QUICKGAME_DESC`和`TXT_QUICKSAVE_SUFFIX`即可。"
+msgstr "如果需要本地化，只需要在`.csf`文件中增加`TXT_QUICKSAVE`，`TXT_QUICKSAVE_DESC`和`TXT_QUICKSAVE_SUFFIX`即可。"
 
 #: ../User-Interface.md:32
 msgid ""


### PR DESCRIPTION
In the Beginning, I thought the mistake was in codes, so the Doc is right. But after my trial, it is the doc's mistake. “TXT_QUICKSAVE” works, but “TXT_QUICKGAME” not.