### PR TITLE
Custom SpyEffects

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -167,6 +167,7 @@ This page lists all the individual contributions to the project by their author.
   - Building `LimboDelivery` logic
   - Fix for `Image` in art rules
   - Power delta counter
+  - SpyEffects expansion, launching Super Weapons on building infiltration
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -275,6 +275,42 @@ PowerPlantEnhancer.Amount=0        ; integer
 PowerPlantEnhancer.Factor=1.0      ; floating point value
 ```
 
+### Spy Effects
+
+- Additional espionage bonuses can be toggled with `SpyEffects.Custom`.
+  - `SpyEffects.VictimSuperWeapon` instantly launches a Super Weapon for the owner of the infiltrated building at building's coordinates.
+  - `SpyEffects.InfiltratorSuperWeapon` behaves the same as above, with the Super Weapon's owner being the owner of the spying unit.
+
+In `rulesmd.ini`:
+```ini
+[SOMEBUILDING]                     ; BuildingType
+SpyEffects.Custom=false            ; boolean
+SpyEffects.VictimSuperWeapon=      ; SuperWeaponType
+SpyEffects.InfiltratorSuperWeapon= ; SuperWeaponType
+```
+
+```{warning}
+The following Super Weapon types are supported:
+`Type=LightningStorm`                     NO
+`Type=MultiMissile`                       NO
+`Type=PsychicDominator`                   NO
+`Type=ChronoSphere`                       NO
+`Type=ChronoWarp`                         NO
+`Type=IronCurtain` and `Type=ForceShield` YES
+`Type=GeneticConverter`                   YES
+`Type=ParaDrop` and `Type=AmerParaDrop`   NO
+`Type=SpyPlane`                           NO
+`Type=PsychicReveal`                      YES
+`Type=SonarPulse` (Ares)                  YES
+`Type=GenericWarhead` (Ares)              YES
+`Type=UnitDelivery` (Ares)                YES
+`Type=Firestorm` (Ares)                   YES
+`Type=HunterSeeker` (Ares)                YES
+`Type=DropPod` (Ares)                     YES
+`Type=EMPulse` (Ares)                     YES
+`Type=Battery` (Ares)                     YES
+```
+
 ## Infantry
 
 ### Customizable FLH When Infantry Is Prone Or Deployed
@@ -875,7 +911,28 @@ TransactMoney.Display.Offset=0,0     ; X,Y, pixels relative to default
 
 ```{note}
 For animation warheads/weapons to take effect, `Damage.DealtByInvoker` must be set.
-Also, due to the nature of some superweapon types, not all superweapons are suitable for launch.
+```
+
+```{warning}
+The following Super Weapon types are supported:
+`Type=LightningStorm`                     NO
+`Type=MultiMissile`                       NO
+`Type=PsychicDominator`                   NO
+`Type=ChronoSphere`                       NO
+`Type=ChronoWarp`                         NO
+`Type=IronCurtain` and `Type=ForceShield` YES
+`Type=GeneticConverter`                   YES
+`Type=ParaDrop` and `Type=AmerParaDrop`   NO
+`Type=SpyPlane`                           NO
+`Type=PsychicReveal`                      YES
+`Type=SonarPulse` (Ares)                  YES
+`Type=GenericWarhead` (Ares)              YES
+`Type=UnitDelivery` (Ares)                YES
+`Type=Firestorm` (Ares)                   YES
+`Type=HunterSeeker` (Ares)                YES
+`Type=DropPod` (Ares)                     YES
+`Type=EMPulse` (Ares)                     YES
+`Type=Battery` (Ares)                     YES
 ```
 
 In `rulesmd.ini`:

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -289,29 +289,6 @@ SpyEffects.VictimSuperWeapon=      ; SuperWeaponType
 SpyEffects.InfiltratorSuperWeapon= ; SuperWeaponType
 ```
 
-```{warning}
-The following Super Weapon types are supported:\
-`Type=IronCurtain` and `Type=ForceShield`\
-`Type=GeneticConverter`\
-`Type=PsychicReveal`\
-`Type=SonarPulse` (Ares)\
-`Type=GenericWarhead` (Ares)\
-`Type=UnitDelivery` (Ares)\
-`Type=Firestorm` (Ares)\
-`Type=HunterSeeker` (Ares)\
-`Type=DropPod` (Ares)\
-`Type=EMPulse` (Ares)\
-`Type=Battery` (Ares)\
-The following Super Weapon types are NOT supported:\
-`Type=LightningStorm`\
-`Type=MultiMissile`\
-`Type=PsychicDominator`\
-`Type=ChronoSphere`\
-`Type=ChronoWarp`\
-`Type=ParaDrop` and `Type=AmerParaDrop`\
-`Type=SpyPlane`
-```
-
 ## Infantry
 
 ### Customizable FLH When Infantry Is Prone Or Deployed
@@ -912,29 +889,7 @@ TransactMoney.Display.Offset=0,0     ; X,Y, pixels relative to default
 
 ```{note}
 For animation warheads/weapons to take effect, `Damage.DealtByInvoker` must be set.
-```
-
-```{warning}
-The following Super Weapon types are supported:\
-`Type=IronCurtain` and `Type=ForceShield`\
-`Type=GeneticConverter`\
-`Type=PsychicReveal`\
-`Type=SonarPulse` (Ares)\
-`Type=GenericWarhead` (Ares)\
-`Type=UnitDelivery` (Ares)\
-`Type=Firestorm` (Ares)\
-`Type=HunterSeeker` (Ares)\
-`Type=DropPod` (Ares)\
-`Type=EMPulse` (Ares)\
-`Type=Battery` (Ares)\
-The following Super Weapon types are NOT supported:\
-`Type=LightningStorm`\
-`Type=MultiMissile`\
-`Type=PsychicDominator`\
-`Type=ChronoSphere`\
-`Type=ChronoWarp`\
-`Type=ParaDrop` and `Type=AmerParaDrop`\
-`Type=SpyPlane`
+Also, due to the nature of some superweapon types, not all superweapons are suitable for launch.
 ```
 
 In `rulesmd.ini`:

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -290,25 +290,26 @@ SpyEffects.InfiltratorSuperWeapon= ; SuperWeaponType
 ```
 
 ```{warning}
-The following Super Weapon types are supported:
-`Type=LightningStorm`                     NO
-`Type=MultiMissile`                       NO
-`Type=PsychicDominator`                   NO
-`Type=ChronoSphere`                       NO
-`Type=ChronoWarp`                         NO
-`Type=IronCurtain` and `Type=ForceShield` YES
-`Type=GeneticConverter`                   YES
-`Type=ParaDrop` and `Type=AmerParaDrop`   NO
-`Type=SpyPlane`                           NO
-`Type=PsychicReveal`                      YES
-`Type=SonarPulse` (Ares)                  YES
-`Type=GenericWarhead` (Ares)              YES
-`Type=UnitDelivery` (Ares)                YES
-`Type=Firestorm` (Ares)                   YES
-`Type=HunterSeeker` (Ares)                YES
-`Type=DropPod` (Ares)                     YES
-`Type=EMPulse` (Ares)                     YES
-`Type=Battery` (Ares)                     YES
+The following Super Weapon types are supported:\
+`Type=IronCurtain` and `Type=ForceShield`\
+`Type=GeneticConverter`\
+`Type=PsychicReveal`\
+`Type=SonarPulse` (Ares)\
+`Type=GenericWarhead` (Ares)\
+`Type=UnitDelivery` (Ares)\
+`Type=Firestorm` (Ares)\
+`Type=HunterSeeker` (Ares)\
+`Type=DropPod` (Ares)\
+`Type=EMPulse` (Ares)\
+`Type=Battery` (Ares)\
+The following Super Weapon types are NOT supported:\
+`Type=LightningStorm`\
+`Type=MultiMissile`\
+`Type=PsychicDominator`\
+`Type=ChronoSphere`\
+`Type=ChronoWarp`\
+`Type=ParaDrop` and `Type=AmerParaDrop`\
+`Type=SpyPlane`
 ```
 
 ## Infantry
@@ -914,25 +915,26 @@ For animation warheads/weapons to take effect, `Damage.DealtByInvoker` must be s
 ```
 
 ```{warning}
-The following Super Weapon types are supported:
-`Type=LightningStorm`                     NO
-`Type=MultiMissile`                       NO
-`Type=PsychicDominator`                   NO
-`Type=ChronoSphere`                       NO
-`Type=ChronoWarp`                         NO
-`Type=IronCurtain` and `Type=ForceShield` YES
-`Type=GeneticConverter`                   YES
-`Type=ParaDrop` and `Type=AmerParaDrop`   NO
-`Type=SpyPlane`                           NO
-`Type=PsychicReveal`                      YES
-`Type=SonarPulse` (Ares)                  YES
-`Type=GenericWarhead` (Ares)              YES
-`Type=UnitDelivery` (Ares)                YES
-`Type=Firestorm` (Ares)                   YES
-`Type=HunterSeeker` (Ares)                YES
-`Type=DropPod` (Ares)                     YES
-`Type=EMPulse` (Ares)                     YES
-`Type=Battery` (Ares)                     YES
+The following Super Weapon types are supported:\
+`Type=IronCurtain` and `Type=ForceShield`\
+`Type=GeneticConverter`\
+`Type=PsychicReveal`\
+`Type=SonarPulse` (Ares)\
+`Type=GenericWarhead` (Ares)\
+`Type=UnitDelivery` (Ares)\
+`Type=Firestorm` (Ares)\
+`Type=HunterSeeker` (Ares)\
+`Type=DropPod` (Ares)\
+`Type=EMPulse` (Ares)\
+`Type=Battery` (Ares)\
+The following Super Weapon types are NOT supported:\
+`Type=LightningStorm`\
+`Type=MultiMissile`\
+`Type=PsychicDominator`\
+`Type=ChronoSphere`\
+`Type=ChronoWarp`\
+`Type=ParaDrop` and `Type=AmerParaDrop`\
+`Type=SpyPlane`
 ```
 
 In `rulesmd.ini`:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -350,6 +350,7 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
+- Launching Super Weapons on building infiltration (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -245,6 +245,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 New:
 - `Crit.AffectsHouses` for critical hit system (by Starkku)
 - Warhead or weapon detonation at superweapon target cell (by Starkku)
+- Launching Super Weapons on building infiltration (by Morton)
 </details>
 
 
@@ -350,7 +351,6 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
-- Launching Super Weapons on building infiltration (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -301,6 +301,32 @@ void BuildingExt::ExtData::ApplyPoweredKillSpawns()
 	}
 }
 
+bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfiltratorHouse)
+{
+	BuildingTypeExt::ExtData* pTypeExt = BuildingTypeExt::ExtMap.Find(pBuilding->Type);
+
+	if (!pTypeExt->SpyEffect_Custom)
+		return false;
+
+	auto pVictimHouse = pBuilding->Owner;
+	if (pInfiltratorHouse != pVictimHouse)
+	{
+		if (pTypeExt->SpyEffect_VictimSuperWeapon)
+		{
+			const auto pSuper = pVictimHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pTypeExt->SpyEffect_VictimSuperWeapon));
+			pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pVictimHouse->IsPlayerControl());
+		}
+
+		if (pTypeExt->SpyEffect_InfiltratorSuperWeapon)
+		{
+			const auto pSuper = pInfiltratorHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pTypeExt->SpyEffect_InfiltratorSuperWeapon));
+			pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pInfiltratorHouse->IsPlayerControl());
+		}
+	}
+
+	return true;
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -314,13 +314,13 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 		if (pTypeExt->SpyEffect_VictimSuperWeapon)
 		{
 			const auto pSuper = pVictimHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pTypeExt->SpyEffect_VictimSuperWeapon));
-			pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pVictimHouse->IsPlayerControl());
+			pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pVictimHouse->IsControlledByHuman());
 		}
 
 		if (pTypeExt->SpyEffect_InfiltratorSuperWeapon)
 		{
 			const auto pSuper = pInfiltratorHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pTypeExt->SpyEffect_InfiltratorSuperWeapon));
-			pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pInfiltratorHouse->IsPlayerControl());
+			pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pInfiltratorHouse->IsControlledByHuman());
 		}
 	}
 

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -89,4 +89,5 @@ public:
 	static bool HasFreeDocks(BuildingClass* pBuilding);
 	static bool CanGrindTechno(BuildingClass* pBuilding, TechnoClass* pTechno);
 	static bool DoGrindingExtras(BuildingClass* pBuilding, TechnoClass* pTechno);
+	static bool HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfiltratorHouse);
 };

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -263,7 +263,7 @@ DEFINE_HOOK(0x443CCA, BuildingClass_KickOutUnit_AircraftType_Phobos, 0xA)
 // that will handle our logic earlier and disable the next hook by writing a very specific number to a free register.
 DEFINE_HOOK(0x45759D, BuildingClass_Infiltrate_Vanilla, 0x5)
 {
-	GET_STACK(HouseClass*, pInfiltratorHouse, STACK_OFFS(0x14, 0x4));
+	GET_STACK(HouseClass*, pInfiltratorHouse, STACK_OFFSET(0x14, -0x4));
 	GET(BuildingClass*, pBuilding, EBP);
 
 	BuildingExt::HandleInfiltrate(pBuilding, pInfiltratorHouse);

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -259,23 +259,36 @@ DEFINE_HOOK(0x443CCA, BuildingClass_KickOutUnit_AircraftType_Phobos, 0xA)
 	return 0;
 }
 
-// Note: We need another hook for when Phobos is run w/o Ares (or with Ares but with SpyEffect.Custom=no),
-// that will handle our logic earlier and disable the next hook by writing a very specific number to a free register.
-DEFINE_HOOK(0x45759D, BuildingClass_Infiltrate_Vanilla, 0x5)
+// Note:
+/*
+Ares has a hook at 0x4571E0 (the beginning of BuildingClass::Infiltrate) and completely overwrites the function.
+Our logic has to be executed at the end (0x4575A2). The hook there assumes that registers have the exact content
+they had in the beginning (when Ares hook started, executed, and jumped) in order to work when Ares logic is used.
+
+However, this will fail if Ares is not involved (either DLL not included or with SpyEffect.Custom=no on BuildingType),
+because by the time we reach our hook, the registers will be different and we'll be reading garbage. That's why
+there is a second hook at 0x45759D, which is only executed when Ares doesn't jump over this function. There,
+we execute our custom logic and then use EAX (which isn't used later, so it's safe to write to it) to "mark"
+that we're done with 0x77777777. This way, when we reach the other hook, we check for this very specific value
+to prevent spy effects from happening twice.
+
+The value itself doesn't matter, it just needs to be unique enough to not be accidentally produced by the game there.
+*/
+#define INFILTRATE_HOOK_MAGIC 0x77777777
+DEFINE_HOOK(0x45759D, BuildingClass_Infiltrate_NoAres, 0x5)
 {
 	GET_STACK(HouseClass*, pInfiltratorHouse, STACK_OFFSET(0x14, -0x4));
 	GET(BuildingClass*, pBuilding, EBP);
 
 	BuildingExt::HandleInfiltrate(pBuilding, pInfiltratorHouse);
-	R->EAX<int>(0x77777777);
+	R->EAX<int>(INFILTRATE_HOOK_MAGIC);
 	return 0;
 }
 
-// Note: Ares hooks at the start of the function and overwrites it entirely, so we have to do it here.
-DEFINE_HOOK(0x4575A2, BuildingClass_Infiltrate_Custom, 0xE)
+DEFINE_HOOK(0x4575A2, BuildingClass_Infiltrate_AfterAres, 0xE)
 {
 	// Check if we've handled it already
-	if (R->EAX<int>() == 0x77777777)
+	if (R->EAX<int>() == INFILTRATE_HOOK_MAGIC)
 	{
 		R->EAX<int>(0);
 		return 0;
@@ -287,3 +300,4 @@ DEFINE_HOOK(0x4575A2, BuildingClass_Infiltrate_Custom, 0xE)
 	BuildingExt::HandleInfiltrate(pBuilding, pInfiltratorHouse);
 	return 0;
 }
+#undef INFILTRATE_HOOK_MAGIC

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -190,6 +190,9 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		this->PlacementPreview_Palette.LoadFromINI(pINI, pSection, "PlacementPreview.Palette");
 		this->PlacementPreview_Translucency.Read(exINI, pSection, "PlacementPreview.Translucency");
 	}
+	this->SpyEffect_Custom.Read(exINI, pSection, "SpyEffect.Custom");
+	this->SpyEffect_VictimSuperWeapon.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon");
+	this->SpyEffect_InfiltratorSuperWeapon.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon");
 }
 
 void BuildingTypeExt::ExtData::CompleteInitialization()
@@ -227,6 +230,9 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PlacementPreview_Remap)
 		.Process(this->PlacementPreview_Palette)
 		.Process(this->PlacementPreview_Translucency)
+		.Process(this->SpyEffect_Custom)
+		.Process(this->SpyEffect_VictimSuperWeapon)
+		.Process(this->SpyEffect_InfiltratorSuperWeapon)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -45,6 +45,10 @@ public:
 		CustomPalette PlacementPreview_Palette;
 		Nullable<TranslucencyLevel> PlacementPreview_Translucency;
 
+		Valueable<bool> SpyEffect_Custom;
+		Nullable<SuperWeaponTypeClass*> SpyEffect_VictimSuperWeapon;
+		Nullable<SuperWeaponTypeClass*> SpyEffect_InfiltratorSuperWeapon;
+
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
 			, PowersUp_Buildings {}
@@ -70,6 +74,9 @@ public:
 			, PlacementPreview_Offset { {0,-15,1} }
 			, PlacementPreview_Palette {}
 			, PlacementPreview_Translucency {}
+			, SpyEffect_Custom { false }
+			, SpyEffect_VictimSuperWeapon {}
+			, SpyEffect_InfiltratorSuperWeapon {}
 		{ }
 
 		// Ares 0.A functions


### PR DESCRIPTION
### Spy Effects

- Additional espionage bonuses can be toggled with `SpyEffects.Custom`.
  - `SpyEffects.VictimSuperWeapon` instantly launches a Super Weapon for the owner of the infiltrated building at building's coordinates.
  - `SpyEffects.InfiltratorSuperWeapon` behaves the same as above, with the Super Weapon's owner being the owner of the spying unit.

In `rulesmd.ini`:
```ini
[SOMEBUILDING]                     ; BuildingType
SpyEffects.Custom=false            ; boolean
SpyEffects.VictimSuperWeapon=      ; SuperWeaponType
SpyEffects.InfiltratorSuperWeapon= ; SuperWeaponType
```

```{warning}
The following Super Weapon types are supported:
`Type=LightningStorm`                     NO
`Type=MultiMissile`                       NO
`Type=PsychicDominator`                   NO
`Type=ChronoSphere`                       NO
`Type=ChronoWarp`                         NO
`Type=IronCurtain` and `Type=ForceShield` YES
`Type=GeneticConverter`                   YES
`Type=ParaDrop` and `Type=AmerParaDrop`   NO
`Type=SpyPlane`                           NO
`Type=PsychicReveal`                      YES
`Type=SonarPulse` (Ares)                  YES
`Type=GenericWarhead` (Ares)              YES
`Type=UnitDelivery` (Ares)                YES
`Type=Firestorm` (Ares)                   YES
`Type=HunterSeeker` (Ares)                YES
`Type=DropPod` (Ares)                     YES
`Type=EMPulse` (Ares)                     YES
`Type=Battery` (Ares)                     YES
```