### PR TITLE
[Campaigns] make AI auto-repair base nodes

### DIFF
--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -63,3 +63,21 @@ DEFINE_HOOK(0x73E474, UnitClass_Unload_Storage, 0x6)
 
 	return 0;
 }
+
+
+DEFINE_HOOK(0x4506D4, BuildingClass_UpdateRepair_Campaign, 0x6)
+{
+	enum { GoRepair = 0x4506F5, SkipRepair = 0x450813 };
+	GET(BuildingClass*, pThis, ESI);
+	GET(HouseClass*, pHouse, ECX);
+
+	//Vanilla code
+	if (pThis->HasBeenCaptured || pThis->ShouldRebuild || pHouse->ControlledByHuman())
+		return GoRepair;
+
+	if (pThis->BeingProduced && SessionClass::Instance->GameMode == GameMode::Campaign)
+		if(RulesExt::Global()->AIRepairBaseNodes)
+			return GoRepair;
+
+	return SkipRepair;
+}

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -91,6 +91,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->IronCurtain_KeptOnDeploy.Read(exINI, "CombatDamage", "IronCurtain.KeptOnDeploy");
 
+	this->AIRepairBaseNodes.Read(exINI, "Basic", "AIRepairBaseNodes");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount(sectionAITargetTypes);
 	for (int i = 0; i < itemsCount; ++i)
@@ -201,6 +203,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_SelfHeal_Units_Offset)
 		.Process(this->Pips_SelfHeal_Buildings_Offset)
 		.Process(this->IronCurtain_KeptOnDeploy)
+		.Process(this->AIRepairBaseNodes)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -53,6 +53,8 @@ public:
 		Valueable<Point2D> Pips_SelfHeal_Buildings_Offset;
 		Valueable<bool> IronCurtain_KeptOnDeploy;
 
+		Valueable<bool> AIRepairBaseNodes;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -78,6 +80,7 @@ public:
 			, Pips_SelfHeal_Units_Offset {{ 33, -32 }}
 			, Pips_SelfHeal_Buildings_Offset {{ 15, 10 }}
 			, IronCurtain_KeptOnDeploy { true }
+			, AIRepairBaseNodes { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
In singleplayer campaigns, base nodes cannot auto-repair. This PR aims to fix this:

In your `campaign.map`:
```ini
[Basic]
AIRepairBaseNodes=no  ; boolean
```
