### PR TITLE
New action 135 Unload from Transports

### DIFF
--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -337,6 +337,7 @@ x=135,n
 6         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Lose transports and keep units. |
 7         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Lose transports and units. |
 
+
 ### `500 - 523` Edit Variable
 - Operate a variable's value
     - The variable's value type is int16 instead of int32 in trigger actions for some reason, which means it ranges from -2^15 to 2^15-1.

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -314,6 +314,29 @@ In `aimd.ini`:
 x=126,n           ; integer n=0, in frames
 ```
 
+### `135` Unload from Transports
+
+- A new unload action similar to x=8,n, but can avoid treating `VehicleTypes` with `OpenTopped=yes` and `Gunner=yes` as transports.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=135,n
+```
+
+- The possible argument values are:
+
+| *Argument* | *Description*                       |
+| :------: | :-------------------------------------------: |
+0         | Keep transports and units. |
+1         | Keep transports and lose units. |
+2         | Lose transports and keep units. |
+3         | Lose transports and units. |
+4         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Keep transports and units. |
+5         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Keep transports and lose units. |
+6         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Lose transports and keep units. |
+7         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Lose transports and units. |
+
 ### `500 - 523` Edit Variable
 - Operate a variable's value
     - The variable's value type is int16 instead of int32 in trigger actions for some reason, which means it ranges from -2^15 to 2^15-1.

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -316,7 +316,9 @@ x=126,n           ; integer n=0, in frames
 
 ### `135` Unload from Transports
 
-- A new unload action similar to x=8,n, but can avoid treating `VehicleTypes` with `OpenTopped=yes` and `Gunner=yes` as transports. If `TransportsReturnOnUnload` is set to `yes` in this TeamType, and transports are lost, they will return after unloading.
+- A new unload action similar to x=8,n, but can avoid treating `VehicleTypes` with `OpenTopped=yes` and `Gunner=yes` as transports.
+  - All `InitialPayload` will be regarded as passengers and added to team.
+  - If `TransportsReturnOnUnload` is set to `yes` in this TeamType, and transports are lost, they will return after unloading.
 
 In `aimd.ini`:
 ```ini

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -316,7 +316,7 @@ x=126,n           ; integer n=0, in frames
 
 ### `135` Unload from Transports
 
-- A new unload action similar to x=8,n, but can avoid treating `VehicleTypes` with `OpenTopped=yes` and `Gunner=yes` as transports.
+- A new unload action similar to x=8,n, but can avoid treating `VehicleTypes` with `OpenTopped=yes` and `Gunner=yes` as transports. If `TransportsReturnOnUnload` is set to `yes` in this TeamType, and transports are lost, they will return after unloading.
 
 In `aimd.ini`:
 ```ini

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -208,6 +208,9 @@ void ScriptExt::ProcessAction(TeamClass* pTeam)
 		// Start Timed Jump that jumps to the same line when the countdown finish (in frames)
 		ScriptExt::Set_ForceJump_Countdown(pTeam, true, -1);
 		break;
+	case PhobosScripts::UnloadFromTransports:
+		ScriptExt::UnloadFromTransports(pTeam);
+		break;
 	default:
 		// Do nothing because or it is a wrong Action number or it is an Ares/YR action...
 		if (action > 70 && !IsExtVariableAction(action))
@@ -3085,4 +3088,173 @@ void ScriptExt::Stop_ForceJump_Countdown(TeamClass *pTeam)
 	// This action finished
 	pTeam->StepCompleted = true;
 	Debug::Log("DEBUG: [%s] [%s](line: %d = %d,%d): Stopped Timed Jump\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
+}
+
+void TransportsReturn(TeamClass* pTeam, FootClass* pTransport)
+{
+	if (pTeam->Type->TransportsReturnOnUnload)
+	{
+		if (!pTransport->GetTechnoType()->HasPrimary)
+		{
+			auto pScript = pTeam->CurrentScript;
+			Debug::Log("DEBUG: [%s] [%s](line: %d = %d,%d): Transport [%s] (UID: %lu) has no weapon and thus cannot return.\n",
+				pTeam->Type->ID,
+				pScript->Type->ID,
+				pScript->CurrentMission,
+				pScript->Type->ScriptActions[pScript->CurrentMission].Action,
+				pScript->Type->ScriptActions[pScript->CurrentMission].Argument,
+				pTransport->GetTechnoType()->get_ID(),
+				pTransport->UniqueID);
+		}
+		pTransport->SetDestination(pTeam->SpawnCell, false);
+		pTransport->QueueMission(Mission::Move, false);
+	}
+	return;
+}
+
+void ScriptExt::UnloadFromTransports(TeamClass* pTeam)
+{
+	if (!pTeam)
+		return;
+
+	auto pTeamData = TeamExt::ExtMap.Find(pTeam);
+	if (!pTeamData)
+		return;
+
+	double maxSizeLimit = 0;
+	DynamicVectorClass<FootClass*> transports;
+	DynamicVectorClass<FootClass*> passengers;
+	int argument = pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->CurrentMission].Argument;
+
+	if (argument > 3)
+	{
+		for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+		{
+			maxSizeLimit = std::max(maxSizeLimit, pUnit->GetTechnoType()->SizeLimit);
+		}
+		for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+		{
+			if (!pUnit->GetTechnoType()->OpenTopped
+				&& !pUnit->GetTechnoType()->Gunner
+				&& pUnit->Passengers.NumPassengers > 0
+				&& pUnit->GetTechnoType()->SizeLimit == maxSizeLimit) //Battle Fortress and IFV are not transports.
+			{
+				pUnit->QueueMission(Mission::Unload, true);
+			}
+		}
+	}
+	else
+	{
+		for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+		{
+			if (!pUnit->GetTechnoType()->OpenTopped && !pUnit->GetTechnoType()->Gunner && pUnit->Passengers.NumPassengers > 0) //Battle Fortress and IFV are not transports.
+			{
+				pUnit->QueueMission(Mission::Unload, true);
+			}
+		}
+	}
+
+	//unload in progress
+	for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+		if (pUnit->GetCurrentMission() == Mission::Unload)
+			return;
+
+	for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+	{
+		if (!pUnit->GetTechnoType()->OpenTopped && !pUnit->GetTechnoType()->Gunner && pUnit->GetTechnoType()->Passengers > 0) //Battle Fortress and IFV are not transports.
+		{
+			transports.AddItem(pUnit);
+		}
+		else
+		{
+			passengers.AddItem(pUnit);
+		}
+	}
+
+	//no valid transports
+	if (transports.Count == 0)
+	{
+		pTeam->StepCompleted = true;
+		return;
+	}
+
+	//Liberate passengers
+	if (argument == 1)
+	{
+		for (auto pPassengers : passengers)
+		{
+			pTeam->LiberateMember(pPassengers);
+		}
+	}
+	//Liberate transports
+	else if (argument == 2)
+	{
+		for (auto pTransport : transports)
+		{
+			TransportsReturn(pTeam, pTransport);
+			pTeam->LiberateMember(pTransport);
+		}
+	}
+	//Liberate whole team
+	else if (argument == 3)
+	{
+		for (auto pTransport : transports)
+		{
+			TransportsReturn(pTeam, pTransport);
+		}
+		for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+		{
+			pTeam->LiberateMember(pUnit);
+			//this team is over :)
+			pTeam->CurrentScript->ClearMission();
+		}
+	}
+	//Liberate passengers and transports that don't have a maxSizeLimit.
+	else if (argument == 5)
+	{
+		for (auto pTransport : transports)
+		{
+			if (!pTransport->GetTechnoType()->SizeLimit == maxSizeLimit)
+			{
+				pTeam->LiberateMember(pTransport);
+			}
+		}
+		for (auto pPassengers : passengers)
+		{
+			pTeam->LiberateMember(pPassengers);
+		}
+	}
+	//Liberate transports that have a maxSizeLimit.
+	else if (argument == 6)
+	{
+		for (auto pTransport : transports)
+		{
+			if (pTransport->GetTechnoType()->SizeLimit == maxSizeLimit)
+			{
+				TransportsReturn(pTeam, pTransport);
+				pTeam->LiberateMember(pTransport);
+			}
+		}
+	}
+	//Liberate whole team. Only transports with maxSizeLimit will return.
+	else if (argument == 7)
+	{
+		for (auto pTransport : transports)
+		{
+			if (pTransport->GetTechnoType()->SizeLimit == maxSizeLimit)
+			{
+				TransportsReturn(pTeam, pTransport);
+			}
+		}
+		for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
+		{
+			pTeam->LiberateMember(pUnit);
+			//this team is over :)
+			pTeam->CurrentScript->ClearMission();
+		}
+	}
+
+	// This action finished
+	pTeam->StepCompleted = true;
+	return;
 }

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -3214,7 +3214,7 @@ void ScriptExt::UnloadFromTransports(TeamClass* pTeam)
 	{
 		for (auto pTransport : transports)
 		{
-			if (!pTransport->GetTechnoType()->SizeLimit == maxSizeLimit)
+			if (pTransport->GetTechnoType()->SizeLimit != maxSizeLimit)
 			{
 				pTeam->LiberateMember(pTransport);
 			}

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -65,6 +65,7 @@ enum class PhobosScripts : unsigned int
 	StopForceJumpCountdown = 124,
 	NextLineForceJumpCountdown = 125,
 	SameLineForceJumpCountdown = 126,
+	UnloadFromTransports = 135,
 
 	// Variables
 	LocalVariableSet = 500,
@@ -206,6 +207,7 @@ public:
 	template<bool IsSrcGlobal, bool IsGlobal, class _Pr>
 	static void VariableBinaryOperationHandler(TeamClass* pTeam, int nVariable, int nVarToOperate);
 
+	static void UnloadFromTransports(TeamClass* pTeam);
 
 	static ExtContainer ExtMap;
 

--- a/src/Ext/Team/Body.cpp
+++ b/src/Ext/Team/Body.cpp
@@ -22,6 +22,7 @@ void TeamExt::ExtData::Serialize(T& Stm)
 		.Process(this->ForceJump_InitialCountdown)
 		.Process(this->ForceJump_RepeatMode)
 		.Process(this->TeamLeader)
+		.Process(this->AllPassengers)
 		;
 }
 

--- a/src/Ext/Team/Body.h
+++ b/src/Ext/Team/Body.h
@@ -27,6 +27,7 @@ public:
 		int ForceJump_InitialCountdown;
 		bool ForceJump_RepeatMode;
 		FootClass* TeamLeader;
+		DynamicVectorClass<FootClass*> AllPassengers;
 
 		ExtData(TeamClass* OwnerObject) : Extension<TeamClass>(OwnerObject)
 			, WaitNoTargetAttempts { 0 }
@@ -41,6 +42,7 @@ public:
 			, ForceJump_InitialCountdown { -1 }
 			, ForceJump_RepeatMode { false }
 			, TeamLeader { nullptr }
+			, AllPassengers { }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### `135` Unload from Transports

- A new unload action similar to x=8,n, but can avoid treating `VehicleTypes` with `OpenTopped=yes` and `Gunner=yes` as transports.
  - All `InitialPayload` will be regarded as passengers and added to team.
  - If `TransportsReturnOnUnload` is set to `yes` in this TeamType, and transports are lost, they will return after unloading.

In `aimd.ini`:
```ini
[SOMESCRIPTTYPE]  ; ScriptType
x=135,n
```

- The possible argument values are:

| *Argument* | *Description*                       |
| :------: | :-------------------------------------------: |
0         | Keep transports and units. |
1         | Keep transports and lose units. |
2         | Lose transports and keep units. |
3         | Lose transports and units. |
4         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Keep transports and units. |
5         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Keep transports and lose units. |
6         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Lose transports and keep units. |
7         | Only `VehicleTypes` with largest `SizeLimit` will be regarded as transports. Lose transports and units. |


here is an example:
```
0=72,0
1=43,0
2=5,5
3=54,0
4=135,6
5=53,0
6=135,0
7=0,1
```
![new unload script](https://user-images.githubusercontent.com/55939089/177389422-7cc976e1-52f7-46be-ad2c-0c913c0b9d97.gif)

