### PR TITLE
Attached particle system for animations

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -174,6 +174,7 @@ This page lists all the individual contributions to the project by their author.
   - FlakScatter distance customization
   - Debris & meteor impact behaviour settings
   - Custom warhead debris animations
+  - Attached particle system for animations
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -254,6 +254,17 @@ CreateUnit.SpawnAnim=                  ; Animation
 Due to technical constraints, infantry death animations including Ares' `InfDeathAnim` cannot have `CreateUnit.Owner` correctly applied to them. You can use Ares' `MakeInfantryOwner` as a workaround instead, which should function for this use-case even without `MakeInfantry` set.
 ```
 
+### Attached particle system
+
+- It is now possible to attach a particle system to an animation. Only particle systems with `BehavesLike=Smoke` are supported. This works similarly to the identically named key on `VoxelAnims`.
+  - On animations with `Next`, the particle system will be deleted when the next animation starts playing and new one created in its stead if the `Next` animation defines a different particle system.
+
+In `artmd.ini`:
+```ini
+[SOMEANIM]       ; AnimationType
+AttachedSystem=  ; ParticleSystem
+```
+
 ## Buildings
 
 ### Extended building upgrades

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -267,6 +267,7 @@ New:
 - Customizable debris & meteor impact and warhead detonation behaviour (by Starkku, Otamaa)
 - Custom warhead debris animations (by Starkku)
 - Multiple burst shots / burst delay within infantry firing sequence (by Starkku)
+- Attached particle system for animations (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -6,6 +6,29 @@
 template<> const DWORD Extension<AnimClass>::Canary = 0xAAAAAAAA;
 AnimExt::ExtContainer AnimExt::ExtMap;
 
+void AnimExt::ExtData::CreateAttachedSystem(ParticleSystemTypeClass* pSystemType)
+{
+	const auto pThis = this->OwnerObject();
+	const auto pType = this->OwnerObject()->Type;
+
+	if (pType && pSystemType && !this->AttachedSystem)
+	{
+		if (auto const pSystem = GameCreate<ParticleSystemClass>(pSystemType, pThis->Location, pThis->GetCell(), pThis, CoordStruct::Empty, nullptr))
+			this->AttachedSystem = pSystem;
+	}
+}
+
+void AnimExt::ExtData::DeleteAttachedSystem()
+{
+	if (this->AttachedSystem)
+	{
+		this->AttachedSystem->Owner = nullptr;
+		this->AttachedSystem->UnInit();
+		this->AttachedSystem = nullptr;
+	}
+
+}
+
 //Modified from Ares
 const bool AnimExt::SetAnimOwnerHouseKind(AnimClass* pAnim, HouseClass* pInvoker, HouseClass* pVictim, bool defaultToVictimOwner)
 {
@@ -51,6 +74,7 @@ void AnimExt::ExtData::Serialize(T& Stm)
 		.Process(this->DeathUnitTurretFacing)
 		.Process(this->DeathUnitHasTurret)
 		.Process(this->Invoker)
+		.Process(this->AttachedSystem)
 		;
 }
 
@@ -81,7 +105,9 @@ DEFINE_HOOK(0x4228D2, AnimClass_CTOR, 0x5)
 {
 	GET(AnimClass*, pItem, ESI);
 
-	AnimExt::ExtMap.FindOrAllocate(pItem);
+	auto const pExt = AnimExt::ExtMap.FindOrAllocate(pItem);
+	auto const pTypeExt = AnimTypeExt::ExtMap.Find(pItem->Type);
+	pExt->CreateAttachedSystem(pTypeExt->AttachedSystem);
 
 	return 0;
 }

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -105,9 +105,12 @@ DEFINE_HOOK(0x4228D2, AnimClass_CTOR, 0x5)
 {
 	GET(AnimClass*, pItem, ESI);
 
-	auto const pExt = AnimExt::ExtMap.FindOrAllocate(pItem);
-	auto const pTypeExt = AnimTypeExt::ExtMap.Find(pItem->Type);
-	pExt->CreateAttachedSystem(pTypeExt->AttachedSystem);
+	if (pItem->Type)
+	{
+		auto const pExt = AnimExt::ExtMap.FindOrAllocate(pItem);
+		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pItem->Type);
+		pExt->CreateAttachedSystem(pTypeExt->AttachedSystem);
+	}
 
 	return 0;
 }

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <AnimClass.h>
+#include <ParticleSystemClass.h>
 
 #include <Ext/AnimType/Body.h>
 #include <Helpers/Macro.h>
@@ -19,6 +20,7 @@ public:
 		bool FromDeathUnit;
 		bool DeathUnitHasTurret;
 		TechnoClass* Invoker;
+		ParticleSystemClass* AttachedSystem;
 
 		ExtData(AnimClass* OwnerObject) : Extension<AnimClass>(OwnerObject)
 			, DeathUnitFacing { 0 }
@@ -26,13 +28,21 @@ public:
 			, FromDeathUnit { false }
 			, DeathUnitHasTurret { false }
 			, Invoker {}
+			, AttachedSystem {}
 		{ }
 
-		virtual ~ExtData() = default;
+		void CreateAttachedSystem(ParticleSystemTypeClass* pSystemType);
+		void DeleteAttachedSystem();
+
+		virtual ~ExtData()
+		{
+			DeleteAttachedSystem();
+		}
 
 		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
 		{
 			AnnounceInvalidPointer(Invoker, ptr);
+			AnnounceInvalidPointer(AttachedSystem, ptr);
 		}
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
@@ -58,6 +68,7 @@ public:
 			case AbstractType::Building:
 			case AbstractType::Infantry:
 			case AbstractType::Unit:
+			case AbstractType::ParticleSystem:
 				return false;
 			default:
 				return true;

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -78,6 +78,6 @@ public:
 
 	static ExtContainer ExtMap;
 
-	static const bool SetAnimOwnerHouseKind(AnimClass* pAnim, HouseClass* pInvoker , HouseClass* pVictim, bool defaultToVictimOwner = true);
+	static const bool SetAnimOwnerHouseKind(AnimClass* pAnim, HouseClass* pInvoker, HouseClass* pVictim, bool defaultToVictimOwner = true);
 	static HouseClass* GetOwnerHouse(AnimClass* pAnim, HouseClass* pDefaultOwner = nullptr);
 };

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -210,6 +210,22 @@ DEFINE_HOOK(0x423CC7, AnimClass_AI_HasExtras_Expired, 0x6)
 	return SkipGameCode;
 }
 
+DEFINE_HOOK(0x424807, AnimClass_AI_Next, 0x6)
+{
+	GET(AnimClass*, pThis, ESI);
+
+	const auto pExt = AnimExt::ExtMap.Find(pThis);
+	const auto pTypeExt = AnimTypeExt::ExtMap.Find(pThis->Type);
+
+	if (pExt->AttachedSystem && pExt->AttachedSystem->Type != pTypeExt->AttachedSystem)
+		pExt->DeleteAttachedSystem();
+
+	if (!pExt->AttachedSystem && pTypeExt->AttachedSystem)
+		pExt->CreateAttachedSystem(pTypeExt->AttachedSystem);
+
+	return 0;
+}
+
 DEFINE_HOOK(0x422CAB, AnimClass_DrawIt_XDrawOffset, 0x5)
 {
 	GET(AnimClass* const, pThis, ECX);

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -107,6 +107,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Warhead_Detonate.Read(exINI, pID, "Warhead.Detonate");
 	this->SplashAnims.Read(exINI, pID, "SplashAnims");
 	this->SplashAnims_PickRandom.Read(exINI, pID, "SplashAnims.PickRandom");
+	this->AttachedSystem.Read(exINI, pID, "AttachedSystem");
 }
 
 template <typename T>
@@ -136,6 +137,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Warhead_Detonate)
 		.Process(this->SplashAnims)
 		.Process(this->SplashAnims_PickRandom)
+		.Process(this->AttachedSystem)
 		;
 }
 

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -107,7 +107,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Warhead_Detonate.Read(exINI, pID, "Warhead.Detonate");
 	this->SplashAnims.Read(exINI, pID, "SplashAnims");
 	this->SplashAnims_PickRandom.Read(exINI, pID, "SplashAnims.PickRandom");
-	this->AttachedSystem.Read(exINI, pID, "AttachedSystem");
+	this->AttachedSystem.Read(exINI, pID, "AttachedSystem", true);
 }
 
 template <typename T>

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -37,6 +37,7 @@ public:
 		Valueable<bool> Warhead_Detonate;
 		NullableVector<AnimTypeClass*> SplashAnims;
 		Valueable<bool> SplashAnims_PickRandom;
+		Valueable<ParticleSystemTypeClass*> AttachedSystem;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -61,6 +62,7 @@ public:
 			, Warhead_Detonate { false }
 			, SplashAnims {}
 			, SplashAnims_PickRandom { false }
+			, AttachedSystem {}
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
Basically `VoxelAnims` / projectile (Ares) `AttachedSystem` but for animations. Primary use case is to use for debris instead of animation trailers but there may be potential for other things too I suppose.

----

- It is now possible to attach a particle system to an animation. Only particle systems with `BehavesLike=Smoke` are supported. This works similarly to the identically named key on `VoxelAnims`.
  - On animations with `Next`, the particle system will be deleted when the next animation starts playing and new one created in its stead if the `Next` animation defines a different particle system.

In `artmd.ini`:
```ini
[SOMEANIM]       ; AnimationType
AttachedSystem=  ; ParticleSystem
```