### PR TITLE
Customizable Tooltip background

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -82,6 +82,7 @@ This page lists all the individual contributions to the project by their author.
   - Retint map actions bugfix
   - Sharpnel enhancement
   - Vanilla map preview reading bugfix
+  - Custom tooltip background
 - **Otamaa (Fahroni, BoredEXE)**:
   - Help with CellSpread
   - Ported and fixed custom RadType code

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -82,7 +82,7 @@ This page lists all the individual contributions to the project by their author.
   - Retint map actions bugfix
   - Sharpnel enhancement
   - Vanilla map preview reading bugfix
-  - Custom tooltip background
+  - Customizable tooltip background
 - **Otamaa (Fahroni, BoredEXE)**:
   - Help with CellSpread
   - Ported and fixed custom RadType code

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />
     <ClCompile Include="src\Ext\Anim\Body.cpp" />
+    <ClCompile Include="src\Ext\Surface\Body.cpp" />
     <ClCompile Include="src\Ext\SWType\FireSuperWeapon.cpp" />
     <ClCompile Include="src\Ext\SWType\Hooks.cpp" />
     <ClCompile Include="src\Ext\TAction\Body.cpp" />
@@ -132,6 +133,7 @@
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />
     <ClInclude Include="src\Ext\Sidebar\Body.h" />
     <ClInclude Include="src\Ext\Anim\Body.h" />
+    <ClInclude Include="src\Ext\Surface\Body.h" />
     <ClInclude Include="src\Ext\TAction\Body.h" />
     <ClInclude Include="src\Ext\Team\Body.h" />
     <ClInclude Include="src\Ext\TEvent\Body.h" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -286,6 +286,7 @@
       <AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4100;4530;4731;4740;4458;4819</DisableSpecificWarnings>
       <EnableModules>true</EnableModules>
+      <OpenMPSupport>true</OpenMPSupport>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -330,6 +331,7 @@
       <DisableSpecificWarnings>4100;4530;4731;4740;4458;4819</DisableSpecificWarnings>
       <EnableModules>true</EnableModules>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <OpenMPSupport>true</OpenMPSupport>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -372,6 +374,7 @@
       <DisableSpecificWarnings>4100;4530;4731;4740;4458;4819</DisableSpecificWarnings>
       <EnableModules>true</EnableModules>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <OpenMPSupport>true</OpenMPSupport>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -293,7 +293,7 @@ ToolTipDescriptions=true  ; boolean
 Same as with harvester counter, you can download the improved font (v4 and higher; can be found on [Phobos supplementaries repo](https://github.com/Phobos-developers/PhobosSupplementaries)) or draw your own icons.
 ```
 
-- Also, the background color and opacity of tooltips can be customized by player's side.
+- The background color and opacity of tooltips can now be customized globally or per side.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -300,9 +300,5 @@ In `rulesmd.ini`:
 [SOMESIDE]
 ToolTip.Background.Color=0,0,0      ; integer - R,G,B, defaults to [AudioVisual]->ToolTip.Background.Color
 ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100], defaults to [AudioVisual]->ToolTip.Background.Opacity
-ToolTip.Background.BlurSize=0       ; integer, defaults to [AudioVisual]->ToolTip.Background.BlurSize
-```
-
-```{note}
-It's not a good idea to have a big BlurSize.
+ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual]->ToolTip.Background.BlurSize
 ```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -310,5 +310,5 @@ The blur effect is resource intensive. Please make sure if you want to enable th
 In `RA2MD.ini`:
 ```ini
 [Phobos]
-ToolTipBlur=false ; boolean, whether the blur effect of tooltips will be enabled.
+ToolTipBlur=false  ; boolean, whether the blur effect of tooltips will be enabled.
 ```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -304,7 +304,7 @@ ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual]->ToolTip.
 ```
 
 ```{note}
-The blur effect is resource intensive. Please make sure if you want to enable this effect. Leave it to 0.0 to disable this effect.
+The blur effect is resource intensive. Please make sure you really want to enable this effect, otherwise leave it to 0.0 so it stays disabled.
 ```
 
 In `RA2MD.ini`:

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -292,3 +292,12 @@ ToolTipDescriptions=true  ; boolean
 ```{note}
 Same as with harvester counter, you can download the improved font (v4 and higher; can be found on [Phobos supplementaries repo](https://github.com/Phobos-developers/PhobosSupplementaries)) or draw your own icons.
 ```
+
+- Also, the background color and transparency of tooltips can be customized by player's side.
+
+In `rulesmd.ini`:
+```ini
+[SOMESIDE]
+ToolTip.Background.Color=0,0,0      ; integer - R,G,B
+ToolTip.Background.Transparency=100 ; integer, ranged in [0, 100]
+```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -306,3 +306,9 @@ ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual]->ToolTip.
 ```{note}
 The blur effect is resource intensive. Please make sure if you want to enable this effect. Leave it to 0.0 to disable this effect.
 ```
+
+In `RA2MD.ini`:
+```ini
+[Phobos]
+ToolTipBlur=false ; boolean, whether the blur effect of tooltips will be enabled.
+```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -300,4 +300,9 @@ In `rulesmd.ini`:
 [SOMESIDE]
 ToolTip.Background.Color=0,0,0      ; integer - R,G,B
 ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100]
+ToolTip.Background.BlurSize=0       ; integer
+```
+
+```{note}
+It's not a good idea to have a big BlurSize.
 ```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -298,9 +298,9 @@ Same as with harvester counter, you can download the improved font (v4 and highe
 In `rulesmd.ini`:
 ```ini
 [SOMESIDE]
-ToolTip.Background.Color=0,0,0      ; integer - R,G,B
-ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100]
-ToolTip.Background.BlurSize=0       ; integer
+ToolTip.Background.Color=0,0,0      ; integer - R,G,B, defaults to [AudioVisual]->ToolTip.Background.Color
+ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100], defaults to [AudioVisual]->ToolTip.Background.Opacity
+ToolTip.Background.BlurSize=0       ; integer, defaults to [AudioVisual]->ToolTip.Background.BlurSize
 ```
 
 ```{note}

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -302,3 +302,7 @@ ToolTip.Background.Color=0,0,0      ; integer - R,G,B, defaults to [AudioVisual]
 ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100], defaults to [AudioVisual]->ToolTip.Background.Opacity
 ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual]->ToolTip.Background.BlurSize
 ```
+
+```{note}
+The blur effect is resource intensive. Please make sure if you want to enable this effect. Leave it to 0.0 to disable this effect.
+```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -293,11 +293,11 @@ ToolTipDescriptions=true  ; boolean
 Same as with harvester counter, you can download the improved font (v4 and higher; can be found on [Phobos supplementaries repo](https://github.com/Phobos-developers/PhobosSupplementaries)) or draw your own icons.
 ```
 
-- Also, the background color and transparency of tooltips can be customized by player's side.
+- Also, the background color and opacity of tooltips can be customized by player's side.
 
 In `rulesmd.ini`:
 ```ini
 [SOMESIDE]
 ToolTip.Background.Color=0,0,0      ; integer - R,G,B
-ToolTip.Background.Transparency=100 ; integer, ranged in [0, 100]
+ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100]
 ```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -298,9 +298,9 @@ Same as with harvester counter, you can download the improved font (v4 and highe
 In `rulesmd.ini`:
 ```ini
 [SOMESIDE]
-ToolTip.Background.Color=0,0,0      ; integer - R,G,B, defaults to [AudioVisual]->ToolTip.Background.Color
-ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100], defaults to [AudioVisual]->ToolTip.Background.Opacity
-ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual]->ToolTip.Background.BlurSize
+ToolTip.Background.Color=0,0,0      ; integer - R,G,B, defaults to [AudioVisual]->ToolTip.Background.Color, which defaults to `0,0,0`
+ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100], defaults to [AudioVisual]->ToolTip.Background.Opacity, which defaults to `100`
+ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual]->ToolTip.Background.BlurSize, which defaults to `0.0`
 ```
 
 ```{note}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -260,6 +260,7 @@ New:
 - Save Game Trigger Action (by secsome)
 - Numeric Variables (by secsome)
 - TechnoType's tooltip would display it's build time now (by secsome)
+- Customizable tooltip background color and transparency (by secsome)
 - Allow `NotHuman=yes` infantry to use random `Death` anim sequence (by Otamaa)
 - Ability for warheads to trigger specific `NotHuman=yes` infantry `Death` anim sequence (by Otamaa)
 - XDrawOffset for animations (by Morton)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -260,7 +260,7 @@ New:
 - Save Game Trigger Action (by secsome)
 - Numeric Variables (by secsome)
 - TechnoType's tooltip would display it's build time now (by secsome)
-- Customizable tooltip background color and transparency (by secsome)
+- Customizable tooltip background color and opacity (by secsome)
 - Allow `NotHuman=yes` infantry to use random `Death` anim sequence (by Otamaa)
 - Ability for warheads to trigger specific `NotHuman=yes` infantry `Death` anim sequence (by Otamaa)
 - XDrawOffset for animations (by Morton)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -89,6 +89,10 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Pips_SelfHeal_Infantry_Offset.Read(exINI, "AudioVisual", "Pips.SelfHeal.Infantry.Offset");
 	this->Pips_SelfHeal_Units_Offset.Read(exINI, "AudioVisual", "Pips.SelfHeal.Units.Offset");
 	this->Pips_SelfHeal_Buildings_Offset.Read(exINI, "AudioVisual", "Pips.SelfHeal.Buildings.Offset");
+	this->ToolTip_Background_Color.Read(exINI, "AudioVisual", "ToolTip.Background.Color");
+	this->ToolTip_Background_Opacity.Read(exINI, "AudioVisual", "ToolTip.Background.Opacity");
+	this->ToolTip_Background_BlurSize.Read(exINI, "AudioVisual", "ToolTip.Background.BlurSize");
+
 
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
 	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
@@ -217,6 +221,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ForbidParallelAIQueues_Navy)
 		.Process(this->ForbidParallelAIQueues_Vehicle)
 		.Process(this->IronCurtain_KeptOnDeploy)
+		.Process(this->ToolTip_Background_Color)
+		.Process(this->ToolTip_Background_Opacity)
+		.Process(this->ToolTip_Background_BlurSize)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -93,7 +93,6 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->ToolTip_Background_Opacity.Read(exINI, "AudioVisual", "ToolTip.Background.Opacity");
 	this->ToolTip_Background_BlurSize.Read(exINI, "AudioVisual", "ToolTip.Background.BlurSize");
 
-
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
 	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
 	this->ForbidParallelAIQueues_Infantry.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -63,7 +63,7 @@ public:
 		Valueable<bool> IronCurtain_KeptOnDeploy;
 		Valueable<ColorStruct> ToolTip_Background_Color;
 		Valueable<int> ToolTip_Background_Opacity;
-		Valueable<int> ToolTip_Background_BlurSize;
+		Valueable<float> ToolTip_Background_BlurSize;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -98,7 +98,7 @@ public:
 			, IronCurtain_KeptOnDeploy { true }
 			, ToolTip_Background_Color { {0, 0, 0} }
 			, ToolTip_Background_Opacity { 100 }
-			, ToolTip_Background_BlurSize { 0 }
+			, ToolTip_Background_BlurSize { 0.f }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -61,6 +61,9 @@ public:
 		Valueable<bool> ForbidParallelAIQueues_Building;
 
 		Valueable<bool> IronCurtain_KeptOnDeploy;
+		Valueable<ColorStruct> ToolTip_Background_Color;
+		Valueable<int> ToolTip_Background_Opacity;
+		Valueable<int> ToolTip_Background_BlurSize;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -93,6 +96,9 @@ public:
 			, ForbidParallelAIQueues_Navy { false }
 			, ForbidParallelAIQueues_Vehicle { false }
 			, IronCurtain_KeptOnDeploy { true }
+			, ToolTip_Background_Color { {0, 0, 0} }
+			, ToolTip_Background_Opacity { 100 }
+			, ToolTip_Background_BlurSize { 0 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -96,9 +96,9 @@ public:
 			, ForbidParallelAIQueues_Navy { false }
 			, ForbidParallelAIQueues_Vehicle { false }
 			, IronCurtain_KeptOnDeploy { true }
-			, ToolTip_Background_Color { {0, 0, 0} }
+			, ToolTip_Background_Color { { 0, 0, 0 } }
 			, ToolTip_Background_Opacity { 100 }
-			, ToolTip_Background_BlurSize { 0.f }
+			, ToolTip_Background_BlurSize { 0.0f }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -36,7 +36,7 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Sidebar_PowerDelta_Red.Read(exINI, pSection, "Sidebar.PowerDelta.ColorRed");
 	this->Sidebar_PowerDelta_Align.Read(exINI, pSection, "Sidebar.PowerDelta.Align");
 	this->ToolTip_Background_Color.Read(exINI, pSection, "ToolTip.Background.Color");
-	this->ToolTip_Background_Transparency.Read(exINI, pSection, "ToolTip.Background.Transparency");
+	this->ToolTip_Background_Opacity.Read(exINI, pSection, "ToolTip.Background.Opacity");
 }
 
 // =============================
@@ -58,7 +58,7 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->Sidebar_PowerDelta_Red)
 		.Process(this->Sidebar_PowerDelta_Align)
 		.Process(this->ToolTip_Background_Color)
-		.Process(this->ToolTip_Background_Transparency)
+		.Process(this->ToolTip_Background_Opacity)
 		.Process(this->IngameScore_WinTheme)
 		.Process(this->IngameScore_LoseTheme)
 		;

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -37,6 +37,7 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Sidebar_PowerDelta_Align.Read(exINI, pSection, "Sidebar.PowerDelta.Align");
 	this->ToolTip_Background_Color.Read(exINI, pSection, "ToolTip.Background.Color");
 	this->ToolTip_Background_Opacity.Read(exINI, pSection, "ToolTip.Background.Opacity");
+	this->ToolTip_Background_BlurSize.Read(exINI, pSection, "ToolTip.Background.BlurSize");
 }
 
 // =============================

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -35,6 +35,8 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Sidebar_PowerDelta_Yellow.Read(exINI, pSection, "Sidebar.PowerDelta.ColorYellow");
 	this->Sidebar_PowerDelta_Red.Read(exINI, pSection, "Sidebar.PowerDelta.ColorRed");
 	this->Sidebar_PowerDelta_Align.Read(exINI, pSection, "Sidebar.PowerDelta.Align");
+	this->ToolTip_Background_Color.Read(exINI, pSection, "ToolTip.Background.Color");
+	this->ToolTip_Background_Transparency.Read(exINI, pSection, "ToolTip.Background.Transparency");
 }
 
 // =============================
@@ -55,7 +57,8 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->Sidebar_PowerDelta_Yellow)
 		.Process(this->Sidebar_PowerDelta_Red)
 		.Process(this->Sidebar_PowerDelta_Align)
-
+		.Process(this->ToolTip_Background_Color)
+		.Process(this->ToolTip_Background_Transparency)
 		.Process(this->IngameScore_WinTheme)
 		.Process(this->IngameScore_LoseTheme)
 		;

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -60,6 +60,7 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->Sidebar_PowerDelta_Align)
 		.Process(this->ToolTip_Background_Color)
 		.Process(this->ToolTip_Background_Opacity)
+		.Process(this->ToolTip_Background_BlurSize)
 		.Process(this->IngameScore_WinTheme)
 		.Process(this->IngameScore_LoseTheme)
 		;

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -26,6 +26,8 @@ public:
 		Valueable<ColorStruct> Sidebar_PowerDelta_Yellow;
 		Valueable<ColorStruct> Sidebar_PowerDelta_Red;
 		Valueable<TextAlign> Sidebar_PowerDelta_Align;
+		Valueable<ColorStruct> ToolTip_Background_Color;
+		Valueable<int> ToolTip_Background_Transparency;
 
 		ExtData(SideClass* OwnerObject) : Extension<SideClass>(OwnerObject)
 			, ArrayIndex { -1 }
@@ -41,6 +43,8 @@ public:
 			, Sidebar_PowerDelta_Yellow { { 255,255,0 } }
 			, Sidebar_PowerDelta_Red { { 255,0,0 } }
 			, Sidebar_PowerDelta_Align { TextAlign::Left }
+			, ToolTip_Background_Color { {0,0,0} }
+			, ToolTip_Background_Transparency { 100 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -28,23 +28,25 @@ public:
 		Valueable<TextAlign> Sidebar_PowerDelta_Align;
 		Valueable<ColorStruct> ToolTip_Background_Color;
 		Valueable<int> ToolTip_Background_Opacity;
+		Valueable<int> ToolTip_Background_BlurSize;
 
 		ExtData(SideClass* OwnerObject) : Extension<SideClass>(OwnerObject)
 			, ArrayIndex { -1 }
 			, Sidebar_GDIPositions { false }
 			, IngameScore_WinTheme { -2 }
 			, IngameScore_LoseTheme { -2 }
-			, Sidebar_HarvesterCounter_Offset { { 0,0 } }
-			, Sidebar_HarvesterCounter_Yellow { { 255,255,0 } }
-			, Sidebar_HarvesterCounter_Red { { 255,0,0 } }
-			, Sidebar_ProducingProgress_Offset { { 0,0 } }
-			, Sidebar_PowerDelta_Offset { { 0,0 } }
-			, Sidebar_PowerDelta_Green { { 0,255,0 } }
-			, Sidebar_PowerDelta_Yellow { { 255,255,0 } }
-			, Sidebar_PowerDelta_Red { { 255,0,0 } }
+			, Sidebar_HarvesterCounter_Offset { { 0, 0 } }
+			, Sidebar_HarvesterCounter_Yellow { { 255, 255, 0 } }
+			, Sidebar_HarvesterCounter_Red { { 255, 0, 0 } }
+			, Sidebar_ProducingProgress_Offset { { 0, 0 } }
+			, Sidebar_PowerDelta_Offset { { 0, 0 } }
+			, Sidebar_PowerDelta_Green { { 0, 255, 0 } }
+			, Sidebar_PowerDelta_Yellow { { 255, 255, 0 } }
+			, Sidebar_PowerDelta_Red { { 255, 0, 0 } }
 			, Sidebar_PowerDelta_Align { TextAlign::Left }
-			, ToolTip_Background_Color { {0,0,0} }
+			, ToolTip_Background_Color { {0, 0, 0} }
 			, ToolTip_Background_Opacity { 100 }
+			, ToolTip_Background_BlurSize { 0 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -28,7 +28,7 @@ public:
 		Valueable<TextAlign> Sidebar_PowerDelta_Align;
 		Nullable<ColorStruct> ToolTip_Background_Color;
 		Nullable<int> ToolTip_Background_Opacity;
-		Nullable<int> ToolTip_Background_BlurSize;
+		Nullable<float> ToolTip_Background_BlurSize;
 
 		ExtData(SideClass* OwnerObject) : Extension<SideClass>(OwnerObject)
 			, ArrayIndex { -1 }

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -27,7 +27,7 @@ public:
 		Valueable<ColorStruct> Sidebar_PowerDelta_Red;
 		Valueable<TextAlign> Sidebar_PowerDelta_Align;
 		Valueable<ColorStruct> ToolTip_Background_Color;
-		Valueable<int> ToolTip_Background_Transparency;
+		Valueable<int> ToolTip_Background_Opacity;
 
 		ExtData(SideClass* OwnerObject) : Extension<SideClass>(OwnerObject)
 			, ArrayIndex { -1 }
@@ -44,7 +44,7 @@ public:
 			, Sidebar_PowerDelta_Red { { 255,0,0 } }
 			, Sidebar_PowerDelta_Align { TextAlign::Left }
 			, ToolTip_Background_Color { {0,0,0} }
-			, ToolTip_Background_Transparency { 100 }
+			, ToolTip_Background_Opacity { 100 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -26,9 +26,9 @@ public:
 		Valueable<ColorStruct> Sidebar_PowerDelta_Yellow;
 		Valueable<ColorStruct> Sidebar_PowerDelta_Red;
 		Valueable<TextAlign> Sidebar_PowerDelta_Align;
-		Valueable<ColorStruct> ToolTip_Background_Color;
-		Valueable<int> ToolTip_Background_Opacity;
-		Valueable<int> ToolTip_Background_BlurSize;
+		Nullable<ColorStruct> ToolTip_Background_Color;
+		Nullable<int> ToolTip_Background_Opacity;
+		Nullable<int> ToolTip_Background_BlurSize;
 
 		ExtData(SideClass* OwnerObject) : Extension<SideClass>(OwnerObject)
 			, ArrayIndex { -1 }
@@ -44,9 +44,9 @@ public:
 			, Sidebar_PowerDelta_Yellow { { 255, 255, 0 } }
 			, Sidebar_PowerDelta_Red { { 255, 0, 0 } }
 			, Sidebar_PowerDelta_Align { TextAlign::Left }
-			, ToolTip_Background_Color { {0, 0, 0} }
-			, ToolTip_Background_Opacity { 100 }
-			, ToolTip_Background_BlurSize { 0 }
+			, ToolTip_Background_Color { }
+			, ToolTip_Background_Opacity { }
+			, ToolTip_Background_BlurSize { }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Surface/Body.cpp
+++ b/src/Ext/Surface/Body.cpp
@@ -4,7 +4,7 @@
 
 void SurfaceExt::BlurRect(const RectangleStruct& rect, int blurSize)
 {
-	if (blurSize <= 0)
+	if (blurSize <= 1)
 		return;
 	if (this->GetBytesPerPixel() < 2)
 		return;

--- a/src/Ext/Surface/Body.cpp
+++ b/src/Ext/Surface/Body.cpp
@@ -3,6 +3,8 @@
 #include <Drawing.h>
 #include <Helpers/Macro.h>
 
+#define ENABLE_OMP 0
+
 // https://www.peterkovesi.com/papers/FastGaussianSmoothing.pdf
 void SurfaceExt::BlurRect(const RectangleStruct& rect, float blurSize)
 {
@@ -43,7 +45,9 @@ void SurfaceExt::BlurRect(const RectangleStruct& rect, float blurSize)
 		const int h = bound.Height;
 		{
 			float iarr = 1.f / (r + r + 1);
+#if ENABLE_OMP
 #pragma omp parallel for
+#endif
 			for (int i = 0; i < h; i++)
 			{
 				int ti = i * w;
@@ -95,7 +99,9 @@ void SurfaceExt::BlurRect(const RectangleStruct& rect, float blurSize)
 		std::swap(in, out);
 		{
 			float iarr = 1.f / (r + r + 1);
+#if ENABLE_OMP
 #pragma omp parallel for
+#endif
 			for (int i = 0; i < w; i++)
 			{
 				int ti = i;

--- a/src/Ext/Surface/Body.cpp
+++ b/src/Ext/Surface/Body.cpp
@@ -17,11 +17,11 @@ void SurfaceExt::BlurRect(const RectangleStruct& rect, int blurSize)
 
 	if (auto ptr = (WORD*)this->Lock(bound.X, bound.Y))
 	{
-		for (int yy = 0; yy < bound.Height; ++yy)
+		for (int yy = bound.Y; yy < bound.Height; ++yy)
 		{
 			const int line = yy * (this->GetPitch() / sizeof(WORD));
 			auto p = &ptr[line];
-			for (int xx = 0; xx < bound.Width; ++xx)
+			for (int xx = bound.X; xx < bound.Width; ++xx)
 			{
 				int avgR = 0, avgG = 0, avgB = 0;
 

--- a/src/Ext/Surface/Body.cpp
+++ b/src/Ext/Surface/Body.cpp
@@ -1,10 +1,12 @@
 #include "Body.h"
 
 #include <Drawing.h>
+#include <Helpers/Macro.h>
 
-void SurfaceExt::BlurRect(const RectangleStruct& rect, int blurSize)
+// https://www.peterkovesi.com/papers/FastGaussianSmoothing.pdf
+void SurfaceExt::BlurRect(const RectangleStruct& rect, float blurSize)
 {
-	if (blurSize <= 1)
+	if (CLOSE_ENOUGH(blurSize, 0))
 		return;
 	if (this->GetBytesPerPixel() < 2)
 		return;
@@ -15,57 +17,179 @@ void SurfaceExt::BlurRect(const RectangleStruct& rect, int blurSize)
 	if (bound.Width <= 0 || bound.Height <= 0)
 		return;
 
-	if (auto ptr = (WORD*)this->Lock(bound.X, bound.Y))
+	const auto line_length = this->GetPitch() / sizeof(WORD);
+
+	auto ptr = (WORD*)this->Lock(bound.X, bound.Y);
+	if (!ptr)
+		return;
+
+	// init boxes
+	int box[3];
 	{
-		for (int yy = bound.Y; yy < bound.Height; ++yy)
-		{
-			const int line = yy * (this->GetPitch() / sizeof(WORD));
-			auto p = &ptr[line];
-			for (int xx = bound.X; xx < bound.Width; ++xx)
-			{
-				int avgR = 0, avgG = 0, avgB = 0;
+		int wl = (int)std::floor(std::sqrt(4 * blurSize * blurSize + 1));
+		if (wl % 2 == 0)
+			--wl;
+		int wu = wl + 2;
 
-				int r = std::min(xx + blurSize, bound.Width);
-				int b = std::min(yy + blurSize, bound.Height);
-
-				int blurPixelCount = 0;
-				for (int y = yy; y < b; ++y)
-				{
-					const int tline = y * (this->GetPitch() / sizeof(WORD));
-					auto tp = &ptr[tline];
-					for (int x = xx; x < r; ++x)
-					{
-						Color16Struct color { *tp };
-
-						avgR += color.R;
-						avgG += color.G;
-						avgB += color.B;
-
-						++blurPixelCount;
-						++tp;
-					}
-				}
-
-				avgR /= blurPixelCount;
-				avgG /= blurPixelCount;
-				avgB /= blurPixelCount;
-
-				WORD color = static_cast<WORD>(ColorStruct { (BYTE)avgR, (BYTE)avgG, (BYTE)avgB });
-				for (int y = yy; y < b; ++y)
-				{
-					const int tline = y * (this->GetPitch() / sizeof(WORD));
-					auto tp = &ptr[tline];
-					for (int x = xx; x < r; ++x)
-					{
-						*tp = color;
-						++tp;
-					}
-				}
-
-				++p;
-			}
-		}
-
-		this->Unlock();
+		const int m = (int)std::round((12 * blurSize * blurSize - 3 * wl * wl - 12 * wl - 9) * 1.f / (-4 * wl - 4));
+		for (int i = 0; i < 3; ++i)
+			box[i] = ((i < m ? wl : wu) - 1) / 2;
 	}
+
+	auto box_blur = [&](BYTE*& in, BYTE*& out, int r)
+	{
+		constexpr int c = 3;
+		const int w = bound.Width;
+		const int h = bound.Height;
+		{
+			float iarr = 1.f / (r + r + 1);
+#pragma omp parallel for
+			for (int i = 0; i < h; i++)
+			{
+				int ti = i * w;
+				int li = ti;
+				int ri = ti + r;
+
+				int fv[3] = { in[ti * c + 0], in[ti * c + 1], in[ti * c + 2] };
+				int lv[3] = { in[(ti + w - 1) * c + 0], in[(ti + w - 1) * c + 1], in[(ti + w - 1) * c + 2] };
+				int val[3] = { (r + 1) * fv[0], (r + 1) * fv[1], (r + 1) * fv[2] };
+
+				for (int j = 0; j < r; j++)
+				{
+					val[0] += in[(ti + j) * c + 0];
+					val[1] += in[(ti + j) * c + 1];
+					val[2] += in[(ti + j) * c + 2];
+				}
+
+				for (int j = 0; j <= r; j++, ri++, ti++)
+				{
+					val[0] += in[ri * c + 0] - fv[0];
+					val[1] += in[ri * c + 1] - fv[1];
+					val[2] += in[ri * c + 2] - fv[2];
+					out[ti * c + 0] = static_cast<BYTE>(val[0] * iarr);
+					out[ti * c + 1] = static_cast<BYTE>(val[1] * iarr);
+					out[ti * c + 2] = static_cast<BYTE>(val[2] * iarr);
+				}
+
+				for (int j = r + 1; j < w - r; j++, ri++, ti++, li++)
+				{
+					val[0] += in[ri * c + 0] - in[li * c + 0];
+					val[1] += in[ri * c + 1] - in[li * c + 1];
+					val[2] += in[ri * c + 2] - in[li * c + 2];
+					out[ti * c + 0] = static_cast<BYTE>(val[0] * iarr);
+					out[ti * c + 1] = static_cast<BYTE>(val[1] * iarr);
+					out[ti * c + 2] = static_cast<BYTE>(val[2] * iarr);
+				}
+
+				for (int j = w - r; j < w; j++, ti++, li++)
+				{
+					val[0] += lv[0] - in[li * c + 0];
+					val[1] += lv[1] - in[li * c + 1];
+					val[2] += lv[2] - in[li * c + 2];
+					out[ti * c + 0] = static_cast<BYTE>(val[0] * iarr);
+					out[ti * c + 1] = static_cast<BYTE>(val[1] * iarr);
+					out[ti * c + 2] = static_cast<BYTE>(val[2] * iarr);
+				}
+			}
+		} // horizonal blur
+		std::swap(in, out);
+		{
+			float iarr = 1.f / (r + r + 1);
+#pragma omp parallel for
+			for (int i = 0; i < w; i++)
+			{
+				int ti = i;
+				int li = ti;
+				int ri = ti + r * w;
+
+				int fv[3] = { in[ti * c + 0], in[ti * c + 1], in[ti * c + 2] };
+				int lv[3] = { in[(ti + w * (h - 1)) * c + 0], in[(ti + w * (h - 1)) * c + 1], in[(ti + w * (h - 1)) * c + 2] };
+				int val[3] = { (r + 1) * fv[0], (r + 1) * fv[1], (r + 1) * fv[2] };
+
+				for (int j = 0; j < r; j++)
+				{
+					val[0] += in[(ti + j * w) * c + 0];
+					val[1] += in[(ti + j * w) * c + 1];
+					val[2] += in[(ti + j * w) * c + 2];
+				}
+
+				for (int j = 0; j <= r; j++, ri += w, ti += w)
+				{
+					val[0] += in[ri * c + 0] - fv[0];
+					val[1] += in[ri * c + 1] - fv[1];
+					val[2] += in[ri * c + 2] - fv[2];
+					out[ti * c + 0] = static_cast<BYTE>(val[0] * iarr);
+					out[ti * c + 1] = static_cast<BYTE>(val[1] * iarr);
+					out[ti * c + 2] = static_cast<BYTE>(val[2] * iarr);
+				}
+
+				for (int j = r + 1; j < h - r; j++, ri += w, ti += w, li += w)
+				{
+					val[0] += in[ri * c + 0] - in[li * c + 0];
+					val[1] += in[ri * c + 1] - in[li * c + 1];
+					val[2] += in[ri * c + 2] - in[li * c + 2];
+					out[ti * c + 0] = static_cast<BYTE>(val[0] * iarr);
+					out[ti * c + 1] = static_cast<BYTE>(val[1] * iarr);
+					out[ti * c + 2] = static_cast<BYTE>(val[2] * iarr);
+				}
+
+				for (int j = h - r; j < h; j++, ti += w, li += w)
+				{
+					val[0] += lv[0] - in[li * c + 0];
+					val[1] += lv[1] - in[li * c + 1];
+					val[2] += lv[2] - in[li * c + 2];
+					out[ti * c + 0] = static_cast<BYTE>(val[0] * iarr);
+					out[ti * c + 1] = static_cast<BYTE>(val[1] * iarr);
+					out[ti * c + 2] = static_cast<BYTE>(val[2] * iarr);
+				}
+			}
+		} // total blur
+	};
+
+	size_t size = bound.Width * bound.Height * 3;
+	BYTE* in = new BYTE[size];
+	BYTE* out = new BYTE[size];
+
+	// write surface data to in
+	{
+		auto d = in;
+		auto p = ptr;
+		for (int y = 0; y < bound.Height; ++y)
+		{
+			auto q = p;
+			for (int x = 0; x < bound.Width; ++x)
+			{
+				Drawing::Int_To_RGB(*q, d[0], d[1], d[2]);
+				d += 3;
+				++q;
+			}
+			p += line_length;
+		}
+	}
+
+	box_blur(in, out, box[0]);
+	box_blur(out, in, box[1]);
+	box_blur(in, out, box[2]);
+
+	// write out to surface data
+	{
+		auto d = out;
+		auto p = ptr;
+		for (int y = 0; y < bound.Height; ++y)
+		{
+			auto q = p;
+			for (int x = 0; x < bound.Width; ++x)
+			{
+				*q = (WORD)Drawing::RGB_To_Int(d[0], d[1], d[2]);
+				d += 3;
+				++q;
+			}
+			p += line_length;
+		}
+	}
+
+	delete[] in;
+	delete[] out;
+
+	this->Unlock();
 }

--- a/src/Ext/Surface/Body.cpp
+++ b/src/Ext/Surface/Body.cpp
@@ -1,0 +1,71 @@
+#include "Body.h"
+
+#include <Drawing.h>
+
+void SurfaceExt::BlurRect(const RectangleStruct& rect, int blurSize)
+{
+	if (blurSize <= 0)
+		return;
+	if (this->GetBytesPerPixel() < 2)
+		return;
+	if (rect.Width <= 0 || rect.Height <= 0)
+		return;
+
+	const auto bound = Drawing::Intersect(rect, this->GetRect());
+	if (bound.Width <= 0 || bound.Height <= 0)
+		return;
+
+	if (auto ptr = (WORD*)this->Lock(bound.X, bound.Y))
+	{
+		for (int yy = 0; yy < bound.Height; ++yy)
+		{
+			const int line = yy * (this->GetPitch() / sizeof(WORD));
+			auto p = &ptr[line];
+			for (int xx = 0; xx < bound.Width; ++xx)
+			{
+				int avgR = 0, avgG = 0, avgB = 0;
+
+				int r = std::min(xx + blurSize, bound.Width);
+				int b = std::min(yy + blurSize, bound.Height);
+
+				int blurPixelCount = 0;
+				for (int y = yy; y < b; ++y)
+				{
+					const int tline = y * (this->GetPitch() / sizeof(WORD));
+					auto tp = &ptr[tline];
+					for (int x = xx; x < r; ++x)
+					{
+						Color16Struct color { *tp };
+
+						avgR += color.R;
+						avgG += color.G;
+						avgB += color.B;
+
+						++blurPixelCount;
+						++tp;
+					}
+				}
+
+				avgR /= blurPixelCount;
+				avgG /= blurPixelCount;
+				avgB /= blurPixelCount;
+
+				WORD color = static_cast<WORD>(ColorStruct { (BYTE)avgR, (BYTE)avgG, (BYTE)avgB });
+				for (int y = yy; y < b; ++y)
+				{
+					const int tline = y * (this->GetPitch() / sizeof(WORD));
+					auto tp = &ptr[tline];
+					for (int x = xx; x < r; ++x)
+					{
+						*tp = color;
+						++tp;
+					}
+				}
+
+				++p;
+			}
+		}
+
+		this->Unlock();
+	}
+}

--- a/src/Ext/Surface/Body.h
+++ b/src/Ext/Surface/Body.h
@@ -5,6 +5,6 @@
 class SurfaceExt : public Surface
 {
 public:
-	void BlurRect(const RectangleStruct& rect, int blurSize);
+	void BlurRect(const RectangleStruct& rect, float blurSize);
 
 };

--- a/src/Ext/Surface/Body.h
+++ b/src/Ext/Surface/Body.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Surface.h>
+
+class SurfaceExt : public Surface
+{
+public:
+	void BlurRect(const RectangleStruct& rect, int blurSize);
+
+};

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -302,11 +302,11 @@ DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 				SidebarClass::Instance->SidebarBackgroundNeedsRedraw = true;
 
 				pThis->FillRectTrans(pRect,
-					&pData->ToolTip_Background_Color,
-					pData->ToolTip_Background_Opacity
+					pData->ToolTip_Background_Color.GetEx(&RulesExt::Global()->ToolTip_Background_Color),
+					pData->ToolTip_Background_Opacity.Get(RulesExt::Global()->ToolTip_Background_Opacity)
 				);
 
-				pThis->BlurRect(*pRect, pData->ToolTip_Background_BlurSize);
+				pThis->BlurRect(*pRect, pData->ToolTip_Background_BlurSize.Get(RulesExt::Global()->ToolTip_Background_BlurSize));
 
 				return (int)_CCToolTip_Draw2_FillRect_RET;
 			}

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -298,7 +298,7 @@ DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 		{
 			pThis->FillRectTrans(pRect,
 				&pData->ToolTip_Background_Color,
-				pData->ToolTip_Background_Transparency
+				pData->ToolTip_Background_Opacity
 			);
 
 			return (int)_CCToolTip_Draw2_FillRect_RET;

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -307,7 +307,8 @@ DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 					pData->ToolTip_Background_Opacity.Get(RulesExt::Global()->ToolTip_Background_Opacity)
 				);
 
-				pThis->BlurRect(*pRect, pData->ToolTip_Background_BlurSize.Get(RulesExt::Global()->ToolTip_Background_BlurSize));
+				if (Phobos::Config::ToolTipBlur)
+					pThis->BlurRect(*pRect, pData->ToolTip_Background_BlurSize.Get(RulesExt::Global()->ToolTip_Background_BlurSize));
 
 				return (int)_CCToolTip_Draw2_FillRect_RET;
 			}

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -287,28 +287,32 @@ void __declspec(naked) _CCToolTip_Draw2_FillRect_RET()
 }
 DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 {
-	GET(SurfaceExt*, pThis, ESI);
-	LEA_STACK(RectangleStruct*, pRect, STACK_OFFS(0x44, 0x10));
-
-	// Should we make some SideExt items as static to improve the effeciency?
-	// Though it might not be a big improvement... - secsome
-	const int nPlayerSideIndex = ScenarioClass::Instance->PlayerSideIndex;
-	if (auto const pSide = SideClass::Array->GetItemOrDefault(nPlayerSideIndex))
+	if (PhobosToolTip::Instance.IsCameo)
 	{
-		if (auto const pData = SideExt::ExtMap.Find(pSide))
+		GET(SurfaceExt*, pThis, ESI);
+		LEA_STACK(RectangleStruct*, pRect, STACK_OFFS(0x44, 0x10));
+
+		// Should we make some SideExt items as static to improve the effeciency?
+		// Though it might not be a big improvement... - secsome
+		const int nPlayerSideIndex = ScenarioClass::Instance->PlayerSideIndex;
+		if (auto const pSide = SideClass::Array->GetItemOrDefault(nPlayerSideIndex))
 		{
-			pThis->FillRectTrans(pRect,
-				&pData->ToolTip_Background_Color,
-				pData->ToolTip_Background_Opacity
-			);
+			if (auto const pData = SideExt::ExtMap.Find(pSide))
+			{
+				SidebarClass::Instance->SidebarBackgroundNeedsRedraw = true;
 
-			pThis->BlurRect(*pRect, pData->ToolTip_Background_BlurSize);
+				pThis->FillRectTrans(pRect,
+					&pData->ToolTip_Background_Color,
+					pData->ToolTip_Background_Opacity
+				);
 
-			return (int)_CCToolTip_Draw2_FillRect_RET;
+				pThis->BlurRect(*pRect, pData->ToolTip_Background_BlurSize);
+
+				return (int)_CCToolTip_Draw2_FillRect_RET;
+			}
 		}
 	}
 
-	// We shouldn't get here though...
 	return 0;
 }
 

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -380,3 +380,4 @@ DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 //
 //	return 0x479048;
 //}
+

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -14,6 +14,7 @@
 #include <BitText.h>
 
 #include <Ext/Side/Body.h>
+#include <Ext/Surface/Body.h>
 
 #include <sstream>
 #include <iomanip>
@@ -286,7 +287,7 @@ void __declspec(naked) _CCToolTip_Draw2_FillRect_RET()
 }
 DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 {
-	GET(DSurface*, pThis, ESI);
+	GET(SurfaceExt*, pThis, ESI);
 	LEA_STACK(RectangleStruct*, pRect, STACK_OFFS(0x44, 0x10));
 
 	// Should we make some SideExt items as static to improve the effeciency?
@@ -300,6 +301,8 @@ DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 				&pData->ToolTip_Background_Color,
 				pData->ToolTip_Background_Opacity
 			);
+
+			pThis->BlurRect(*pRect, pData->ToolTip_Background_BlurSize);
 
 			return (int)_CCToolTip_Draw2_FillRect_RET;
 		}

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -299,6 +299,7 @@ DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
 		{
 			if (auto const pData = SideExt::ExtMap.Find(pSide))
 			{
+				// Could this flag be lazy?
 				SidebarClass::Instance->SidebarBackgroundNeedsRedraw = true;
 
 				pThis->FillRectTrans(pRect,

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -13,6 +13,8 @@
 #include <BitFont.h>
 #include <BitText.h>
 
+#include <Ext/Side/Body.h>
+
 #include <sstream>
 #include <iomanip>
 
@@ -274,6 +276,36 @@ DEFINE_HOOK(0x479029, CCToolTip_Draw2_SetPadding, 0x5)
 			R->EDX(R->EDX() - 5);
 	}
 
+	return 0;
+}
+
+void __declspec(naked) _CCToolTip_Draw2_FillRect_RET()
+{
+	ADD_ESP(8); // We need to handle origin two push here...
+	JMP(0x478FE1);
+}
+DEFINE_HOOK(0x478FDC, CCToolTip_Draw2_FillRect, 0x5)
+{
+	GET(DSurface*, pThis, ESI);
+	LEA_STACK(RectangleStruct*, pRect, STACK_OFFS(0x44, 0x10));
+
+	// Should we make some SideExt items as static to improve the effeciency?
+	// Though it might not be a big improvement... - secsome
+	const int nPlayerSideIndex = ScenarioClass::Instance->PlayerSideIndex;
+	if (auto const pSide = SideClass::Array->GetItemOrDefault(nPlayerSideIndex))
+	{
+		if (auto const pData = SideExt::ExtMap.Find(pSide))
+		{
+			pThis->FillRectTrans(pRect,
+				&pData->ToolTip_Background_Color,
+				pData->ToolTip_Background_Transparency
+			);
+
+			return (int)_CCToolTip_Draw2_FillRect_RET;
+		}
+	}
+
+	// We shouldn't get here though...
 	return 0;
 }
 

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -52,6 +52,7 @@ double Phobos::UI::PowerDelta_ConditionYellow = 0.75;
 double Phobos::UI::PowerDelta_ConditionRed = 1.0;
 
 bool Phobos::Config::ToolTipDescriptions = true;
+bool Phobos::Config::ToolTipBlur = false;
 bool Phobos::Config::PrioritySelectionFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
@@ -200,6 +201,7 @@ DEFINE_HOOK(0x52F639, _YR_CmdLineParse, 0x5)
 DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 {
 	Phobos::Config::ToolTipDescriptions = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ToolTipDescriptions", true);
+	Phobos::Config::ToolTipBlur = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ToolTipBlur", false);
 	Phobos::Config::PrioritySelectionFiltering = CCINIClass::INI_RA2MD->ReadBool("Phobos", "PrioritySelectionFiltering", true);
 	Phobos::Config::EnableBuildingPlacementPreview = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowBuildingPlacementPreview", false);
 

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -67,6 +67,7 @@ public:
 	{
 	public:
 		static bool ToolTipDescriptions;
+		static bool ToolTipBlur;
 		static bool PrioritySelectionFiltering;
 		static bool DevelopmentCommands;
 		static bool ArtImageSwap;


### PR DESCRIPTION
In `rulesmd.ini`:
```ini
[SOMESIDE]
ToolTip.Background.Color=0,0,0      ; integer - R,G,B, defaults to [AudioVisual]->ToolTip.Background.Color
ToolTip.Background.Opacity=100      ; integer, ranged in [0, 100], defaults to [AudioVisual]->ToolTip.Background.Opacity
ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual]->ToolTip.Background.BlurSize
```

Ready for test.