### PR TITLE
Dehardcode SP campaign AI's ability of auto-repairing structures built from base nodes / trigger action 125/ SW delivery

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -182,6 +182,7 @@ This page lists all the individual contributions to the project by their author.
    - Object Self-destruction logic
    - Building EVA_StructureSold and SellSound dehardcode
    - Slaves' house customization when owner is killed
+   - Campaign AI's base node/SW-delivered/trigger action 125-delivered structures' auto-repairability dehardcode
    - Misc CN doc fix, code refactor
    - Harvester counter
    - Warhead superweapon launch logic

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -6,9 +6,14 @@ This page describes all AI scripting and mapping related additions and changes i
 
 - Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's a RA1 leftover)
 - The game now can reads waypoints ranges in [0, 2147483647]. (was [0,701])
-- Map trigger action `125 Build At...` can now play buildup anim optionally (needs [following changes to `fadata.ini`](Whats-New.md#for-map-editor-final-alert-2).
+- Map trigger action `125 Build At...` can now play buildup anim and becomes singleplayer-AI-repairable optionally (needs [following changes to `fadata.ini`](Whats-New.md#for-map-editor-final-alert-2).
 - Both Global Variables (`VariableNames` in `rulesmd.ini`) and Local Variables (`VariableNames` in map) are now unlimited.
 - Script action `Deploy` now has vehicles with `DeploysInto` searching for free space to deploy at if failing to do so at initial location, instead of simply getting stuck.
+- In singleplayer campaigns, AI can now repair the base nodes/buildings delivered by SW (Ares) by setting
+```ini
+[Country House]
+RepairBaseNodes=no,no,no ; 3 booleans indicating whether AI repair basenodes in Easy/ Normal/ Difficult game diffculty.
+```
 
 ## Script Actions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -55,6 +55,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
   58=Upper bound,0
   59=Operate var is global,10
   60=Operate var index,0
+  65=Campaign AI Repairable,0
 
   [EventsRA2]
   500=Local variable is greater than,48,6,0,0,[LONG DESC],0,1,500,1
@@ -96,7 +97,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
   600=Shield of the attached object is broken,0,0,0,0,[LONG DESC],0,1,600,1
 
   [ActionsRA2]
-  125=Build at...,-10,47,53,0,0,0,1,0,0,[LONG DESC],0,1,125
+  125=Build at...,-10,47,53,65,0,0,1,0,0,[LONG DESC],0,1,125
   500=Save game,-4,13,0,0,0,0,0,0,0,[LONG DESC],0,1,500,1
   501=Edit variable,0,56,55,6,54,0,0,0,0,[LONG DESC],0,1,501,1
   502=Generate random number,0,56,57,58,54,0,0,0,0,[LONG DESC],0,1,502,1
@@ -245,6 +246,10 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 New:
 - `Crit.AffectsHouses` for critical hit system (by Starkku)
 - Warhead or weapon detonation at superweapon target cell (by Starkku)
+
+Vanilla fixes:
+- Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
+
 </details>
 
 

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -72,6 +72,25 @@ HouseClass* HouseExt::GetHouseKind(OwnerHouseKind const kind, bool const allowRa
 		return pDefault;
 	}
 }
+
+void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
+{
+	const char* pSection = this->OwnerObject()->PlainName;
+
+	INI_EX exINI(pINI);
+
+	ValueableVector<bool> readBaseNodeRepairInfo;
+	readBaseNodeRepairInfo.Read(exINI, pSection, "RepairBaseNodes");
+	size_t nWritten = readBaseNodeRepairInfo.size();
+	if (nWritten > 0)
+	{
+		for (size_t i = 0; i < 3; i++)
+			this->RepairBaseNodes[i] = readBaseNodeRepairInfo[i < nWritten ? i : nWritten - 1];
+	}
+
+}
+
+
 // =============================
 // load / save
 
@@ -85,6 +104,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 		.Process(this->Factory_VehicleType)
 		.Process(this->Factory_NavyType)
 		.Process(this->Factory_AircraftType)
+		.Process(this->RepairBaseNodes)
 		;
 }
 

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -25,6 +25,9 @@ public:
 		BuildingClass* Factory_NavyType;
 		BuildingClass* Factory_AircraftType;
 
+		//Read from INI
+		bool RepairBaseNodes[3];
+
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, OwnedLimboBuildingTypes {}
 			, Factory_BuildingType { nullptr }
@@ -32,10 +35,12 @@ public:
 			, Factory_VehicleType { nullptr }
 			, Factory_NavyType { nullptr }
 			, Factory_AircraftType { nullptr }
+			, RepairBaseNodes { false,false,false }
 		{ }
 
 		virtual ~ExtData() = default;
 
+		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		//virtual void Initialize() override;
 		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
 		{

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -1,5 +1,5 @@
 #include "Body.h"
-
+#include <GameOptionsClass.h>
 #include "../Techno/Body.h"
 #include "../Building/Body.h"
 #include <unordered_map>
@@ -62,4 +62,19 @@ DEFINE_HOOK(0x73E474, UnitClass_Unload_Storage, 0x6)
 	}
 
 	return 0;
+}
+
+DEFINE_HOOK(0x440B4F, BuildingClass_Unlimbo_SetShouldRebuild, 0x5)
+{
+	enum { ContinueCheck = 0x440B58, SetShouldRebuild = 0x440B7A, SkipCheck = 0x440B81 };
+	GET(BuildingClass* const, pThis, ESI);
+
+	if (SessionClass::IsCampaign())
+	{
+		auto hExt = HouseExt::ExtMap.Find(pThis->Owner);
+		if (!hExt->RepairBaseNodes[GameOptionsClass::Instance->Difficulty])
+			return SkipCheck;
+	}
+
+	return ContinueCheck;
 }

--- a/src/Ext/TAction/Hooks.cpp
+++ b/src/Ext/TAction/Hooks.cpp
@@ -27,8 +27,8 @@ DEFINE_HOOK(0x6DD8B0, TActionClass_Execute, 0x6)
 	return handled ? 0x6DD910 : 0;
 }
 
-// Bugfix: TAction 125 Build At do not display the buildups
-// Author: secsome
+// TODO: Sometimes Buildup anims plays while the building image is already there in faster gamespeed.
+// Bugfix: TAction 125 Build At could neither display the buildups nor be AI-repairable in singleplayer mode
 DEFINE_HOOK(0x6E427D, TActionClass_CreateBuildingAt, 0x9)
 {
 	GET(TActionClass*, pThis, ESI);
@@ -62,6 +62,10 @@ DEFINE_HOOK(0x6E427D, TActionClass_CreateBuildingAt, 0x9)
 				pBld->Place(false);
 
 			pBld->IsReadyToCommence = true;
+
+			if (SessionClass::IsCampaign() && !pHouse->IsControlledByHuman())
+				pBld->ShouldRebuild = pThis->Param4 > 0;
+
 			bCreated = true;
 		}
 	}


### PR DESCRIPTION
Sorry I accidentally deleted #711 
In singleplayer campaigns, base nodes cannot auto-repair, neither can buildings delivered from trigger action 125 or Ares' UnitDelivery SW. This PR aims to fix this:

In your `campaign.map`:
```ini
[Country House]
RepairBaseNodes=no,no,no ; 3 booleans indicating whether AI should repair produced structures in Easy/ Normal/ Difficult game diffculty.
```
If set to `yes` at the corresponding difficulty level, the corresponding **house** will be able to repair base node structures.

For trigger action 125, note `Param3` and `Param4` from
```ini
[Actions]
...
ACTIONID=COUNT,...,125,10,BuildingTypeID,Param3,Param4,0,0,WaypointID,...
...
```
If `Param3=1`, the buildup will be played. If `Param4=1`, the building will be repairable for AI in SP missions. 

