### PR TITLE
Disguise logic improvements & reimplemented insignia drawing

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -165,7 +165,7 @@ This page lists all the individual contributions to the project by their author.
   - Railgun particle target coordinate fix
   - Building target coordinate offset fix
   - Warhead / weapon detonation at superweapon target cell
-  - Cloaked objects displaying to observers
+  - Cloaked & disguised objects displaying to observers
   - Building airstrike target eligibility customization
   - IvanBomb detonation & image display centered on buildings
   - Customizable ROF random delay
@@ -184,6 +184,8 @@ This page lists all the individual contributions to the project by their author.
   - TechnoType target evaluation map zone check behaviour customization
   - CanC4 damage rounding fix & toggle
   - Option to center pause menu background
+  - Disguise logic improvements
+  - Custom insignias
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile Include="src\Ext\Unit\Hooks.DeployFire.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.DisallowMoving.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Disguise.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />
     <ClCompile Include="src\Ext\VoxelAnimType\Body.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -121,6 +121,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and passengers firing out no longer have the passenger firing offset shift lateral position based on burst index.
 - Fixed disguised infantry not using custom palette for drawing the disguise when needed.
 - Disguised infantry now show appropriate insignia when disguise is visible based on the disguise type and house.
+- Disguises will now blink for observers, allowing them to see if an unit is disguised.
 
 ## Animations
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -95,7 +95,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug when `MakeInfantry` logic on BombClass resulted in `Neutral` side infantry.
 - Fixed railgun particles being drawn to wrong coordinate against buildings with non-default `TargetCoordOffset` or when force-firing on bridges.
 - Fixed building `TargetCoordOffset` not being taken into accord for several things like fire angle calculations and target lines.
-- Observers can now see cloaked objects owned by non-allied houses.
 - In singleplayer missions, the player can now see cloaked objects owned by allied houses.
 - IvanBomb images now display and the bombs detonate at center of buildings instead of in top-leftmost cell of the building foundation.
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations.
@@ -120,6 +119,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Buildings with primary weapon that has `AG=false` projectile now have attack cursor when selected.
 - Weapons with `AA=true` projectiles can now be set to fire exclusively at air targets by setting `AAOnly=true`, regardless of other conditions. This is useful because `AG=false` only prevents targeting ground cells (and cannot be changed without breaking existing behaviour) and for cases where `LandTargeting` cannot be used.
 - Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and passengers firing out no longer have the passenger firing offset shift lateral position based on burst index.
+- Fixed disguised infantry not using custom palette for drawing the disguise when needed.
+- Disguised infantry now show appropriate insignia when disguise is visible based on the disguise type and house.
 
 ## Animations
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -120,7 +120,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Weapons with `AA=true` projectiles can now be set to fire exclusively at air targets by setting `AAOnly=true`, regardless of other conditions. This is useful because `AG=false` only prevents targeting ground cells (and cannot be changed without breaking existing behaviour) and for cases where `LandTargeting` cannot be used.
 - Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and passengers firing out no longer have the passenger firing offset shift lateral position based on burst index.
 - Fixed disguised infantry not using custom palette for drawing the disguise when needed.
-- Disguised infantry now show appropriate insignia when disguise is visible based on the disguise type and house.
+- Disguised infantry now show appropriate insignia when disguise is visible, based on the disguise type and house.
 
 ## Animations
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -121,7 +121,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and passengers firing out no longer have the passenger firing offset shift lateral position based on burst index.
 - Fixed disguised infantry not using custom palette for drawing the disguise when needed.
 - Disguised infantry now show appropriate insignia when disguise is visible based on the disguise type and house.
-- Disguises will now blink for observers, allowing them to see if an unit is disguised.
 
 ## Animations
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -652,24 +652,34 @@ AutoFire.TargetSelf=false  ; boolean
   - `Insignia.(Rookie|Veteran|Elite)` can be used to set a custom insignia file, optionally for each veterancy stage. Like the original / default file, `pips.shp`, they are drawn using `palette.pal` as palette.
   - `InsigniaFrame(.Rookie|Veteran|Elite)` can be used to set (zero-based) frame index of the insignia to display, optionally for each veterancy stage. Using -1 uses the default setting. Default settings are -1 (none) for rookie, 14 for veteran and 15 for elite.
     - A shorthand `InsigniaFrames` can be used to list them in order from rookie, veteran and elite instead as well. `InsigniaFrame(.Rookie|Veteran|Elite)` takes priority over this.
+  - Normal insignia can be overridden for specific weapon modes of `Gunner=true` units by setting `Insignia(.Frame/.Frames).WeaponN` where `N` stands for 1-based weapon mode index. If not set, defaults to non-mode specific insignia settings.
   - `Insignia.ShowEnemy` controls whether or not the insignia is shown to enemy players. Defaults to `[General]` -> `EnemyInsignia`, which in turn defaults to true.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-EnemyInsignia=true        ; boolean
+EnemyInsignia=true                ; boolean
 
-[SOMETECHNO]              ; TechnoType
-Insignia=                 ; filename - excluding the .shp extension
-Insignia.Rookie=          ; filename - excluding the .shp extension
-Insignia.Veteran=         ; filename - excluding the .shp extension
-Insignia.Elite=           ; filename - excluding the .shp extension
-InsigniaFrame=-1          ; int, frame of insignia shp (zero-based) or -1 for default
-InsigniaFrame.Rookie=-1   ; int, frame of insignia shp (zero-based) or -1 for default
-InsigniaFrame.Veteran=-1  ; int, frame of insignia shp (zero-based) or -1 for default
-InsigniaFrame.Elite=-1    ; int, frame of insignia shp (zero-based) or -1 for default
-InsigniaFrames=-1,-1,-1   ; int, frames of insignia shp (zero-based) or -1 for default
-Insignia.ShowEnemy=       ; boolean
+[SOMETECHNO]                      ; TechnoType
+Insignia=                         ; filename - excluding the .shp extension
+Insignia.Rookie=                  ; filename - excluding the .shp extension
+Insignia.Veteran=                 ; filename - excluding the .shp extension
+Insignia.Elite=                   ; filename - excluding the .shp extension
+InsigniaFrame=-1                  ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.Rookie=-1           ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.Veteran=-1          ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.Elite=-1            ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrames=-1,-1,-1           ; int, frames of insignia shp (zero-based) or -1 for default
+Insignia.WeaponN=                 ; filename - excluding the .shp extension
+Insignia.WeaponN.Rookie=          ; filename - excluding the .shp extension
+Insignia.WeaponN.Veteran=         ; filename - excluding the .shp extension
+Insignia.WeaponN.Elite=           ; filename - excluding the .shp extension
+InsigniaFrame.WeaponN=-1          ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.WeaponN.Rookie=-1   ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.WeaponN.Veteran=-1  ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.WeaponN.Elite=-1    ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrames.WeaponN=-1,-1,-1   ; int, frames of insignia shp (zero-based) or -1 for default
+Insignia.ShowEnemy=               ; boolean
 ```
 
 ```{note}

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -712,18 +712,18 @@ NoSecondaryWeaponFallback=false          ; boolean
 NoSecondaryWeaponFallback.AllowAA=false  ; boolean
 ```
 
-### Disguise logic additions (disguise-based movement speed, ally disguise blinking)
+### Disguise logic additions (disguise-based movement speed, disguise blinking visibility)
 
-- `ShowAllyDisguiseBlinking`, if set to true, will allow players to see blinking disguises on disguised ally units.
+- `DisguiseBlinkingVisibility` can be used to customize which players can see disguises blinking on units.
 - `UseDisguiseMovementSpeed`, if set, makes disguised unit adjust its movement speed to match that of the disguise, if applicable. Note that this applies even when the disguise is revealed, as long as it has not been removed.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-ShowAllyDisguiseBlinking=false   ; boolean
-
-[SOMETECHNO]                     ; TechnoType
-UseDisguiseMovementSpeed=false   ; boolean
+DisguiseBlinkingVisibility=owner  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+                                  
+[SOMETECHNO]                      ; TechnoType
+UseDisguiseMovementSpeed=false    ; boolean
 ```
 
 ### Firing offsets for specific Burst shots

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -646,6 +646,32 @@ AutoFire=false             ; boolean
 AutoFire.TargetSelf=false  ; boolean
 ```
 
+### Customizable veterancy insignias
+
+- You can now customize veterancy insignia of TechnoTypes.
+  - `Insignia.Rookie|Veteran|Elite` can be used to set a custom insignia file for each veterancy stage. Like the original / default file, `pips.shp`, they are drawn using `palette.pal` as palette.
+  - `InsigniaFrame.Rookie|Veteran|Elite` can be used to set (zero-based) frame index of the insignia to display for each veterancy stage. Using -1 uses the default setting. Default settings are -1 (none) for rookie, 14 for veteran and 15 for elite.
+  - `Insignia.ShowEnemy` controls whether or not the insignia is shown to enemy players. Defaults to `[General]` -> `EnemyInsignia`, which in turn defaults to true.
+
+In `rulesmd.ini`:
+```ini
+[General]
+EnemyInsignia=true        ; boolean
+
+[SOMETECHNO]              ; TechnoType
+Insignia.Rookie=          ; filename - excluding the .shp extension
+Insignia.Veteran=         ; filename - excluding the .shp extension
+Insignia.Elite=           ; filename - excluding the .shp extension
+InsigniaFrame.Rookie=-1   ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.Veteran=-1  ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrame.Elite=-1    ; int, frame of insignia shp (zero-based) or -1 for default
+Insignia.ShowEnemy=       ; boolean
+```
+
+```{note}
+Insignia customization should function similarly to the equivalent feature introduced by Ares and takes precedence over it if Phobos is used together with Ares.
+```
+
 ### Customizable OpenTopped properties
 
 - You can now override global `OpenTopped` transport properties per TechnoType.
@@ -680,6 +706,20 @@ In `rulesmd.ini`:
 [SOMETECHNO]                             ; TechnoType
 NoSecondaryWeaponFallback=false          ; boolean
 NoSecondaryWeaponFallback.AllowAA=false  ; boolean
+```
+
+### Disguise logic additions (disguise-based movement speed, ally disguise blinking)
+
+- `ShowAllyDisguiseBlinking`, if set to true, will allow players to see blinking disguises on disguised ally units. Additionally observer players can see blinking disguises of all players.
+- `UseDisguiseMovementSpeed`, if set, makes disguised unit adjust its movement speed to match that of the disguise, if applicable. Note that this applies even when the disguise is revealed, as long as it has not been removed.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ShowAllyDisguiseBlinking=false   ; boolean
+
+[SOMETECHNO]                     ; TechnoType
+UseDisguiseMovementSpeed=false   ; boolean
 ```
 
 ### Firing offsets for specific Burst shots

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -721,7 +721,7 @@ In `rulesmd.ini`:
 ```ini
 [General]
 DisguiseBlinkingVisibility=owner  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
-                                  
+
 [SOMETECHNO]                      ; TechnoType
 UseDisguiseMovementSpeed=false    ; boolean
 ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -714,7 +714,7 @@ NoSecondaryWeaponFallback.AllowAA=false  ; boolean
 
 ### Disguise logic additions (disguise-based movement speed, ally disguise blinking)
 
-- `ShowAllyDisguiseBlinking`, if set to true, will allow players to see blinking disguises on disguised ally units. Additionally observer players can see blinking disguises of all players.
+- `ShowAllyDisguiseBlinking`, if set to true, will allow players to see blinking disguises on disguised ally units.
 - `UseDisguiseMovementSpeed`, if set, makes disguised unit adjust its movement speed to match that of the disguise, if applicable. Note that this applies even when the disguise is revealed, as long as it has not been removed.
 
 In `rulesmd.ini`:

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -649,8 +649,9 @@ AutoFire.TargetSelf=false  ; boolean
 ### Customizable veterancy insignias
 
 - You can now customize veterancy insignia of TechnoTypes.
-  - `Insignia.Rookie|Veteran|Elite` can be used to set a custom insignia file for each veterancy stage. Like the original / default file, `pips.shp`, they are drawn using `palette.pal` as palette.
-  - `InsigniaFrame.Rookie|Veteran|Elite` can be used to set (zero-based) frame index of the insignia to display for each veterancy stage. Using -1 uses the default setting. Default settings are -1 (none) for rookie, 14 for veteran and 15 for elite.
+  - `Insignia.(Rookie|Veteran|Elite)` can be used to set a custom insignia file, optionally for each veterancy stage. Like the original / default file, `pips.shp`, they are drawn using `palette.pal` as palette.
+  - `InsigniaFrame(.Rookie|Veteran|Elite)` can be used to set (zero-based) frame index of the insignia to display, optionally for each veterancy stage. Using -1 uses the default setting. Default settings are -1 (none) for rookie, 14 for veteran and 15 for elite.
+    - A shorthand `InsigniaFrames` can be used to list them in order from rookie, veteran and elite instead as well. `InsigniaFrame(.Rookie|Veteran|Elite)` takes priority over this.
   - `Insignia.ShowEnemy` controls whether or not the insignia is shown to enemy players. Defaults to `[General]` -> `EnemyInsignia`, which in turn defaults to true.
 
 In `rulesmd.ini`:
@@ -659,17 +660,20 @@ In `rulesmd.ini`:
 EnemyInsignia=true        ; boolean
 
 [SOMETECHNO]              ; TechnoType
+Insignia=                 ; filename - excluding the .shp extension
 Insignia.Rookie=          ; filename - excluding the .shp extension
 Insignia.Veteran=         ; filename - excluding the .shp extension
 Insignia.Elite=           ; filename - excluding the .shp extension
+InsigniaFrame=-1          ; int, frame of insignia shp (zero-based) or -1 for default
 InsigniaFrame.Rookie=-1   ; int, frame of insignia shp (zero-based) or -1 for default
 InsigniaFrame.Veteran=-1  ; int, frame of insignia shp (zero-based) or -1 for default
 InsigniaFrame.Elite=-1    ; int, frame of insignia shp (zero-based) or -1 for default
+InsigniaFrames=-1,-1,-1   ; int, frames of insignia shp (zero-based) or -1 for default
 Insignia.ShowEnemy=       ; boolean
 ```
 
 ```{note}
-Insignia customization should function similarly to the equivalent feature introduced by Ares and takes precedence over it if Phobos is used together with Ares.
+Insignia customization besides the `InsigniaFrames` shorthand should function similarly to the equivalent feature introduced by Ares and takes precedence over it if Phobos is used together with Ares.
 ```
 
 ### Customizable OpenTopped properties

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -303,6 +303,8 @@ New:
 - `CreateUnit` improvements & additions (units spawning in air, spawn animation) (by Starkku)
 - Option to center pause menu background (by Starkku)
 - LaunchSW.DisplayMoney (by Starkku)
+- Disguise logic improvements (by Starkku)
+- Custom insignias (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
@@ -312,7 +314,7 @@ Vanilla fixes:
 - Prevented units from retaining previous order after ownership change (by Trsdy)
 - Break the mind-control link when capturing a mind-controlled building with an engineer (by Trsdy)
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations (by Starkku)
-- Cloaked objects displaying to observers (by Starkku)
+- Cloaked & disguised objects displaying to observers (by Starkku)
 - Cloaked objects from allies displaying to player in single player missions (by Trsdy)
 - Skip `NaturalParticleSystem` displaying from in-map pre-placed structures (by Trsdy)
 - Made sure that `Suicide=yes` weapon does kill the firer (by Trsdy)
@@ -334,6 +336,7 @@ Vanilla fixes:
 - Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and passengers firing out no longer have the passenger firing offset shift lateral position based on burst index (by Starkku)
 - Light tint created by a building is now able to be removed after loading the game (by Trsdy)
 - Prevented crashing jumpjet units from firing (by Trsdy)
+- Fixed disguised infantry not using custom palette for drawing the disguise when needed (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -70,7 +70,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->InfantryGainSelfHealCap.Read(exINI, GameStrings::General, "InfantryGainSelfHealCap");
 	this->UnitsGainSelfHealCap.Read(exINI, GameStrings::General, "UnitsGainSelfHealCap");
 	this->EnemyInsignia.Read(exINI, GameStrings::General, "EnemyInsignia");
-	this->ShowAllyDisguiseBlinking.Read(exINI, GameStrings::General, "ShowAllyDisguiseBlinking");
+	this->DisguiseBlinkingVisibility.Read(exINI, GameStrings::General, "DisguiseBlinkingVisibility");
 	this->UseGlobalRadApplicationDelay.Read(exINI, GameStrings::Radiation, "UseGlobalRadApplicationDelay");
 	this->RadApplicationDelay_Building.Read(exINI, GameStrings::Radiation, "RadApplicationDelay.Building");
 	this->RadWarhead_Detonate.Read(exINI, GameStrings::Radiation, "RadSiteWarhead.Detonate");
@@ -187,7 +187,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->InfantryGainSelfHealCap)
 		.Process(this->UnitsGainSelfHealCap)
 		.Process(this->EnemyInsignia)
-		.Process(this->ShowAllyDisguiseBlinking)
+		.Process(this->DisguiseBlinkingVisibility)
 		.Process(this->UseGlobalRadApplicationDelay)
 		.Process(this->RadApplicationDelay_Building)
 		.Process(this->RadWarhead_Detonate)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -69,6 +69,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Storage_TiberiumIndex.Read(exINI, GameStrings::General, "Storage.TiberiumIndex");
 	this->InfantryGainSelfHealCap.Read(exINI, GameStrings::General, "InfantryGainSelfHealCap");
 	this->UnitsGainSelfHealCap.Read(exINI, GameStrings::General, "UnitsGainSelfHealCap");
+	this->EnemyInsignia.Read(exINI, GameStrings::General, "EnemyInsignia");
+	this->ShowAllyDisguiseBlinking.Read(exINI, GameStrings::General, "ShowAllyDisguiseBlinking");
 	this->UseGlobalRadApplicationDelay.Read(exINI, GameStrings::Radiation, "UseGlobalRadApplicationDelay");
 	this->RadApplicationDelay_Building.Read(exINI, GameStrings::Radiation, "RadApplicationDelay.Building");
 	this->RadWarhead_Detonate.Read(exINI, GameStrings::Radiation, "RadSiteWarhead.Detonate");
@@ -184,6 +186,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Storage_TiberiumIndex)
 		.Process(this->InfantryGainSelfHealCap)
 		.Process(this->UnitsGainSelfHealCap)
+		.Process(this->EnemyInsignia)
+		.Process(this->ShowAllyDisguiseBlinking)
 		.Process(this->UseGlobalRadApplicationDelay)
 		.Process(this->RadApplicationDelay_Building)
 		.Process(this->RadWarhead_Detonate)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -33,7 +33,7 @@ public:
 		Nullable<int> InfantryGainSelfHealCap;
 		Nullable<int> UnitsGainSelfHealCap;
 		Valueable<bool> EnemyInsignia;
-		Valueable<bool> ShowAllyDisguiseBlinking;
+		Valueable<AffectedHouse> DisguiseBlinkingVisibility;
 		Valueable<bool> UseGlobalRadApplicationDelay;
 		Valueable<int> RadApplicationDelay_Building;
 		Valueable<bool> RadWarhead_Detonate;
@@ -85,7 +85,7 @@ public:
 			, InfantryGainSelfHealCap {}
 			, UnitsGainSelfHealCap {}
 			, EnemyInsignia { true }
-			, ShowAllyDisguiseBlinking { false }
+			, DisguiseBlinkingVisibility { AffectedHouse::Owner }
 			, UseGlobalRadApplicationDelay { true }
 			, RadApplicationDelay_Building { 0 }
 			, RadWarhead_Detonate { false }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -32,6 +32,8 @@ public:
 		Valueable<int> Storage_TiberiumIndex;
 		Nullable<int> InfantryGainSelfHealCap;
 		Nullable<int> UnitsGainSelfHealCap;
+		Valueable<bool> EnemyInsignia;
+		Valueable<bool> ShowAllyDisguiseBlinking;
 		Valueable<bool> UseGlobalRadApplicationDelay;
 		Valueable<int> RadApplicationDelay_Building;
 		Valueable<bool> RadWarhead_Detonate;
@@ -82,6 +84,8 @@ public:
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
 			, UnitsGainSelfHealCap {}
+			, EnemyInsignia { true }
+			, ShowAllyDisguiseBlinking { false }
 			, UseGlobalRadApplicationDelay { true }
 			, RadApplicationDelay_Building { 0 }
 			, RadWarhead_Detonate { false }

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -120,22 +120,32 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 	if (!isVisibleToPlayer)
 		return;
 
+	bool isCustomInsignia = false;
+
 	if (SHPStruct* pCustomShapeFile = pExt->Insignia.Get(pThis))
 	{
 		pShapeFile = pCustomShapeFile;
 		defaultFrameIndex = 0;
+		isCustomInsignia = true;
 	}
-	else
-	{
-		VeterancyStruct* pVeterancy = &pThis->Veterancy;
 
-		if (pVeterancy->IsElite())
-			defaultFrameIndex = 15;
-		else if (pVeterancy->IsVeteran())
-			defaultFrameIndex = 14;
+	VeterancyStruct* pVeterancy = &pThis->Veterancy;
+	auto& insigniaFrames = pExt->InsigniaFrames.Get();
+	int insigniaFrame = insigniaFrames.X;
+
+	if (pVeterancy->IsVeteran())
+	{
+		defaultFrameIndex = !isCustomInsignia ? 14 : defaultFrameIndex;
+		insigniaFrame = insigniaFrames.Y;
+	}
+	else if (pVeterancy->IsElite())
+	{
+		defaultFrameIndex = !isCustomInsignia ? 15 : defaultFrameIndex;
+		insigniaFrame = insigniaFrames.Z;
 	}
 
 	int frameIndex = pExt->InsigniaFrame.Get(pThis);
+	frameIndex = frameIndex == -1 ? insigniaFrame : frameIndex;
 
 	if (frameIndex == -1)
 		frameIndex = defaultFrameIndex;
@@ -144,6 +154,7 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 	{
 		offset.X += 5;
 		offset.Y += 2;
+
 		if (pThis->WhatAmI() != AbstractType::Infantry)
 		{
 			offset.X += 5;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -98,14 +98,14 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 	auto pTechnoType = pThis->GetTechnoType();
 	auto pOwner = pThis->Owner;
 
-	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::Player))
+	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
 	{
 		if (auto const pType = TechnoTypeExt::GetTechnoType(pThis->Disguise))
 		{
 			pTechnoType = pType;
 			pOwner = pThis->DisguisedAsHouse;
 		}
-		else if (!pOwner->IsAlliedWith(HouseClass::Player) && !HouseClass::IsPlayerObserver())
+		else if (!pOwner->IsAlliedWith(HouseClass::CurrentPlayer) && !HouseClass::IsCurrentPlayerObserver())
 		{
 			return;
 		}
@@ -113,8 +113,8 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 
 	TechnoTypeExt::ExtData* pExt = TechnoTypeExt::ExtMap.Find(pTechnoType);
 
-	bool isVisibleToPlayer = (pOwner && pOwner->IsAlliedWith(HouseClass::Player))
-		|| HouseClass::IsPlayerObserver()
+	bool isVisibleToPlayer = (pOwner && pOwner->IsAlliedWith(HouseClass::CurrentPlayer))
+		|| HouseClass::IsCurrentPlayerObserver()
 		|| pExt->Insignia_ShowEnemy.Get(RulesExt::Global()->EnemyInsignia);
 
 	if (!isVisibleToPlayer)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -100,16 +100,20 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 
 	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::Player))
 	{
-		if (auto const pType = static_cast<TechnoTypeClass*>(pThis->Disguise))
+		if (auto const pType = TechnoTypeExt::GetTechnoType(pThis->Disguise))
 		{
 			pTechnoType = pType;
 			pOwner = pThis->DisguisedAsHouse;
+		}
+		else if (!pOwner->IsAlliedWith(HouseClass::Player) && !HouseClass::IsPlayerObserver())
+		{
+			return;
 		}
 	}
 
 	TechnoTypeExt::ExtData* pExt = TechnoTypeExt::ExtMap.Find(pTechnoType);
 
-	bool isVisibleToPlayer = pOwner->IsAlliedWith(HouseClass::Player)
+	bool isVisibleToPlayer = (pOwner && pOwner->IsAlliedWith(HouseClass::Player))
 		|| HouseClass::IsPlayerObserver()
 		|| pExt->Insignia_ShowEnemy.Get(RulesExt::Global()->EnemyInsignia);
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -114,6 +114,7 @@ public:
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);
 	static void DisplayDamageNumberString(TechnoClass* pThis, int damage, bool isShieldDamage);
 	static void DrawSelfHealPips(TechnoClass* pThis, Point2D* pLocation, RectangleStruct* pBounds);
+	static void DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleStruct* pBounds);
 	static void ApplyGainedSelfHeal(TechnoClass* pThis);
 	static void SyncIronCurtainStatus(TechnoClass* pFrom, TechnoClass* pTo);
 	static CoordStruct PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger, int maxAttempts);

--- a/src/Ext/Techno/Hooks.Disguise.cpp
+++ b/src/Ext/Techno/Hooks.Disguise.cpp
@@ -1,5 +1,6 @@
 #include "Body.h"
 
+#include <Utilities/EnumFunctions.h>
 
 DEFINE_HOOK_AGAIN(0x522790, TechnoClass_DefaultDisguise, 0x6) // InfantryClass_SetDisguise_DefaultDisguise
 DEFINE_HOOK(0x6F421C, TechnoClass_DefaultDisguise, 0x6) // TechnoClass_DefaultDisguise
@@ -24,7 +25,7 @@ DEFINE_HOOK(0x6F421C, TechnoClass_DefaultDisguise, 0x6) // TechnoClass_DefaultDi
 }
 
 #define CAN_BLINK_DISGUISE(pTechno) \
-HouseClass::IsCurrentPlayerObserver() || (RulesExt::Global()->ShowAllyDisguiseBlinking && pTechno->Owner->IsAlliedWith(HouseClass::CurrentPlayer))
+HouseClass::IsCurrentPlayerObserver() || EnumFunctions::CanTargetHouse(RulesExt::Global()->DisguiseBlinkingVisibility, HouseClass::CurrentPlayer, pTechno->Owner)
 
 DEFINE_HOOK(0x70EE53, TechnoClass_IsClearlyVisibleTo_BlinkAllyDisguise1, 0xA)
 {
@@ -43,38 +44,38 @@ DEFINE_HOOK(0x70EE53, TechnoClass_IsClearlyVisibleTo_BlinkAllyDisguise1, 0xA)
 
 DEFINE_HOOK(0x70EE6A, TechnoClass_IsClearlyVisibleTo_BlinkAllyDisguise2, 0x6)
 {
-	enum { SkipCheck = 0x70EE79 };
+	enum { ContinueChecks = 0x70EE79, DisallowBlinking = 0x70EEB6 };
 
 	GET(TechnoClass*, pThis, ESI);
 
 	if (CAN_BLINK_DISGUISE(pThis))
-		return SkipCheck;
+		return ContinueChecks;
 
-	return 0;
+	return DisallowBlinking;
 }
 
 DEFINE_HOOK(0x7062F5, TechnoClass_TechnoClass_DrawObject_BlinkAllyDisguise, 0x6)
 {
-	enum { SkipCheck = 0x706304 };
+	enum { ContinueChecks = 0x706304, DisallowBlinking = 0x70631F };
 
 	GET(TechnoClass*, pThis, ESI);
 
 	if (CAN_BLINK_DISGUISE(pThis))
-		return SkipCheck;
+		return ContinueChecks;
 
-	return 0;
+	return DisallowBlinking;
 }
 
 DEFINE_HOOK(0x70EDAD, TechnoClass_DisguiseBlitFlags_BlinkAllyDisguise, 0x6)
 {
-	enum { SkipCheck = 0x70EDBC };
+	enum { AllowBlinking = 0x70EDBC, DisallowBlinking = 0x70EDB8 };
 
 	GET(TechnoClass*, pThis, EDI);
 
 	if (CAN_BLINK_DISGUISE(pThis))
-		return SkipCheck;
+		return AllowBlinking;
 
-	return 0;
+	return DisallowBlinking;
 }
 
 DEFINE_HOOK(0x7060A9, TechnoClass_TechnoClass_DrawObject_DisguisePalette, 0x6)

--- a/src/Ext/Techno/Hooks.Disguise.cpp
+++ b/src/Ext/Techno/Hooks.Disguise.cpp
@@ -24,7 +24,7 @@ DEFINE_HOOK(0x6F421C, TechnoClass_DefaultDisguise, 0x6) // TechnoClass_DefaultDi
 }
 
 #define CAN_BLINK_DISGUISE(pTechno) \
-RulesExt::Global()->ShowAllyDisguiseBlinking && (HouseClass::IsPlayerObserver() || pTechno->Owner->IsAlliedWith(HouseClass::Player))
+HouseClass::IsCurrentPlayerObserver() || (RulesExt::Global()->ShowAllyDisguiseBlinking && pTechno->Owner->IsAlliedWith(HouseClass::CurrentPlayer))
 
 DEFINE_HOOK(0x70EE53, TechnoClass_IsClearlyVisibleTo_BlinkAllyDisguise1, 0xA)
 {
@@ -35,7 +35,7 @@ DEFINE_HOOK(0x70EE53, TechnoClass_IsClearlyVisibleTo_BlinkAllyDisguise1, 0xA)
 
 	if (CAN_BLINK_DISGUISE(pThis))
 		return SkipGameCode;
-	else if (accum && !pThis->Owner->ControlledByPlayer())
+	else if (accum && !pThis->Owner->IsControlledByCurrentPlayer())
 		return Return;
 
 	return SkipGameCode;

--- a/src/Ext/Techno/Hooks.Disguise.cpp
+++ b/src/Ext/Techno/Hooks.Disguise.cpp
@@ -92,7 +92,7 @@ DEFINE_HOOK(0x7060A9, TechnoClass_TechnoClass_DrawObject_DisguisePalette, 0x6)
 		convert = pType->Palette->GetItem(colorIndex)->LightConvert;
 	else
 		convert = ColorScheme::Array->GetItem(colorIndex)->LightConvert;
-	
+
 	R->EBX(convert);
 
 	return SkipGameCode;

--- a/src/Ext/Techno/Hooks.Disguise.cpp
+++ b/src/Ext/Techno/Hooks.Disguise.cpp
@@ -1,0 +1,99 @@
+#include "Body.h"
+
+
+DEFINE_HOOK_AGAIN(0x522790, TechnoClass_DefaultDisguise, 0x6) // InfantryClass_SetDisguise_DefaultDisguise
+DEFINE_HOOK(0x6F421C, TechnoClass_DefaultDisguise, 0x6) // TechnoClass_DefaultDisguise
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	enum { SetDisguise = 0x5227BF, DefaultDisguise = 0x6F4277 };
+
+	if (auto const pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
+	{
+		if (pExt->DefaultDisguise.isset())
+		{
+			pThis->Disguise = pExt->DefaultDisguise;
+			pThis->Disguised = true;
+			return R->Origin() == 0x522790 ? SetDisguise : DefaultDisguise;
+		}
+	}
+
+	pThis->Disguised = false;
+
+	return 0;
+}
+
+#define CAN_BLINK_DISGUISE(pTechno) \
+RulesExt::Global()->ShowAllyDisguiseBlinking && (HouseClass::IsPlayerObserver() || pTechno->Owner->IsAlliedWith(HouseClass::Player))
+
+DEFINE_HOOK(0x70EE53, TechnoClass_IsClearlyVisibleTo_BlinkAllyDisguise1, 0xA)
+{
+	enum { SkipGameCode = 0x70EE6A, Return = 0x70EEEC };
+
+	GET(TechnoClass*, pThis, ESI);
+	GET(int, accum, EAX);
+
+	if (CAN_BLINK_DISGUISE(pThis))
+		return SkipGameCode;
+	else if (accum && !pThis->Owner->ControlledByPlayer())
+		return Return;
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x70EE6A, TechnoClass_IsClearlyVisibleTo_BlinkAllyDisguise2, 0x6)
+{
+	enum { SkipCheck = 0x70EE79 };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	if (CAN_BLINK_DISGUISE(pThis))
+		return SkipCheck;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7062F5, TechnoClass_TechnoClass_DrawObject_BlinkAllyDisguise, 0x6)
+{
+	enum { SkipCheck = 0x706304 };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	if (CAN_BLINK_DISGUISE(pThis))
+		return SkipCheck;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x70EDAD, TechnoClass_DisguiseBlitFlags_BlinkAllyDisguise, 0x6)
+{
+	enum { SkipCheck = 0x70EDBC };
+
+	GET(TechnoClass*, pThis, EDI);
+
+	if (CAN_BLINK_DISGUISE(pThis))
+		return SkipCheck;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7060A9, TechnoClass_TechnoClass_DrawObject_DisguisePalette, 0x6)
+{
+	enum { SkipGameCode = 0x7060CA };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	LightConvertClass* convert = nullptr;
+
+	auto const pType = pThis->IsDisguised() ? static_cast<TechnoTypeClass*>(pThis->Disguise) : nullptr;
+	int colorIndex = pThis->GetDisguiseHouse(true)->ColorSchemeIndex;
+
+	if (pType && pType->Palette && pType->Palette->Count > 0)
+		convert = pType->Palette->GetItem(colorIndex)->LightConvert;
+	else
+		convert = ColorScheme::Array->GetItem(colorIndex)->LightConvert;
+	
+	R->EBX(convert);
+
+	return SkipGameCode;
+}

--- a/src/Ext/Techno/Hooks.Disguise.cpp
+++ b/src/Ext/Techno/Hooks.Disguise.cpp
@@ -85,7 +85,7 @@ DEFINE_HOOK(0x7060A9, TechnoClass_TechnoClass_DrawObject_DisguisePalette, 0x6)
 
 	LightConvertClass* convert = nullptr;
 
-	auto const pType = pThis->IsDisguised() ? static_cast<TechnoTypeClass*>(pThis->Disguise) : nullptr;
+	auto const pType = pThis->IsDisguised() ? TechnoTypeExt::GetTechnoType(pThis->Disguise) : nullptr;
 	int colorIndex = pThis->GetDisguiseHouse(true)->ColorSchemeIndex;
 
 	if (pType && pType->Palette && pType->Palette->Count > 0)

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -413,3 +413,42 @@ DEFINE_HOOK(0x6F7E47, TechnoClass_EvaluateObject_MapZone, 0x7)
 
 	return AllowedObject;
 }
+
+DEFINE_HOOK(0x6F534E, TechnoClass_DrawExtras_Insignia, 0x5)
+{
+	enum { SkipGameCode = 0x6F5388 };
+
+	GET(TechnoClass*, pThis, EBP);
+	GET_STACK(Point2D*, pLocation, STACK_OFFS(0x98, -0x4));
+	GET(RectangleStruct*, pBounds, ESI);
+
+	if (pThis->VisualCharacter(false, nullptr) != VisualType::Hidden)
+		TechnoExt::DrawInsignia(pThis, pLocation, pBounds);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x70EFE0, TechnoClass_GetMaxSpeed, 0x6)
+{
+	enum { SkipGameCode = 0x70EFF2 };
+
+	GET(TechnoClass*, pThis, ECX);
+
+	int maxSpeed = 0;
+
+	if (pThis)
+	{
+		maxSpeed = pThis->GetTechnoType()->Speed;
+
+		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+		if (pTypeExt->UseDisguiseMovementSpeed && pThis->IsDisguised())
+		{
+			if (auto const pType = static_cast<TechnoTypeClass*>(pThis->Disguise))
+				maxSpeed = pType->Speed;
+		}
+	}
+
+	R->EAX(maxSpeed);
+	return SkipGameCode;
+}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -419,7 +419,7 @@ DEFINE_HOOK(0x6F534E, TechnoClass_DrawExtras_Insignia, 0x5)
 	enum { SkipGameCode = 0x6F5388 };
 
 	GET(TechnoClass*, pThis, EBP);
-	GET_STACK(Point2D*, pLocation, STACK_OFFS(0x98, -0x4));
+	GET_STACK(Point2D*, pLocation, STACK_OFFSET(0x98, 0x4));
 	GET(RectangleStruct*, pBounds, ESI);
 
 	if (pThis->VisualCharacter(false, nullptr) != VisualType::Hidden)

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -444,7 +444,7 @@ DEFINE_HOOK(0x70EFE0, TechnoClass_GetMaxSpeed, 0x6)
 
 		if (pTypeExt->UseDisguiseMovementSpeed && pThis->IsDisguised())
 		{
-			if (auto const pType = static_cast<TechnoTypeClass*>(pThis->Disguise))
+			if (auto const pType = TechnoTypeExt::GetTechnoType(pThis->Disguise))
 				maxSpeed = pType->Speed;
 		}
 	}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -95,10 +95,10 @@ void TechnoTypeExt::ExtData::ParseBurstFLHs(INI_EX &exArtINI, const char* pArtSe
 
 TechnoTypeClass* TechnoTypeExt::GetTechnoType(ObjectTypeClass* pType)
 {
-	if (pType->AbsID == AbstractType::AircraftType ||
-		pType->AbsID == AbstractType::BuildingType ||
-		pType->AbsID == AbstractType::InfantryType ||
-		pType->AbsID == AbstractType::UnitType)
+	if (pType->WhatAmI() == AbstractType::AircraftType ||
+		pType->WhatAmI() == AbstractType::BuildingType ||
+		pType->WhatAmI() == AbstractType::InfantryType ||
+		pType->WhatAmI() == AbstractType::UnitType)
 	{
 		return static_cast<TechnoTypeClass*>(pType);
 	}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -173,6 +173,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->NotHuman_RandomDeathSequence.Read(exINI, pSection, "NotHuman.RandomDeathSequence");
 
 	this->DefaultDisguise.Read(exINI, pSection, "DefaultDisguise");
+	this->UseDisguiseMovementSpeed.Read(exINI, pSection, "UseDisguiseMovementSpeed");
 
 	this->OpenTopped_RangeBonus.Read(exINI, pSection, "OpenTopped.RangeBonus");
 	this->OpenTopped_DamageMultiplier.Read(exINI, pSection, "OpenTopped.DamageMultiplier");
@@ -211,6 +212,10 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Explodes_KillPassengers.Read(exINI, pSection, "Explodes.KillPassengers");
 	this->DeployFireWeapon.Read(exINI, pSection, "DeployFireWeapon");
 	this->TargetZoneScanType.Read(exINI, pSection, "TargetZoneScanType");
+
+	this->Insignia.Read(exINI, pSection, "Insignia.%s");
+	this->InsigniaFrame.Read(exINI, pSection, "InsigniaFrame.%s");
+	this->Insignia_ShowEnemy.Read(exINI, pSection, "Insignia.ShowEnemy");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -381,6 +386,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DestroyAnim_Random)
 		.Process(this->NotHuman_RandomDeathSequence)
 		.Process(this->DefaultDisguise)
+		.Process(this->UseDisguiseMovementSpeed)
 		.Process(this->WeaponBurstFLHs)
 		.Process(this->EliteWeaponBurstFLHs)
 		.Process(this->AlternateFLHs)
@@ -432,6 +438,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Explodes_KillPassengers)
 		.Process(this->DeployFireWeapon)
 		.Process(this->TargetZoneScanType)
+		.Process(this->Insignia)
+		.Process(this->InsigniaFrame)
+		.Process(this->Insignia_ShowEnemy)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -225,6 +225,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->TargetZoneScanType.Read(exINI, pSection, "TargetZoneScanType");
 
 	this->Insignia.Read(exINI, pSection, "Insignia.%s");
+	this->InsigniaFrames.Read(exINI, pSection, "InsigniaFrames");
 	this->InsigniaFrame.Read(exINI, pSection, "InsigniaFrame.%s");
 	this->Insignia_ShowEnemy.Read(exINI, pSection, "Insignia.ShowEnemy");
 
@@ -450,6 +451,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DeployFireWeapon)
 		.Process(this->TargetZoneScanType)
 		.Process(this->Insignia)
+		.Process(this->InsigniaFrames)
 		.Process(this->InsigniaFrame)
 		.Process(this->Insignia_ShowEnemy)
 		;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -95,8 +95,10 @@ void TechnoTypeExt::ExtData::ParseBurstFLHs(INI_EX &exArtINI, const char* pArtSe
 
 TechnoTypeClass* TechnoTypeExt::GetTechnoType(ObjectTypeClass* pType)
 {
-	if (pType->AbsID == AbstractType::AircraftType || pType->AbsID == AbstractType::BuildingType ||
-		pType->AbsID == AbstractType::InfantryType || pType->AbsID == AbstractType::UnitType)
+	if (pType->AbsID == AbstractType::AircraftType ||
+		pType->AbsID == AbstractType::BuildingType ||
+		pType->AbsID == AbstractType::InfantryType ||
+		pType->AbsID == AbstractType::UnitType)
 	{
 		return static_cast<TechnoTypeClass*>(pType);
 	}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -91,7 +91,18 @@ void TechnoTypeExt::ExtData::ParseBurstFLHs(INI_EX &exArtINI, const char* pArtSe
 			nEFlh[i].push_back(eliteFLH.Get());
 		}
 	}
-};
+}
+
+TechnoTypeClass* TechnoTypeExt::GetTechnoType(ObjectTypeClass* pType)
+{
+	if (pType->AbsID == AbstractType::AircraftType || pType->AbsID == AbstractType::BuildingType ||
+		pType->AbsID == AbstractType::InfantryType || pType->AbsID == AbstractType::UnitType)
+	{
+		return static_cast<TechnoTypeClass*>(pType);
+	}
+
+	return nullptr;
+}
 
 // =============================
 // load / save

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -90,6 +90,7 @@ public:
 		Valueable<bool> NotHuman_RandomDeathSequence;
 
 		Nullable<InfantryTypeClass*> DefaultDisguise;
+		Valueable<bool> UseDisguiseMovementSpeed;
 
 		Nullable<int> OpenTopped_RangeBonus;
 		Nullable<float> OpenTopped_DamageMultiplier;
@@ -132,6 +133,10 @@ public:
 		Valueable<bool> Explodes_KillPassengers;
 		Nullable<int> DeployFireWeapon;
 		Valueable<TargetZoneScanType> TargetZoneScanType;
+
+		Promotable<SHPStruct*> Insignia;
+		Promotable<int> InsigniaFrame;
+		Nullable<bool> Insignia_ShowEnemy;
 
 		struct LaserTrailDataEntry
 		{
@@ -205,7 +210,8 @@ public:
 			, NotHuman_RandomDeathSequence { false }
 
 			, DefaultDisguise {}
-
+			, UseDisguiseMovementSpeed {}
+			
 			, OpenTopped_RangeBonus {}
 			, OpenTopped_DamageMultiplier {}
 			, OpenTopped_WarpDistance {}
@@ -262,6 +268,9 @@ public:
 			, Explodes_KillPassengers { true }
 			, DeployFireWeapon {}
 			, TargetZoneScanType { TargetZoneScanType::Same }
+			, Insignia {}
+			, InsigniaFrame { -1 }
+			, Insignia_ShowEnemy {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -135,6 +135,7 @@ public:
 		Valueable<TargetZoneScanType> TargetZoneScanType;
 
 		Promotable<SHPStruct*> Insignia;
+		Valueable<Vector3D<int>> InsigniaFrames;
 		Promotable<int> InsigniaFrame;
 		Nullable<bool> Insignia_ShowEnemy;
 
@@ -269,6 +270,7 @@ public:
 			, DeployFireWeapon {}
 			, TargetZoneScanType { TargetZoneScanType::Same }
 			, Insignia {}
+			, InsigniaFrames {{ -1, -1, -1 }}
 			, InsigniaFrame { -1 }
 			, Insignia_ShowEnemy {}
 		{ }

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -305,6 +305,7 @@ public:
 	static ExtContainer ExtMap;
 
 	static void ApplyTurretOffset(TechnoTypeClass* pType, Matrix3D* mtx, double factor = 1.0);
+	static TechnoTypeClass* GetTechnoType(ObjectTypeClass* pType);
 
 	// Ares 0.A
 	static const char* GetSelectionGroupID(ObjectTypeClass* pType);

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -270,7 +270,7 @@ public:
 			, DeployFireWeapon {}
 			, TargetZoneScanType { TargetZoneScanType::Same }
 			, Insignia {}
-			, InsigniaFrames {{ -1, -1, -1 }}
+			, InsigniaFrames { { -1, -1, -1 } }
 			, InsigniaFrame { -1 }
 			, Insignia_ShowEnemy {}
 		{ }

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -138,6 +138,9 @@ public:
 		Valueable<Vector3D<int>> InsigniaFrames;
 		Promotable<int> InsigniaFrame;
 		Nullable<bool> Insignia_ShowEnemy;
+		std::vector<Promotable<SHPStruct*>> Insignia_Weapon;
+		std::vector<Promotable<int>> InsigniaFrame_Weapon;
+		std::vector<Vector3D<int>> InsigniaFrames_Weapon;
 
 		struct LaserTrailDataEntry
 		{
@@ -251,28 +254,38 @@ public:
 			, SellSound {}
 			, EVA_Sold {}
 			, EnemyUIName {}
+
 			, ForceWeapon_Naval_Decloaked { -1 }
 			, ForceWeapon_Cloaked { -1 }
 			, ForceWeapon_Disguised { -1 }
+
 			, Ammo_Shared { false }
 			, Ammo_Shared_Group { -1 }
+
 			, SelfHealGainType {}
 			, Passengers_SyncOwner { false }
 			, Passengers_SyncOwner_RevertOnExit { true }
+
 			, PronePrimaryFireFLH {}
 			, ProneSecondaryFireFLH {}
 			, DeployedPrimaryFireFLH {}
 			, DeployedSecondaryFireFLH {}
+
 			, IronCurtain_KeptOnDeploy {}
 			, IronCurtain_Effect {}
 			, IronCurtain_KillWarhead {}
+
 			, Explodes_KillPassengers { true }
 			, DeployFireWeapon {}
 			, TargetZoneScanType { TargetZoneScanType::Same }
+
 			, Insignia {}
 			, InsigniaFrames { { -1, -1, -1 } }
 			, InsigniaFrame { -1 }
 			, Insignia_ShowEnemy {}
+			, Insignia_Weapon {}
+			, InsigniaFrame_Weapon {}
+			, InsigniaFrames_Weapon {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -212,7 +212,7 @@ public:
 
 			, DefaultDisguise {}
 			, UseDisguiseMovementSpeed {}
-			
+
 			, OpenTopped_RangeBonus {}
 			, OpenTopped_DamageMultiplier {}
 			, OpenTopped_WarpDistance {}

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -164,28 +164,6 @@ DEFINE_HOOK(0x700C58, TechnoClass_CanPlayerMove_NoManualMove, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK_AGAIN(0x522790, TechnoClass_DefaultDisguise, 0x6) // InfantryClass_SetDisguise_DefaultDisguise
-DEFINE_HOOK(0x6F421C, TechnoClass_DefaultDisguise, 0x6) // TechnoClass_DefaultDisguise
-{
-	GET(TechnoClass*, pThis, ESI);
-
-	enum { SetDisguise = 0x5227BF, DefaultDisguise = 0x6F4277 };
-
-	if (auto const pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
-	{
-		if (pExt->DefaultDisguise.isset())
-		{
-			pThis->Disguise = pExt->DefaultDisguise;
-			pThis->Disguised = true;
-			return R->Origin() == 0x522790 ? SetDisguise : DefaultDisguise;
-		}
-	}
-
-	pThis->Disguised = false;
-
-	return 0;
-}
-
 DEFINE_HOOK(0x73CF46, UnitClass_Draw_It_KeepUnitVisible, 0x6)
 {
 	enum { KeepUnitVisible = 0x73CF62 };


### PR DESCRIPTION
### Disguise logic additions (disguise-based movement speed, ally disguise blinking)

- `DisguiseBlinkingVisibility` can be used to customize which players can see disguises blinking on units.
- `UseDisguiseMovementSpeed`, if set, makes disguised unit adjust its movement speed to match that of the disguise, if applicable. Note that this applies even when the disguise is revealed, as long as it has not been removed.

In `rulesmd.ini`:
```ini
[General]
DisguiseBlinkingVisibility=owner  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)

[SOMETECHNO]                      ; TechnoType
UseDisguiseMovementSpeed=false    ; boolean
```

Additionally, there are following changes / fixes to the logic:
- Fixed disguised infantry not using custom palette for drawing the disguise when needed.
- Disguised infantry now show appropriate insignia when disguise is visible based on the disguise type and house.
- Disguises will now blink for observers, allowing them to see if an unit is disguised.

And insignia customization is reimplemented on Phobos' side now to facilitate drawing correct insignia for disguised infantry.

### Customizable veterancy insignias

- You can now customize veterancy insignia of TechnoTypes.
  - `Insignia.Rookie|Veteran|Elite` can be used to set a custom insignia file for each veterancy stage. Like the original / default file, `pips.shp`, they are drawn using `palette.pal` as palette.
  - `InsigniaFrame.Rookie|Veteran|Elite` can be used to set (zero-based) frame index of the insignia to display for each veterancy stage. Using -1 uses the default setting. Default settings are -1 (none) for rookie, 14 for veteran and 15 for elite.
  - `Insignia.ShowEnemy` controls whether or not the insignia is shown to enemy players. Defaults to `[General]` -> `EnemyInsignia`, which in turn defaults to true.

In `rulesmd.ini`:
```ini
[General]
EnemyInsignia=true        ; boolean

[SOMETECHNO]              ; TechnoType
Insignia.Rookie=          ; filename - excluding the .shp extension
Insignia.Veteran=         ; filename - excluding the .shp extension
Insignia.Elite=           ; filename - excluding the .shp extension
InsigniaFrame.Rookie=-1   ; int, frame of insignia shp (zero-based) or -1 for default
InsigniaFrame.Veteran=-1  ; int, frame of insignia shp (zero-based) or -1 for default
InsigniaFrame.Elite=-1    ; int, frame of insignia shp (zero-based) or -1 for default
Insignia.ShowEnemy=       ; boolean
```

*Insignia customization should function similarly to the equivalent feature introduced by Ares and takes precedence over it if Phobos is used together with Ares.*