### PR TITLE
`SW.AuxTechno`

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="src\Ext\Anim\Body.cpp" />
     <ClCompile Include="src\Ext\SWType\FireSuperWeapon.cpp" />
     <ClCompile Include="src\Ext\SWType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\SWType\Hooks.Update.cpp" />
     <ClCompile Include="src\Ext\TAction\Body.cpp" />
     <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
     <ClCompile Include="src\Ext\Team\Body.cpp" />

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -401,6 +401,20 @@ Shrapnel.AffectsBuildings=false  ; boolean
 
 ## Super Weapons
 
+### `AuxTechno` and `NegTechno`
+
+Like Ares entry `SW.AuxBuildings` and `SW.NegBuildings`, for all technotype.
+
+In `rulesmd.ini`:
+```ini
+
+SW.AuxTechno=      ; TechnoTypes, like SW.AuxBuildings
+SW.AuxTechno.Any=  ; boolean, one of or all of, default yes(one of)
+SW.NegTechno=      ; TechnoTypes, like SW.NegBuildings
+SW.NegTechno.Any=  ; boolean, one of or all of, default yes(one of)
+
+```
+
 ### LimboDelivery
 
 - Super Weapons can now deliver off-map buildings that act as if they were on the field.

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -1,6 +1,10 @@
 #include "Body.h"
 
+#include <SuperClass.h>
+
 #include <Ext/House/Body.h>
+#include <Ext/SWType/Body.h>
+
 #include <Utilities/GeneralUtils.h>
 
 template<> const DWORD Extension<BuildingTypeClass>::Canary = 0x11111111;
@@ -67,6 +71,60 @@ int BuildingTypeExt::GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass*
 void BuildingTypeExt::ExtData::Initialize()
 {
 
+}
+
+
+int BuildingTypeExt::ExtData::GetSWCount()
+{
+	return SuperWeapons.Count + (OwnerObject()->SuperWeapon != -1) + (OwnerObject()->SuperWeapon2 != -1);
+}
+
+int BuildingTypeExt::ExtData::GetSWidx(int idx)
+{
+	BuildingTypeClass* pType = OwnerObject();
+
+	if (pType->SuperWeapon >= 0)
+	{
+		if (idx == 0)
+		{
+			return pType->SuperWeapon;
+		}
+
+		--idx;
+	}
+
+	if (pType->SuperWeapon2 >= 0)
+	{
+		if (idx == 0)
+		{
+			return pType->SuperWeapon2;
+		}
+
+		--idx;
+	}
+
+	if (idx >= SuperWeapons.Count)
+		return -1;
+
+	return SuperWeapons.GetItem(idx)->ArrayIndex;
+}
+
+int BuildingTypeExt::ExtData::GetSWidx(int idx, HouseClass* pHouse)
+{
+	if (idx < 0)
+		return -1;
+
+	int idxSW = this->GetSWidx(idx);
+	SuperClass* pSuper = pHouse->Supers.GetItemOrDefault(idxSW);
+
+	if (pSuper != nullptr)
+	{
+		SWTypeExt::ExtData* pSWTypeExt = SWTypeExt::ExtMap.Find(pSuper->Type);
+
+		return pSWTypeExt->IsAvailable(pHouse) ? idxSW : -1;
+	}
+
+	return idxSW;
 }
 
 // =============================

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -44,6 +44,14 @@ public:
 		CustomPalette PlacementPreview_Palette;
 		Nullable<int> PlacementPreview_TranslucentLevel;
 
+		//functions
+
+		int GetSWCount();
+
+		//return -1 if unavaliable
+		int GetSWidx(int idx, HouseClass* pHouse);
+		int GetSWidx(int idx);
+
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
 			, PowersUp_Buildings {}

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -89,7 +89,9 @@ template <typename T>
 void HouseExt::ExtData::Serialize(T& Stm)
 {
 	Stm
-		.Process(this->BuildingCounter);
+		.Process(this->BuildingCounter)
+		.Process(this->SW_FireTimes)
+		;
 }
 
 void HouseExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -18,9 +18,11 @@ public:
 	public:
 		std::map<BuildingTypeExt::ExtData*, int> BuildingCounter;
 		CounterClass OwnedLimboBuildingTypes;
+		std::unordered_map<int, int> SW_FireTimes;
 
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, OwnedLimboBuildingTypes {}
+			, SW_FireTimes {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -1,12 +1,14 @@
 #include "Body.h"
 
-#include <HouseClass.h>
 #include <SuperWeaponTypeClass.h>
 #include <StringTable.h>
 
+#include <Utilities/EnumFunctions.h>
+
+#include <Ext/House/Body.h>
+
 template<> const DWORD Extension<SuperWeaponTypeClass>::Canary = 0x11111111;
 SWTypeExt::ExtContainer SWTypeExt::ExtMap;
-
 
 // Ares 0.A
 // I don't know Ares 3.0 has add some new things in this 
@@ -24,6 +26,11 @@ bool SWTypeExt::ExtData::IsAvailable(HouseClass* pHouse)
 	if (!pHouse->ControlledByHuman() && !SW_AllowAI)
 		return false;
 
+	HouseExt::ExtData* pHouseExt = HouseExt::ExtMap.Find(pHouse);
+
+	if (SW_Shots >= 0 && pHouseExt->SW_FireTimes[pThis->ArrayIndex] >= SW_Shots)
+		return false;
+
 	// check whether the optional aux building exists
 	if (pThis->AuxBuilding && pHouse->CountOwnedAndPresent(pThis->AuxBuilding) <= 0)
 		return false;
@@ -36,7 +43,7 @@ bool SWTypeExt::ExtData::IsAvailable(HouseClass* pHouse)
 	// check that any aux building exist and no neg building
 	auto IsTechnoPresent = [pHouse](TechnoTypeClass* pType)
 	{
-		return pType && pHouse->CountOwnedAndPresent(pType) > 0;
+		return pHouse->CountOwnedAndPresent(pType) > 0;
 	};
 
 	if (!SW_AuxBuildings.empty() && std::none_of(SW_AuxBuildings.begin(), SW_AuxBuildings.end(), IsTechnoPresent))
@@ -45,27 +52,42 @@ bool SWTypeExt::ExtData::IsAvailable(HouseClass* pHouse)
 	if (std::any_of(SW_NegBuildings.begin(), SW_NegBuildings.end(), IsTechnoPresent))
 		return false;
 
-	if (SW_AuxTechno_Any)
+	for (HouseClass* pTmpHouse : *HouseClass::Array)
 	{
+		auto IsHouseTechnoPresent = [pTmpHouse](TechnoTypeClass* pType)
+		{
+			return pTmpHouse->CountOwnedAndPresent(pType) > 0;
+		};
 
-		if (!SW_AuxTechno.empty() && std::none_of(SW_AuxTechno.begin(), SW_AuxTechno.end(), IsTechnoPresent))
-			return false;
-	}
-	else
-	{
-		if (!SW_AuxTechno.empty() && !std::all_of(SW_AuxTechno.begin(), SW_AuxTechno.end(), IsTechnoPresent))
-			return false;
-	}
+		if (EnumFunctions::CanTargetHouse(SW_AuxTechno_Owner, pHouse, pTmpHouse))
+		{
 
-	if (SW_NegTechno_Any)
-	{
-		if (std::any_of(SW_NegTechno.begin(), SW_NegTechno.end(), IsTechnoPresent))
-			return false;
-	}
-	else
-	{
-		if (std::all_of(SW_NegTechno.begin(), SW_NegTechno.end(), IsTechnoPresent))
-			return false;
+			if (SW_AuxTechno_Any)
+			{
+
+				if (!SW_AuxTechno.empty() && std::none_of(SW_AuxTechno.begin(), SW_AuxTechno.end(), IsHouseTechnoPresent))
+					return false;
+			}
+			else
+			{
+				if (!SW_AuxTechno.empty() && !std::all_of(SW_AuxTechno.begin(), SW_AuxTechno.end(), IsHouseTechnoPresent))
+					return false;
+			}
+		}
+
+		if (EnumFunctions::CanTargetHouse(SW_NegTechno_Owner, pHouse, pTmpHouse))
+		{
+			if (SW_NegTechno_Any)
+			{
+				if (std::any_of(SW_NegTechno.begin(), SW_NegTechno.end(), IsHouseTechnoPresent))
+					return false;
+			}
+			else
+			{
+				if (std::all_of(SW_NegTechno.begin(), SW_NegTechno.end(), IsHouseTechnoPresent))
+					return false;
+			}
+		}
 	}
 
 	return true;
@@ -91,6 +113,8 @@ void SWTypeExt::ExtData::Serialize(T& Stm) {
 		.Process(this->RandomBuffer)
 		.Process(this->SW_AuxTechno)
 		.Process(this->SW_NegTechno)
+		.Process(this->SW_AuxTechno_Owner)
+		.Process(this->SW_NegTechno_Owner)
 		.Process(this->SW_AuxTechno_Any)
 		.Process(this->SW_NegTechno_Any)
 		.Process(this->SW_AuxBuildings)
@@ -102,6 +126,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm) {
 		.Process(this->SW_AllowAI)
 		.Process(this->SW_ShowCameo)
 		.Process(this->SW_AutoFire)
+		.Process(this->SW_Shots)
 		;
 }
 
@@ -148,6 +173,8 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 
 	this->SW_AuxTechno.Read(exINI, pSection, "SW.AuxTechno");
 	this->SW_NegTechno.Read(exINI, pSection, "SW.NegTechno");
+	this->SW_AuxTechno_Owner.Read(exINI, pSection, "SW.AuxTechno.Owner");
+	this->SW_NegTechno_Owner.Read(exINI, pSection, "SW.NegTechno.Owner");
 	this->SW_AuxTechno_Any.Read(exINI, pSection, "SW.AuxTechno.Any");
 	this->SW_NegTechno_Any.Read(exINI, pSection, "SW.NegTechno.Any");
 	this->SW_AuxBuildings.Read(exINI, pSection, "SW.AuxBuildings");
@@ -159,6 +186,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->SW_AllowAI.Read(exINI, pSection, "SW.AllowAI");
 	this->SW_ShowCameo.Read(exINI, pSection, "SW.ShowCameo");
 	this->SW_AutoFire.Read(exINI, pSection, "SW.AutoFire");
+	this->SW_Shots.Read(exINI, pSection, "SW.Shots");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -30,7 +30,9 @@ public:
 		ValueableVector<ValueableVector<int>> LimboDelivery_RandomWeightsData;
 
 		ValueableVector<TechnoTypeClass*> SW_AuxTechno;
+		Valueable<AffectedHouse> SW_AuxTechno_Owner;
 		ValueableVector<TechnoTypeClass*> SW_NegTechno;
+		Valueable<AffectedHouse> SW_NegTechno_Owner;
 		Valueable<bool> SW_AuxTechno_Any;
 		Valueable<bool> SW_NegTechno_Any;
 
@@ -44,6 +46,7 @@ public:
 		Valueable<bool> SW_AllowAI;
 		Valueable<bool> SW_ShowCameo;
 		Valueable<bool> SW_AutoFire;
+		Valueable<int> SW_Shots;
 
 		bool IsAvailable(HouseClass* pHouse);
 
@@ -60,6 +63,22 @@ public:
 			, LimboKill_Affected { AffectedHouse::Owner }
 			, LimboKill_IDs {}
 			, RandomBuffer { 0.0 }
+			, SW_AuxTechno {}
+			, SW_NegTechno {}
+			, SW_AuxTechno_Owner { AffectedHouse::Owner }
+			, SW_NegTechno_Owner { AffectedHouse::Owner }
+			, SW_AuxTechno_Any { true }
+			, SW_NegTechno_Any { true }
+			, SW_AuxBuildings {}
+			, SW_NegBuildings {}
+			, SW_RequiredHouses { ULONG_MAX }
+			, SW_ForbiddenHouses { 0UL }
+			, SW_AlwaysGranted { false }
+			, SW_AllowAI { true }
+			, SW_AllowPlayer { true }
+			, SW_ShowCameo { true }
+			, SW_AutoFire { false }
+			, SW_Shots { -1 }
 		{ }
 
 

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -27,9 +27,25 @@ public:
 		Valueable<AffectedHouse> LimboKill_Affected;
 		ValueableVector<int> LimboKill_IDs;
 		Valueable<double> RandomBuffer;
-
-
 		ValueableVector<ValueableVector<int>> LimboDelivery_RandomWeightsData;
+
+		ValueableVector<TechnoTypeClass*> SW_AuxTechno;
+		ValueableVector<TechnoTypeClass*> SW_NegTechno;
+		Valueable<bool> SW_AuxTechno_Any;
+		Valueable<bool> SW_NegTechno_Any;
+
+		//Ares
+		ValueableVector<BuildingTypeClass*> SW_AuxBuildings;
+		ValueableVector<BuildingTypeClass*> SW_NegBuildings;
+		DWORD SW_RequiredHouses;
+		DWORD SW_ForbiddenHouses;
+		Valueable<bool> SW_AlwaysGranted;
+		Valueable<bool> SW_AllowPlayer;
+		Valueable<bool> SW_AllowAI;
+		Valueable<bool> SW_ShowCameo;
+		Valueable<bool> SW_AutoFire;
+
+		bool IsAvailable(HouseClass* pHouse);
 
 		ExtData(SuperWeaponTypeClass* OwnerObject) : Extension<SuperWeaponTypeClass>(OwnerObject)
 			, Money_Amount { 0 }

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -74,6 +74,9 @@ void LimboDeliver(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 
 void SWTypeExt::ExtData::FireSuperWeapon(SuperClass* pSW, HouseClass* pHouse, CoordStruct coords)
 {
+	HouseExt::ExtData* pHouseExt = HouseExt::ExtMap.Find(pHouse);
+	++pHouseExt->SW_FireTimes[OwnerObject()->ArrayIndex];
+
 	if (this->LimboDelivery_Types.size())
 		ApplyLimboDelivery(pHouse);
 

--- a/src/Ext/SWType/Hooks.Update.cpp
+++ b/src/Ext/SWType/Hooks.Update.cpp
@@ -1,0 +1,235 @@
+#include <HouseClass.h>
+
+#include <SuperClass.h>
+
+#include <Ext/Techno/Body.h>
+#include <Ext/BuildingType/Body.h>
+#include <Ext/SWType/Body.h>
+
+#include <Utilities/Macro.h>
+
+// most code copy from Ares 0.A
+// abandon Ares hook
+// 50AF10 = HouseClass_UpdateSuperWeaponsOwned, 5
+// 50B1D0 = HouseClass_UpdateSuperWeaponsUnavailable, 6
+
+struct SWStatus
+{
+	bool Available;
+	bool PowerSourced;
+	bool Charging;
+};
+
+void __forceinline UpdateStatus(BuildingClass* pBuilding, SWStatus& status, int idxSW)
+{
+	if (idxSW > -1)
+	{
+		status.Available = true;
+
+		if (!status.Charging && pBuilding->HasPower && !pBuilding->IsUnderEMP())
+		{
+			status.PowerSourced = true;
+
+			if (!pBuilding->IsBeingWarpedOut()
+				&& (pBuilding->CurrentMission != Mission::Construction)
+				&& (pBuilding->CurrentMission != Mission::Selling)
+				&& (pBuilding->QueuedMission != Mission::Construction)
+				&& (pBuilding->QueuedMission != Mission::Selling))
+			{
+				status.Charging = true;
+			}
+		}
+	}
+}
+
+std::vector<SWStatus> __forceinline GetSuperWeaponStatuses(HouseClass* pHouse, std::vector<SWStatus>& vStatus)
+{
+	vStatus = std::move(std::vector<SWStatus>(pHouse->Supers.Count));
+
+	if (!pHouse->Defeated)
+	{
+		for (BuildingClass* pBuilding : pHouse->Buildings)
+		{
+			if (pBuilding->IsAlive && !pBuilding->InLimbo)
+			{
+				BuildingTypeClass* pBuildingType = pBuilding->Type;
+				BuildingTypeExt::ExtData* pBuildingTypeExt = BuildingTypeExt::ExtMap.Find(pBuildingType);
+
+				for (const BuildingTypeClass* pUpgrade : pBuilding->Upgrades)
+				{
+					if (pUpgrade != nullptr)
+					{
+						BuildingTypeExt::ExtData* pUpgradeExt = BuildingTypeExt::ExtMap.Find(pUpgrade);
+						int swCount = pUpgradeExt->GetSWCount();
+
+						for (int i = 0; i < swCount; i++)
+						{
+							int idx = pUpgradeExt->GetSWidx(i, pHouse);
+							UpdateStatus(pBuilding, vStatus[idx], idx);
+						}
+					}
+				}
+
+				int swCount = pBuildingTypeExt->GetSWCount();
+
+				for (int i = 0; i < swCount; i++)
+				{
+					int idx = pBuildingTypeExt->GetSWidx(i, pHouse);
+					UpdateStatus(pBuilding, vStatus[idx], idx);
+				}
+			}
+		}
+
+		bool hasPower = pHouse->HasFullPower();
+
+		for (SuperClass* pSuper : pHouse->Supers)
+		{
+			int idx = pSuper->Type->ArrayIndex;
+			SWStatus& status = vStatus[idx];
+			SuperWeaponTypeClass* pSWType = pSuper->Type;
+			SWTypeExt::ExtData* pSWTypeExt = SWTypeExt::ExtMap.Find(pSWType);
+
+			if (SessionClass::Instance->GameMode != GameMode::Campaign && !Unsorted::SWAllowed)
+			{
+				if (pSuper->Type->DisableableFromShell)
+					status.Available = false;
+			}
+
+			if (pSWTypeExt->SW_AlwaysGranted && pSWTypeExt->IsAvailable(pHouse))
+			{
+				status.Available = true;
+				status.Charging = true;
+				status.PowerSourced = true;
+			}
+
+			if (pSuper->IsPowered())
+				status.PowerSourced &= hasPower;
+		}
+	}
+
+	return vStatus;
+}
+
+void __forceinline UpdateSuperWeaponsOwned(HouseClass* pHouse, std::vector<SWStatus>& vStatus)
+{
+	for (SuperClass* pSuper : pHouse->Supers)
+	{
+		if (pSuper->Granted)
+		{
+			SuperWeaponTypeClass* pType = pSuper->Type;
+			int idx = pType->ArrayIndex;
+			SWStatus& status = vStatus[idx];
+
+			// is this a super weapon to be updated?
+			// sw is bound to a building and no single-shot => create goody otherwise
+			bool isCreateGoody = (!pSuper->CanHold || pSuper->OneTime);
+
+			if (!isCreateGoody || pHouse->Defeated)
+			{
+
+				// shut down or power up super weapon and decide whether
+				// a sidebar tab update is needed.
+				bool update = false;
+				if (!status.Available || pHouse->Defeated)
+				{
+					update = (pSuper->Lose() && HouseClass::Player);
+				}
+				else if (status.Charging && !pSuper->IsPowered())
+				{
+					update = pSuper->IsOnHold && pSuper->SetOnHold(false);
+				}
+				else if (!status.Charging && !pSuper->IsPowered())
+				{
+					update = !pSuper->IsOnHold && pSuper->SetOnHold(true);
+				}
+				else if (!status.PowerSourced)
+				{
+					update = (pSuper->IsPowered() && pSuper->SetOnHold(true));
+				}
+				else
+				{
+					update = (status.PowerSourced && pSuper->SetOnHold(false));
+				}
+
+				// update only if needed.
+				if (update)
+				{
+					// only the human player can see the sidebar.
+					if (pHouse->IsPlayer())
+					{
+						if (Unsorted::CurrentSWType == idx)
+						{
+							Unsorted::CurrentSWType = -1;
+						}
+
+						int idxTab = SidebarClass::GetObjectTabIdx(SuperClass::AbsID, idx, 0);
+						MouseClass::Instance->RepaintSidebar(idxTab);
+					}
+
+					pHouse->RecheckTechTree = true;
+				}
+			}
+		}
+	}
+}
+
+void __forceinline UpdateSuperWeaponsUnavailable(HouseClass* pHouse, std::vector<SWStatus>& vStatus)
+{
+	if (!pHouse->Defeated)
+	{
+		// update all super weapons not repeatedly available
+		for (SuperClass* pSuper : pHouse->Supers)
+		{
+			if (!pSuper->Granted || pSuper->OneTime)
+			{
+				int idx = pSuper->Type->ArrayIndex;
+				SWStatus& status = vStatus[idx];
+
+				if (status.Available)
+				{
+					pSuper->Grant(false, pHouse->IsPlayer(), !status.PowerSourced);
+
+					if (pHouse->IsPlayer())
+					{
+						// hide the cameo (only if this is an auto-firing SW)
+						SWTypeExt::ExtData* pSWTypeExt = SWTypeExt::ExtMap.Find(pSuper->Type);
+
+						if (pSWTypeExt->SW_ShowCameo || !pSWTypeExt->SW_AutoFire)
+						{
+							MouseClass::Instance->AddCameo(AbstractType::Special, idx);
+							int idxTab = SidebarClass::GetObjectTabIdx(SuperClass::AbsID, idx, 0);
+							MouseClass::Instance->RepaintSidebar(idxTab);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+
+static void __fastcall HouseClass_UpdateSuperWeaponsOwned(HouseClass* pThis)
+{
+	std::vector<SWStatus> vStatus;
+	GetSuperWeaponStatuses(pThis, vStatus);
+	UpdateSuperWeaponsOwned(pThis, vStatus);
+}
+
+DEFINE_JUMP(CALL, 0x43BEF0, GET_OFFSET(HouseClass_UpdateSuperWeaponsOwned));
+DEFINE_JUMP(CALL, 0x451700, GET_OFFSET(HouseClass_UpdateSuperWeaponsOwned));
+DEFINE_JUMP(CALL, 0x451739, GET_OFFSET(HouseClass_UpdateSuperWeaponsOwned));
+DEFINE_JUMP(CALL, 0x4F92F6, GET_OFFSET(HouseClass_UpdateSuperWeaponsOwned));
+DEFINE_JUMP(CALL, 0x508DDB, GET_OFFSET(HouseClass_UpdateSuperWeaponsOwned));
+
+static void __fastcall HouseClass_UpdateSuperWeaponsUnavailable(HouseClass* pThis)
+{
+	if (!pThis->Defeated)
+	{
+		std::vector<SWStatus> vStatus;
+		GetSuperWeaponStatuses(pThis, vStatus);
+		UpdateSuperWeaponsUnavailable(pThis, vStatus);
+	}
+}
+
+DEFINE_JUMP(CALL, 0x4409EF, GET_OFFSET(HouseClass_UpdateSuperWeaponsUnavailable));
+DEFINE_JUMP(CALL, 0x4F92FD, GET_OFFSET(HouseClass_UpdateSuperWeaponsUnavailable));

--- a/src/Ext/SWType/Hooks.Update.cpp
+++ b/src/Ext/SWType/Hooks.Update.cpp
@@ -1,5 +1,4 @@
 #include <HouseClass.h>
-
 #include <SuperClass.h>
 
 #include <Ext/Techno/Body.h>

--- a/src/Utilities/SavegameDef.h
+++ b/src/Utilities/SavegameDef.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <bitset>
 #include <memory>
 
@@ -430,6 +431,47 @@ namespace Savegame
 		}
 
 		bool WriteToStream(PhobosStreamWriter& Stm, const std::map<TKey, TValue>& Value) const
+		{
+			Stm.Save(Value.size());
+
+			for (const auto& item : Value)
+			{
+				if (!Savegame::WritePhobosStream(Stm, item))
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+	};
+
+	template <typename TKey, typename TValue>
+	struct Savegame::PhobosStreamObject<std::unordered_map<TKey, TValue>>
+	{
+		bool ReadFromStream(PhobosStreamReader& Stm, std::unordered_map<TKey, TValue>& Value, bool RegisterForChange) const
+		{
+			Value.clear();
+
+			size_t Count = 0;
+			if (!Stm.Load(Count))
+			{
+				return false;
+			}
+
+			for (auto ix = 0u; ix < Count; ++ix)
+			{
+				std::pair<TKey, TValue> buffer;
+				if (!Savegame::ReadPhobosStream(Stm, buffer, RegisterForChange))
+				{
+					return false;
+				}
+				Value.insert(buffer);
+			}
+
+			return true;
+		}
+
+		bool WriteToStream(PhobosStreamWriter& Stm, const std::unordered_map<TKey, TValue>& Value) const
 		{
 			Stm.Save(Value.size());
 


### PR DESCRIPTION
Like Ares entry `SW.AuxBuildings` and `SW.NegBuildings`, for all technotype.

In `rulesmd.ini`:
```ini

SW.AuxTechno=      ; TechnoTypes, like SW.AuxBuildings
SW.AuxTechno.Any=  ; boolean, one of or all of, default yes(one of)
SW.NegTechno=      ; TechnoTypes, like SW.NegBuildings
SW.NegTechno.Any=  ; boolean, one of or all of, default yes(one of)

```

Need test:

If don't abandon Ares hook, SW while exist but don't charge, so needs to test Ares SW available entries could work as use Ares hook.