### PR TITLE
[Shield additions] Fix Psychedelic warhead damage & add "Shield is broken" trigger event 

### DIFF
--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -1,7 +1,7 @@
 #include "Body.h"
 
 #include <Utilities/SavegameDef.h>
-
+#include <New/Entity/ShieldClass.h>
 #include <Ext/Scenario/Body.h>
 #include <BuildingClass.h>
 #include <InfantryClass.h>
@@ -116,6 +116,10 @@ bool TEventExt::Execute(TEventClass* pThis, int iEvent, HouseClass* pHouse, Obje
 		return TEventExt::VariableCheckBinary<true, true, std::less_equal<int>>(pThis);
 	case PhobosTriggerEvent::GlobalVariableAndIsTrueGlobalVariable:
 		return TEventExt::VariableCheckBinary<true, true, and_with>(pThis);
+
+
+	case PhobosTriggerEvent::ShieldBroken:
+		return ShieldClass::TEventIsShieldBroken(pObject);
 
 	default:
 		bHandled = false;

--- a/src/Ext/TEvent/Body.h
+++ b/src/Ext/TEvent/Body.h
@@ -47,6 +47,10 @@ enum PhobosTriggerEvent
 	GlobalVariableGreaterThanOrEqualsToGlobalVariable = 533,
 	GlobalVariableLessThanOrEqualsToGlobalVariable = 534,
 	GlobalVariableAndIsTrueGlobalVariable = 535,
+
+	ShieldBroken = 600,
+
+	DummyMaximum = 114514,
 };
 
 class TEventExt

--- a/src/Ext/TEvent/Hooks.cpp
+++ b/src/Ext/TEvent/Hooks.cpp
@@ -33,7 +33,7 @@ DEFINE_HOOK(0x7271F9, TEventClass_GetFlags, 0x5)
 	GET(TEventClass*, pThis, ESI);
 
 	int nEvent = static_cast<int>(pThis->EventKind);
-	if (nEvent >= PhobosTriggerEvent::LocalVariableGreaterThan && nEvent <= PhobosTriggerEvent::GlobalVariableAndIsTrueGlobalVariable)
+	if (nEvent >= PhobosTriggerEvent::LocalVariableGreaterThan && nEvent < PhobosTriggerEvent::DummyMaximum)
 		eAttach |= 0x10; // LOGIC
 
 	R->EAX(eAttach);
@@ -47,7 +47,7 @@ DEFINE_HOOK(0x71F3FE, TEventClass_BuildINIEntry, 0x5)
 	GET(TEventClass*, pThis, ECX);
 
 	int nEvent = static_cast<int>(pThis->EventKind);
-	if (nEvent >= PhobosTriggerEvent::LocalVariableGreaterThan && nEvent <= PhobosTriggerEvent::GlobalVariableAndIsTrueGlobalVariable)
+	if (nEvent >= PhobosTriggerEvent::LocalVariableGreaterThan && nEvent < PhobosTriggerEvent::DummyMaximum)
 		eNeedType = 43;
 
 	R->EAX(eNeedType);
@@ -60,7 +60,7 @@ DEFINE_HOOK(0x726577, TEventClass_Persistable, 0x7)
 	GET(TEventClass*, pThis, EDI);
 
 	int nEvent = static_cast<int>(pThis->EventKind);
-	if (nEvent >= PhobosTriggerEvent::LocalVariableGreaterThan && nEvent <= PhobosTriggerEvent::GlobalVariableAndIsTrueGlobalVariable)
+	if (nEvent >= PhobosTriggerEvent::LocalVariableGreaterThan && nEvent < PhobosTriggerEvent::DummyMaximum)
 		R->AL(true);
 	else
 		R->AL(pThis->GetStateB());

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -1,6 +1,6 @@
 #include "Body.h"
 #include <SpecificStructures.h>
-
+#include<Ext/TEvent/Body.h>
 #include <Utilities/Macro.h>
 #include <Utilities/GeneralUtils.h>
 #include <Ext/TechnoType/Body.h>
@@ -22,7 +22,13 @@ DEFINE_HOOK(0x701900, TechnoClass_ReceiveDamage_Shield, 0x6)
 
 			const int nDamageLeft = pShieldData->ReceiveDamage(args);
 			if (nDamageLeft >= 0)
+			{
 				*args->Damage = nDamageLeft;
+
+				if (auto pTag = pThis->AttachedTag)
+					pTag->RaiseEvent((TriggerEvent)PhobosTriggerEvent::ShieldBroken, pThis,
+						*(CellStruct*)0xB0EA50);//where is this? is this correct?
+			}
 		}
 	}
 	return 0;

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -93,6 +93,18 @@ void ShieldClass::SyncShieldToAnother(TechnoClass* pFrom, TechnoClass* pTo)
 		pFromExt->Shield = nullptr;
 }
 
+bool ShieldClass::TEventIsShieldBroken(ObjectClass* pAttached)
+{
+	if (auto pThis = abstract_cast<TechnoClass*>(pAttached))
+	{
+		if (const auto pExt = TechnoExt::ExtMap.Find(pThis))
+		{
+			return pExt->Shield->HP <= 0;
+		}
+	}
+	return false;
+}
+
 int ShieldClass::ReceiveDamage(args_ReceiveDamage* args)
 {
 	const auto pWHExt = WarheadTypeExt::ExtMap.Find(args->WH);
@@ -231,6 +243,9 @@ bool ShieldClass::CanBePenetrated(WarheadTypeClass* pWarhead)
 
 	if (pWHExt->Shield_AffectTypes.size() > 0 && !pWHExt->Shield_AffectTypes.Contains(this->Type))
 		return false;
+
+	if (pWarhead->Psychedelic)
+		return !this->Type->ImmuneToPsychedelic;
 
 	return pWHExt->Shield_Penetrate;
 }

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -42,6 +42,8 @@ public:
 
 	static void SyncShieldToAnother(TechnoClass* pFrom, TechnoClass* pTo);
 
+	static bool TEventIsShieldBroken(ObjectClass* pThis);
+
 	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	bool Save(PhobosStreamWriter& Stm) const;
 

--- a/src/New/Type/ShieldTypeClass.cpp
+++ b/src/New/Type/ShieldTypeClass.cpp
@@ -60,6 +60,8 @@ void ShieldTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->Pips_Background.Read(exINI, pSection, "Pips.Background");
 	this->Pips_Building.Read(exINI, pSection, "Pips.Building");
 	this->Pips_Building_Empty.Read(exINI, pSection, "Pips.Building.Empty");
+
+	this->ImmuneToPsychedelic.Read(exINI, pSection, "ImmuneToPsychedelic");
 }
 
 template <typename T>
@@ -89,6 +91,7 @@ void ShieldTypeClass::Serialize(T& Stm)
 		.Process(this->Pips_Background)
 		.Process(this->Pips_Building)
 		.Process(this->Pips_Building_Empty)
+		.Process(this->ImmuneToPsychedelic)
 		;
 }
 

--- a/src/New/Type/ShieldTypeClass.h
+++ b/src/New/Type/ShieldTypeClass.h
@@ -37,6 +37,8 @@ public:
 	Valueable<Vector3D<int>> Pips_Building;
 	Nullable<int> Pips_Building_Empty;
 
+	Valueable<bool> ImmuneToPsychedelic;
+
 private:
 	Valueable<double> Respawn_Rate__InMinutes;
 	Valueable<double> SelfHealing_Rate__InMinutes;
@@ -69,6 +71,7 @@ public:
 		, Pips_Background { }
 		, Pips_Building { { -1,-1,-1 } }
 		, Pips_Building_Empty { }
+		, ImmuneToPsychedelic{ false }
 	{ };
 
 	virtual ~ShieldTypeClass() override = default;


### PR DESCRIPTION
# Default setting of Psychedelic damage to shields

In previous builds, `Psychedelic=yes` warhead can damage shields without giving the actual berserk effect. 
From now on `Psychedelic=yes` warheads directly penetrate shields by default. An additional parameter can be given to shields for the immunity against berserk effect:

In `rulesmd.ini`:
```ini
[SOMESHIELDTYPE]
ImmuneToPsychedelic=no
```

# Trigger Event 600: Shield of the attached object is broken

The trigger event is raised when the shield of the attached object is broken.
In `mycampaign.map`:
```ini
[Events]
...
ID=EventCount,[Event1],...,600,2,0,0,[EventX],...
...