### PR TITLE
Custom Theater

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -150,6 +150,10 @@
     <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
     <ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
     <ClCompile Include="src\Misc\TypeConvertHelper.cpp" />
+    <ClCompile Include="src\Misc\CustomTheater\CustomTheater.cpp" />
+    <ClCompile Include="src\Misc\CustomTheater\Hook.RMP.cpp" />
+    <ClCompile Include="src\Misc\CustomTheater\Hooks.cpp" />
+    <ClCompile Include="src\Misc\CustomTheater\TheaterProto.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
     <ClCompile Include="src\Phobos.COM.cpp" />
     <ClCompile Include="src\Phobos.CRT.cpp" />
@@ -197,6 +201,8 @@
     <ClInclude Include="src\Misc\PhobosToolTip.h" />
     <ClInclude Include="src\Misc\SyncLogging.h" />
     <ClInclude Include="src\Misc\TypeConvertHelper.h" />
+    <ClInclude Include="src\Misc\CustomTheater\CustomTheater.h" />
+    <ClInclude Include="src\Misc\CustomTheater\TheaterProto.h" />
     <ClInclude Include="src\New\Type\DigitalDisplayTypeClass.h" />
     <ClInclude Include="src\New\Type\RadTypeClass.h" />
     <ClInclude Include="src\New\Type\ShieldTypeClass.h" />

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -115,10 +115,11 @@ template <typename T>
 void ScenarioExt::ExtData::Serialize(T& Stm)
 {
 	Stm
+		.Process(SessionClass::Instance->Config)
 		.Process(this->Waypoints)
 		.Process(this->Variables[0])
 		.Process(this->Variables[1])
-		.Process(SessionClass::Instance->Config)
+		.Process(this->CustomTheaterID)
 		;
 }
 

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -26,10 +26,12 @@ public:
 	public:
 		std::map<int, CellStruct> Waypoints;
 		std::map<int, ExtendedVariable> Variables[2]; // 0 for local, 1 for global
+		PhobosFixedString<0x40> CustomTheaterID;
 
 		ExtData(ScenarioClass* OwnerObject) : Extension<ScenarioClass>(OwnerObject)
 			, Waypoints { }
 			, Variables { }
+			, CustomTheaterID { NONE_STR }
 		{ }
 
 		void SetVariableToByID(bool bIsGlobal, int nIndex, char bState);

--- a/src/Misc/CustomTheater/CustomTheater.cpp
+++ b/src/Misc/CustomTheater/CustomTheater.cpp
@@ -1,0 +1,166 @@
+#include "CustomTheater.h"
+#include <Ext/Scenario/Body.h>
+
+std::unique_ptr<CustomTheater> CustomTheater::Instance = std::make_unique<CustomTheater>();
+
+void CustomTheater::Init(const char* id)
+{
+	Debug::Log("Initialized CustomTheater: %s\n", id);
+	Game::SetProgress(8);
+
+	// Just like the vanilla game, we don't reload the theater as it's an expensive operation
+	if (_stricmp(this->ID, id) != 0)
+	{
+		ScenarioClass::LastTheater = TheaterType::None; // Causes the game to reload tiles files
+
+		strcpy_s(this->ID, id);
+		sprintf_s(this->TheaterFileName, "%s.theater.ini", this->ID);
+
+		auto pProto = TheaterProto::Get(this->ID);
+		this->LoadFromProto(pProto);
+
+		this->UnloadMIXes();
+		MixFileClass::DestroyCache();
+		Game::SetProgress(6);
+		if (auto pConfig = CCINIClass::LoadINIFile(this->TheaterFileName))
+		{
+			this->LoadFromINIFile(pConfig);
+			this->LoadMIXesFromINIFile(pConfig);
+			CCINIClass::UnloadINIFile(pConfig);
+		}
+		else
+		{
+			this->LoadMIXesFromProto(pProto);
+		}
+
+		this->Patch();
+
+		Game::SetProgress(12);
+
+		Debug::Log("Loading SpecificMixes\n");
+		for (auto pMix : this->SpecificMixes)
+			Debug::Log("\t%s\n", pMix->FileName);
+	}
+
+	ScenarioClass::Instance->Theater = this->Slot;
+}
+
+void CustomTheater::Patch()
+{
+	// These variables are used many times throughout the game's code.
+	// Therefore, it is easier to overwrite their values ​​than to change all pointers to them.
+	// Also causing a problem is the fact that they are also used in Ares
+
+	// Makes memory available for writing, if not already done
+	static DWORD protectFlag = 0;
+	if (protectFlag == 0)
+		VirtualProtect(Theater::Array, sizeof(Theater) * 6, PAGE_EXECUTE_READWRITE, &protectFlag);
+
+	// To avoid a name conflict, we must clear the name of the first slot
+	if (this->Slot == TheaterType::Snow)
+		Theater::Array[0].ID[0] = 0;
+
+	// The new ID has a larger size 64 vs 16 in the vanilla variable
+	// This is us using the memory that was occupied by values that are no longer used
+	auto slot = Theater::Get(this->Slot);
+	memcpy(slot->ID, this->ID, sizeof(this->ID));
+	strcpy_s(slot->Extension, this->Extension);
+	slot->Letter[0] = this->Letter[0];
+
+	// This variable is only used on 0x47C318, but it's convenient to set it here
+	slot->RadarTerrainBrightness = this->RadarBrightness;
+}
+
+void CustomTheater::LoadFromProto(TheaterProto* pTheaterProto)
+{
+	strcpy_s(this->TerrainControl, pTheaterProto->TerrainControl);
+	strcpy_s(this->ExtendedRules, NONE_STR);
+
+	strcpy_s(this->PaletteISO, pTheaterProto->PaletteISO);
+	strcpy_s(this->PaletteOverlay, pTheaterProto->PaletteOverlay);
+	strcpy_s(this->PaletteUnit, pTheaterProto->PaletteUnit);
+
+	strcpy_s(this->Extension, pTheaterProto->Extension);
+	strcpy_s(this->Letter, pTheaterProto->Letter);
+
+	this->Slot = pTheaterProto->IsArctic ? TheaterType::Snow : TheaterType::Temperate;
+	this->RadarBrightness = pTheaterProto->RadarBrightness;
+}
+
+void CustomTheater::LoadFromINIFile(CCINIClass* pINI)
+{
+	const char* pSection = "Theater";
+
+	pINI->ReadString(pSection, "TerrainControl", this->TerrainControl, this->TerrainControl);
+	if (_strcmpi(this->TerrainControl, "<self>") == 0)
+		strcpy_s(this->TerrainControl, this->TheaterFileName);
+
+	pINI->ReadString(pSection, "ExtendedRules", this->ExtendedRules, this->ExtendedRules);
+	if (_strcmpi(this->ExtendedRules, "<self>") == 0)
+		strcpy_s(this->ExtendedRules, this->TheaterFileName);
+
+	this->Slot = pINI->ReadBool(pSection, "IsArctic", (bool)this->Slot) ? TheaterType::Snow : TheaterType::Temperate;
+
+	pINI->ReadString(pSection, "PaletteISO", this->PaletteISO, this->PaletteISO);
+	pINI->ReadString(pSection, "PaletteOverlay", this->PaletteOverlay, this->PaletteOverlay);
+	pINI->ReadString(pSection, "PaletteUnit", this->PaletteUnit, this->PaletteUnit);
+
+	pINI->ReadString(pSection, "Extension", this->Extension, this->Extension);
+	pINI->ReadString(pSection, "Letter", this->Letter, this->Letter);
+
+	this->RadarBrightness = (float)pINI->ReadDouble(pSection, "RadarBrightness", this->RadarBrightness);
+}
+
+void CustomTheater::LoadMIXesFromProto(TheaterProto* pTheaterProto)
+{
+	char* context = nullptr;
+	strcpy_s(Phobos::readBuffer, pTheaterProto->SpecificMixes);
+	char* fileName = strtok_s(Phobos::readBuffer, Phobos::readDelims, &context);
+	while (fileName)
+	{
+		auto pFile = CCFileClass(fileName);
+		if (pFile.Exists())
+			this->SpecificMixes.AddItem(GameCreate<MixFileClass>(fileName));
+
+		fileName = strtok_s(nullptr, Phobos::readDelims, &context);
+	}
+}
+
+void CustomTheater::LoadMIXesFromINIFile(CCINIClass* pINI)
+{
+	const char* pSection = "SpecificMixes";
+
+	if (!pINI->GetSection(pSection))
+	{
+		this->LoadMIXesFromProto(TheaterProto::Get(this->ID));
+		return;
+	}
+
+	const int itemsCount = pINI->GetKeyCount(pSection);
+	for (int i = 0; i < itemsCount; ++i)
+	{
+		auto pKey = pINI->GetKeyName(pSection, i);
+
+		char fileName[0x80];
+		pINI->ReadString(pSection, pKey, NONE_STR, fileName);
+
+		if (fileName[0] != 0 || _strcmpi(fileName, NONE_STR) != 0)
+		{
+			auto pFile = CCFileClass(fileName);
+			if (pFile.Exists())
+				this->SpecificMixes.AddItem(GameCreate<MixFileClass>(fileName));
+
+		}
+	}
+}
+
+void CustomTheater::UnloadMIXes()
+{
+	if (this->SpecificMixes.Count == 0)
+		return;
+
+	for (auto pMixFile : this->SpecificMixes)
+		GameDelete(pMixFile);
+
+	this->SpecificMixes.Clear();
+}

--- a/src/Misc/CustomTheater/CustomTheater.h
+++ b/src/Misc/CustomTheater/CustomTheater.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "TheaterProto.h"
+
+#include <CCINIClass.h>
+#include <GeneralDefinitions.h>
+#include <MixFileClass.h>
+
+class CustomTheater
+{
+public:
+	// properties:
+	char ID[0x40];
+
+	char TerrainControl[0x80];
+	char ExtendedRules[0x80];
+	TheaterType Slot;
+
+	char PaletteISO[0x80];
+	char PaletteOverlay[0x80];
+	char PaletteUnit[0x80];
+
+	char Extension[4];
+	char Letter[2];
+
+	float RadarBrightness;
+
+private:
+	char TheaterFileName[0x80];
+	DynamicVectorClass<MixFileClass*> SpecificMixes;
+
+public:
+	// methods:
+	void Init(const char* id);
+
+	void LoadFromProto(TheaterProto* pTheaterProto);
+	void LoadFromINIFile(CCINIClass* pINI);
+	void LoadMIXesFromProto(TheaterProto* pTheaterProto);
+	void LoadMIXesFromINIFile(CCINIClass* pINI);
+	void UnloadMIXes();
+
+	static std::unique_ptr<CustomTheater> Instance;
+private:
+	void Patch();
+};

--- a/src/Misc/CustomTheater/Hook.RMP.cpp
+++ b/src/Misc/CustomTheater/Hook.RMP.cpp
@@ -1,0 +1,40 @@
+#include "CustomTheater.h"
+
+#include <Ext/Scenario/Body.h>
+#include <MapSeedClass.h>
+#include <Randomizer.h>
+
+// Writes the name of the theater to generated map
+DEFINE_HOOK(0x5997AB, MapGeneratorClass_init, 0x9)
+{
+	R->ECX(ScenarioExt::Global()->CustomTheaterID.data());
+	return 0x5997C6;
+}
+
+// Overrides the Ares hook RMG_EnableDesert on 0x5970EA
+DEFINE_HOOK(0x5970AF, MapSeedClass_SetMenuOptions, 0x7)
+{
+	GET(HWND, hWnd, EDI);
+
+	auto AddOption = [hWnd](const char* label, int index)
+	{
+		auto ListItem = SendMessageA(hWnd, WW_CB_ADDITEM, 0,
+			reinterpret_cast<LPARAM>(StringTable::FetchString(label))
+		);
+
+		// Set the item data (Theater ID)
+		SendMessageA(hWnd, CB_SETITEMDATA, ListItem, index);
+	};
+
+	AddOption(TheaterProto::Temperate->UIName, 0);
+	AddOption(TheaterProto::Snow->UIName, 1);
+	AddOption(TheaterProto::Desert->UIName, 3);
+
+	auto pTheater = &TheaterProto::Array[MapSeedClass::Instance->Theater];
+	auto pUIName = StringTable::FetchString(pTheater->UIName);
+	auto item = SendMessageA(hWnd, WW_CB_GETITEMINDEX, 0, reinterpret_cast<LPARAM>(pUIName));
+	SendMessageA(hWnd, CB_SETCURSEL, item, 0);
+
+	R->EBP(&MapSeedClass::Instance);
+	return 0x59712A;
+}

--- a/src/Misc/CustomTheater/Hooks.cpp
+++ b/src/Misc/CustomTheater/Hooks.cpp
@@ -1,0 +1,80 @@
+#include "CustomTheater.h"
+#include "RulesClass.h"
+
+#include <Ext/Scenario/Body.h>
+#include <Utilities/GeneralUtils.h>
+#include <Utilities/Macro.h>
+
+DEFINE_HOOK(0x687631, Read_Scenario_INI, 0x8)
+{
+	GET(CCINIClass*, pMapINI, EBP);
+	ScenarioExt::Global()->CustomTheaterID.Read(pMapINI, "Map", "Theater", TheaterProto::Temperate->ID);
+	ScenarioExt::Global()->CustomTheaterID.Read(pMapINI, "Map", "CustomTheater");
+
+	Theater::Init(TheaterType::None);
+
+	if (auto pExtendedRulesINI = CCINIClass::LoadINIFile(CustomTheater::Instance->ExtendedRules))
+	{
+		RulesClass::Instance->Read_File(pExtendedRulesINI);
+		CCINIClass::UnloadINIFile(pExtendedRulesINI);
+	}
+
+	return 0x687660;
+}
+
+DEFINE_HOOK(0x5349C9, Theater_Init, 0x6)
+{
+	GET(int, theaterIndex, ECX);
+	LEA_STACK(TheaterType*, slot, STACK_OFFSET(0x6C, -0x54));
+
+	// For RMP
+	if (ScenarioClass::Instance->Theater <= TheaterType::None && theaterIndex >= 0)
+		strcpy_s(ScenarioExt::Global()->CustomTheaterID.data(), TheaterProto::Array[theaterIndex].ID);
+
+	CustomTheater::Instance->Init(ScenarioExt::Global()->CustomTheaterID);
+
+	*slot = ScenarioClass::Instance->Theater;
+	R->EAX(FileSystem::LoadFile(CustomTheater::Instance->PaletteOverlay));
+	R->EDI(0);
+	R->EDX(0);
+	return 0x534C09;
+}
+
+DEFINE_HOOK(0x534CA9, Init_Theaters_SetPaletteUnit, 0x8)
+{
+	R->ESI(FileSystem::LoadFile(CustomTheater::Instance->PaletteUnit));
+	return 0x534CCA;
+}
+
+DEFINE_HOOK(0x54547F, IsometricTileTypeClass_ReadINI_SetPaletteISO, 0x6)
+{
+	R->ECX<char*>(CustomTheater::Instance->PaletteISO);
+	return 0x5454A2;
+}
+
+DEFINE_HOOK(0x5454F0, IsometricTileTypeClass_ReadINI_TerrainControl, 0x6)
+{
+	R->ECX<char*>(CustomTheater::Instance->TerrainControl);
+	return 0x545513;
+}
+
+// Reinitialize forcibly, regardless of LastTheater value
+DEFINE_JUMP(LJMP, 0x6268C7, 0x6268CF) // INIColors_6267A0
+
+// Skip rereading Theater tag, in DisplayClass
+DEFINE_JUMP(LJMP, 0x4ACFD8, 0x4ACFF6) // DisplayClass_ReadINI
+
+// To prevent log spam in debug.log when parsing Prerequisite.RequiredTheaters (Ares)
+// I changed the return value of the Theater::FindIndex function to -2
+// in case the theater is not found in the vanilla Theater::Array
+// https://github.com/Ares-Developers/Ares/blob/4f1d929920aca31924c6cd4d3dfa849daa65252a/src/Ext/TechnoType/Body.cpp#L137
+DEFINE_PATCH(0x48DC0A, (byte)-2)
+
+// Unload MIXes when process exits. For what ?
+// Vanilla game does it, it's good practice to keep this behavior
+DEFINE_JUMP(LJMP, 0x6BE633, 0x6BE659)
+DEFINE_HOOK(0x6BE5B9, Prog_End, 0x6)
+{
+	CustomTheater::Instance->UnloadMIXes();
+	return 0x6BE607;
+}

--- a/src/Misc/CustomTheater/TheaterProto.cpp
+++ b/src/Misc/CustomTheater/TheaterProto.cpp
@@ -1,0 +1,111 @@
+#include <string.h>
+#include "TheaterProto.h"
+
+// This is listed default values for vanilla theaters
+TheaterProto TheaterProto::Array[] = {
+	TheaterProto /* TEMPERATE */ {
+		"TEMPERATE",
+		"Name:Temperate",
+		"TEMPERATMD.INI",
+		false,
+		"ISOTEM.PAL",
+		"TEMPERAT.PAL",
+		"UNITTEM.PAL",
+		"TEM",
+		"T",
+		1.0f,
+		"TEMPERAT.MIX,TEM.MIX,ISOTEMMD.MIX,ISOTEMP.MIX"
+	},
+	TheaterProto /* SNOW */ {
+		"SNOW",
+		"Name:Snow",
+		"SNOWMD.INI",
+		true,
+		"ISOSNO.PAL",
+		"SNOW.PAL",
+		"UNITSNO.PAL",
+		"SNO",
+		"A",
+		0.8f,
+		"SNOWMD.MIX,SNOW.MIX,SNO.MIX,ISOSNOMD.MIX,ISOSNOW.MIX"
+	},
+	TheaterProto /* URBAN */ {
+		"URBAN",
+		"Name:Urban",
+		"URBANMD.INI",
+		false,
+		"ISOURB.PAL",
+		"URBAN.PAL",
+		"UNITURB.PAL",
+		"URB",
+		"U",
+		1.0f,
+		"URBAN.MIX,URB.MIX,ISOURBMD.MIX,ISOURB.MIX"
+	},
+	TheaterProto /* DESERT */ {
+		"DESERT",
+		"Name:Desert",
+		"DESERTMD.INI",
+		false,
+		"ISODES.PAL",
+		"DESERT.PAL",
+		"UNITDES.PAL",
+		"DES",
+		"D",
+		1.0f,
+		"DESERT.MIX,DES.MIX,ISODESMD.MIX,ISODES.MIX"
+	},
+	TheaterProto /* NEWURBAN */ {
+		"NEWURBAN",
+		"Name:New Urban",
+		"URBANNMD.INI",
+		false,
+		"ISOUBN.PAL",
+		"URBANN.PAL",
+		"UNITUBN.PAL",
+		"UBN",
+		"N",
+		1.0f,
+		"URBANN.MIX,UBN.MIX,ISOUBNMD.MIX,ISOUBN.MIX"
+	},
+	TheaterProto /* LUNAR */ {
+		"LUNAR",
+		"Name:Lunar",
+		"LUNARMD.INI",
+		false,
+		"ISOLUN.PAL",
+		"LUNAR.PAL",
+		"UNITLUN.PAL",
+		"LUN",
+		"L",
+		1.0f,
+		"LUNAR.MIX,LUN.MIX,ISOLUNMD.MIX,ISOLUN.MIX"
+	}
+};
+constexpr int TheaterProto::ArraySize = sizeof(TheaterProto::Array) / sizeof(*TheaterProto::Array);
+
+TheaterProto* TheaterProto::Temperate = &TheaterProto::Array[0];
+TheaterProto* TheaterProto::Snow = &TheaterProto::Array[1];
+TheaterProto* TheaterProto::Urban = &TheaterProto::Array[2];
+TheaterProto* TheaterProto::Desert = &TheaterProto::Array[3];
+TheaterProto* TheaterProto::NewUrban = &TheaterProto::Array[4];
+TheaterProto* TheaterProto::Lunar = &TheaterProto::Array[5];
+
+int TheaterProto::FindIndex(const char* id, int iDefault)
+{
+	for (int i = 0; i < TheaterProto::ArraySize; i++)
+	{
+		if (_stricmp(TheaterProto::Array[i].ID, id) == 0)
+			return i;
+	}
+	return iDefault;
+}
+
+TheaterProto* TheaterProto::Get(const char* id, TheaterProto* nDefault)
+{
+	const int index = TheaterProto::FindIndex(id);
+	if (index >= 0)
+		return &TheaterProto::Array[index];
+
+	return nDefault;
+}

--- a/src/Misc/CustomTheater/TheaterProto.h
+++ b/src/Misc/CustomTheater/TheaterProto.h
@@ -1,0 +1,34 @@
+#pragma once
+
+struct TheaterProto
+{
+	char ID[0x40];
+	char UIName[0x20];
+
+	char TerrainControl[0x80];
+	bool IsArctic;
+
+	char PaletteISO[0x80];
+	char PaletteOverlay[0x80];
+	char PaletteUnit[0x80];
+
+	char Extension[4];
+	char Letter[2];
+
+	float RadarBrightness;
+	char SpecificMixes[0x80];
+
+	// static
+	static TheaterProto Array[];
+	static const int ArraySize;
+
+	static TheaterProto* Temperate;
+	static TheaterProto* Snow;
+	static TheaterProto* Urban;
+	static TheaterProto* Desert;
+	static TheaterProto* NewUrban;
+	static TheaterProto* Lunar;
+
+	static int FindIndex(const char* id, int iDefault = -1);
+	static TheaterProto* Get(const char* name, TheaterProto* nDefault = TheaterProto::Temperate);
+};


### PR DESCRIPTION
# Custom Theaters

In **Map**:
```ini
[Map]
Theater=SomeTheaterName        ; default TEMPERATE
CustomTheater=SomeTheaterName  ; default [Map]->Theater
```
- Tag `CustomTheater` is the same as `Theater`, but it has a higher priority. It's needed for more convenient work with **FA2** and **CNCMaps Renderer**, since these tools do not yet support **Custom Theaters**

In **\<SomeTheaterName\>.theater.ini**:
```ini
[Theater]                     ; default values ​​for vanilla theaters are different, see table below
TerrainControl=TEMPERATMD.INI ; filename - including the .ini extension or <self>
ExtendedRules=<none>          ; filename - including the .ini extension or <self>

IsArctic=no                   ; boolean

PaletteISO=ISOTEM.PAL         ; filename - including the .pal extension
PaletteOverlay=TEMPERAT.PAL   ; filename - including the .pal extension
PaletteUnit=UNITTEM.PAL       ; filename - including the .pal extension

Extension=TEM                 ; String of 3 characters
Letter=T                      ; String of 1 characters

RadarBrightness=100%          ; floating point value, percents

[SpecificMixes]               ; list of Mix filename - including the .mix extension
1=TEMPERAT.MIX                ; default values ​​applied if the section is not found
2=TEM.MIX
3=ISOTEMMD.MIX
4=ISOTEMP.MIX
5=
...
```
- `ExtendedRules` Allows you to specify an ini file to force rules to be included in all maps of this theater
- The special value `<self>` of the `TerrainControl` and `ExtendedRules` tags is equivalent to `<SomeTheaterName>.Theater.ini`
- The `IsArctic=yes` tag means that this is an arctic theater and should work the same as SNOW. This applies to the <a href=https://modenc.renegadeprojects.com/AlternateArcticArt>AlternateArcticArt</a> tag and also to the features of light generation in the Random Map Generator, maybe something else...

# Bonus
- Tags `ShorePieces`, `WaterSet`, `CliffSet`, `WaterCliffs`, `WaterBridge`, `BridgeSet`, `WoodBridgeSet` have been hardcoded to `-1` for the **Lunar** theatre, this is no longer the case


# Default Values for Vanilla Theaters
|                           | *TEMPERATE*     | *SNOW*       | *URBAN*      | *DESERT*      | *NEWURBAN*    | *LUNAR*      |
|:------------------------- | :-------------- | :----------- | :----------- | :------------ | :------------ | :----------- |
|<pre>TerrainControl</pre>  |`TEMPERATMD.INI` |`SNOWMD.INI`  |`URBANMD.INI` |`DESERTMD.INI` |`URBANNMD.INI` |`LUNARMD.INI` |
|<pre>IsArctic</pre>        |`no`             |`yes`         |`no`          |`no`           |`no`           |`no`          |
|<pre>PaletteISO</pre>      |`ISOTEM.PAL`     |`ISOSNO.PAL`  |`ISOURB.PAL`  |`ISODES.PAL`   |`ISOUBN.PAL`   |`ISOLUN.PAL`  |
|<pre>PaletteOverlay</pre>  |`TEMPERAT.PAL`   |`SNOW.PAL`    |`URBAN.PAL`   |`DESERT.PAL`   |`URBANN.PAL`   |`LUNAR.PAL`   |
|<pre>PaletteUnit</pre>     |`UNITTEM.PAL`    |`UNITSNO.PAL` |`UNITURB.PAL` |`UNITDES.PAL`  |`UNITUBN.PAL`  |`UNITLUN.PAL` |
|<pre>Extension</pre>       |`TEM`            |`SNO`         |`URB`         |`DES`          |`UBN`          |`LUN`         |
|<pre>Letter</pre>          |`T`              |`A`           |`U`           |`D`            |`N`            |`L`           |
|<pre>RadarBrightness</pre> |`100%`           |`80%`         |`100%`        |`100%`         |`100%`         |`100%`        |
|<pre>SpecificMixes</pre>   |<pre><ol><li>TEMPERAT.MIX</li><li>-</li><li>TEM.MIX</li><li>ISOTEMMD.MIX</li><li>ISOTEMP.MIX</li></ol></pre>|<pre><ol><li>SNOWMD.MIX</li><li>SNOW.MIX</li><li>SNO.MIX</li><li>ISOSNOMD.MIX</li><li>ISOSNOW.MIX</li></ol></pre>|<pre><ol><li>URBAN.MIX</li><li>-</li><li>URB.MIX</li><li>ISOURBMD.MIX</li><li>ISOURB.MIX</li></ol></pre>|<pre><ol><li>DESERT.MIX</li><li>-</li><li>DES.MIX</li><li>ISODESMD.MIX</li><li>ISODES.MIX</li></ol></pre>|<pre><ol><li>URBANN.MIX</li><li>-</li><li>UBN.MIX</li><li>ISOUBNMD.MIX</li><li>ISOUBN.MIX</li></ol></pre>|<pre><ol><li>LUNAR.MIX</li><li>-</li><li>LUN.MIX</li><li>ISOLUNMD.MIX</li><li>ISOLUN.MIX</li></ol></pre>
