### PR TITLE
Add IgnoreDesignator option for LaunchSW, Refactor ParallelAIQueue & SWTypeExt;

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -177,6 +177,7 @@ This page lists all the individual contributions to the project by their author.
    - Harvester counter
    - Warhead superweapon launch logic
    - "Shield is broken" trigger event
+   - Forbidding parallel AI queues by type
 - **NetsuNegi** - Forbidding parallel AI queues by type
 - **Apollo** - Translucent SHP drawing patches
 - **FlyStar** - Campaign load screen PCX support

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -848,7 +848,8 @@ TransactMoney.Display.Offset=0,0     ; X,Y, pixels relative to default
 - Superweapons can now be launched when a warhead is detonated.
   - `LaunchSW` specifies the superweapons to launch when the warhead is detonated.
   - `LaunchSW.RealLaunch` controls whether the owner who fired the warhead must own all listed superweapons and sufficient fund to support `Money.Amout`. Otherwise they will be launched out of nowhere.
-  - `LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors` of each superweapon, otherwise only non-inhibited superweapons are launched. `SW.Designators` are always ignored.
+  - `LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of each superweapon, otherwise only non-inhibited superweapons are launched.
+  - `LaunchSW.IgnoreDesignators` ignores `SW.Designators`/`SW.AnyDesignator` respectively.
 
 ```{note}
 For animation warheads/weapons to take effect, `Damage.DealtByInvoker` must be set.
@@ -861,6 +862,7 @@ In `rulesmd.ini`:
 LaunchSW=                        ; list of superweapons
 LaunchSW.RealLaunch=true         ; boolean
 LaunchSW.IgnoreInhibitors=false  ; boolean
+LaunchSW.IgnoreDesignators=true  ; boolean
 ```
 
 ### Remove disguise on impact

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -325,7 +325,7 @@ New:
 - Enhanced projectile interception logic, including projectile strength & armor types (by Starkku)
 - Initial Strength for Cloned Infantry (by FS-21)
 - OpenTopped transport rangefinding & deactivated state customizations (by Starkku)
-- Forbidding parallel AI queues by type (by NetsuNegi)
+- Forbidding parallel AI queues by type (by NetsuNegi & Trsdy)
 - Animation damage / weapon improvements (by Starkku)
 - Warhead self-damaging toggle (by Starkku)
 - Trailer animations inheriting owner (by Starkku)

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -127,21 +127,21 @@ DEFINE_HOOK(0x4502F4, BuildingClass_Update_Factory_Phobos, 0x6)
 
 	if (pOwner->Production && Phobos::Config::AllowParallelAIQueues)
 	{
-		auto pHouseExt = HouseExt::ExtMap.Find(pOwner);
+		auto pOwnerExt = HouseExt::ExtMap.Find(pOwner);
 		BuildingClass** currFactory = nullptr;
 		switch (pThis->Type->Factory)
 		{
 		case AbstractType::BuildingType:
-			currFactory = &pHouseExt->Factory_BuildingType;
+			currFactory = &pOwnerExt->Factory_BuildingType;
 			break;
 		case AbstractType::UnitType:
-			currFactory = pThis->Type->Naval ? &pHouseExt->Factory_NavyType : &pHouseExt->Factory_VehicleType;
+			currFactory = pThis->Type->Naval ? &pOwnerExt->Factory_NavyType : &pOwnerExt->Factory_VehicleType;
 			break;
 		case AbstractType::InfantryType:
-			currFactory = &pHouseExt->Factory_InfantryType;
+			currFactory = &pOwnerExt->Factory_InfantryType;
 			break;
 		case AbstractType::AircraftType:
-			currFactory = &pHouseExt->Factory_AircraftType;
+			currFactory = &pOwnerExt->Factory_AircraftType;
 			break;
 		}
 

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -37,7 +37,14 @@ public:
 		virtual ~ExtData() = default;
 
 		//virtual void Initialize() override;
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override {}
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
+		{
+			AnnounceInvalidPointer(Factory_AircraftType, ptr);
+			AnnounceInvalidPointer(Factory_NavyType, ptr);
+			AnnounceInvalidPointer(Factory_InfantryType, ptr);
+			AnnounceInvalidPointer(Factory_VehicleType, ptr);
+			AnnounceInvalidPointer(Factory_BuildingType, ptr);
+		}
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -90,6 +90,12 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Pips_SelfHeal_Units_Offset.Read(exINI, "AudioVisual", "Pips.SelfHeal.Units.Offset");
 	this->Pips_SelfHeal_Buildings_Offset.Read(exINI, "AudioVisual", "Pips.SelfHeal.Buildings.Offset");
 
+	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
+	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
+	this->ForbidParallelAIQueues_Infantry.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
+	this->ForbidParallelAIQueues_Navy.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Navy");
+	this->ForbidParallelAIQueues_Vehicle.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Vehicle");
+
 	this->IronCurtain_KeptOnDeploy.Read(exINI, "CombatDamage", "IronCurtain.KeptOnDeploy");
 
 	// Section AITargetTypes
@@ -204,6 +210,12 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_SelfHeal_Infantry_Offset)
 		.Process(this->Pips_SelfHeal_Units_Offset)
 		.Process(this->Pips_SelfHeal_Buildings_Offset)
+		.Process(Phobos::Config::AllowParallelAIQueues)
+		.Process(this->ForbidParallelAIQueues_Aircraft)
+		.Process(this->ForbidParallelAIQueues_Building)
+		.Process(this->ForbidParallelAIQueues_Infantry)
+		.Process(this->ForbidParallelAIQueues_Navy)
+		.Process(this->ForbidParallelAIQueues_Vehicle)
 		.Process(this->IronCurtain_KeptOnDeploy)
 		;
 }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -53,6 +53,13 @@ public:
 		Valueable<Point2D> Pips_SelfHeal_Infantry_Offset;
 		Valueable<Point2D> Pips_SelfHeal_Units_Offset;
 		Valueable<Point2D> Pips_SelfHeal_Buildings_Offset;
+
+		Valueable<bool> ForbidParallelAIQueues_Infantry;
+		Valueable<bool> ForbidParallelAIQueues_Vehicle;
+		Valueable<bool> ForbidParallelAIQueues_Navy;
+		Valueable<bool> ForbidParallelAIQueues_Aircraft;
+		Valueable<bool> ForbidParallelAIQueues_Building;
+
 		Valueable<bool> IronCurtain_KeptOnDeploy;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
@@ -74,12 +81,17 @@ public:
 			, Pips_Shield_Background { }
 			, Pips_Shield_Building { { -1,-1,-1 } }
 			, Pips_Shield_Building_Empty { }
-			, Pips_SelfHeal_Infantry {{ 13, 20 }}
-			, Pips_SelfHeal_Units {{ 13, 20 }}
-			, Pips_SelfHeal_Buildings {{ 13, 20 }}
-			, Pips_SelfHeal_Infantry_Offset {{ 25, -35 }}
-			, Pips_SelfHeal_Units_Offset {{ 33, -32 }}
-			, Pips_SelfHeal_Buildings_Offset {{ 15, 10 }}
+			, Pips_SelfHeal_Infantry { { 13, 20 } }
+			, Pips_SelfHeal_Units { { 13, 20 } }
+			, Pips_SelfHeal_Buildings { { 13, 20 } }
+			, Pips_SelfHeal_Infantry_Offset { { 25, -35 } }
+			, Pips_SelfHeal_Units_Offset { { 33, -32 } }
+			, Pips_SelfHeal_Buildings_Offset { { 15, 10 } }
+			, ForbidParallelAIQueues_Aircraft { false }
+			, ForbidParallelAIQueues_Building { false }
+			, ForbidParallelAIQueues_Infantry { false }
+			, ForbidParallelAIQueues_Navy { false }
+			, ForbidParallelAIQueues_Vehicle { false }
 			, IronCurtain_KeptOnDeploy { true }
 		{ }
 

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -15,6 +15,8 @@ void SWTypeExt::ExtData::Serialize(T& Stm) {
 		.Process(this->Money_Amount)
 		.Process(this->SW_Inhibitors)
 		.Process(this->SW_AnyInhibitor)
+		.Process(this->SW_Designators)
+		.Process(this->SW_AnyDesignator)
 		.Process(this->UIDescription)
 		.Process(this->CameoPriority)
 		.Process(this->LimboDelivery_Types)
@@ -41,6 +43,8 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->Money_Amount.Read(exINI, pSection, "Money.Amount");
 	this->SW_Inhibitors.Read(exINI, pSection, "SW.Inhibitors");
 	this->SW_AnyInhibitor.Read(exINI, pSection, "SW.AnyInhibitor");
+	this->SW_Designators.Read(exINI, pSection, "SW.Designators");
+	this->SW_AnyDesignator.Read(exINI, pSection, "SW.AnyDesignator");
 
 	this->UIDescription.Read(exINI, pSection, "UIDescription");
 	this->CameoPriority.Read(exINI, pSection, "CameoPriority");

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -18,6 +18,8 @@ public:
 		Valueable<int> Money_Amount;
 		ValueableVector<TechnoTypeClass*> SW_Inhibitors;
 		Valueable<bool> SW_AnyInhibitor;
+		ValueableVector<TechnoTypeClass*> SW_Designators;
+		Valueable<bool> SW_AnyDesignator;
 
 		Valueable<CSFText> UIDescription;
 		Valueable<int> CameoPriority;
@@ -35,6 +37,8 @@ public:
 			, Money_Amount { 0 }
 			, SW_Inhibitors {}
 			, SW_AnyInhibitor { false }
+			, SW_Designators { }
+			, SW_AnyDesignator { false }
 			, UIDescription {}
 			, CameoPriority { 0 }
 			, LimboDelivery_Types {}
@@ -46,8 +50,17 @@ public:
 			, RandomBuffer { 0.0 }
 		{ }
 
+		// Ares 0.A functions
+		bool IsInhibitor(HouseClass* pOwner, TechnoClass* pTechno) const;
+		bool HasInhibitor(HouseClass* pOwner, const CellStruct& coords) const;
+		bool IsInhibitorEligible(HouseClass* pOwner, const CellStruct& coords, TechnoClass* pTechno) const;
 
-		void FireSuperWeapon(SuperClass* pSW, HouseClass* pHouse, CoordStruct coords);
+		bool IsDesignator(HouseClass* pOwner, TechnoClass* pTechno) const;
+		bool HasDesignator(HouseClass* pOwner, const CellStruct& coords) const;
+		bool IsDesignatorEligible(HouseClass* pOwner, const CellStruct& coords, TechnoClass* pTechno) const;
+
+		void ApplyLimboDelivery(HouseClass* pHouse);
+		void ApplyLimboKill(HouseClass* pHouse);
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		virtual ~ExtData() = default;
@@ -57,9 +70,6 @@ public:
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
-	private:
-		void ApplyLimboDelivery(HouseClass* pHouse);
-		void ApplyLimboKill(HouseClass* pHouse);
 
 		template <typename T>
 		void Serialize(T& Stm);
@@ -72,11 +82,10 @@ public:
 		~ExtContainer();
 	};
 
+	static void FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell);
+
 	static ExtContainer ExtMap;
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
 
-	static bool IsInhibitor(SWTypeExt::ExtData* pSWType, HouseClass* pOwner, TechnoClass* pTechno);
-	static bool HasInhibitor(SWTypeExt::ExtData* pSWType, HouseClass* pOwner, const CellStruct& Coords);
-	static bool IsInhibitorEligible(SWTypeExt::ExtData* pSWType, HouseClass* pOwner, const CellStruct& Coords, TechnoClass* pTechno);
 };

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -2,13 +2,14 @@
 
 #include <SuperClass.h>
 
-DEFINE_HOOK(0x6CDE40, SuperClass_Place, 0x5)
+//Ares hooked from 0x6CC390 and jumped to this offset
+DEFINE_HOOK(0x6CDE40, SuperClass_Place_FireExt, 0x3)
 {
 	GET(SuperClass* const, pSuper, ECX);
-	GET_STACK(CoordStruct const, coords, 0x230); // I think?
+	GET_STACK(CellStruct const* const, pCell, 0x4);
+	// GET_STACK(bool const, isPlayer, 0x8);
 
-	if (auto const pSWExt = SWTypeExt::ExtMap.Find(pSuper->Type))
-		pSWExt->FireSuperWeapon(pSuper, pSuper->Owner, coords);
+	SWTypeExt::FireSuperWeaponExt(pSuper, *pCell);
 
 	return 0;
 }

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -76,38 +76,36 @@ void TechnoExt::ExtData::ApplyInterceptor()
 
 void TechnoExt::ExtData::CheckDeathConditions()
 {
-	auto const pThis = this->OwnerObject();
-	auto const pType = pThis->GetTechnoType();
 	auto const pTypeExt = this->TypeExtData;
 
-	if (pTypeExt)
+	if (!pTypeExt->AutoDeath_Behavior.isset())
+		return;
+
+	auto const pThis = this->OwnerObject();
+	auto const pType = pThis->GetTechnoType();
+
+	// Self-destruction must be enabled
+	const auto howToDie = pTypeExt->AutoDeath_Behavior.Get();
+
+	// Death if no ammo
+	if (pType->Ammo > 0 && pThis->Ammo <= 0 && pTypeExt->AutoDeath_OnAmmoDepletion)
 	{
-		if (!pTypeExt->AutoDeath_Behavior.isset())
-			return;
+		TechnoExt::KillSelf(pThis, howToDie);
+		return;
+	}
 
-		// Self-destruction must be enabled
-		const auto howToDie = pTypeExt->AutoDeath_Behavior.Get();
-
-		// Death if no ammo
-		if (pType->Ammo > 0 && pThis->Ammo <= 0 && pTypeExt->AutoDeath_OnAmmoDepletion)
+	// Death if countdown ends
+	if (pTypeExt->AutoDeath_AfterDelay > 0)
+	{
+		//using Expired() may be confusing
+		if (this->AutoDeathTimer.StartTime == -1 && this->AutoDeathTimer.TimeLeft == 0)
+		{
+			this->AutoDeathTimer.Start(pTypeExt->AutoDeath_AfterDelay);
+		}
+		else if (!pThis->Transporter && this->AutoDeathTimer.Completed())
 		{
 			TechnoExt::KillSelf(pThis, howToDie);
 			return;
-		}
-
-		// Death if countdown ends
-		if (pTypeExt->AutoDeath_AfterDelay > 0)
-		{
-			//using Expired() may be confusing
-			if (this->AutoDeathTimer.StartTime == -1 && this->AutoDeathTimer.TimeLeft == 0)
-			{
-				this->AutoDeathTimer.Start(pTypeExt->AutoDeath_AfterDelay);
-			}
-			else if (!pThis->Transporter && this->AutoDeathTimer.Completed())
-			{
-				TechnoExt::KillSelf(pThis, howToDie);
-				return;
-			}
 		}
 	}
 }
@@ -555,6 +553,7 @@ void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption)
 	case AutoDeathBehavior::Vanish:
 	{
 		pThis->KillPassengers(pThis);
+		pThis->vt_entry_3A0();
 		pThis->Limbo();
 		pThis->RegisterKill(pThis->Owner);
 		pThis->UnInit();
@@ -578,7 +577,7 @@ void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption)
 	}
 
 	default: //must be AutoDeathBehavior::Kill
-		pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
+		pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance->C4Warhead, nullptr, true, false, pThis->Owner);
 		// Due to Ares, ignoreDefense=true will prevent passenger/crew/hijacker from escaping
 		return;
 	}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -74,12 +74,12 @@ void TechnoExt::ExtData::ApplyInterceptor()
 	}
 }
 
-void TechnoExt::ExtData::CheckDeathConditions()
+bool TechnoExt::ExtData::CheckDeathConditions()
 {
 	auto const pTypeExt = this->TypeExtData;
 
 	if (!pTypeExt->AutoDeath_Behavior.isset())
-		return;
+		return false;
 
 	auto const pThis = this->OwnerObject();
 	auto const pType = pThis->GetTechnoType();
@@ -91,7 +91,7 @@ void TechnoExt::ExtData::CheckDeathConditions()
 	if (pType->Ammo > 0 && pThis->Ammo <= 0 && pTypeExt->AutoDeath_OnAmmoDepletion)
 	{
 		TechnoExt::KillSelf(pThis, howToDie);
-		return;
+		return true;
 	}
 
 	// Death if countdown ends
@@ -105,9 +105,10 @@ void TechnoExt::ExtData::CheckDeathConditions()
 		else if (!pThis->Transporter && this->AutoDeathTimer.Completed())
 		{
 			TechnoExt::KillSelf(pThis, howToDie);
-			return;
+			return true;
 		}
 	}
+	return false;
 }
 
 void TechnoExt::ExtData::EatPassengers()
@@ -240,7 +241,7 @@ void TechnoExt::ExtData::ApplyPoweredKillSpawns()
 					if (pItem->Status == SpawnNodeStatus::Attacking || pItem->Status == SpawnNodeStatus::Returning)
 					{
 						pItem->Unit->ReceiveDamage(&pItem->Unit->Health, 0,
-							RulesClass::Instance()->C4Warhead, nullptr, false, false, nullptr);
+							RulesClass::Instance()->C4Warhead, nullptr, true, false, nullptr);
 					}
 				}
 			}
@@ -553,7 +554,7 @@ void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption)
 	case AutoDeathBehavior::Vanish:
 	{
 		pThis->KillPassengers(pThis);
-		pThis->vt_entry_3A0();
+		pThis->vt_entry_3A0(); // Stun? what is this?
 		pThis->Limbo();
 		pThis->RegisterKill(pThis->Owner);
 		pThis->UnInit();

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -55,7 +55,7 @@ public:
 		{ }
 
 		void ApplyInterceptor();
-		void CheckDeathConditions();
+		bool CheckDeathConditions();
 		void EatPassengers();
 		void UpdateShield();
 		void ApplyPoweredKillSpawns();

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -20,8 +20,10 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	if (!pExt->TypeExtData || pExt->TypeExtData->OwnerObject() != pType)
 		pExt->TypeExtData = TechnoTypeExt::ExtMap.Find(pType);
 
+	if (pExt->CheckDeathConditions())
+		return 0;
+
 	pExt->ApplyInterceptor();
-	pExt->CheckDeathConditions();
 	pExt->EatPassengers();
 	pExt->UpdateShield();
 	pExt->ApplyPoweredKillSpawns();

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -209,6 +209,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	// Ares 0.9
 	this->InhibitorRange.Read(exINI, pSection, "InhibitorRange");
+	this->DesignatorRange.Read(exINI, pSection, "DesignatorRange");
 
 	// Ares 0.A
 	this->GroupAs.Read(pINI, pSection, "GroupAs");
@@ -281,6 +282,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->GroupAs)
 		.Process(this->RadarJamRadius)
 		.Process(this->InhibitorRange)
+		.Process(this->DesignatorRange)
 		.Process(this->TurretOffset)
 		.Process(this->Powered_KillSpawns)
 		.Process(this->Spawn_LimitedRange)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -24,6 +24,7 @@ public:
 		PhobosFixedString<0x20> GroupAs;
 		Valueable<int> RadarJamRadius;
 		Nullable<int> InhibitorRange;
+		Nullable<int> DesignatorRange;
 		Valueable<Leptons> MindControlRangeLimit;
 		Valueable<bool> Interceptor;
 		Valueable<AffectedHouse> Interceptor_CanTargetHouses;
@@ -156,6 +157,7 @@ public:
 			, GroupAs { NONE_STR }
 			, RadarJamRadius { 0 }
 			, InhibitorRange { }
+			, DesignatorRange { }
 			, MindControlRangeLimit {}
 			, Interceptor { false }
 			, Interceptor_CanTargetHouses { AffectedHouse::Enemies }

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -160,6 +160,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->LaunchSW.Read(exINI, pSection, "LaunchSW");
 	this->LaunchSW_RealLaunch.Read(exINI, pSection, "LaunchSW.RealLaunch");
 	this->LaunchSW_IgnoreInhibitors.Read(exINI, pSection, "LaunchSW.IgnoreInhibitors");
+	this->LaunchSW_IgnoreDesignators.Read(exINI, pSection, "LaunchSW.IgnoreDesignators");
+
 	this->AllowDamageOnSelf.Read(exINI, pSection, "AllowDamageOnSelf");
 
 	this->DetonateOnAllMapObjects.Read(exINI, pSection, "DetonateOnAllMapObjects");
@@ -235,6 +237,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->LaunchSW)
 		.Process(this->LaunchSW_RealLaunch)
 		.Process(this->LaunchSW_IgnoreInhibitors)
+		.Process(this->LaunchSW_IgnoreDesignators)
 		.Process(this->AllowDamageOnSelf)
 
 		.Process(this->DetonateOnAllMapObjects)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -74,6 +74,7 @@ public:
 		ValueableVector<SuperWeaponTypeClass*> LaunchSW;
 		Valueable<bool> LaunchSW_RealLaunch;
 		Valueable<bool> LaunchSW_IgnoreInhibitors;
+		Valueable<bool> LaunchSW_IgnoreDesignators;
 		Valueable<bool> AllowDamageOnSelf;
 
 		Valueable<bool> DetonateOnAllMapObjects;
@@ -156,6 +157,7 @@ public:
 			, LaunchSW {}
 			, LaunchSW_RealLaunch { true }
 			, LaunchSW_IgnoreInhibitors { false }
+			, LaunchSW_IgnoreDesignators { true }
 			, AllowDamageOnSelf { false }
 
 			, DetonateOnAllMapObjects { false }

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -82,7 +82,8 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 				const auto cell = CellClass::Coord2Cell(coords);
 				if ((pSWExt && pSuper->IsCharged && pHouse->CanTransactMoney(pSWExt->Money_Amount)) || !this->LaunchSW_RealLaunch)
 				{
-					if (this->LaunchSW_IgnoreInhibitors || !SWTypeExt::HasInhibitor(pSWExt, pHouse, cell))
+					if (this->LaunchSW_IgnoreInhibitors || !pSWExt->HasInhibitor(pHouse, cell)
+					&& (this->LaunchSW_IgnoreDesignators || pSWExt->HasDesignator(pHouse, cell)))
 					{
 						pSuper->SetReadiness(true);
 						pSuper->Launch(cell, true);

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -56,11 +56,6 @@ bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::AllowParallelAIQueues = true;
 bool Phobos::Config::EnableBuildingPlacementPreview = false;
-bool Phobos::Config::ForbidParallelAIQueues_Infantry = false;
-bool Phobos::Config::ForbidParallelAIQueues_Vehicle = false;
-bool Phobos::Config::ForbidParallelAIQueues_Navy = false;
-bool Phobos::Config::ForbidParallelAIQueues_Aircraft = false;
-bool Phobos::Config::ForbidParallelAIQueues_Building = false;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -245,12 +240,6 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 DEFINE_HOOK(0x66E9DF, RulesClass_Process_Phobos, 0x8)
 {
 	GET(CCINIClass*, rulesINI, EDI);
-
-	Phobos::Config::ForbidParallelAIQueues_Infantry = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Infantry", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Vehicle = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Vehicle", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Navy = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Navy", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Aircraft = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Aircraft", Phobos::Config::AllowParallelAIQueues);
-	Phobos::Config::ForbidParallelAIQueues_Building = rulesINI->ReadBool("GlobalControls", "ForbidParallelAIQueues.Building", Phobos::Config::AllowParallelAIQueues);
 
 	// Ares tags
 	Phobos::Config::DevelopmentCommands = rulesINI->ReadBool("GlobalControls", "DebugKeysEnabled", Phobos::Config::DevelopmentCommands);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -69,10 +69,5 @@ public:
 		static bool ArtImageSwap;
 		static bool AllowParallelAIQueues;
 		static bool EnableBuildingPlacementPreview;
-		static bool ForbidParallelAIQueues_Infantry;
-		static bool ForbidParallelAIQueues_Vehicle;
-		static bool ForbidParallelAIQueues_Navy;
-		static bool ForbidParallelAIQueues_Aircraft;
-		static bool ForbidParallelAIQueues_Building;
 	};
 };


### PR DESCRIPTION
I accidentally deleted #720, this PR restores it.

### Launch superweapons on impact
In `rulesmd.ini`:
```ini
[SOMEWARHEAD]                    ; Warhead
LaunchSW.IgnoreDesignators=true  ; boolean
```
Detached shield pointer invalidation part into #740 

### additional refactor
1. Fix the wrong hook size and stack offset for future usage of SW cell coordinates in `SuperClass::Launch` hook. Minor refactored limbo delivery part to improve the readability of #379 

2. **Moved all ForbidParalleAIlQueue related settings to `RulesExt`** #638 , serialized all related items as well as `[GlobalControls]->AllowParallelAIQueues` , fixed related code errors