### PR TITLE
Minor refactor SWTypeExt and ForbidParalleAIlQueue

### DIFF
--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -61,7 +61,7 @@ DEFINE_HOOK(0x4401BB, Factory_AI_PickWithFreeDocks, 0x6)
 		return 0;
 
 	if (pBuilding->Type->Factory == AbstractType::AircraftType
-		&& Phobos::Config::ForbidParallelAIQueues_Aircraft)
+		&& RulesExt::Global()->ForbidParallelAIQueues_Aircraft)
 	{
 		if (pBuilding->Factory
 			&& !BuildingExt::HasFreeDocks(pBuilding))
@@ -178,29 +178,29 @@ DEFINE_HOOK(0x4502F4, BuildingClass_Update_Factory, 0x6)
 		{
 			enum { Skip = 0x4503CA };
 			if (pBuilding->Type->Factory == AbstractType::BuildingType
-				&& Phobos::Config::ForbidParallelAIQueues_Building)
+				&& RulesExt::Global()->ForbidParallelAIQueues_Building)
 			{
 				return Skip;
 			}
 			else if (pBuilding->Type->Factory == AbstractType::UnitType
-				&& Phobos::Config::ForbidParallelAIQueues_Vehicle
+				&& RulesExt::Global()->ForbidParallelAIQueues_Vehicle
 				&& !pBuilding->Type->Naval)
 			{
 				return Skip;
 			}
 			else if (pBuilding->Type->Factory == AbstractType::UnitType
-				&& Phobos::Config::ForbidParallelAIQueues_Navy
+				&& RulesExt::Global()->ForbidParallelAIQueues_Navy
 				&& pBuilding->Type->Naval)
 			{
 				return Skip;
 			}
 			else if (pBuilding->Type->Factory == AbstractType::InfantryType
-				&& Phobos::Config::ForbidParallelAIQueues_Infantry)
+				&& RulesExt::Global()->ForbidParallelAIQueues_Infantry)
 			{
 				return Skip;
 			}
 			else if (pBuilding->Type->Factory == AbstractType::AircraftType
-				&& Phobos::Config::ForbidParallelAIQueues_Aircraft)
+				&& RulesExt::Global()->ForbidParallelAIQueues_Aircraft)
 			{
 				return Skip;
 			}
@@ -224,27 +224,27 @@ DEFINE_HOOK(0x4CA07A, FactoryClass_AbandonProduction, 0x8)
 	switch (pTechno->WhatAmI())
 	{
 	case AbstractType::Building:
-		if (Phobos::Config::ForbidParallelAIQueues_Building)
+		if (RulesExt::Global()->ForbidParallelAIQueues_Building)
 			pData->Factory_BuildingType = nullptr;
 		break;
 	case AbstractType::Unit:
 		if (!pTechno->GetTechnoType()->Naval)
 		{
-			if (Phobos::Config::ForbidParallelAIQueues_Vehicle)
+			if (RulesExt::Global()->ForbidParallelAIQueues_Vehicle)
 				pData->Factory_VehicleType = nullptr;
 		}
 		else
 		{
-			if (Phobos::Config::ForbidParallelAIQueues_Navy)
+			if (RulesExt::Global()->ForbidParallelAIQueues_Navy)
 				pData->Factory_NavyType = nullptr;
 		}
 		break;
 	case AbstractType::Infantry:
-		if (Phobos::Config::ForbidParallelAIQueues_Infantry)
+		if (RulesExt::Global()->ForbidParallelAIQueues_Infantry)
 			pData->Factory_InfantryType = nullptr;
 		break;
 	case AbstractType::Aircraft:
-		if (Phobos::Config::ForbidParallelAIQueues_Aircraft)
+		if (RulesExt::Global()->ForbidParallelAIQueues_Aircraft)
 			pData->Factory_AircraftType = nullptr;
 		break;
 	}
@@ -264,12 +264,12 @@ DEFINE_HOOK(0x444119, BuildingClass_KickOutUnit_UnitType, 0x6)
 
 	if (!pUnit->Type->Naval)
 	{
-		if (Phobos::Config::ForbidParallelAIQueues_Vehicle)
+		if (RulesExt::Global()->ForbidParallelAIQueues_Vehicle)
 			pData->Factory_VehicleType = nullptr;
 	}
 	else
 	{
-		if (Phobos::Config::ForbidParallelAIQueues_Navy)
+		if (RulesExt::Global()->ForbidParallelAIQueues_Navy)
 			pData->Factory_NavyType = nullptr;
 	}
 
@@ -280,7 +280,7 @@ DEFINE_HOOK(0x444131, BuildingClass_KickOutUnit_InfantryType, 0x6)
 {
 	GET(HouseClass*, pHouse, EAX);
 
-	if (Phobos::Config::AllowParallelAIQueues || Phobos::Config::ForbidParallelAIQueues_Infantry)
+	if (Phobos::Config::AllowParallelAIQueues || RulesExt::Global()->ForbidParallelAIQueues_Infantry)
 		return 0;
 
 	HouseExt::ExtMap.Find(pHouse)->Factory_InfantryType = nullptr;
@@ -291,7 +291,7 @@ DEFINE_HOOK(0x44531F, BuildingClass_KickOutUnit_BuildingType, 0xA)
 {
 	GET(HouseClass*, pHouse, EAX);
 
-	if (Phobos::Config::AllowParallelAIQueues || Phobos::Config::ForbidParallelAIQueues_Building)
+	if (Phobos::Config::AllowParallelAIQueues || RulesExt::Global()->ForbidParallelAIQueues_Building)
 		return 0;
 
 	HouseExt::ExtMap.Find(pHouse)->Factory_BuildingType = nullptr;
@@ -302,7 +302,7 @@ DEFINE_HOOK(0x443CCA, BuildingClass_KickOutUnit_AircraftType, 0xA)
 {
 	GET(HouseClass*, pHouse, EDX);
 
-	if (Phobos::Config::AllowParallelAIQueues || Phobos::Config::ForbidParallelAIQueues_Aircraft)
+	if (Phobos::Config::AllowParallelAIQueues || RulesExt::Global()->ForbidParallelAIQueues_Aircraft)
 		return 0;
 
 	HouseExt::ExtMap.Find(pHouse)->Factory_AircraftType = nullptr;

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -89,6 +89,12 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Pips_SelfHeal_Units_Offset.Read(exINI, "AudioVisual", "Pips.SelfHeal.Units.Offset");
 	this->Pips_SelfHeal_Buildings_Offset.Read(exINI, "AudioVisual", "Pips.SelfHeal.Buildings.Offset");
 
+	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
+	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
+	this->ForbidParallelAIQueues_Infantry.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
+	this->ForbidParallelAIQueues_Navy.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Navy");
+	this->ForbidParallelAIQueues_Vehicle.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Vehicle");
+
 	this->IronCurtain_KeptOnDeploy.Read(exINI, "CombatDamage", "IronCurtain.KeptOnDeploy");
 
 	// Section AITargetTypes
@@ -201,6 +207,11 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_SelfHeal_Infantry_Offset)
 		.Process(this->Pips_SelfHeal_Units_Offset)
 		.Process(this->Pips_SelfHeal_Buildings_Offset)
+		.Process(this->ForbidParallelAIQueues_Aircraft)
+		.Process(this->ForbidParallelAIQueues_Building)
+		.Process(this->ForbidParallelAIQueues_Infantry)
+		.Process(this->ForbidParallelAIQueues_Navy)
+		.Process(this->ForbidParallelAIQueues_Vehicle)
 		.Process(this->IronCurtain_KeptOnDeploy)
 		;
 }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -51,6 +51,13 @@ public:
 		Valueable<Point2D> Pips_SelfHeal_Infantry_Offset;
 		Valueable<Point2D> Pips_SelfHeal_Units_Offset;
 		Valueable<Point2D> Pips_SelfHeal_Buildings_Offset;
+
+		Valueable<bool> ForbidParallelAIQueues_Infantry;
+		Valueable<bool> ForbidParallelAIQueues_Vehicle;
+		Valueable<bool> ForbidParallelAIQueues_Navy;
+		Valueable<bool> ForbidParallelAIQueues_Aircraft;
+		Valueable<bool> ForbidParallelAIQueues_Building;
+
 		Valueable<bool> IronCurtain_KeptOnDeploy;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
@@ -71,12 +78,17 @@ public:
 			, Pips_Shield_Background { }
 			, Pips_Shield_Building { { -1,-1,-1 } }
 			, Pips_Shield_Building_Empty { }
-			, Pips_SelfHeal_Infantry {{ 13, 20 }}
-			, Pips_SelfHeal_Units {{ 13, 20 }}
-			, Pips_SelfHeal_Buildings {{ 13, 20 }}
-			, Pips_SelfHeal_Infantry_Offset {{ 25, -35 }}
-			, Pips_SelfHeal_Units_Offset {{ 33, -32 }}
-			, Pips_SelfHeal_Buildings_Offset {{ 15, 10 }}
+			, Pips_SelfHeal_Infantry { { 13, 20 } }
+			, Pips_SelfHeal_Units { { 13, 20 } }
+			, Pips_SelfHeal_Buildings { { 13, 20 } }
+			, Pips_SelfHeal_Infantry_Offset { { 25, -35 } }
+			, Pips_SelfHeal_Units_Offset { { 33, -32 } }
+			, Pips_SelfHeal_Buildings_Offset { { 15, 10 } }
+			, ForbidParallelAIQueues_Aircraft { false }
+			, ForbidParallelAIQueues_Building { false }
+			, ForbidParallelAIQueues_Infantry { false }
+			, ForbidParallelAIQueues_Navy { false }
+			, ForbidParallelAIQueues_Vehicle { false }
 			, IronCurtain_KeptOnDeploy { true }
 		{ }
 

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -47,7 +47,7 @@ public:
 		{ }
 
 
-		void FireSuperWeapon(SuperClass* pSW, HouseClass* pHouse, CoordStruct coords);
+		void FireSuperWeapon(SuperClass* pSW, const CellStruct& cell);
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		virtual ~ExtData() = default;

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -2,13 +2,15 @@
 
 #include <SuperClass.h>
 
-DEFINE_HOOK(0x6CDE40, SuperClass_Place, 0x5)
+//Ares hooked from 0x6CC390 and jumped to this offset
+DEFINE_HOOK(0x6CDE40, SuperClass_Launch_finale, 0x3)
 {
 	GET(SuperClass* const, pSuper, ECX);
-	GET_STACK(CoordStruct const, coords, 0x230); // I think?
+	GET_STACK(CellStruct const* const, pCell, 0x4);
+	// GET_STACK(bool const, isPlayer, 0x8);
 
 	if (auto const pSWExt = SWTypeExt::ExtMap.Find(pSuper->Type))
-		pSWExt->FireSuperWeapon(pSuper, pSuper->Owner, coords);
+		pSWExt->FireSuperWeapon(pSuper, *pCell);
 
 	return 0;
 }

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -56,11 +56,6 @@ bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::AllowParallelAIQueues = true;
 bool Phobos::Config::EnableBuildingPlacementPreview = false;
-bool Phobos::Config::ForbidParallelAIQueues_Infantry = false;
-bool Phobos::Config::ForbidParallelAIQueues_Vehicle = false;
-bool Phobos::Config::ForbidParallelAIQueues_Navy = false;
-bool Phobos::Config::ForbidParallelAIQueues_Aircraft = false;
-bool Phobos::Config::ForbidParallelAIQueues_Building = false;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -245,12 +240,6 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 DEFINE_HOOK(0x66E9DF, RulesClass_Process_Phobos, 0x8)
 {
 	GET(CCINIClass*, rulesINI, EDI);
-
-	Phobos::Config::ForbidParallelAIQueues_Infantry = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Infantry", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Vehicle = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Vehicle", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Navy = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Navy", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Aircraft = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Aircraft", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Building = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Building", Phobos::Config::AllowParallelAIQueues);
 
 	// Ares tags
 	Phobos::Config::DevelopmentCommands = rulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", Phobos::Config::DevelopmentCommands);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -69,10 +69,5 @@ public:
 		static bool ArtImageSwap;
 		static bool AllowParallelAIQueues;
 		static bool EnableBuildingPlacementPreview;
-		static bool ForbidParallelAIQueues_Infantry;
-		static bool ForbidParallelAIQueues_Vehicle;
-		static bool ForbidParallelAIQueues_Navy;
-		static bool ForbidParallelAIQueues_Aircraft;
-		static bool ForbidParallelAIQueues_Building;
 	};
 };


### PR DESCRIPTION
1. Fix the wrong hook size and stack offset for future usage
2. Minor refactored limbo delivery part to improve readability of #379 
3. **Moved all ForbidParalleAIlQueue related settings to `RulesExt`** #638 :

I noticed that `[GlobalControls]->AllowParallelAIQueues` is serialized in Ares, so I think these ones should be serialized as well? Need someone to elaborate on this one