### PR TITLE
Fix jumpjets' Sensors being unable to detect cloaked objects (temporarily)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -168,12 +168,14 @@ This page lists all the individual contributions to the project by their author.
    - Laser fixes prototype
 - **Trsdy**
    - Preserve IronCurtain status upon DeploysInto/UndeploysInto
-   - Jumpjet facing towards target fix
-   - Turreted jumpjet idle direction fix
+   - Misc jumpjet fixes:
+      - Facing towards target fix
+      - Turret direction in idle state fix
+      - Sensor fix
    - Object Self-destruction logic
    - Building EVA_StructureSold and SellSound dehardcode
    - Slaves' house customization when owner is killed
-   - Misc doc fix & code refactor
+   - Misc CN doc fix, code refactor
    - Harvester counter
    - Warhead superweapon launch logic
    - "Shield is broken" trigger event

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -22,6 +22,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead.
 - Fixed jumpjet units being unable to turn to the target when firing from a different direction.
 - Fixed turreted jumpjet units always facing bottom-right direction when motion stops.
+- Fixed jumpjet objects being unable to use `Sensors`.
 - Fixed interaction of `UnitAbsorb` & `InfantryAbsorb` with `Grinding` buildings. The keys will now make the building only accept appropriate types of objects.
 - Fixed missing 'no enter' cursor for VehicleTypes being unable to enter a `Grinding` building.
 - Fixed Engineers being able to enter `Grinding` buildings even when they shouldn't (such as ally building at full HP).

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -353,6 +353,7 @@ Vanilla fixes:
 - Fixed buildings not reverting to undamaged graphics when HP was restored above `[AudioVisual]`->`ConditionYellow` via `SelfHealing` (by Starkku)
 - Fixed jumpjet units being unable to turn to the target when firing from a different direction (by Trsdy)
 - Fixed turreted jumpjet units always facing bottom-right direction when stop moving (by Trsdy)
+- Fixed jumpjet objects being unable to detect cloaked objects beneath (by Trsdy)
 - Anim owner is now set for warhead AnimList/SplashList anims and Play Anim at Waypoint trigger animations (by Starkku)
 - Fixed AI script action Deploy getting stuck with vehicles with `DeploysInto` if there was no space to deploy at initial location (by Starkku)
 - Fixed `Foundation=0x0` causing crashes if used on TerrainTypes.

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -186,25 +186,6 @@ DEFINE_HOOK(0x6F421C, TechnoClass_DefaultDisguise, 0x6) // TechnoClass_DefaultDi
 	return 0;
 }
 
-DEFINE_HOOK(0x54B8E9, JumpjetLocomotionClass_In_Which_Layer_Deviation, 0x6)
-{
-	GET(TechnoClass*, pThis, EAX);
-
-	if (pThis->IsInAir())
-	{
-		if (auto const pExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType()))
-		{
-			if (!pExt->JumpjetAllowLayerDeviation.Get(RulesExt::Global()->JumpjetAllowLayerDeviation.Get()))
-			{
-				R->EDX(INT32_MAX); // Override JumpjetHeight / CruiseHeight check so it always results in 3 / Layer::Air.
-				return 0x54B96B;
-			}
-		}
-	}
-
-	return 0;
-}
-
 DEFINE_HOOK(0x73CF46, UnitClass_Draw_It_KeepUnitVisible, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -79,15 +79,18 @@ DEFINE_HOOK(0x736BF3, UnitClass_UpdateRotation_TurretFacing, 0x6)
 // Bugfix: Jumpjet detect cloaked objects beneath
 DEFINE_HOOK(0x54C036, JumpjetLocomotionClass_State3_54BFF0_UpdateSensors, 0x7)
 {
-
 	GET(FootClass* const, pLinkedTo, ECX);
 	GET(CellStruct const, currentCell, EAX);
 
 	// Copied from FootClass::UpdatePosition
 	if (pLinkedTo->GetTechnoType()->SensorsSight)
 	{
-		pLinkedTo->RemoveSensorsAt(pLinkedTo->LastJumpjetMapCoords);
-		pLinkedTo->AddSensorsAt(currentCell);
+		CellStruct const lastCell = pLinkedTo->LastJumpjetMapCoords;
+		if (lastCell != currentCell)
+		{
+			pLinkedTo->RemoveSensorsAt(lastCell);
+			pLinkedTo->AddSensorsAt(currentCell);
+		}
 	}
 	// Something more may be missing
 

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -77,13 +77,19 @@ DEFINE_HOOK(0x736BF3, UnitClass_UpdateRotation_TurretFacing, 0x6)
 }
 
 // Bugfix: Jumpjet detect cloaked objects beneath
-DEFINE_HOOK(0x54C14B, JumpjetLocomotionClass_State3_54BFF0_UpdateSensors, 0x7)
+DEFINE_HOOK(0x54C036, JumpjetLocomotionClass_State3_54BFF0_UpdateSensors, 0x7)
 {
-	GET(FootClass* const, pLinkedTo, EDI);
-	// State4 did UpdatePosition(2), however if I do it here regardless of type the game speed drops a lot
-	auto const pType = pLinkedTo->GetTechnoType();
-	if (pType->Sensors || pType->SensorsSight > 0 || pLinkedTo->CloakState == CloakState::Cloaked)
-		pLinkedTo->UpdatePosition(2);
+
+	GET(FootClass* const, pLinkedTo, ECX);
+	GET(CellStruct const, currentCell, EAX);
+
+	// Copied from FootClass::UpdatePosition
+	if (pLinkedTo->GetTechnoType()->SensorsSight)
+	{
+		pLinkedTo->RemoveSensorsAt(pLinkedTo->LastJumpjetMapCoords);
+		pLinkedTo->AddSensorsAt(currentCell);
+	}
+	// Something more may be missing
 
 	return 0;
 }


### PR DESCRIPTION
Just as the title said.
BTW the bug of turreted jumpjet units always facing the bottom-right direction when not targeting anything is fixed too in #738, welcome to test them together. Only `Jumpjet=yes` units are considered.


Note:
My idb is very poor, and I can only assume at this moment that `JumpjetLocomotionClass::State` is an enum, where
* 0 - On the ground
* 1 - Taking off from the ground
* 2 - Hovering in the air
* 3 - Moving in air
* 4 - Deploying to land
* 5 - Crashing
* 6 - Unknown, probably related to crashing

It seems that `ObjectClass::UpdatePosition` is called in `4`, but not the others. I decided to add it in 3, but I'm not sure if it's also done elsewhere so I limited it to `Sensors=yes` types only for now.
Since there's something else processed in this function so there may be some additional (side) effects as well, which may be related with
* threat evaluation and targeting
*  trigger events evaluation (entered by sort of stuff)
*  planning waypoints processing