### PR TITLE
Refactor Harvester counter to improve performance

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -173,7 +173,8 @@ This page lists all the individual contributions to the project by their author.
    - Object Self-destruction logic
    - Building EVA_StructureSold and SellSound dehardcode
    - Slaves' house customization when owner is killed
-   - Misc CN doc fix
+   - Misc CN doc fix, code refactor
+   - Harvester counter
    - Warhead superweapon launch logic
    - "Shield is broken" trigger event
 - **NetsuNegi** - Forbidding parallel AI queues by type

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -379,6 +379,7 @@ Phobos fixes:
 - Fixed issue with incorrect input in edit dialog element when using IME (by Belonit)
 - Fixed an issue where tooltip text could be clipped by tooltip rectangle border if using `MaxWidth` > 0 (by Starkku)
 - Fixed projectiles with `Trajectory=Straight` suffering from potential inaccuracy problems if combined with `Airburst=yes` or Warhead with `EMEffect=true` (by Starkku)
+- Fixed teleporting chronominer considered to be idle by harvester counter, improved related game performance (by Trsdy)
 
 Non-DLL:
 - Implemented a tool (sed wrapper) to semi-automatically upgrade INIs to use latest Phobos tags (by Kerbiter)

--- a/src/Commands/NextIdleHarvester.h
+++ b/src/Commands/NextIdleHarvester.h
@@ -53,7 +53,7 @@ public:
 		do {
 			if (auto pTechno = abstract_cast<TechnoClass*>(pNextObject)) {
 				if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType())) {
-					if (pTypeExt->IsCountedAsHarvester() && !TechnoExt::IsHarvesting(pTechno)) {
+					if (pTypeExt->Harvester_Counted.Get() && !TechnoExt::IsHarvesting(pTechno)) {
 						pObjectToSelect = pNextObject;
 						idleHarvestersPresent = true;
 						break;

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -73,10 +73,7 @@ DEFINE_HOOK(0x422967, AnimClass_DTOR, 0x6)
 {
 	GET(AnimClass*, pItem, ESI);
 
-	if (AnimExt::ExtMap.Find(pItem))
-		AnimExt::ExtMap.Remove(pItem);
-
-	R->EAX(pItem->Type);
+	AnimExt::ExtMap.Remove(pItem);
 
 	return 0;
 }

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -13,32 +13,30 @@ HouseExt::ExtContainer HouseExt::ExtMap;
 
 int HouseExt::ActiveHarvesterCount(HouseClass* pThis)
 {
-	if (!pThis) return 0;
+	if (!pThis || pThis->Defeated) return 0;
 
 	int result = 0;
-	for (auto techno : *TechnoClass::Array) {
-		if (auto pTechnoExt = TechnoTypeExt::ExtMap.Find(techno->GetTechnoType())) {
-			if (pTechnoExt->IsCountedAsHarvester() && techno->Owner == pThis) {
-				if (auto pTechno = TechnoExt::ExtMap.Find(techno)) {
-					result += TechnoExt::IsHarvesting(techno);
-				}
-			}
+	for (auto techno : *TechnoClass::Array)
+	{
+		if (techno->Owner == pThis)
+		{
+			if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(techno->GetTechnoType()))
+				result += pTypeExt->Harvester_Counted && TechnoExt::IsHarvesting(techno);
 		}
 	}
-
-	return result;
 }
 
 int HouseExt::TotalHarvesterCount(HouseClass* pThis)
 {
-	if (!pThis)	return 0;
+	if (!pThis || pThis->Defeated)	return 0;
 
 	int result = 0;
-	for (auto techno : *TechnoTypeClass::Array) {
-		if (auto pTechnoExt = TechnoTypeExt::ExtMap.Find(techno)) {
-			if (pTechnoExt->IsCountedAsHarvester()) {
+	for (auto techno : *TechnoTypeClass::Array)
+	{
+		if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(techno))
+		{
+			if (pTypeExt->Harvester_Counted)
 				result += pThis->CountOwnedAndPresent(techno);
-			}
 		}
 	}
 

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -13,32 +13,23 @@ HouseExt::ExtContainer HouseExt::ExtMap;
 
 int HouseExt::ActiveHarvesterCount(HouseClass* pThis)
 {
-	if (!pThis || pThis->Defeated) return 0;
-
 	int result = 0;
-	for (auto techno : *TechnoClass::Array)
+	for (auto pTechno : *TechnoClass::Array)
 	{
-		if (techno->Owner == pThis)
+		if (pTechno->Owner == pThis)
 		{
-			if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(techno->GetTechnoType()))
-				result += pTypeExt->Harvester_Counted && TechnoExt::IsHarvesting(techno);
+			if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType()))
+				result += pTypeExt->Harvester_Counted && TechnoExt::IsHarvesting(pTechno);
 		}
 	}
+	return result;
 }
 
 int HouseExt::TotalHarvesterCount(HouseClass* pThis)
 {
-	if (!pThis || pThis->Defeated)	return 0;
-
 	int result = 0;
-	for (auto techno : *TechnoTypeClass::Array)
-	{
-		if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(techno))
-		{
-			if (pTypeExt->Harvester_Counted)
-				result += pThis->CountOwnedAndPresent(techno);
-		}
-	}
+	for (auto pType : TechnoTypeExt::HarvesterTypes)
+		result += pThis->CountOwnedAndPresent(pType);
 
 	return result;
 }

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -18,8 +18,8 @@ int HouseExt::ActiveHarvesterCount(HouseClass* pThis)
 	{
 		if (pTechno->Owner == pThis)
 		{
-			if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType()))
-				result += pTypeExt->Harvester_Counted && TechnoExt::IsHarvesting(pTechno);
+			auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType());
+			result += pTypeExt->Harvester_Counted && TechnoExt::IsHarvesting(pTechno);
 		}
 	}
 	return result;
@@ -28,7 +28,8 @@ int HouseExt::ActiveHarvesterCount(HouseClass* pThis)
 int HouseExt::TotalHarvesterCount(HouseClass* pThis)
 {
 	int result = 0;
-	for (auto pType : TechnoTypeExt::HarvesterTypes)
+
+	for (auto pType : RulesExt::Global()->HarvesterTypes)
 		result += pThis->CountOwnedAndPresent(pType);
 
 	return result;

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -204,6 +204,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_SelfHeal_Units_Offset)
 		.Process(this->Pips_SelfHeal_Buildings_Offset)
 		.Process(this->IronCurtain_KeptOnDeploy)
+		.Process(this->HarvesterTypes)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -26,6 +26,7 @@ public:
 	public:
 		DynamicVectorClass<DynamicVectorClass<TechnoTypeClass*>> AITargetTypesLists;
 		DynamicVectorClass<DynamicVectorClass<ScriptTypeClass*>> AIScriptsLists;
+		ValueableVector<TechnoTypeClass*> HarvesterTypes;
 
 		Valueable<int> Storage_TiberiumIndex;
 		Nullable<int> InfantryGainSelfHealCap;
@@ -80,6 +81,7 @@ public:
 			, Pips_SelfHeal_Units_Offset {{ 33, -32 }}
 			, Pips_SelfHeal_Buildings_Offset {{ 15, 10 }}
 			, IronCurtain_KeptOnDeploy { true }
+			, HarvesterTypes { }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -359,10 +359,11 @@ bool TechnoExt::IsHarvesting(TechnoClass* pThis)
 		case Mission::Unload:
 		case Mission::Enter:
 			return true;
-		case Mission::Guard: // issue#603: idk how to do better
+		case Mission::Guard: // issue#603: not exactly correct, but idk how to do better
 			if (auto pUnit = abstract_cast<UnitClass*>(pThis))
 				return !pUnit->IsSelected && pUnit->Locomotor->Is_Really_Moving_Now();
-		default:break;
+		default:
+			return false;
 		}
 	}
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -351,11 +351,19 @@ bool TechnoExt::IsHarvesting(TechnoClass* pThis)
 	if (pThis->WhatAmI() == AbstractType::Building && pThis->IsPowerOnline())
 		return true;
 
-	auto mission = pThis->GetCurrentMission();
-	if ((mission == Mission::Harvest || mission == Mission::Unload || mission == Mission::Enter)
-		&& TechnoExt::HasAvailableDock(pThis))
+	if (TechnoExt::HasAvailableDock(pThis))
 	{
-		return true;
+		switch (pThis->GetCurrentMission())
+		{
+		case Mission::Harvest:
+		case Mission::Unload:
+		case Mission::Enter:
+			return true;
+		case Mission::Guard: // issue#603: idk how to do better
+			if (auto pUnit = abstract_cast<UnitClass*>(pThis))
+				return !pUnit->IsSelected && pUnit->Locomotor->Is_Really_Moving_Now();
+		default:break;
+		}
 	}
 
 	return false;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -11,7 +11,6 @@
 
 template<> const DWORD Extension<TechnoTypeClass>::Canary = 0x11111111;
 TechnoTypeExt::ExtContainer TechnoTypeExt::ExtMap;
-std::vector<TechnoTypeClass*> TechnoTypeExt::HarvesterTypes;
 
 void TechnoTypeExt::ExtData::Initialize()
 {
@@ -142,8 +141,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	if (!this->Harvester_Counted.isset() && pThis->Enslaves)
 		this->Harvester_Counted = true;
 	if (this->Harvester_Counted.Get())
-		HarvesterTypes.push_back(pThis);
-
+	{
+		auto& list = RulesExt::Global()->HarvesterTypes;
+		if (!list.Contains(pThis))
+			list.emplace_back(pThis);
+	}
 	this->Promote_IncludeSpawns.Read(exINI, pSection, "Promote.IncludeSpawns");
 	this->ImmuneToCrit.Read(exINI, pSection, "ImmuneToCrit");
 	this->MultiMindControl_ReleaseVictim.Read(exINI, pSection, "MultiMindControl.ReleaseVictim");
@@ -494,7 +496,9 @@ DEFINE_HOOK(0x747E90, UnitTypeClass_LoadFromINI, 0x5)
 		if (!pTypeExt->Harvester_Counted.isset() && pItem->Harvester)
 		{
 			pTypeExt->Harvester_Counted = true;
-			TechnoTypeExt::HarvesterTypes.push_back(pItem);
+			auto& list = RulesExt::Global()->HarvesterTypes;
+			if(!list.Contains(pItem))
+				list.emplace_back(pItem);
 		}
 	}
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -53,21 +53,6 @@ bool TechnoTypeExt::HasSelectionGroupID(ObjectTypeClass* pType, const char* pID)
 	return (_strcmpi(id, pID) == 0);
 }
 
-[[deprecated("Use Harvester_Counted directly.")]]
-bool TechnoTypeExt::ExtData::IsCountedAsHarvester()
-{
-	auto pThis = this->OwnerObject();
-
-	bool isHarvester = pThis->Enslaves;
-	if (!isHarvester)
-	{
-		if (auto pUnit = abstract_cast<UnitTypeClass*>(pThis))
-			isHarvester = pUnit->Harvester;
-	}
-
-	return this->Harvester_Counted.Get(isHarvester);
-}
-
 void TechnoTypeExt::GetBurstFLHs(TechnoTypeClass* pThis, INI_EX &exArtINI, const char* pArtSection,
 	std::vector<DynamicVectorClass<CoordStruct>>& nFLH, std::vector<DynamicVectorClass<CoordStruct>>& nEFlh, const char* pPrefixTag)
 {
@@ -497,7 +482,7 @@ DEFINE_HOOK(0x747E90, UnitTypeClass_LoadFromINI, 0x5)
 		{
 			pTypeExt->Harvester_Counted = true;
 			auto& list = RulesExt::Global()->HarvesterTypes;
-			if(!list.Contains(pItem))
+			if (!list.Contains(pItem))
 				list.emplace_back(pItem);
 		}
 	}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -11,6 +11,7 @@
 
 template<> const DWORD Extension<TechnoTypeClass>::Canary = 0x11111111;
 TechnoTypeExt::ExtContainer TechnoTypeExt::ExtMap;
+std::vector<TechnoTypeClass*> TechnoTypeExt::HarvesterTypes;
 
 void TechnoTypeExt::ExtData::Initialize()
 {
@@ -140,6 +141,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Harvester_Counted.Read(exINI, pSection, "Harvester.Counted");
 	if (!this->Harvester_Counted.isset() && pThis->Enslaves)
 		this->Harvester_Counted = true;
+	if (this->Harvester_Counted.Get())
+		HarvesterTypes.push_back(pThis);
 
 	this->Promote_IncludeSpawns.Read(exINI, pSection, "Promote.IncludeSpawns");
 	this->ImmuneToCrit.Read(exINI, pSection, "ImmuneToCrit");
@@ -488,8 +491,11 @@ DEFINE_HOOK(0x747E90, UnitTypeClass_LoadFromINI, 0x5)
 
 	if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(pItem))
 	{
-		if (!pTypeExt->Harvester_Counted.isset())
-			pTypeExt->Harvester_Counted = pItem->Harvester;
+		if (!pTypeExt->Harvester_Counted.isset() && pItem->Harvester)
+		{
+			pTypeExt->Harvester_Counted = true;
+			TechnoTypeExt::HarvesterTypes.push_back(pItem);
+		}
 	}
 
 	return 0;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -53,18 +53,19 @@ bool TechnoTypeExt::HasSelectionGroupID(ObjectTypeClass* pType, const char* pID)
 	return (_strcmpi(id, pID) == 0);
 }
 
+[[deprecated("Use Harvester_Counted directly.")]]
 bool TechnoTypeExt::ExtData::IsCountedAsHarvester()
 {
 	auto pThis = this->OwnerObject();
-	UnitTypeClass* pUnit = nullptr;
 
-	if (pThis->WhatAmI() == AbstractType::UnitType)
-		pUnit = abstract_cast<UnitTypeClass*>(pThis);
+	bool isHarvester = pThis->Enslaves;
+	if (!isHarvester)
+	{
+		if (auto pUnit = abstract_cast<UnitTypeClass*>(pThis))
+			isHarvester = pUnit->Harvester;
+	}
 
-	if (this->Harvester_Counted.Get(pThis->Enslaves || pUnit && (pUnit->Harvester || pUnit->Enslaves)))
-		return true;
-
-	return false;
+	return this->Harvester_Counted.Get(isHarvester);
 }
 
 void TechnoTypeExt::GetBurstFLHs(TechnoTypeClass* pThis, INI_EX &exArtINI, const char* pArtSection,
@@ -135,7 +136,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Powered_KillSpawns.Read(exINI, pSection, "Powered.KillSpawns");
 	this->Spawn_LimitedRange.Read(exINI, pSection, "Spawner.LimitRange");
 	this->Spawn_LimitedExtraRange.Read(exINI, pSection, "Spawner.ExtraLimitRange");
+
 	this->Harvester_Counted.Read(exINI, pSection, "Harvester.Counted");
+	if (!this->Harvester_Counted.isset() && pThis->Enslaves)
+		this->Harvester_Counted = true;
+
 	this->Promote_IncludeSpawns.Read(exINI, pSection, "Promote.IncludeSpawns");
 	this->ImmuneToCrit.Read(exINI, pSection, "ImmuneToCrit");
 	this->MultiMindControl_ReleaseVictim.Read(exINI, pSection, "MultiMindControl.ReleaseVictim");
@@ -472,6 +477,19 @@ DEFINE_HOOK(0x679CAF, RulesClass_LoadAfterTypeData_CompleteInitialization, 0x5)
 	{
 		auto const pExt = BuildingTypeExt::ExtMap.Find(pType);
 		pExt->CompleteInitialization();
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x747E90, UnitTypeClass_LoadFromINI, 0x5)
+{
+	GET(UnitTypeClass*, pItem, ESI);
+
+	if (auto pTypeExt = TechnoTypeExt::ExtMap.Find(pItem))
+	{
+		if (!pTypeExt->Harvester_Counted.isset())
+			pTypeExt->Harvester_Counted = pItem->Harvester;
 	}
 
 	return 0;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -251,7 +251,6 @@ public:
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 
 		void ApplyTurretOffset(Matrix3D* mtx, double factor = 1.0);
-		bool IsCountedAsHarvester();
 
 		// Ares 0.A
 		const char* GetSelectionGroupID() const;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -270,7 +270,6 @@ public:
 
 	static ExtContainer ExtMap;
 
-	static std::vector<TechnoTypeClass*> HarvesterTypes;
 	static void ApplyTurretOffset(TechnoTypeClass* pType, Matrix3D* mtx, double factor = 1.0);
 	static void GetBurstFLHs(TechnoTypeClass* pThis, INI_EX& exArtINI, const char* pArtSection, std::vector<DynamicVectorClass<CoordStruct>>& nFLH, std::vector<DynamicVectorClass<CoordStruct>>& nEFlh, const char* pPrefixTag);
 

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -270,6 +270,7 @@ public:
 
 	static ExtContainer ExtMap;
 
+	static std::vector<TechnoTypeClass*> HarvesterTypes;
 	static void ApplyTurretOffset(TechnoTypeClass* pType, Matrix3D* mtx, double factor = 1.0);
 	static void GetBurstFLHs(TechnoTypeClass* pThis, INI_EX& exArtINI, const char* pArtSection, std::vector<DynamicVectorClass<CoordStruct>>& nFLH, std::vector<DynamicVectorClass<CoordStruct>>& nEFlh, const char* pPrefixTag);
 

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -76,10 +76,13 @@ DEFINE_HOOK(0x641EE0, PreviewClass_ReadPreview, 0x6)
 
 DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 {
+	auto const pPlayer = HouseClass::Player();
+	if (!pPlayer || pPlayer->Defeated)
+		return 0;
+
 	if (Phobos::UI::ShowHarvesterCounter)
 	{
-		auto pPlayer = HouseClass::Player();
-		auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->GetItem(HouseClass::Player->SideIndex));
+		auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->GetItem(pPlayer->SideIndex));
 		wchar_t counter[0x20];
 		auto nActive = HouseExt::ActiveHarvesterCount(pPlayer);
 		auto nTotal = HouseExt::TotalHarvesterCount(pPlayer);
@@ -105,12 +108,12 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 
 	if (Phobos::UI::ShowPowerDelta)
 	{
-		auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->GetItem(HouseClass::Player->SideIndex));
+		auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->GetItem(pPlayer->SideIndex));
 		wchar_t counter[0x20];
-		auto delta = HouseClass::Player->PowerOutput - HouseClass::Player->PowerDrain;
+		auto delta = pPlayer->PowerOutput - pPlayer->PowerDrain;
 
-		double percent = HouseClass::Player->PowerOutput != 0
-			? (double)HouseClass::Player->PowerDrain / (double)HouseClass::Player->PowerOutput : HouseClass::Player->PowerDrain != 0
+		double percent = pPlayer->PowerOutput != 0
+			? (double)pPlayer->PowerDrain / (double)pPlayer->PowerOutput : pPlayer->PowerDrain != 0
 			? Phobos::UI::PowerDelta_ConditionRed*2.f : Phobos::UI::PowerDelta_ConditionYellow;
 
 		ColorStruct clrToolTip = percent < Phobos::UI::PowerDelta_ConditionYellow


### PR DESCRIPTION
Detached from #723 ,  restore #628 , closes #603 

* Consider non-selected guarding state as harvesting miner (can subject to change, Needs review from @Metadorius @Thrifinesma ). Returning chronominers will stop blinking the counter.

* Deprecate `TechnoTypeExt::ExtData::IsCountedAsHarvester` and merged the entire logic into `Harverster.Counted` in order to improve performance. Minor refactored related harvester-counter code.

* Add a static array of TechnoTypeClasses that are considered to be `Harvester.Counted=yes` to avoid loop through all technotypes every frame.

* Do not display harvester counter or power delta for defeated players

