### PR TITLE
Artillery projectile trajectory

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -111,6 +111,7 @@ This page lists all the individual contributions to the project by their author.
   - AI Aircraft docks fix
   - Shared Ammo logic
   - Customizable FLH When Infantry Is Prone Or Deployed
+  - Artillery projectile trajectory
 - **Starkku**:
   - Warhead shield penetration & breaking
   - Strafing aircraft weapon customization

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -21,6 +21,7 @@
     <ClCompile Include="src\Commands\Commands.cpp" />
     <ClCompile Include="src\Commands\Dummy.h" />
     <ClCompile Include="src\Ext\AnimType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Trajectories\ArtilleryTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\BombardTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
@@ -125,6 +126,7 @@
     <ClInclude Include="src\Commands\Commands.h" />
     <ClInclude Include="src\Commands\DamageDisplay.h" />
     <ClInclude Include="src\Commands\QuickSave.h" />
+    <ClInclude Include="src\Ext\Bullet\Trajectories\ArtilleryTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -389,6 +389,19 @@ Trajectory=Bombard             ; Trajectory type
 Trajectory.Bombard.Height=0.0  ; double
 ```
 
+#### Artillery trajectory
+
+- High altitude projctile capable to hit targets in high places.
+- Height determined by `Trajectory.Artillery.MaxHeight`.
+- Supported `Inaccurate=yes` and Ares costumization tags `BallisticScatter.Max` and `BallisticScatter.Min`.
+
+In `rulesmd.ini`:
+```ini
+[SOMEPROJECTILE]                     ; Projectile
+Trajectory=Artillery                 ; Trajectory type
+Trajectory.Artillery.MaxHeight=2000  ; integer
+```
+
 ### Shrapnel enhancement
 - Shrapnel behavior can be triggered on the ground and buildings.
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -308,6 +308,7 @@ New:
 - Correct owner house for Warhead Anim/SplashList & Play Animation trigger animations (by Starkku)
 - Customizable FLH When Infantry Is Crouched Or Deployed (by FS-21)
 - Enhanced projectile interception logic, including projectile strength & armor types (by Starkku)
+- Artillery projectile trajectory (by FS-21)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Bullet/Trajectories/ArtilleryTrajectory.cpp
+++ b/src/Ext/Bullet/Trajectories/ArtilleryTrajectory.cpp
@@ -1,0 +1,134 @@
+#include "ArtilleryTrajectory.h"
+#include <Ext/BulletType/Body.h>
+#include <Ext/Bullet/Body.h>
+
+
+bool ArtilleryTrajectoryType::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
+	this->PhobosTrajectoryType::Load(Stm, false);
+	Stm.Process(this->MaxHeight, false);
+	return true;
+}
+
+bool ArtilleryTrajectoryType::Save(PhobosStreamWriter& Stm) const
+{
+	this->PhobosTrajectoryType::Save(Stm);
+	Stm.Process(this->MaxHeight);
+	return true;
+}
+
+
+void ArtilleryTrajectoryType::Read(CCINIClass* const pINI, const char* pSection)
+{
+	this->MaxHeight = pINI->ReadDouble(pSection, "Trajectory.Artillery.MaxHeight", 1500);
+}
+
+bool ArtilleryTrajectory::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
+	this->PhobosTrajectory::Load(Stm, false);
+
+	Stm
+		.Process(this->MaxHeight) // Creo que esto no hace falta aquí porque no se actualiza....
+		;
+
+	return true;
+}
+
+bool ArtilleryTrajectory::Save(PhobosStreamWriter& Stm) const
+{
+	this->PhobosTrajectory::Save(Stm);
+
+	Stm
+		.Process(this->MaxHeight) // Creo que esto no hace falta aquí porque no se actualiza....
+		;
+
+	return true;
+}
+
+void ArtilleryTrajectory::OnUnlimbo(BulletClass* pBullet, CoordStruct* pCoord, BulletVelocity* pVelocity)
+{
+	//this->Height = this->GetTrajectoryType<ArtilleryTrajectoryType>(pBullet)->Height;
+
+	this->InitialTargetLocation = pBullet->TargetCoords; // YYY0
+	this->InitialSourceLocation = pBullet->SourceCoords; // Y0
+	CoordStruct initialSourceLocation = this->InitialSourceLocation;
+	initialSourceLocation.Z = 0;
+	//pBullet->GetTargetCoords()     //<--- Current Target
+	pBullet->Velocity.X = static_cast<double>(pBullet->TargetCoords.X - pBullet->SourceCoords.X);
+	pBullet->Velocity.Y = static_cast<double>(pBullet->TargetCoords.Y - pBullet->SourceCoords.Y);
+	pBullet->Velocity.Z = static_cast<double>(pBullet->TargetCoords.Z - pBullet->SourceCoords.Z);
+	pBullet->Velocity *= this->GetTrajectorySpeed(pBullet) / pBullet->Velocity.Magnitude();
+}
+
+void ArtilleryTrajectory::OnAI(BulletClass* pBullet)
+{
+	double maxHeight = this->GetTrajectoryType<ArtilleryTrajectoryType>(pBullet)->MaxHeight;
+
+	CoordStruct currentTargetCoords = pBullet->TargetCoords; // ¿Se usa esto?
+	CoordStruct bulletCoords = pBullet->Location;
+	bulletCoords.Z = 0;
+
+	CoordStruct initialTargetLocation = this->InitialTargetLocation;
+	initialTargetLocation.Z = 0;
+	CoordStruct initialSourceLocation = this->InitialSourceLocation;
+	initialSourceLocation.Z = 0;
+
+	double fullInitialDistance = initialSourceLocation.DistanceFrom(initialTargetLocation);
+	double halfInitialDistance = fullInitialDistance / 2;
+	double currentBulletDistance = initialSourceLocation.DistanceFrom(bulletCoords);
+
+	int sinDecimalTrajectoryAngle = 90;
+	double sinRadTrajectoryAngle = Math::sin(Math::deg2rad(sinDecimalTrajectoryAngle));
+
+	double angle = (currentBulletDistance * sinDecimalTrajectoryAngle) / halfInitialDistance;
+	double sinAngle = Math::sin(Math::deg2rad(angle));
+
+	double currHeight = (sinAngle * maxHeight) / sinRadTrajectoryAngle;
+
+	int fallAcceleration = 0;
+
+	// Needed for increasing the bullet aim when the target is in lower locations compared to the source
+	if (angle >= 90 && this->InitialSourceLocation.Z > pBullet->TargetCoords.Z)
+		fallAcceleration = ((int)angle - 90) * 21;
+
+	if (currHeight != 0)
+		pBullet->Location.Z = this->InitialSourceLocation.Z + (int)currHeight - fallAcceleration;
+
+	// Close enough
+	double closeEnough = pBullet->TargetCoords.DistanceFrom(pBullet->Location);
+	//closeEnough < 150 || 
+	if (closeEnough < 100 || fallAcceleration > 0 && pBullet->Location.Z < pBullet->Target->GetCoords().Z)// || (closeEnough < 550.0 && currHeight < 0)) // This value maybe adjusted?
+	{
+		auto pBulletExt = BulletExt::ExtMap.Find(pBullet);
+
+		if (pBulletExt && pBulletExt->LaserTrails.size())
+			pBulletExt->LaserTrails.clear();
+
+		if (pBullet->Target->WhatAmI() == AbstractType::Unit ||
+			pBullet->Target->WhatAmI() == AbstractType::Building ||
+			pBullet->Target->WhatAmI() == AbstractType::Infantry ||
+			pBullet->Target->WhatAmI() == AbstractType::Aircraft)
+		{
+			pBullet->Location = pBullet->TargetCoords;
+		}
+
+		pBullet->Explode(true);
+		pBullet->UnInit();
+		pBullet->LastMapCoords = CellClass::Coord2Cell(pBullet->Location);
+	}
+}
+
+void ArtilleryTrajectory::OnAIVelocity(BulletClass* pBullet, BulletVelocity* pSpeed, BulletVelocity* pPosition)
+{
+	pSpeed->Z += BulletTypeExt::GetAdjustedGravity(pBullet->Type); // We don't want to take the gravity into account
+}
+
+TrajectoryCheckReturnType ArtilleryTrajectory::OnAITargetCoordCheck(BulletClass* pBullet)
+{
+	return TrajectoryCheckReturnType::ExecuteGameCheck; // Execute game checks.
+}
+
+TrajectoryCheckReturnType ArtilleryTrajectory::OnAITechnoCheck(BulletClass* pBullet, TechnoClass* pTechno)
+{
+	return TrajectoryCheckReturnType::SkipGameCheck; // Bypass game checks entirely.
+}

--- a/src/Ext/Bullet/Trajectories/ArtilleryTrajectory.h
+++ b/src/Ext/Bullet/Trajectories/ArtilleryTrajectory.h
@@ -22,13 +22,11 @@ public:
 	ArtilleryTrajectory() : PhobosTrajectory(TrajectoryFlag::Artillery)
 		, InitialTargetLocation{ CoordStruct::Empty }
 		, InitialSourceLocation{ CoordStruct::Empty }
-		, MaxHeight{ 0.0 }
 	{}
 
 	ArtilleryTrajectory(PhobosTrajectoryType* pType) : PhobosTrajectory(TrajectoryFlag::Artillery)
 		, InitialTargetLocation{ CoordStruct::Empty }
 		, InitialSourceLocation{ CoordStruct::Empty }
-		, MaxHeight{ 0.0 }
 	{}
 
 	virtual bool Load(PhobosStreamReader& Stm, bool RegisterForChange) override;
@@ -42,5 +40,4 @@ public:
 
 	CoordStruct InitialTargetLocation;
 	CoordStruct InitialSourceLocation;
-	double MaxHeight;
 };

--- a/src/Ext/Bullet/Trajectories/ArtilleryTrajectory.h
+++ b/src/Ext/Bullet/Trajectories/ArtilleryTrajectory.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "PhobosTrajectory.h"
+
+class ArtilleryTrajectoryType final : public PhobosTrajectoryType
+{
+public:
+	ArtilleryTrajectoryType() : PhobosTrajectoryType(TrajectoryFlag::Artillery)
+		, MaxHeight{ 0.0 }
+	{ }
+
+	virtual bool Load(PhobosStreamReader& Stm, bool RegisterForChange) override;
+	virtual bool Save(PhobosStreamWriter& Stm) const override;
+
+	virtual void Read(CCINIClass* const pINI, const char* pSection) override;
+	double MaxHeight;
+};
+
+class ArtilleryTrajectory final : public PhobosTrajectory
+{
+public:
+	ArtilleryTrajectory() : PhobosTrajectory(TrajectoryFlag::Artillery)
+		, InitialTargetLocation{ CoordStruct::Empty }
+		, InitialSourceLocation{ CoordStruct::Empty }
+		, MaxHeight{ 0.0 }
+	{}
+
+	ArtilleryTrajectory(PhobosTrajectoryType* pType) : PhobosTrajectory(TrajectoryFlag::Artillery)
+		, InitialTargetLocation{ CoordStruct::Empty }
+		, InitialSourceLocation{ CoordStruct::Empty }
+		, MaxHeight{ 0.0 }
+	{}
+
+	virtual bool Load(PhobosStreamReader& Stm, bool RegisterForChange) override;
+	virtual bool Save(PhobosStreamWriter& Stm) const override;
+
+	virtual void OnUnlimbo(BulletClass* pBullet, CoordStruct* pCoord, BulletVelocity* pVelocity) override;
+	virtual void OnAI(BulletClass* pBullet) override;
+	virtual void OnAIVelocity(BulletClass* pBullet, BulletVelocity* pSpeed, BulletVelocity* pPosition) override;
+	virtual TrajectoryCheckReturnType OnAITargetCoordCheck(BulletClass* pBullet) override;
+	virtual TrajectoryCheckReturnType OnAITechnoCheck(BulletClass* pBullet, TechnoClass* pTechno) override;
+
+	CoordStruct InitialTargetLocation;
+	CoordStruct InitialSourceLocation;
+	double MaxHeight;
+};

--- a/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
+++ b/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
@@ -9,6 +9,7 @@
 
 #include "BombardTrajectory.h"
 #include "StraightTrajectory.h"
+#include "ArtilleryTrajectory.h"
 
 bool PhobosTrajectoryType::Load(PhobosStreamReader& Stm, bool RegisterForChange)
 {
@@ -34,6 +35,8 @@ void PhobosTrajectoryType::CreateType(PhobosTrajectoryType*& pType, CCINIClass* 
 		pNewType = GameCreate<StraightTrajectoryType>();
 	else if (_stricmp(Phobos::readBuffer, "Bombard") == 0)
 		pNewType = GameCreate<BombardTrajectoryType>();
+	else if (_stricmp(Phobos::readBuffer, "Artillery") == 0)
+		pNewType = GameCreate<ArtilleryTrajectoryType>();
 	else
 		bUpdateType = false;
 
@@ -62,6 +65,10 @@ PhobosTrajectoryType* PhobosTrajectoryType::LoadFromStream(PhobosStreamReader& S
 
 		case TrajectoryFlag::Bombard:
 			pType = GameCreate<BombardTrajectoryType>();
+			break;
+
+		case TrajectoryFlag::Artillery:
+			pType = GameCreate<ArtilleryTrajectoryType>();
 			break;
 
 		default:
@@ -127,6 +134,10 @@ PhobosTrajectory* PhobosTrajectory::CreateInstance(PhobosTrajectoryType* pType, 
 	case TrajectoryFlag::Bombard:
 		pRet = GameCreate<BombardTrajectory>(pType);
 		break;
+
+	case TrajectoryFlag::Artillery:
+		pRet = GameCreate<ArtilleryTrajectory>(pType);
+		break;
 	}
 
 	if (pRet)
@@ -150,6 +161,10 @@ PhobosTrajectory* PhobosTrajectory::LoadFromStream(PhobosStreamReader& Stm)
 
 		case TrajectoryFlag::Bombard:
 			pTraj = GameCreate<BombardTrajectory>();
+			break;
+
+		case TrajectoryFlag::Artillery:
+			pTraj = GameCreate<ArtilleryTrajectory>();
 			break;
 
 		default:

--- a/src/Ext/Bullet/Trajectories/PhobosTrajectory.h
+++ b/src/Ext/Bullet/Trajectories/PhobosTrajectory.h
@@ -11,6 +11,7 @@ enum class TrajectoryFlag : int
 	Invalid = -1,
 	Straight = 0,
 	Bombard = 1,
+	Artillery = 2,
 };
 
 enum class TrajectoryCheckReturnType : int
@@ -24,7 +25,7 @@ class PhobosTrajectoryType
 {
 public:
 	PhobosTrajectoryType(noinit_t) { }
-	PhobosTrajectoryType(TrajectoryFlag flag) : Flag { flag } { }
+	PhobosTrajectoryType(TrajectoryFlag flag) : Flag{ flag } { }
 
 	virtual bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	virtual bool Save(PhobosStreamWriter& Stm) const;
@@ -45,7 +46,7 @@ class PhobosTrajectory
 {
 public:
 	PhobosTrajectory(noinit_t) { }
-	PhobosTrajectory(TrajectoryFlag flag) : Flag { flag } { }
+	PhobosTrajectory(TrajectoryFlag flag) : Flag{ flag } { }
 
 	virtual bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	virtual bool Save(PhobosStreamWriter& Stm) const;
@@ -70,76 +71,76 @@ public:
 	static PhobosTrajectory* ProcessFromStream(PhobosStreamReader& Stm, PhobosTrajectory* pTraj);
 	static PhobosTrajectory* ProcessFromStream(PhobosStreamWriter& Stm, PhobosTrajectory* pTraj);
 
-	TrajectoryFlag Flag { TrajectoryFlag::Invalid };
+	TrajectoryFlag Flag{ TrajectoryFlag::Invalid };
 };
 
 /*
 * This is a guidance to tell you how to add your trajectory here
 * Firstly, we just image the game coordinate into a 2D-plain
-* 
-* ZAxis            
+*
+* ZAxis
 *   |			        	 TargetCoord
 *   |
-*   |  
+*   |
 *   |
 *   |
 *   |  SourceCoord
 *   O-------------------------------------XYPlain
-* 
+*
 * Then our problem just turns into:
 * Find an equation whose curve just passes both two coord
 * And the curve is just your trajectory
-* 
+*
 * Luckily, what we need to implement this is just calculate the velocity during the movement
 * So a possible way is to find out the equation and find the derivative of it, which is just the velocity
 * And the just code on it!
-* 
+*
 * There is a SampleTrajectory already, you can just copy it and do some edits.
 * Following that, you can create a fun trajectory very easily. - secsome
-* 
-*                                           ^*##^                                                                            
-*                *###$                     *##^*#*                                                                           
-*               ##^ $##                  ^##^   ^##                                                                          
-*              ##     ##$               ^##      ^##                                                                         
-*             ##       $#*  ^^^  ^^^^^^$#*         ##    ^$*###################*$^                                           
-*            *#^        ^###############$          ^#######*$^    ^#*****#^  ^$*####$^                                       
-*           ^#$          $##^  ##*  $##^            ^*$            #*****#       ^#####*^                                    
-*           ##                                                     $#####^       *#***####$^                                 
-*          ##                                            $###$       ^$^         ^#####* ^###^                               
-*  *#**$  ^#^                                         *###$^                      ^$$$$     *##                              
-*  $$$*#####                                          ^^                                      ##*                            
-*        $#^       ^###*        *$        ####         $*####*^                                ^##                           
-* ^$***$$#*        $####        ##       ^####^       ^**$$$*#^                                  ##^                         
-* $#***$##^         ^$^      $######^      $$                                                     ##^                        
-*       ##                    $^  ^^                                                               ##                        
-*      $#^                                                                                          ##                       
-*      ##                                                                                           $#^                      
-*     ^#$                                                                                            ##                      
-*     *#                                                                                             ^#$                     
-*     ##                                                                                              ##                     
-*     #*                                                                                              $#                     
-*    ^#$                                                                                               ###################*^ 
+*
+*                                           ^*##^
+*                *###$                     *##^*#*
+*               ##^ $##                  ^##^   ^##
+*              ##     ##$               ^##      ^##
+*             ##       $#*  ^^^  ^^^^^^$#*         ##    ^$*###################*$^
+*            *#^        ^###############$          ^#######*$^    ^#*****#^  ^$*####$^
+*           ^#$          $##^  ##*  $##^            ^*$            #*****#       ^#####*^
+*           ##                                                     $#####^       *#***####$^
+*          ##                                            $###$       ^$^         ^#####* ^###^
+*  *#**$  ^#^                                         *###$^                      ^$$$$     *##
+*  $$$*#####                                          ^^                                      ##*
+*        $#^       ^###*        *$        ####         $*####*^                                ^##
+* ^$***$$#*        $####        ##       ^####^       ^**$$$*#^                                  ##^
+* $#***$##^         ^$^      $######^      $$                                                     ##^
+*       ##                    $^  ^^                                                               ##
+*      $#^                                                                                          ##
+*      ##                                                                                           $#^
+*     ^#$                                                                                            ##
+*     *#                                                                                             ^#$
+*     ##                                                                                              ##
+*     #*                                                                                              $#
+*    ^#$                                                                                               ###################*^
 *    $#                                                                                                $###^  ^#**#^   #*###*
 *    $#                                                                                                $***    ****    **$*##
 *    $#                                                                                                $###^   *#*#^   #####$
-*    $#                                                                                                *#**##############*$  
-*    $#                                                                                                #*                    
-*    ^#^                                                                                              ^#^                    
-*     #$                                                                                              *#                     
-*     ##                                                                                              #*                     
-*     *#^                                                                                            *#                      
-*      ##                                                                                            #*                      
-*      $#^                                                                                          ##                       
-*       ##                                                                                         *#^                       
-*       ^##                                                                                       $#$                        
-*        ^##                                                                                     $#*                         
-*          ##                                                                                   $#*                          
-*           ##*                                                                                *#*                           
-*            ^##$                                                                             ##^                            
-*              $##$                                                                         *##                              
-*                $##*^                                                                   ^###^                               
-*                  ^##  ^###**$$$$$$$$$$$   ^$$$$$$$$$$$$$$$$$$****$   *##############  ^##$                                 
-*                    #####$$*****#########^##*#########*#**###*****##$##$^$$$$^$$^^^^##*##                                   
-*                     ^$^                *##^                       ***               ^$                                     
-* 
+*    $#                                                                                                *#**##############*$
+*    $#                                                                                                #*
+*    ^#^                                                                                              ^#^
+*     #$                                                                                              *#
+*     ##                                                                                              #*
+*     *#^                                                                                            *#
+*      ##                                                                                            #*
+*      $#^                                                                                          ##
+*       ##                                                                                         *#^
+*       ^##                                                                                       $#$
+*        ^##                                                                                     $#*
+*          ##                                                                                   $#*
+*           ##*                                                                                *#*
+*            ^##$                                                                             ##^
+*              $##$                                                                         *##
+*                $##*^                                                                   ^###^
+*                  ^##  ^###**$$$$$$$$$$$   ^$$$$$$$$$$$$$$$$$$****$   *##############  ^##$
+*                    #####$$*****#########^##*#########*#**###*****##$##$^$$$$^$$^^^^##*##
+*                     ^$^                *##^                       ***               ^$
+*
 */

--- a/src/Ext/BulletType/Body.cpp
+++ b/src/Ext/BulletType/Body.cpp
@@ -45,6 +45,9 @@ void BulletTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Shrapnel_AffectsGround.Read(exINI, pSection, "Shrapnel.AffectsGround");
 	this->Shrapnel_AffectsBuildings.Read(exINI, pSection, "Shrapnel.AffectsBuildings");
 
+	this->BallisticScatter_Min.Read(exINI, pSection, "BallisticScatter.Min");
+	this->BallisticScatter_Max.Read(exINI, pSection, "BallisticScatter.Max");
+
 	INI_EX exArtINI(CCINIClass::INI_Art);
 
 	if (strlen(pThis->ImageFile))
@@ -66,6 +69,8 @@ void BulletTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Gravity)
 		.Process(this->Shrapnel_AffectsGround)
 		.Process(this->Shrapnel_AffectsBuildings)
+		.Process(this->BallisticScatter_Min)
+		.Process(this->BallisticScatter_Max)
 		;
 
 	this->TrajectoryType = PhobosTrajectoryType::ProcessFromStream(Stm, this->TrajectoryType);

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -30,6 +30,9 @@ public:
 		Valueable<bool> Shrapnel_AffectsGround;
 		Valueable<bool> Shrapnel_AffectsBuildings;
 
+		Nullable<double> BallisticScatter_Min;
+		Nullable<double> BallisticScatter_Max;
+
 		ExtData(BulletTypeClass* OwnerObject) : Extension<BulletTypeClass>(OwnerObject)
 			, Strength { 0 }
 			, Armor { -1 }
@@ -41,6 +44,9 @@ public:
 			, TrajectoryType { nullptr }
 			, Shrapnel_AffectsGround { false }
 			, Shrapnel_AffectsBuildings { false }
+			, BallisticScatter_Min {}
+			, BallisticScatter_Max {}
+
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- High altitude projctile capable to hit targets in high places.
- Height determined by `Trajectory.Artillery.MaxHeight`.
- Supported `Inaccurate=yes` and Ares costumization tags `BallisticScatter.Max` and `BallisticScatter.Min`.

In `rulesmd.ini`:
```ini
[SOMEPROJECTILE]                     ; Projectile
Trajectory=Artillery                 ; Trajectory type
Trajectory.Artillery.MaxHeight=2000  ; integer
```

Note: Re-used some code for Inaccurate projectiles from "arcing-fix" Phobos PR.