### PR TITLE
Trigger owner can set as player of multiplayer game map

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -400,6 +400,10 @@ In `rulesmd.ini`:
 MinimapColor=  ; integer - Red,Green,Blue
 ```
 
+## Trigger
+
+- In a multiplayer map, set trigger owner as '4475'-'4482' is player@A-player@G, if nonexist, trigger will be desotroyed. 
+
 ## Vehicles
 
 ### IsSimpleDeployer vehicle deploy animation / direction customization

--- a/src/Misc/Hooks.Trigger.cpp
+++ b/src/Misc/Hooks.Trigger.cpp
@@ -1,0 +1,84 @@
+#include <HouseClass.h>
+#include <TriggerTypeClass.h>
+#include <TriggerClass.h>
+
+#include <Helpers/Macro.h>
+
+#include <Misc/TriggerMPOwner.h>
+
+DEFINE_HOOK(0x7272AE, TriggerTypeClass_LoadFromINI_House, 0x8)
+{
+	GET(TriggerTypeClass*, pThis, EBP);
+	GET(const char*, pID, ESI);
+
+	int idx = atoi(pID);
+
+	if (HouseClass::PlayerAtA <= idx && idx <= HouseClass::PlayerAtH)
+	{
+		TriggerMPOwner::TriggerType_Owner[pThis->GetArrayIndex()] = idx;
+
+		R->EDX(HouseTypeClass::Find("special"));
+
+		return 0x7272C1;
+	}
+
+	R->EAX(HouseTypeClass::FindIndex(pID));
+
+	return 0x7272B5;
+}
+
+DEFINE_HOOK(0x72612C, TriggerClass_CTOR_DestoryIfMultiplayerNonexist, 0x8)
+{
+	GET(TriggerClass*, pThis, ESI);
+
+	if (pThis->Type == nullptr)
+		return 0;
+
+	int idx = pThis->Type->GetArrayIndex();
+	const auto& houseIdxMapper = TriggerMPOwner::TriggerType_Owner;
+
+	if (houseIdxMapper.count(idx))
+	{
+		HouseClass* pHouse = HouseClass::FindByIndex(houseIdxMapper.at(idx));
+
+		if (pHouse == nullptr)
+			pThis->Destroyed = true;
+	}
+
+	return 0;
+}
+
+
+DEFINE_HOOK(0x726538, TriggerClass_RaiseEvent_ReplaceHouse, 0x5)
+{
+	GET(TriggerClass*, pThis, ESI);
+
+	int idx = pThis->Type->GetArrayIndex();
+	const auto& houseIdxMapper = TriggerMPOwner::TriggerType_Owner;
+
+	if (houseIdxMapper.count(idx))
+	{
+		HouseClass* pHouse = HouseClass::FindByIndex(houseIdxMapper.at(idx));
+		R->EAX(pHouse == nullptr ? HouseClass::FindSpecial() : pHouse);
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7265F7, TriggerClass_FireActions_ReplaceHouse, 0x6)
+{
+	GET(TriggerClass*, pThis, EDI);
+
+	int idx = pThis->Type->GetArrayIndex();
+	const auto& houseIdxMapper = TriggerMPOwner::TriggerType_Owner;
+
+	if (houseIdxMapper.count(idx))
+	{
+		HouseClass* pHouse = HouseClass::FindByIndex(houseIdxMapper.at(idx));
+		R->EAX(pHouse == nullptr ? HouseClass::FindSpecial() : pHouse);
+
+		return 0x726602;
+	}
+
+	return 0;
+}

--- a/src/Misc/TriggerMPOwner.h
+++ b/src/Misc/TriggerMPOwner.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <map>
+
+#include <Utilities/Savegame.h>
+
+class TriggerMPOwner
+{
+public:
+	static std::map<int, int> TriggerType_Owner;
+
+	static bool LoadGlobals(PhobosStreamReader& stm)
+	{
+		return stm
+			.Process(TriggerType_Owner)
+			.Success();
+	}
+
+	static bool SaveGlobals(PhobosStreamWriter& stm)
+	{
+		return stm
+			.Process(TriggerType_Owner)
+			.Success();
+	}
+};

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -28,6 +28,8 @@
 #include <New/Type/RadTypeClass.h>
 #include <New/Type/LaserTrailTypeClass.h>
 
+#include <Misc/TriggerMPOwner.h>
+
 #include <utility>
 
 #pragma region Implementation details
@@ -251,8 +253,9 @@ auto MassActions = MassAction <
 	// New classes
 	ShieldTypeClass,
 	LaserTrailTypeClass,
-	RadTypeClass
+	RadTypeClass,
 	// other classes
+	TriggerMPOwner
 > ();
 
 DEFINE_HOOK(0x7258D0, AnnounceInvalidPointer, 0x6)


### PR DESCRIPTION
In a multiplayer map, set trigger owner as '4475'-'4482' is `player@A`-`player@G`. If player nonexist, trigger will be desotroyed.