### PR TITLE
New action 134 Jump Back To Previous Script after action 94

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -334,6 +334,7 @@ This page lists all the individual contributions to the project by their author.
   - Re-enable the Veinhole Monster and Weeds from TS
   - Recreate the weed-charging of SWs like the TS Chemical Missile
   - Allow to change the speed of gas particles
+- **handama** - AI script action to jump back to previous script
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares
   - unfinished RadTypes code

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -418,6 +418,16 @@ In `rulesmd.ini`:
 ; ...
 ```
 
+### `16005` Jump Back To Previous Script
+
+- Used in a Random Script picked by action 94. It can jump back to the previous script, and continue in the line after x=94,n.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=16005,0
+```
+
 ### `18000-18999` Variable Manipulation
 
 #### `18000-18023` Edit Variable

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -417,6 +417,7 @@ New:
 - Shield hit flash (by Starkku)
 - Option to scatter `Anim/SplashList` animations around impact coordinates (by Starkku)
 - Customizable wake anim (by TwinkleStar)
+- AI script action to jump back to previous script after picking a random script (by handama)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1164,19 +1164,18 @@ void ScriptExt::Stop_ForceJump_Countdown(TeamClass* pTeam)
 
 void ScriptExt::JumpBackToPreviousScript(TeamClass* pTeam)
 {
-	auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+	auto const pTeamData = TeamExt::ExtMap.Find(pTeam);
 
 	if (!pTeamData->PreviousScriptList.empty())
 	{
-		pTeam->CurrentScript = nullptr;
 		pTeam->CurrentScript = pTeamData->PreviousScriptList.back();
 		pTeamData->PreviousScriptList.pop_back();
 		pTeam->StepCompleted = true;
 	}
 	else
 	{
-		auto pScript = pTeam->CurrentScript;
-		Debug::Log("DEBUG: [%s] [%s](line: %d = %d,%d): Can't find the previous script! This script action must be used after PickRandomScript.\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
+		auto const pScript = pTeam->CurrentScript;
+		ScriptExt::Log("AI Scripts - JumpBackToPreviousScript: [%s] [%s](line: %d = %d,%d): Can't find the previous script! This script action must be used after PickRandomScript.\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
 		pTeam->StepCompleted = true;
 	}
 }

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1175,7 +1175,8 @@ void ScriptExt::JumpBackToPreviousScript(TeamClass* pTeam)
 	}
 	else
 	{
-		Debug::Log("DEBUG: Can't find the previous script! This script action must be used after PickRandomScript.\n");
+		auto pScript = pTeam->CurrentScript;
+		Debug::Log("DEBUG: [%s] [%s](line: %d = %d,%d): Can't find the previous script! This script action must be used after PickRandomScript.\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
 		pTeam->StepCompleted = true;
 	}
 }

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -209,6 +209,9 @@ void ScriptExt::ProcessAction(TeamClass* pTeam)
 		// Start Timed Jump that jumps to the same line when the countdown finish (in frames)
 		ScriptExt::Set_ForceJump_Countdown(pTeam, true, -1);
 		break;
+	case PhobosScripts::JumpBackToPreviousScript:
+		ScriptExt::JumpBackToPreviousScript(pTeam);
+		break;
 	case PhobosScripts::ChronoshiftToEnemyBase:
 		// Chronoshift to enemy base, argument is additional distance modifier
 		ScriptExt::ChronoshiftToEnemyBase(pTeam, argument);
@@ -650,6 +653,7 @@ void ScriptExt::PickRandomScript(TeamClass* pTeam, int idxScriptsList = -1)
 				if (pNewScript->ActionsCount > 0)
 				{
 					changeFailed = false;
+					TeamExt::ExtMap.Find(pTeam)->PreviousScriptList.push_back(pTeam->CurrentScript);
 					pTeam->CurrentScript = nullptr;
 					pTeam->CurrentScript = GameCreate<ScriptClass>(pNewScript);
 
@@ -1156,6 +1160,24 @@ void ScriptExt::Stop_ForceJump_Countdown(TeamClass* pTeam)
 	// This action finished
 	pTeam->StepCompleted = true;
 	ScriptExt::Log("AI Scripts - StopForceJumpCountdown: [%s] [%s](line: %d = %d,%d): Stopped Timed Jump\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
+}
+
+void ScriptExt::JumpBackToPreviousScript(TeamClass* pTeam)
+{
+	auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+
+	if (!pTeamData->PreviousScriptList.empty())
+	{
+		pTeam->CurrentScript = nullptr;
+		pTeam->CurrentScript = pTeamData->PreviousScriptList.back();
+		pTeamData->PreviousScriptList.pop_back();
+		pTeam->StepCompleted = true;
+	}
+	else
+	{
+		Debug::Log("DEBUG: Can't find the previous script! This script action must be used after PickRandomScript.\n");
+		pTeam->StepCompleted = true;
+	}
 }
 
 void ScriptExt::ChronoshiftToEnemyBase(TeamClass* pTeam, int extraDistance)

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -58,7 +58,6 @@ enum class PhobosScripts : unsigned int
 	GatherAroundLeader = 10102,
 	LoadIntoTransports = 10103,
 	ChronoshiftToEnemyBase = 10104,
-	JumpBackToPreviousScript = 134,
 
 	// Range 12000-12999 are suplementary/setup pre-actions
 	WaitIfNoTarget = 12000,
@@ -77,6 +76,7 @@ enum class PhobosScripts : unsigned int
 	StopForceJumpCountdown = 16002,
 	RandomSkipNextAction = 16003,
 	PickRandomScript = 16004,
+	JumpBackToPreviousScript = 16005,
 
 	// Range 18000-18999 are variable actions
 	LocalVariableSet = 18000,

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -58,6 +58,7 @@ enum class PhobosScripts : unsigned int
 	GatherAroundLeader = 10102,
 	LoadIntoTransports = 10103,
 	ChronoshiftToEnemyBase = 10104,
+	JumpBackToPreviousScript = 134,
 
 	// Range 12000-12999 are suplementary/setup pre-actions
 	WaitIfNoTarget = 12000,
@@ -206,6 +207,7 @@ public:
 	static FootClass* FindTheTeamLeader(TeamClass* pTeam);
 	static void Set_ForceJump_Countdown(TeamClass* pTeam, bool repeatLine, int count);
 	static void Stop_ForceJump_Countdown(TeamClass* pTeam);
+	static void JumpBackToPreviousScript(TeamClass* pTeam);
 	static void ChronoshiftToEnemyBase(TeamClass* pTeam, int extraDistance);
 
 	static bool IsExtVariableAction(int action);
@@ -216,7 +218,6 @@ public:
 	static void VariableBinaryOperationHandler(TeamClass* pTeam, int nVariable, int nVarToOperate);
 	static bool IsUnitAvailable(TechnoClass* pTechno, bool checkIfInTransportOrAbsorbed);
 	static void Log(const char* pFormat, ...);
-
 	// Mission.Attack.cpp
 	static void Mission_Attack(TeamClass* pTeam, bool repeatAction, int calcThreatMode, int attackAITargetType, int IdxAITargetTypeItem);
 	static TechnoClass* GreatestThreat(TechnoClass* pTechno, int method, int calcThreatMode, HouseClass* onlyTargetThisHouseEnemy, int attackAITargetType, int idxAITargetTypeItem, bool agentMode);

--- a/src/Ext/Team/Body.cpp
+++ b/src/Ext/Team/Body.cpp
@@ -21,6 +21,7 @@ void TeamExt::ExtData::Serialize(T& Stm)
 		.Process(this->ForceJump_InitialCountdown)
 		.Process(this->ForceJump_RepeatMode)
 		.Process(this->TeamLeader)
+		.Process(this->PreviousScriptList)
 		;
 }
 

--- a/src/Ext/Team/Body.h
+++ b/src/Ext/Team/Body.h
@@ -31,6 +31,7 @@ public:
 		int ForceJump_InitialCountdown;
 		bool ForceJump_RepeatMode;
 		FootClass* TeamLeader;
+		std::vector<ScriptClass*> PreviousScriptList;
 
 		ExtData(TeamClass* OwnerObject) : Extension<TeamClass>(OwnerObject)
 			, WaitNoTargetAttempts { 0 }
@@ -45,6 +46,7 @@ public:
 			, ForceJump_InitialCountdown { -1 }
 			, ForceJump_RepeatMode { false }
 			, TeamLeader { nullptr }
+			, PreviousScriptList { }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
It can allow the team to go back to previous script and continue the lines after action 94.
And it can be used in multiple layers, like the example:

example:
in aimd.ini:
```
[s1]
Name=test1
0=54,0
1=94,18
2=0,1

[s2]
Name=test2
0=42,0
1=5,5
2=94,19
3=134,0

[s3]
Name=test3
0=42,2
1=5,5
2=94,20
3=134,0

[s4]
Name=test4
0=42,4
1=5,5
2=134,0
```
in rulesmd.ini:
```
[AIScriptsList]
18=s2
19=s3
20=s4
```
https://user-images.githubusercontent.com/55939089/177151602-0a5e2310-8c54-47b0-bb8f-70d57a6c302d.mp4