### PR TITLE
[Hotfix][Urgent] Fix MindControlled building cannot fire normally

### DIFF
--- a/src/Misc/CaptureManager.cpp
+++ b/src/Misc/CaptureManager.cpp
@@ -124,8 +124,16 @@ bool CaptureManager::CaptureUnit(CaptureManagerClass* pManager, TechnoClass* pTa
 					}
 				}
 
-				pTarget->QueueMission(Mission::Move, false);
-				pTarget->SetDestination(pTarget->GetCell(), true);
+				pTarget->SetTarget(nullptr);
+				if (pManager->Owner->IsHumanControlled)
+				{
+					if (auto pTargetFoot = abstract_cast<FootClass*>(pTarget))
+					{
+						pTargetFoot->QueueMission(Mission::Guard, false);
+						pTargetFoot->SetDestination(pTarget->GetCell(), true);
+						pTargetFoot->NextMission();
+					}
+				}
 
 				return true;
 			}


### PR DESCRIPTION
Resolves #731 
Restores #675

Issue: #532 Shouldn't be merged at the beginning.
@secsome How can a building move???

Note: neither #532 nor #380 can solve #314, even this PR cannot. #675 can but it's too annoying to be accepted as an alternative.