### PR TITLE
[Hotfix] Fix slaves not always dying from suicide option when slave-miner gets killed

### DIFF
--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -570,7 +570,7 @@ void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption)
 
 	default: //must be AutoDeathBehavior::Kill
 		pThis->ReceiveDamage(&pThis->Health, 0, RulesClass::Instance()->C4Warhead, nullptr, true, false, pThis->Owner);
-
+		// Due to Ares, ignoreDefense=true will prevent passenger/crew/hijacker from escaping
 		return;
 	}
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -432,7 +432,7 @@ DEFINE_HOOK(0x6B0B9C, SlaveManagerClass_Killed_DecideOwner, 0x6)
 	return 0x0;
 }
 
-//Fix slaves cannot always suicide due to armor multiplier or something
+// Fix slaves cannot always suicide due to armor multiplier or something
 DEFINE_PATCH(0x6B0BF7,
 	0x6A, 0x01  // push 1       // ignoreDefense=false->true
 	);

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2,7 +2,7 @@
 #include <ScenarioClass.h>
 
 #include "Body.h"
-
+#include <Utilities/Macro.h>
 #include <Ext/TechnoType/Body.h>
 #include <Ext/WarheadType/Body.h>
 #include <Ext/WeaponType/Body.h>
@@ -431,6 +431,11 @@ DEFINE_HOOK(0x6B0B9C, SlaveManagerClass_Killed_DecideOwner, 0x6)
 
 	return 0x0;
 }
+
+//Fix slaves cannot always suicide due to armor multiplier or something
+DEFINE_PATCH(0x6B0BF7,
+	0x6A, 0x01  // push 1       // ignoreDefense=false->true
+	);
 
 DEFINE_HOOK(0x70A4FB, TechnoClass_Draw_Pips_SelfHealGain, 0x5)
 {


### PR DESCRIPTION
Fixed a parameter misuse from vanilla: when YR kills a slave it used `ignoreDefense=false` rather than true. Slaves may not always get killed