### PR TITLE
Performance refactor: Detach shield anim pointer invalidation from techno

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -173,7 +173,7 @@ This page lists all the individual contributions to the project by their author.
    - Object Self-destruction logic
    - Building EVA_StructureSold and SellSound dehardcode
    - Slaves' house customization when owner is killed
-   - Misc CN doc fix
+   - Misc doc fix & code refactor
    - Warhead superweapon launch logic
    - "Shield is broken" trigger event
 - **NetsuNegi** - Forbidding parallel AI queues by type

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -379,6 +379,7 @@ Phobos fixes:
 - Fixed issue with incorrect input in edit dialog element when using IME (by Belonit)
 - Fixed an issue where tooltip text could be clipped by tooltip rectangle border if using `MaxWidth` > 0 (by Starkku)
 - Fixed projectiles with `Trajectory=Straight` suffering from potential inaccuracy problems if combined with `Airburst=yes` or Warhead with `EMEffect=true` (by Starkku)
+- Minor performance optimization related to shields (by Trsdy)
 
 Non-DLL:
 - Implemented a tool (sed wrapper) to semi-automatically upgrade INIs to use latest Phobos tags (by Kerbiter)

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -63,11 +63,7 @@ public:
 
 		virtual ~ExtData() = default;
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
-		{
-			if (auto const pShield = this->Shield.get())
-				pShield->InvalidatePointer(ptr);
-		}
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
@@ -82,18 +78,6 @@ public:
 	public:
 		ExtContainer();
 		~ExtContainer();
-
-		virtual bool InvalidateExtDataIgnorable(void* const ptr) const override
-		{
-			auto const abs = static_cast<AbstractClass*>(ptr)->WhatAmI();
-			switch (abs)
-			{
-			case AbstractType::Anim:
-				return false;
-			default:
-				return true;
-			}
-		}
 
 		virtual void InvalidatePointer(void* ptr, bool bRemoved) override;
 	};

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -12,15 +12,14 @@
 #include <RadarEventClass.h>
 #include <TacticalClass.h>
 
-namespace NewEntities
-{
-	std::vector<ShieldClass*> Shields;
-}
+std::vector<ShieldClass*> ShieldClass::Array;
 
 ShieldClass::ShieldClass() : Techno { nullptr }
 	, HP { 0 }
 	, Timers { }
-{ }
+{
+	ShieldClass::Array.emplace_back(this);
+}
 
 ShieldClass::ShieldClass(TechnoClass* pTechno, bool isAttached) : Techno { pTechno }
 	, IdleAnim { nullptr }
@@ -36,14 +35,14 @@ ShieldClass::ShieldClass(TechnoClass* pTechno, bool isAttached) : Techno { pTech
 	this->UpdateType();
 	SetHP(this->Type->InitialStrength.Get(this->Type->Strength));
 	strcpy(this->TechnoID, this->Techno->get_ID());
-	NewEntities::Shields.emplace_back(this);
+	ShieldClass::Array.emplace_back(this);
 }
 
 ShieldClass::~ShieldClass()
 {
-	auto it = std::find(NewEntities::Shields.begin(), NewEntities::Shields.end(), this);
-	if (it != NewEntities::Shields.end())
-		NewEntities::Shields.erase(it);
+	auto it = std::find(ShieldClass::Array.begin(), ShieldClass::Array.end(), this);
+	if (it != ShieldClass::Array.end())
+		ShieldClass::Array.erase(it);
 }
 
 void ShieldClass::UpdateType()
@@ -55,7 +54,7 @@ void ShieldClass::PointerGotInvalid(void* ptr, bool removed)
 {
 	if (auto const pAnim = abstract_cast<AnimClass*>(static_cast<AbstractClass*>(ptr)))
 	{
-		for (auto pShield : NewEntities::Shields)
+		for (auto pShield : ShieldClass::Array)
 		{
 			if (pAnim == pShield->IdleAnim)
 				pShield->KillAnim();
@@ -100,20 +99,6 @@ bool ShieldClass::Load(PhobosStreamReader& Stm, bool RegisterForChange)
 bool ShieldClass::Save(PhobosStreamWriter& Stm) const
 {
 	return const_cast<ShieldClass*>(this)->Serialize(Stm);
-}
-
-bool ShieldClass::LoadGlobals(PhobosStreamReader& Stm)
-{
-	return Stm
-		.Process(NewEntities::Shields)
-		.Success();
-}
-
-bool ShieldClass::SaveGlobals(PhobosStreamWriter& Stm)
-{
-	return Stm
-		.Process(NewEntities::Shields)
-		.Success();
 }
 
 // =============================

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -14,7 +14,7 @@
 
 namespace NewEntities
 {
-	ValueableVector<ShieldClass*> Shields;
+	std::vector<ShieldClass*> Shields;
 }
 
 ShieldClass::ShieldClass() : Techno { nullptr }
@@ -258,9 +258,9 @@ void ShieldClass::ResponseAttack()
 		if (pUnit->Type->Harvester)
 		{
 			const auto pos = pUnit->GetDestination(pUnit);
-
+			enum { EVA_OreMinerUnderAttack = 0x824784 };
 			if (RadarEventClass::Create(RadarEventType::HarvesterAttacked, CellClass::Coord2Cell(pos)))
-				VoxClass::Play("EVA_OreMinerUnderAttack");
+				VoxClass::Play((const char*)EVA_OreMinerUnderAttack);
 		}
 	}
 }

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -15,6 +15,8 @@ public:
 	ShieldClass(TechnoClass* pTechno) : ShieldClass(pTechno, false) {};
 	~ShieldClass();
 
+	static std::vector<ShieldClass*> Array;
+
 	int ReceiveDamage(args_ReceiveDamage* args);
 	bool CanBeTargeted(WeaponTypeClass* pWeapon);
 	bool CanBePenetrated(WarheadTypeClass* pWarhead);
@@ -44,8 +46,6 @@ public:
 	static void SyncShieldToAnother(TechnoClass* pFrom, TechnoClass* pTo);
 	static bool ShieldIsBrokenTEvent(ObjectClass* pAttached);
 
-	static bool LoadGlobals(PhobosStreamReader& Stm);
-	static bool SaveGlobals(PhobosStreamWriter& Stm);
 	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	bool Save(PhobosStreamWriter& Stm) const;
 

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -10,30 +10,25 @@ class WarheadTypeClass;
 class ShieldClass
 {
 public:
+	static std::vector<ShieldClass*> Array;
+
 	ShieldClass();
 	ShieldClass(TechnoClass* pTechno, bool isAttached);
-	ShieldClass(TechnoClass* pTechno) : ShieldClass(pTechno, false) {};
+	ShieldClass(TechnoClass* pTechno) : ShieldClass(pTechno, false) { };
 	~ShieldClass();
-
-	static std::vector<ShieldClass*> Array;
 
 	int ReceiveDamage(args_ReceiveDamage* args);
 	bool CanBeTargeted(WeaponTypeClass* pWeapon);
 	bool CanBePenetrated(WarheadTypeClass* pWarhead);
-
 	void BreakShield(AnimTypeClass* pBreakAnim = nullptr, WeaponTypeClass* pBreakWeapon = nullptr);
+
 	void SetRespawn(int duration, double amount, int rate, bool resetTimer);
 	void SetSelfHealing(int duration, double amount, int rate, bool resetTimer);
-
 	void KillAnim();
-
 	void AI_Temporal();
 	void AI();
 
 	void DrawShieldBar(int iLength, Point2D* pLocation, RectangleStruct* pBound);
-
-	static void PointerGotInvalid(void* ptr, bool removed);
-
 	double GetHealthRatio();
 	void SetHP(int amount);
 	int GetHP();
@@ -46,6 +41,7 @@ public:
 	static void SyncShieldToAnother(TechnoClass* pFrom, TechnoClass* pTo);
 	static bool ShieldIsBrokenTEvent(ObjectClass* pAttached);
 
+	static void PointerGotInvalid(void* ptr, bool removed);
 	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	bool Save(PhobosStreamWriter& Stm) const;
 
@@ -101,9 +97,9 @@ private:
 	struct Timers
 	{
 		Timers() :
-			SelfHealing{ }
+			SelfHealing { }
 			, SelfHealing_Warhead { }
-			, Respawn{ }
+			, Respawn { }
 			, Respawn_Warhead { }
 		{ }
 

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -13,7 +13,7 @@ public:
 	ShieldClass();
 	ShieldClass(TechnoClass* pTechno, bool isAttached);
 	ShieldClass(TechnoClass* pTechno) : ShieldClass(pTechno, false) {};
-	~ShieldClass() = default;
+	~ShieldClass();
 
 	int ReceiveDamage(args_ReceiveDamage* args);
 	bool CanBeTargeted(WeaponTypeClass* pWeapon);
@@ -29,7 +29,8 @@ public:
 	void AI();
 
 	void DrawShieldBar(int iLength, Point2D* pLocation, RectangleStruct* pBound);
-	void InvalidatePointer(void* ptr);
+
+	static void PointerGotInvalid(void* ptr, bool removed);
 
 	double GetHealthRatio();
 	void SetHP(int amount);
@@ -41,9 +42,10 @@ public:
 	int GetFramesSinceLastBroken();
 
 	static void SyncShieldToAnother(TechnoClass* pFrom, TechnoClass* pTo);
-
 	static bool ShieldIsBrokenTEvent(ObjectClass* pAttached);
 
+	static bool LoadGlobals(PhobosStreamReader& Stm);
+	static bool SaveGlobals(PhobosStreamWriter& Stm);
 	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	bool Save(PhobosStreamWriter& Stm) const;
 

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -251,7 +251,8 @@ auto MassActions = MassAction <
 	// New classes
 	ShieldTypeClass,
 	LaserTrailTypeClass,
-	RadTypeClass
+	RadTypeClass,
+	ShieldClass
 	// other classes
 > ();
 


### PR DESCRIPTION
Given the importance and the difficulty of this task, I detached this part from #721 

Prior to this PR, `ContainerMap.Find` and `InvalidatePointerHelper::Process<TechnoExt>` are the 2 major factors that greatly impact the performance, causing a significant FPS drop when objects number surpasses hundreds. 

This PR aims to detach the shield `IdleAnim` pointer invalidation from `TechnoExt` by nullifying the existing pointer invalidation virtual function of `TechnoExt::ExtData` and introducing a static one inside `ShieldClass`. So I used a global vector storing all shield class pointers. As for pointer invalidation, it loops through the vector to see if any `IdleAnim` matches. 
