### PR TITLE
Customizable Multiple AI Conditions

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -20,6 +20,8 @@
   <ItemGroup>
     <ClCompile Include="src\Commands\Commands.cpp" />
     <ClCompile Include="src\Commands\Dummy.h" />
+    <ClCompile Include="src\Ext\AITriggerType\Body.cpp" />
+    <ClCompile Include="src\Ext\AITriggerType\Hooks.cpp" />
     <ClCompile Include="src\Ext\AnimType\Hooks.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\BombardTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.cpp" />
@@ -125,6 +127,7 @@
     <ClInclude Include="src\Commands\Commands.h" />
     <ClInclude Include="src\Commands\DamageDisplay.h" />
     <ClInclude Include="src\Commands\QuickSave.h" />
+    <ClInclude Include="src\Ext\AITriggerType\Body.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -262,7 +262,7 @@ Available Compare Modes are:
 17         | Iron Curtain doesn't meet the percentage in `AIMinorSuperReadyPercent` |
 18         | Chrono Sphere doesn't meet the percentage in `AIMinorSuperReadyPercent` |
 
-- When `CompareMode` is between 6~18, `TechnoType` should be `<none>`. When `CompareMode` is between 6~8, 15~18, `Number` should be 0.
+- When `CompareMode` is between 6-18, `TechnoType` should be `<none>`. When `CompareMode` is between 6-8, 15-18, `Number` should be 0.
 
 Here is an example:
 ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -242,18 +242,33 @@ Available Pick Modes are:
 Available Compare Modes are:
 | *Mode*  | *Description*                                 |
 | :------: | :-------------------------------------------: |
-0         | < |
-1         | <= |
-2         | == |
-3         | >= |
-4         | > |
-5         | != |
+0         | (count TechnoTypes)< |
+1         | (count TechnoTypes)<= |
+2         | (count TechnoTypes)== |
+3         | (count TechnoTypes)>= |
+4         | (count TechnoTypes)> |
+5         | (count TechnoTypes)!= |
+6         | Power Green |
+7         | Power Yellow |
+8         | Power Red |
+9         | (count Money)< |
+10         | (count Money)<= |
+11         | (count Money)== |
+12         | (count Money)>= |
+13         | (count Money)> |
+14         | (count Money)!= |
+15         | Iron Curtain meets the percentage in `AIMinorSuperReadyPercent` |
+16         | Chrono Sphere meets the percentage in `AIMinorSuperReadyPercent` |
+17         | Iron Curtain doesn't meet the percentage in `AIMinorSuperReadyPercent` |
+18         | Chrono Sphere doesn't meet the percentage in `AIMinorSuperReadyPercent` |
 
-Here is an example
+- When `CompareMode` is between 6~18, `TechnoType` should be `<none>`. When `CompareMode` is between 6~8, 15~18, `Number` should be 0.
+
+Here is an example:
 ```
-1=1,2/2,3,1,NATECH/0,3,5,SREF/0,3,3,BFRT/0,3,8,MGTK/0,3,12,MTNK
+1=2,2/2,3,1,NATECH/0,8,0,<none>/0,3,5,SREF/0,3,3,BFRT/0,3,8,MGTK/0,3,12,MTNK
 ```
-- This means AI itself must has 1 or more NATECH, and least 2 of 4 optional requirements are needed: its enemies have more than 5 SREFs, 3 BFRTs, 8 MGTKs, 12 MTNKs.
+- This means AI itself must has 1 or more NATECH, its enemy must has low power, and least 2 of 4 optional requirements are needed: its enemies have more than 5 SREFs, 3 BFRTs, 8 MGTKs, 12 MTNKs.
 
 ## Animations
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -215,7 +215,7 @@ In `aimd.ini`:
 ExampleAITrigger=Name,Team1,OwnerHouse,TechLevel,-1,<none>,00000000000000000000000000000000000000000000000000000000xxxxyyyy,StartingWeight,MinimumWeight,MaximumWeight,IsForSkirmish,unused,Side,IsBaseDefense,Team2,EnabledInE,EnabledInM,EnabledInH
 ```
 
-- An `AICondition` has multiple sections, and they are divided by `/`. The first part are two integers, defining  the number of essential requirements and optional requirements. The rest parts have the same format: `PickMode,CompareMode,Number,TechnoType`. They define each requirement.
+- An `AICondition` has multiple sections, and they are divided by `/`. The first part are two integers, defining  the number of essential requirements and optional requirements. The rest parts have the same format: `PickMode,CompareMode,Number,TechnoType`. They define each requirement. The first few parts covered by the number of essential requirements are regarded as essential requirements, and the rest of them are regarded as optional requirements.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -200,6 +200,61 @@ Shield.InheritStateOnReplace=false   ; boolean
       - `Shield.MinimumReplaceDelay` can be used to control how long after the shield has been broken (in game frames) can it be replaced. If not enough frames have passed, it won't be replaced.
     - If `Shield.InheritStateOnReplace` is set, shields replaced via `Shield.ReplaceOnly` inherit the current strength (relative to ShieldType `Strength`) of the previous shield and whether or not the shield was currently broken. Self-healing and respawn timers are always reset.
 
+## AI Triggers
+
+### Customizable Multiple AI Conditions
+
+- AI Triggers can now have multiple conditions.
+  - The conditions are divided into 2 parts, essential requirements and optional requirements. All the essential requirements are required to be achieved, while only a given number of optional requirements are needed.
+
+- In an `AITriggerType` in `aimd.ini`, its ConditionType must be set to `-1`, and ComparisonObject must be set to `<none>`. Comparator should be filled with 0 except for last 8 characters. Eighth to fifth from the bottom(xxxx) should be 0001 to enable this feature, and last 4 characters(yyyy) should be an index number from `AIConditionsList` in `rulesmd.ini`. Notice: xxxx and yyyy are both decimal integers.
+
+In `aimd.ini`:
+```ini
+[AITriggerTypes]
+ExampleAITrigger=Name,Team1,OwnerHouse,TechLevel,-1,<none>,00000000000000000000000000000000000000000000000000000000xxxxyyyy,StartingWeight,MinimumWeight,MaximumWeight,IsForSkirmish,unused,Side,IsBaseDefense,Team2,EnabledInE,EnabledInM,EnabledInH
+```
+
+- An `AICondition` has multiple sections, and they are divided by `/`. The first part are two integers, defining  the number of essential requirements and optional requirements. The rest parts have the same format: `PickMode,CompareMode,Number,TechnoType`. They define each requirement.
+
+In `rulesmd.ini`:
+```ini
+[AIConditionsList] ;zero-based index
+0=NumberOfEssentialRequirements,NumberOfOptionalRequirements/PickMode,CompareMode,Number,TechnoType/PickMode,CompareMode,Number,TechnoType......
+;...
+```
+Available Pick Modes are:
+| *Mode*  | *Description*                                 |
+| :------: | :-------------------------------------------: |
+0         | pick enemies(except for neutral) |
+1         | pick allies(except for neutral) |
+2         | pick self |
+3         | pick all(except for neutral) |
+4         | pick enemy human players |
+5         | pick allied human players |
+6         | pick all human players |
+7         | pick enemy computer players(except for neutral) |
+8         | pick allied computer players(except for neutral) |
+9         | pick all computer players(except for neutral) |
+10         | pick neutral |
+11         | pick all(including neutral) |
+
+Available Compare Modes are:
+| *Mode*  | *Description*                                 |
+| :------: | :-------------------------------------------: |
+0         | < |
+1         | <= |
+2         | == |
+3         | >= |
+4         | > |
+5         | != |
+
+Here is an example
+```
+1=1,2/2,3,1,NATECH/0,3,5,SREF/0,3,3,BFRT/0,3,8,MGTK/0,3,12,MTNK
+```
+- This means AI itself must has 1 or more NATECH, and least 2 of 4 optional requirements are needed: its enemies have more than 5 SREFs, 3 BFRTs, 8 MGTKs, 12 MTNKs.
+
 ## Animations
 
 ### Anim-to-Unit

--- a/src/Ext/AITriggerType/Body.cpp
+++ b/src/Ext/AITriggerType/Body.cpp
@@ -125,7 +125,7 @@ void AITriggerTypeExt::CustomizableAICondition(AITriggerTypeClass* pAITriggerTyp
 		if (thisAICondition.Count < 2)
 		{
 			pAITriggerType->IsEnabled = false;
-			Debug::Log("DEBUG: [AIConditionsLists]: Error parsing line [%d].\n", condition);
+			Debug::Log("DEBUG: [AIConditionsList]: Error parsing line [%d].\n", condition);
 			return;
 		}
 
@@ -170,8 +170,8 @@ void AITriggerTypeExt::CustomizableAICondition(AITriggerTypeClass* pAITriggerTyp
 			}
 			else
 			{
-				Debug::Log("DEBUG: [AIConditionsLists][%d]: Error parsing [%s]\n", condition, cur2[3]);
-				Debug::Log("DEBUG: [AIConditionsLists]: Error parsing line [%d].\n", condition);
+				Debug::Log("DEBUG: [AIConditionsList][%d]: Error parsing [%s]\n", condition, cur2[3]);
+				Debug::Log("DEBUG: [AIConditionsList]: Error parsing line [%d].\n", condition);
 				pAITriggerType->IsEnabled = false;
 				return;
 			}
@@ -198,7 +198,7 @@ void AITriggerTypeExt::CustomizableAICondition(AITriggerTypeClass* pAITriggerTyp
 			}
 			else
 			{
-				Debug::Log("DEBUG: [AIConditionsLists]: Error parsing line [%d].\n", condition);
+				Debug::Log("DEBUG: [AIConditionsList]: Error parsing line [%d].\n", condition);
 				pAITriggerType->IsEnabled = false;
 				return;
 			}
@@ -208,7 +208,7 @@ void AITriggerTypeExt::CustomizableAICondition(AITriggerTypeClass* pAITriggerTyp
 	{
 		//thoroughly disable it
 		pAITriggerType->IsEnabled = false;
-		Debug::Log("DEBUG: [AIConditionsLists]: Conditin number overflew!.\n");
+		Debug::Log("DEBUG: [AIConditionsList]: Conditin number overflew!.\n");
 		return;
 	}
 	if (essentialRequirementsCount == essentialRequirementsMetCount && leastOptionalRequirementsCount <= optionalRequirementsMetCount)

--- a/src/Ext/AITriggerType/Body.cpp
+++ b/src/Ext/AITriggerType/Body.cpp
@@ -1,0 +1,218 @@
+#include "Body.h"
+#include <Utilities/Macro.h>
+#include <Ext/Scenario/Body.h>
+
+#include <comutil.h>
+#include  <string>
+#include <Ext/Rules/Body.h>
+#pragma comment(lib, "comsuppw.lib")
+
+template<> const DWORD Extension<AITriggerTypeClass>::Canary = 0x2C2C2C2C;
+AITriggerTypeExt::ExtContainer AITriggerTypeExt::ExtMap;
+
+// =============================
+// load / save
+
+void AITriggerTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
+{
+	// Nothing yet
+}
+
+void AITriggerTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
+{
+	// Nothing yet
+}
+
+// =============================
+// container
+
+AITriggerTypeExt::ExtContainer::ExtContainer() : Container("AITriggerTypeClass") { }
+AITriggerTypeExt::ExtContainer::~ExtContainer() = default;
+
+void AITriggerTypeExt::ProcessCondition(AITriggerTypeClass* pAITriggerType, HouseClass* pHouse, int type, int condition)
+{
+	//AITriggerType is disabled by default
+	DisableAITrigger(pAITriggerType);
+	switch (static_cast<PhobosAIConditionTypes>(type))
+	{
+	case PhobosAIConditionTypes::CustomizableAICondition:
+		AITriggerTypeExt::CustomizableAICondition(pAITriggerType, pHouse, condition);
+		break;
+	default:
+		break;
+	}
+	return;
+}
+
+void AITriggerTypeExt::DisableAITrigger(AITriggerTypeClass* pAITriggerType)
+{
+	pAITriggerType->ConditionType = AITriggerCondition::AIOwns;
+	pAITriggerType->ConditionObject = nullptr;
+	return;
+}
+
+void AITriggerTypeExt::EnableAITrigger(AITriggerTypeClass* pAITriggerType)
+{
+	pAITriggerType->ConditionType = AITriggerCondition::Pool;
+	pAITriggerType->ConditionObject = nullptr;
+	return;
+}
+
+bool AITriggerTypeExt::ReadCustomizableAICondition(HouseClass* pHouse ,int pickMode, int compareMode, int Number, TechnoTypeClass* TechnoType)
+{
+	//0 = pick enemies(except for neutral); 1 = pick allies(except for neutral); 2 = pick self; 3 = pick all(except for neutral); 
+	//4 = pick enemy human players; 5 = pick allied human players; 6 = pick all human players; 
+	//7 = pick enemy computer players(except for neutral); 8 = pick allied computer players(except for neutral); 9 = pick all computer players(except for neutral);
+	//10 = pick neutral; 11 = pick all(including neutral);
+	//int pickMode;
+
+	//0 = "<"; 1 = "<="; 2 = "=="; 3 = ">="; 4 = ">"; 5 = "!="; 
+	//int compareMode;
+
+	int count = 0;
+
+	for (int i = 0; i < TechnoClass::Array->Count; i++)
+	{
+		auto pTechno = TechnoClass::Array->GetItem(i);
+		if (pTechno->GetTechnoType() == TechnoType
+			&& pTechno->IsAlive
+			&& !pTechno->InLimbo
+			&& pTechno->IsOnMap
+			&& !pTechno->Absorbed
+			&& ((!pTechno->Owner->IsAlliedWith(pHouse) && !pTechno->Owner->IsNeutral() && pickMode == 0)
+				|| (pTechno->Owner->IsAlliedWith(pHouse) && !pTechno->Owner->IsNeutral() && pickMode == 1)
+				|| (pTechno->Owner == pHouse && pickMode == 2)
+				|| (!pTechno->Owner->IsNeutral() && pickMode == 3)
+				|| (pTechno->Owner->ControlledByHuman() && !pTechno->Owner->IsAlliedWith(pHouse) && pickMode == 4)
+				|| (pTechno->Owner->ControlledByHuman() && pTechno->Owner->IsAlliedWith(pHouse) && pickMode == 5)
+				|| (pTechno->Owner->ControlledByHuman() && pickMode == 6)
+				|| (!pTechno->Owner->ControlledByHuman() && !pTechno->Owner->IsNeutral() && !pTechno->Owner->IsAlliedWith(pHouse) && pickMode == 7)
+				|| (!pTechno->Owner->ControlledByHuman() && !pTechno->Owner->IsNeutral() && pTechno->Owner->IsAlliedWith(pHouse) && pickMode == 8)
+				|| (!pTechno->Owner->ControlledByHuman() && !pTechno->Owner->IsNeutral() && pickMode == 9)
+				|| (pTechno->Owner->IsNeutral() && pickMode == 10)
+				|| (pickMode == 11)
+				))
+
+		{
+			count++;
+		}
+	}
+	if ((count < Number && compareMode == 0)
+		|| (count <= Number && compareMode == 1)
+		|| (count == Number && compareMode == 2)
+		|| (count >= Number && compareMode == 3)
+		|| (count > Number && compareMode == 4)
+		|| (count != Number && compareMode == 5)
+		)
+		return true;
+	else
+		return false;
+}
+
+void AITriggerTypeExt::CustomizableAICondition(AITriggerTypeClass* pAITriggerType, HouseClass* pHouse, int condition)
+{
+	auto AIConditionsLists = RulesExt::Global()->AIConditionsLists;
+
+	int essentialRequirementsCount = -1;
+	int leastOptionalRequirementsCount = -1;
+	int essentialRequirementsMetCount = 0;
+	int optionalRequirementsMetCount = 0;
+
+	if (condition < AIConditionsLists.Count)
+	{
+		auto thisAICondition = AIConditionsLists.GetItem(condition);
+
+		if (thisAICondition.Count < 2)
+		{
+			pAITriggerType->IsEnabled = false;
+			Debug::Log("DEBUG: [AIConditionsLists]: Error parsing line [%d].\n", condition);
+			return;
+		}
+
+		//parse first string
+		auto FirstAIConditionString = thisAICondition.GetItem(0);
+		char* context = nullptr;
+		char* cur[3];
+		cur[0] = strtok_s(FirstAIConditionString.data(), Phobos::readDelims, &context);
+		int j = 0;
+		while (cur[j])
+		{
+			j++;
+			cur[j] = strtok_s(NULL, ",", &context);
+		}
+		essentialRequirementsCount = atoi(cur[0]);
+		leastOptionalRequirementsCount = atoi(cur[1]);
+
+		//parse other strings
+		for (int i = 1; i < thisAICondition.Count; i++)
+		{
+			auto AIConditionString = thisAICondition.GetItem(i);
+			int pickMode = -1;
+			int compareMode = -1;
+			int Number = -1;
+			TechnoTypeClass* TechnoType;
+
+			char* cur2[5];
+			cur2[0] = strtok_s(AIConditionString.data(), Phobos::readDelims, &context);
+			int k = 0;
+			while (cur2[k])
+			{
+				k++;
+				cur2[k] = strtok_s(NULL, Phobos::readDelims, &context);
+			}
+			TechnoTypeClass* buffer;
+			if (Parser<TechnoTypeClass*>::TryParse(cur2[3], &buffer))
+			{
+				pickMode = atoi(cur2[0]);
+				compareMode = atoi(cur2[1]);
+				Number = atoi(cur2[2]);
+				TechnoType = buffer;
+			}
+			else
+			{
+				Debug::Log("DEBUG: [AIConditionsLists][%d]: Error parsing [%s]\n", condition, cur2[3]);
+				Debug::Log("DEBUG: [AIConditionsLists]: Error parsing line [%d].\n", condition);
+				pAITriggerType->IsEnabled = false;
+				return;
+			}
+			
+			if (essentialRequirementsCount > -1
+				&& leastOptionalRequirementsCount > -1
+				&& essentialRequirementsCount + leastOptionalRequirementsCount < thisAICondition.Count
+				&& pickMode >= 0 && pickMode <= 11
+				&& compareMode >= 0 && compareMode <= 5
+				&& Number >= 0)
+			{
+				//essential requirements judgement
+				if (i <= essentialRequirementsCount)
+				{
+					if (ReadCustomizableAICondition(pHouse, pickMode, compareMode, Number, TechnoType))
+						essentialRequirementsMetCount++;
+				}
+				//optional requirements judgement
+				else
+				{
+					if (ReadCustomizableAICondition(pHouse, pickMode, compareMode, Number, TechnoType))
+						optionalRequirementsMetCount++;
+				}
+			}
+			else
+			{
+				Debug::Log("DEBUG: [AIConditionsLists]: Error parsing line [%d].\n", condition);
+				pAITriggerType->IsEnabled = false;
+				return;
+			}
+		}
+	}
+	else
+	{
+		//thoroughly disable it
+		pAITriggerType->IsEnabled = false;
+		Debug::Log("DEBUG: [AIConditionsLists]: Conditin number overflew!.\n");
+		return;
+	}
+	if (essentialRequirementsCount == essentialRequirementsMetCount && leastOptionalRequirementsCount <= optionalRequirementsMetCount)
+		EnableAITrigger(pAITriggerType);
+
+	return;
+}

--- a/src/Ext/AITriggerType/Body.h
+++ b/src/Ext/AITriggerType/Body.h
@@ -41,8 +41,9 @@ public:
 
 	static void DisableAITrigger(AITriggerTypeClass* pAITriggerType);
 	static void EnableAITrigger(AITriggerTypeClass* pAITriggerType);
-	static bool ReadCustomizableAICondition(HouseClass* pHouse, int pickMode, int compareMode, int Number, TechnoTypeClass* TechnoType);
+	static bool ReadCustomizableAICondition(AITriggerTypeClass* pAITriggerType, HouseClass* pHouse, int pickMode, int compareMode, int Number, TechnoTypeClass* TechnoType);
 	static void CustomizableAICondition(AITriggerTypeClass* pAITriggerType, HouseClass* pHouse, int condition);
+	static bool PickValidHouse(HouseClass* pHouse, HouseClass* pThisHouse, int pickMode);
 
 	static ExtContainer ExtMap;
 

--- a/src/Ext/AITriggerType/Body.h
+++ b/src/Ext/AITriggerType/Body.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <AITriggerTypeClass.h>
+#include <Utilities/Container.h>
+
+//this is a 1-based index.
+enum class PhobosAIConditionTypes : int
+{
+	CustomizableAICondition = 1,
+};
+
+class AITriggerTypeExt
+{
+public:
+	using base_type = AITriggerTypeClass;
+
+	class ExtData final : public Extension<AITriggerTypeClass>
+	{
+	public:
+
+		ExtData(AITriggerTypeClass* OwnerObject) : Extension<AITriggerTypeClass>(OwnerObject)
+			// Nothing yet
+		{ }
+
+		virtual ~ExtData() = default;
+
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
+
+		virtual void LoadFromStream(PhobosStreamReader & Stm);
+		virtual void SaveToStream(PhobosStreamWriter & Stm);
+	};
+
+	class ExtContainer final : public Container<AITriggerTypeExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+	};
+
+	static void ProcessCondition(AITriggerTypeClass* pAITriggerType, HouseClass* pHouse, int type, int condition);
+
+	static void DisableAITrigger(AITriggerTypeClass* pAITriggerType);
+	static void EnableAITrigger(AITriggerTypeClass* pAITriggerType);
+	static bool ReadCustomizableAICondition(HouseClass* pHouse, int pickMode, int compareMode, int Number, TechnoTypeClass* TechnoType);
+	static void CustomizableAICondition(AITriggerTypeClass* pAITriggerType, HouseClass* pHouse, int condition);
+
+	static ExtContainer ExtMap;
+
+};

--- a/src/Ext/AITriggerType/Hooks.cpp
+++ b/src/Ext/AITriggerType/Hooks.cpp
@@ -1,0 +1,45 @@
+#include <Utilities/Macro.h>
+#include <AITriggerTypeClass.h>
+#include <Ext/AITriggerType/Body.h>
+#include <Phobos.h>
+#include "Body.h"
+
+DEFINE_HOOK_AGAIN(0x41E8DD, Phobos_AITrigger_Handler, 0x8)
+DEFINE_HOOK(0x41E8F0, Phobos_AITrigger_Handler, 0x8)
+{
+	GET(AITriggerTypeClass*, pAITriggerType, ESI);
+	GET(HouseClass*, pHouse, EDI);
+
+	//get Condition String
+	char ConditionString[68];
+	int idx = 0;
+	char* condStr = ConditionString;
+	auto buf = reinterpret_cast<const byte*>(&pAITriggerType->Conditions);
+	do
+	{
+		sprintf_s(condStr, 4, "%02x", *buf);
+		++buf;
+		++idx;
+		condStr += 2;
+	}
+	while (idx < 0x20);
+	*condStr = '\0';
+
+	//this is when Phobos strats to work
+	if ((pAITriggerType->ConditionType == AITriggerCondition::Pool || pAITriggerType->ConditionType == AITriggerCondition::AIOwns)
+		&& pAITriggerType->ConditionObject == nullptr)
+	{
+		std::string ConditionString2 = ConditionString;
+		int PhobosAIConditionType = atoi(ConditionString2.substr(56, 4).c_str());		
+		int PhobosAIConditionList = atoi(ConditionString2.substr(60, 4).c_str());
+
+		if (PhobosAIConditionType > 0)
+		{
+			AITriggerTypeExt::ProcessCondition(pAITriggerType, pHouse, PhobosAIConditionType, PhobosAIConditionList);
+		}
+	}
+		
+	return 0;
+}
+
+

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -63,6 +63,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	const char* sectionAITargetTypes = "AITargetTypes";
 	const char* sectionAIScriptsList = "AIScriptsList";
+	const char* sectionAIConditionsList = "AIConditionsList";
 
 	INI_EX exINI(pINI);
 
@@ -125,6 +126,24 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		AIScriptsLists.AddItem(objectsList);
 		objectsList.Clear();
 	}
+
+	// Section AIConditionsList
+	int AIConditionsitemsCount = pINI->GetKeyCount(sectionAIConditionsList);
+	for (int i = 0; i < AIConditionsitemsCount; ++i)
+	{
+		DynamicVectorClass<std::string> objectsList;
+
+		char* context = nullptr;
+		pINI->ReadString(sectionAIConditionsList, pINI->GetKeyName(sectionAIConditionsList, i), "", Phobos::readBuffer);
+
+		for (char* cur = strtok_s(Phobos::readBuffer, "/", &context); cur; cur = strtok_s(nullptr, "/", &context))
+		{
+			objectsList.AddItem(cur);
+		}
+
+		AIConditionsLists.AddItem(objectsList);
+		objectsList.Clear();
+	}
 }
 
 // this runs between the before and after type data loading methods for rules ini
@@ -172,6 +191,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 	Stm
 		.Process(this->AITargetTypesLists)
 		.Process(this->AIScriptsLists)
+		.Process(this->AIConditionsLists)
 		.Process(this->Storage_TiberiumIndex)
 		.Process(this->InfantryGainSelfHealCap)
 		.Process(this->UnitsGainSelfHealCap)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -26,6 +26,7 @@ public:
 	public:
 		DynamicVectorClass<DynamicVectorClass<TechnoTypeClass*>> AITargetTypesLists;
 		DynamicVectorClass<DynamicVectorClass<ScriptTypeClass*>> AIScriptsLists;
+		DynamicVectorClass<DynamicVectorClass<std::string>> AIConditionsLists;
 
 		Valueable<int> Storage_TiberiumIndex;
 		Nullable<int> InfantryGainSelfHealCap;

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -1,6 +1,7 @@
 #include <Phobos.h>
 
 #include <Ext/Aircraft/Body.h>
+#include <Ext/AITriggerType/Body.h>
 #include <Ext/AnimType/Body.h>
 #include <Ext/Anim/Body.h>
 #include <Ext/Building/Body.h>
@@ -29,6 +30,7 @@
 #include <New/Type/LaserTrailTypeClass.h>
 
 #include <utility>
+
 
 #pragma region Implementation details
 
@@ -225,6 +227,7 @@ private:
 auto MassActions = MassAction <
 	// Ext classes
 	AircraftExt,
+	AITriggerTypeExt,
 	AnimTypeExt,
 	AnimExt,
 	BuildingExt,


### PR DESCRIPTION
## AI Triggers

### Customizable Multiple AI Conditions

- AI Triggers can now have multiple conditions.
  - The conditions are divided into 2 parts, essential requirements and optional requirements. All the essential requirements are required to be achieved, while only a given number of optional requirements are needed.

- In an `AITriggerType` in `aimd.ini`, its ConditionType must be set to `-1`, and ComparisonObject must be set to `<none>`. Comparator should be filled with 0 except for last 8 characters. Eighth to fifth from the bottom(xxxx) should be 0001 to enable this feature, and last 4 characters(yyyy) should be an index number from `AIConditionsList` in `rulesmd.ini`. Notice: xxxx and yyyy are both decimal integers.

In `aimd.ini`:
```ini
[AITriggerTypes]
ExampleAITrigger=Name,Team1,OwnerHouse,TechLevel,-1,<none>,00000000000000000000000000000000000000000000000000000000xxxxyyyy,StartingWeight,MinimumWeight,MaximumWeight,IsForSkirmish,unused,Side,IsBaseDefense,Team2,EnabledInE,EnabledInM,EnabledInH
```

- An `AICondition` has multiple sections, and they are divided by `/`. The first part are two integers, defining  the number of essential requirements and optional requirements. The rest parts have the same format: `PickMode,CompareMode,Number,TechnoType`. They define each requirement. The first few parts covered by the number of essential requirements are regarded as essential requirements, and the rest of them are regarded as optional requirements.

In `rulesmd.ini`:
```ini
[AIConditionsList] ;zero-based index
0=NumberOfEssentialRequirements,NumberOfOptionalRequirements/PickMode,CompareMode,Number,TechnoType/PickMode,CompareMode,Number,TechnoType......
;...
```
Available Pick Modes are:
| *Mode*  | *Description*                                 |
| :------: | :-------------------------------------------: |
0         | pick enemies(except for neutral) |
1         | pick allies(except for neutral) |
2         | pick self |
3         | pick all(except for neutral) |
4         | pick enemy human players |
5         | pick allied human players |
6         | pick all human players |
7         | pick enemy computer players(except for neutral) |
8         | pick allied computer players(except for neutral) |
9         | pick all computer players(except for neutral) |
10         | pick neutral |
11         | pick all(including neutral) |

Available Compare Modes are:
| *Mode*  | *Description*                                 |
| :------: | :-------------------------------------------: |
0         | (count TechnoTypes)< |
1         | (count TechnoTypes)<= |
2         | (count TechnoTypes)== |
3         | (count TechnoTypes)>= |
4         | (count TechnoTypes)> |
5         | (count TechnoTypes)!= |
6         | Power Green |
7         | Power Yellow |
8         | Power Red |
9         | (count Money)< |
10         | (count Money)<= |
11         | (count Money)== |
12         | (count Money)>= |
13         | (count Money)> |
14         | (count Money)!= |
15         | Iron Curtain meets the percentage in `AIMinorSuperReadyPercent` |
16         | Chrono Sphere meets the percentage in `AIMinorSuperReadyPercent` |
17         | Iron Curtain doesn't meet the percentage in `AIMinorSuperReadyPercent` |
18         | Chrono Sphere doesn't meet the percentage in `AIMinorSuperReadyPercent` |

- When `CompareMode` is between 6-18, `TechnoType` should be `<none>`. When `CompareMode` is between 6-8, 15-18, `Number` should be 0.

Here is an example:
```
1=2,2/2,3,1,NATECH/0,8,0,<none>/0,3,5,SREF/0,3,3,BFRT/0,3,8,MGTK/0,3,12,MTNK
```
- This means AI itself must has 1 or more NATECH, its enemy must has low power, and least 2 of 4 optional requirements are needed: its enemies have more than 5 SREFs, 3 BFRTs, 8 MGTKs, 12 MTNKs.
