### PR TITLE
Changed Forced Jump timer from frames to ingame seconds

### DIFF
--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -301,7 +301,7 @@ x=124,0
 In `aimd.ini`:
 ```ini
 [SOMESCRIPTTYPE]  ; ScriptType
-x=125,n           ; integer n=0, in frames
+x=125,n           ; integer n=0, in ingame seconds
 ```
 
 ### `126` Start a Timed Jump to the same line
@@ -311,7 +311,7 @@ x=125,n           ; integer n=0, in frames
 In `aimd.ini`:
 ```ini
 [SOMESCRIPTTYPE]  ; ScriptType
-x=126,n           ; integer n=0, in frames
+x=126,n           ; integer n=0, in ingame seconds
 ```
 
 ### `500 - 523` Edit Variable

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -21,7 +21,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - `Trajectory.Speed` is now defined on projectile instead of weapon.
 - `Gravity=0` is not supported anymore as it will cause the projectile to fly backwards and be unable to hit the target which is not at the same height. Use `Straight` Trajectory instead. See [here](New-or-Enhanced-Logics.md#projectile-trajectories).
 - Automatic self-destruction logic logic has been reimplemented, `Death.NoAmmo`, `Death.Countdown` and `Death.Peaceful` tags have been remade/renamed and require adjustments to function.
-- Script actions 125 and 126 (timed jump) now take the time measured in ingame seconds instead of frames. Divide your value by 15 to accomodate to this change. 
+- Script actions 125 and 126 (timed jump) now take the time measured in ingame seconds instead of frames. Divide your value by 15 to accomodate to this change.
 
 #### From 0.2.2.2
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -21,6 +21,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - `Trajectory.Speed` is now defined on projectile instead of weapon.
 - `Gravity=0` is not supported anymore as it will cause the projectile to fly backwards and be unable to hit the target which is not at the same height. Use `Straight` Trajectory instead. See [here](New-or-Enhanced-Logics.md#projectile-trajectories).
 - Automatic self-destruction logic logic has been reimplemented, `Death.NoAmmo`, `Death.Countdown` and `Death.Peaceful` tags have been remade/renamed and require adjustments to function.
+- Script actions 125 and 126 (timed jump) now take the time measured in ingame seconds instead of frames. Divide your value by 15 to accomodate to this change. 
 
 #### From 0.2.2.2
 

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -3043,7 +3043,7 @@ void ScriptExt::Set_ForceJump_Countdown(TeamClass *pTeam, bool repeatLine = fals
 		return;
 
 	if (count <= 0)
-		count = pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->CurrentMission].Argument;
+		count = 15 * pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->CurrentMission].Argument;
 
 	if (count > 0)
 	{


### PR DESCRIPTION
Like Timed Area Guard (script action 71) it now use seconds in the argument.
Is more easy to use "15" for 15 seconds than "225" for the same seconds.