### PR TITLE
Trigger Action can use more than one string as parameter

### DIFF
--- a/src/Ext/TAction/Body.h
+++ b/src/Ext/TAction/Body.h
@@ -18,6 +18,7 @@ enum class PhobosTriggerAction : unsigned int
 	BinaryOperation = 504,
 	RunSuperWeaponAtLocation = 505,
 	RunSuperWeaponAtWaypoint = 506,
+	DrawLaserBetweenWeaypoints = 9940
 };
 
 class TActionExt
@@ -28,6 +29,14 @@ public:
 	class ExtData final : public Extension<TActionClass>
 	{
 	public:
+
+		std::string Value1;
+		std::string Value2;
+		std::string Parm3;
+		std::string Parm4;
+		std::string Parm5;
+		std::string Parm6;
+
 		ExtData(TActionClass* const OwnerObject) : Extension<TActionClass>(OwnerObject)
 		{ }
 
@@ -59,6 +68,7 @@ public:
 	ACTION_FUNC(BinaryOperation);
 	ACTION_FUNC(RunSuperWeaponAtLocation);
 	ACTION_FUNC(RunSuperWeaponAtWaypoint);
+	ACTION_FUNC(DrawLaserBetweenWaypoints);
 
 	static bool RunSuperWeaponAt(TActionClass* pThis, int X, int Y);
 

--- a/src/Ext/TAction/Hooks.cpp
+++ b/src/Ext/TAction/Hooks.cpp
@@ -1,5 +1,8 @@
 #include "Body.h"
 
+#include <queue>
+#include <sstream>
+
 #include <Helpers\Macro.h>
 
 #include <HouseClass.h>
@@ -113,6 +116,85 @@ DEFINE_HOOK(0x6E2EA7, TActionClass_Retint_LightSourceFix, 0x3) // Red
 			pRadSite->LightSource->Activate();
 		}
 	}
+
+	return 0;
+}
+
+
+namespace ActionsString
+{
+	std::string ActionsString;
+	std::deque<std::string> SubStrings;
+}
+
+DEFINE_HOOK(0x727544, TriggerClass_LoadFromINI_Actions, 0x5)
+{
+	GET(const char*, pString, EDX);
+	ActionsString::ActionsString = pString;
+	std::stringstream sin(ActionsString::ActionsString);
+	std::deque<std::string>& substrs = ActionsString::SubStrings;
+	substrs.clear();
+	std::string tmp;
+	while (std::getline(sin, tmp, ','))
+	{
+		substrs.emplace_back(tmp);
+	}
+	if (!ActionsString::SubStrings.empty())
+		ActionsString::SubStrings.pop_front();
+	return 0;
+}
+
+DEFINE_HOOK(0x6DD5B0, TActionClass_LoadFromINI_Parm, 0x5)
+{
+	GET(TActionClass*, pThis, ECX);
+	auto pExt = TActionExt::ExtMap.Find(pThis);
+	std::deque<std::string>& substrs = ActionsString::SubStrings;
+
+	if (substrs.empty())
+		return 0;
+
+	substrs.pop_front();
+
+	if (substrs.empty())
+		return 0;
+
+	pExt->Value1 = substrs.front();
+	substrs.pop_front();
+
+	if (substrs.empty())
+		return 0;
+
+	pExt->Value2 = substrs.front();
+	substrs.pop_front();
+
+	if (substrs.empty())
+		return 0;
+
+	pExt->Parm3 = substrs.front();
+	substrs.pop_front();
+
+	if (substrs.empty())
+		return 0;
+
+	pExt->Parm4 = substrs.front();
+	substrs.pop_front();
+
+	if (substrs.empty())
+		return 0;
+
+	pExt->Parm5 = substrs.front();
+	substrs.pop_front();
+
+	if (substrs.empty())
+		return 0;
+
+	pExt->Parm6 = substrs.front();
+	substrs.pop_front();
+
+	if (substrs.empty())
+		return 0;
+
+	substrs.pop_front();
 
 	return 0;
 }


### PR DESCRIPTION
Why use WW action with only one text parameter.

Action 9940 as sample.

In `fadata.ini`
```ini
76=duration,0
77=InnerColor,8
78=OuterColor,9

9940=Draw Laser Between Two Waypoints,0,76,30,30,77,78,0,0,0,Draw laser between two waypoints color is hexadecimal of RGB24,0,1,9940,1
```