### PR TITLE
Fixed unit playing crashing voice when crashing after being attacked by locomotor warhead

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,7 +187,7 @@ This page lists all the individual contributions to the project by their author.
    - Forbidding parallel AI queues by type
 - **NetsuNegi**
    - Forbidding parallel AI queues by type
-   - Fixed unit will play crash voice when crashing after attacked by locomotor warhead
+   - Fixed unit playing crashing voice when crashing after being attacked by locomotor warhead
 - **Apollo** - Translucent SHP drawing patches
 - **FlyStar** - Campaign load screen PCX support
 - **SukaHati (Erzoid)** - Minimum interceptor guard range

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,7 +187,7 @@ This page lists all the individual contributions to the project by their author.
    - Forbidding parallel AI queues by type
 - **NetsuNegi**
    - Forbidding parallel AI queues by type
-   - Fix unit will play crash voice when crashing after attacked by locomotor warhead
+   - Fixed unit will play crash voice when crashing after attacked by locomotor warhead
 - **Apollo** - Translucent SHP drawing patches
 - **FlyStar** - Campaign load screen PCX support
 - **SukaHati (Erzoid)** - Minimum interceptor guard range

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -185,7 +185,9 @@ This page lists all the individual contributions to the project by their author.
    - Warhead superweapon launch logic
    - "Shield is broken" trigger event
    - Forbidding parallel AI queues by type
-- **NetsuNegi** - Forbidding parallel AI queues by type
+- **NetsuNegi**
+   - Forbidding parallel AI queues by type
+   - Fix unit will play crash voice when crashing after attacked by locomotor warhead
 - **Apollo** - Translucent SHP drawing patches
 - **FlyStar** - Campaign load screen PCX support
 - **SukaHati (Erzoid)** - Minimum interceptor guard range

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -73,7 +73,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that caused vehicles killed by damage dealt by a known house but without a known source TechnoType (f.ex animation warhead damage) to not be recorded as killed correctly and thus not spring map trigger events etc.
 - `IsAnimated`, `AnimationRate` and `AnimationProbability` now work on TerrainTypes without `SpawnsTiberium` set to true.
 - Fixed transports recursively put into each other not having a correct killer set after second transport when being killed by something.
-- Fixed unit will play crash voice when crashing after attacked by locomotor warhead.
+- Fixed unit playing crashing voice when crashing after being attacked by locomotor warhead.
 
 ![image](_static/images/translucency-fix.png)
 *Example gradient SHP drawing with 75% translucency, before and after*

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -73,6 +73,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that caused vehicles killed by damage dealt by a known house but without a known source TechnoType (f.ex animation warhead damage) to not be recorded as killed correctly and thus not spring map trigger events etc.
 - `IsAnimated`, `AnimationRate` and `AnimationProbability` now work on TerrainTypes without `SpawnsTiberium` set to true.
 - Fixed transports recursively put into each other not having a correct killer set after second transport when being killed by something.
+- Fixed unit will play crash voice when crashing after attacked by locomotor warhead.
 
 ![image](_static/images/translucency-fix.png)
 *Example gradient SHP drawing with 75% translucency, before and after*

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -615,3 +615,29 @@ DEFINE_HOOK(0x70265F, TechnoClass_ReceiveDamage_Explodes, 0x6)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x4DACDD, FootClass_CrashingVoice, 0x6)
+{
+	GET(FootClass*, pThis, ESI);
+
+	if (pThis->IsCrashing != pThis->WasCrashingAlready)
+	{
+		if (pThis->IsCrashing && !pThis->IsAttackedByLocomotor)
+		{
+			pThis->Audio7.ShutUp();
+			const auto pType = pThis->GetTechnoType();
+
+			if (pType->VoiceCrashing != -1 && pThis->Owner->IsControlledByCurrentPlayer())
+				VocClass::PlayAt(pType->VoiceCrashing, pThis->GetCoords());
+
+			if (pType->CrashingSound != -1)
+				VocClass::PlayAt(pType->CrashingSound, pThis->GetCoords(), &pThis->Audio7);
+		}
+		else if (pThis->unknown_bool_53C)
+			pThis->Audio7.ShutUp();
+
+		pThis->WasCrashingAlready = pThis->IsCrashing;
+	}
+
+	return 0x4DADC8;
+}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -615,29 +615,3 @@ DEFINE_HOOK(0x70265F, TechnoClass_ReceiveDamage_Explodes, 0x6)
 
 	return 0;
 }
-
-DEFINE_HOOK(0x4DACDD, FootClass_CrashingVoice, 0x6)
-{
-	GET(FootClass*, pThis, ESI);
-
-	if (pThis->IsCrashing != pThis->WasCrashingAlready)
-	{
-		if (pThis->IsCrashing && !pThis->IsAttackedByLocomotor)
-		{
-			pThis->Audio7.ShutUp();
-			const auto pType = pThis->GetTechnoType();
-
-			if (pType->VoiceCrashing != -1 && pThis->Owner->IsControlledByCurrentPlayer())
-				VocClass::PlayAt(pType->VoiceCrashing, pThis->GetCoords());
-
-			if (pType->CrashingSound != -1)
-				VocClass::PlayAt(pType->CrashingSound, pThis->GetCoords(), &pThis->Audio7);
-		}
-		else if (pThis->unknown_bool_53C)
-			pThis->Audio7.ShutUp();
-
-		pThis->WasCrashingAlready = pThis->IsCrashing;
-	}
-
-	return 0x4DADC8;
-}

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -426,6 +426,32 @@ DEFINE_HOOK(0x54D138, JumpjetLocomotionClass_Movement_AI_SpeedModifiers, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x4DACDD, FootClass_CrashingVoice, 0x6)
+{
+	GET(FootClass*, pThis, ESI);
+
+	if (pThis->IsCrashing != pThis->WasCrashingAlready)
+	{
+		if (pThis->IsCrashing && !pThis->IsAttackedByLocomotor)
+		{
+			pThis->Audio7.ShutUp();
+			const auto pType = pThis->GetTechnoType();
+
+			if (pType->VoiceCrashing != -1 && pThis->Owner->IsControlledByCurrentPlayer())
+				VocClass::PlayAt(pType->VoiceCrashing, pThis->GetCoords());
+
+			if (pType->CrashingSound != -1)
+				VocClass::PlayAt(pType->CrashingSound, pThis->GetCoords(), &pThis->Audio7);
+		}
+		else if (pThis->unknown_bool_53C)
+			pThis->Audio7.ShutUp();
+
+		pThis->WasCrashingAlready = pThis->IsCrashing;
+	}
+
+	return 0x4DADC8;
+}
+
 DEFINE_HOOK(0x73B2A2, UnitClass_DrawObject_DrawerBlitterFix, 0x6)
 {
 	enum { SkipGameCode = 0x73B2C3 };

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -426,30 +426,16 @@ DEFINE_HOOK(0x54D138, JumpjetLocomotionClass_Movement_AI_SpeedModifiers, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x4DACDD, FootClass_CrashingVoice, 0x6)
+DEFINE_HOOK(0x4DACF3, FootClass_CrashingVoice, 0x6)
 {
+	enum { Continue = 0x4DACF9, Skip = 0x4DADA9 };
+
 	GET(FootClass*, pThis, ESI);
 
-	if (pThis->IsCrashing != pThis->WasCrashingAlready)
-	{
-		if (pThis->IsCrashing && !pThis->IsAttackedByLocomotor)
-		{
-			pThis->Audio7.ShutUp();
-			const auto pType = pThis->GetTechnoType();
+	if (pThis->IsCrashing && !pThis->IsAttackedByLocomotor)
+		return Continue;
 
-			if (pType->VoiceCrashing != -1 && pThis->Owner->IsControlledByCurrentPlayer())
-				VocClass::PlayAt(pType->VoiceCrashing, pThis->GetCoords());
-
-			if (pType->CrashingSound != -1)
-				VocClass::PlayAt(pType->CrashingSound, pThis->GetCoords(), &pThis->Audio7);
-		}
-		else if (pThis->unknown_bool_53C)
-			pThis->Audio7.ShutUp();
-
-		pThis->WasCrashingAlready = pThis->IsCrashing;
-	}
-
-	return 0x4DADC8;
+	return Skip;
 }
 
 DEFINE_HOOK(0x73B2A2, UnitClass_DrawObject_DrawerBlitterFix, 0x6)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -426,7 +426,7 @@ DEFINE_HOOK(0x54D138, JumpjetLocomotionClass_Movement_AI_SpeedModifiers, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x4DACF3, FootClass_CrashingVoice, 0x6)
+DEFINE_HOOK(0x4DACF3, FootClass_AI_CrashingVoice, 0x6)
 {
 	enum { Continue = 0x4DACF9, Skip = 0x4DADA9 };
 


### PR DESCRIPTION
This is a vanilla bug, when a unit begin to crashing after attacked by locomotor warhead, it will play crashing voice and crashing sound. Now it has been fixed, won't play that again.