### PR TITLE
Animated TerrainTypes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -152,6 +152,7 @@ This page lists all the individual contributions to the project by their author.
   - Warhead self-damaging toggle
   - Trailer animation owner inheritance
   - Warhead detonation on all objects on map
+  - Animated TerrainTypes extension
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -69,6 +69,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Trailer animations now inherit the owner of the object (animation, projectile or aircraft) they are attached to.
 - Buildings now correctly use laser parameters set for Secondary weapons instead of reading them from Primary weapon.
 - Fixed an issue that caused vehicles killed by damage dealt by a known house but without a known source TechnoType (f.ex animation warhead damage) to not be recorded as killed correctly and thus not spring map trigger events etc.
+- `IsAnimated`, `AnimationRate` and `AnimationProbability` now work on TerrainTypes without `SpawnsTiberium` set to true.
 
 ![image](_static/images/translucency-fix.png)  
 *Example gradient SHP drawing with 75% translucency, before and after*

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -314,6 +314,7 @@ New:
 - Warhead self-damaging toggle (by Starkku)
 - Trailer animations inheriting owner (by Starkku)
 - Warhead detonation on all objects on map (by Starkku)
+- Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -34,7 +34,7 @@ void TEventExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 }
 
 bool TEventExt::Execute(TEventClass* pThis, int iEvent, HouseClass* pHouse, ObjectClass* pObject,
-	TimerStruct* pTimer, bool* isPersitant, TechnoClass* pSource, bool& bHandled)
+	CDTimerClass* pTimer, bool* isPersitant, TechnoClass* pSource, bool& bHandled)
 {
 	bHandled = true;
 	switch (static_cast<PhobosTriggerEvent>(pThis->EventKind))

--- a/src/Ext/TEvent/Body.h
+++ b/src/Ext/TEvent/Body.h
@@ -73,7 +73,7 @@ public:
 	};
 
 	static bool Execute(TEventClass* pThis, int iEvent, HouseClass* pHouse, ObjectClass* pObject,
-					TimerStruct* pTimer, bool* isPersitant, TechnoClass* pSource, bool& bHandled);
+					CDTimerClass* pTimer, bool* isPersitant, TechnoClass* pSource, bool& bHandled);
 
 	template<bool IsGlobal, typename _Pr>
 	static bool VariableCheck(TEventClass* pThis);

--- a/src/Ext/TEvent/Hooks.cpp
+++ b/src/Ext/TEvent/Hooks.cpp
@@ -16,7 +16,7 @@ DEFINE_HOOK(0x71E940, TEventClass_Execute, 0x5)
 	GET_STACK(int, iEvent, 0x4); // now trigger what?
 	GET_STACK(HouseClass*, pHouse, 0x8);
 	GET_STACK(ObjectClass*, pObject, 0xC);
-	GET_STACK(TimerStruct*, pTimer, 0x10);
+	GET_STACK(CDTimerClass*, pTimer, 0x10);
 	GET_STACK(bool*, isPersitant, 0x14);
 	GET_STACK(TechnoClass*, pSource, 0x18);
 

--- a/src/Ext/Team/Body.h
+++ b/src/Ext/Team/Body.h
@@ -22,8 +22,8 @@ public:
 		int Countdown_RegroupAtLeader;
 		int MoveMissionEndMode;
 		int WaitNoTargetCounter;
-		TimerStruct WaitNoTargetTimer;
-		TimerStruct ForceJump_Countdown;
+		CDTimerClass WaitNoTargetTimer;
+		CDTimerClass ForceJump_Countdown;
 		int ForceJump_InitialCountdown;
 		bool ForceJump_RepeatMode;
 		FootClass* TeamLeader;

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -23,7 +23,7 @@ public:
 		std::vector<std::unique_ptr<LaserTrailClass>> LaserTrails;
 		bool ReceiveDamage;
 		bool LastKillWasTeamTarget;
-		TimerStruct	PassengerDeletionTimer;
+		CDTimerClass PassengerDeletionTimer;
 		int PassengerDeletionCountDown;
 		ShieldTypeClass* CurrentShieldType;
 		int LastWarpDistance;

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -103,10 +103,10 @@ private:
 			, Respawn_Warhead { }
 		{ }
 
-		TimerStruct SelfHealing;
-		TimerStruct SelfHealing_Warhead;
-		TimerStruct Respawn;
-		TimerStruct Respawn_Warhead;
+		CDTimerClass SelfHealing;
+		CDTimerClass SelfHealing_Warhead;
+		CDTimerClass Respawn;
+		CDTimerClass Respawn_Warhead;
 
 	} Timers;
 };


### PR DESCRIPTION
`IsAnimated`, `AnimationRate` and `AnimationProbability` now work on TerrainTypes without `SpawnsTiberium` set to true.

For a refresher, `AnimationRate` is how many game frames it takes to increment one animation frame and `AnimationProbability` is a probability (0.0 to 1.0) that animation sequence starts playing if it already is not, checked at every game frame (set to 1.0 for constant loop).