### PR TITLE
Super Weapons launching Super Weapons, SWTypeExt improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -167,6 +167,7 @@ This page lists all the individual contributions to the project by their author.
   - Building `LimboDelivery` logic
   - Fix for `Image` in art rules
   - Power delta counter
+  - Super Weapons launching other Super Weapons
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -456,7 +456,7 @@ Shrapnel.AffectsBuildings=false  ; boolean
   - `LimboKill.IDs` lists IDs that will be targeted. Buildings with these IDs will be removed from the game instantly.
 
 - Delivery can be made random with these optional tags. The game will randomly choose only a single building from the list for each roll chance provided.
-  - `LimboDelivery.RollChance` lits chances of each "dice roll" happening. Valid values range from 0% (never happens) to 100% (always happens). Defaults to a single sure roll.
+  - `LimboDelivery.RollChances` lists chances of each "dice roll" happening. Valid values range from 0% (never happens) to 100% (always happens). Defaults to a single sure roll.
   - `LimboDelivery.RandomWeightsN` lists the weights for each "dice roll" that increase the probability of picking a specific building. Valid values are 0 (don't pick) and above (the higher value, the bigger the likelyhood). `RandomWeights` are a valid alias for `RandomWeights0`. If a roll attempt doesn't have weights specified, the last weights will be used.
 
 Note: This feature might not support every building flag. Flags that are confirmed to work correctly are listed below:
@@ -481,6 +481,18 @@ LimboDelivery.RollChances=      ; List of percentages.
 LimboDelivery.RandomWeightsN=   ; List of integers.
 LimboKill.Affects=self          ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 LimboKill.IDs=                  ; List of numeric IDs.
+```
+
+### Next
+
+Super Weapons can now launch other Super Weapons at the same target. Launched types can be additionally randomized using the same rules as with LimboDelivery (see above).
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]                        ; Super Weapon
+SW.Next=                        ; List of Super Weapons
+LimboDelivery.RollChances=      ; List of percentages.
+LimboDelivery.RandomWeightsN=   ; List of integers.
 ```
 
 ### Warhead or Weapon detonation at target cell

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -485,14 +485,20 @@ LimboKill.IDs=                  ; List of numeric IDs.
 
 ### Next
 
-Super Weapons can now launch other Super Weapons at the same target. Launched types can be additionally randomized using the same rules as with LimboDelivery (see above).
+Super Weapons can now launch other superweapons at the same target. Launched types can be additionally randomized using the same rules as with LimboDelivery (see above).
+  - `SW.Next.RealLaunch` controls whether the owner who fired the initial superweapon must own all listed superweapons and sufficient funds to support `Money.Amout`. Otherwise they will be launched forcibly.
+  - `SW.Next.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of each superweapon, otherwise only non-inhibited superweapons are launched.
+  - `SW.Next.IgnoreDesignators` ignores `SW.Designators`/`SW.AnyDesignator` respectively.
 
 In `rulesmd.ini`:
 ```ini
 [SOMESW]                        ; Super Weapon
 SW.Next=                        ; List of Super Weapons
-LimboDelivery.RollChances=      ; List of percentages.
-LimboDelivery.RandomWeightsN=   ; List of integers.
+SW.Next.RealLaunch=true         ; boolean
+SW.Next.IgnoreInhibitors=false  ; boolean
+SW.Next.IgnoreDesignators=true  ; boolean
+SW.Next.RollChances=            ; List of percentages.
+SW.Next.RandomWeightsN=         ; List of integers.
 ```
 
 ### Warhead or Weapon detonation at target cell

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -447,11 +447,11 @@ Shrapnel.AffectsBuildings=false  ; boolean
 
 ### LimboDelivery
 
-- Super Weapons can now deliver off-map buildings that act as if they were on the field.
-  - `LimboDelivery.Types` is the list of BuildingTypes that will be created when the Super Weapons fire. Super Weapon Type and coordinates do not matter.
+- Superweapons can now deliver off-map buildings that act as if they were on the field.
+  - `LimboDelivery.Types` is the list of BuildingTypes that will be created when the Superweapons fire. Superweapon `Type` and coordinates do not matter.
   - `LimboDelivery.IDs` is the list of numeric IDs that will be assigned to buildings. Necessary for LimboKill to work.
 
-- Created buildings are not affected by any on-map threats. The only way to remove them from the game is by using a Super Weapon with LimboKill set.
+- Created buildings are not affected by any on-map threats. The only way to remove them from the game is by using a Superweapon with `LimboKill.IDs` set.
   - `LimboKill.Affects` sets which houses are affected by this feature.
   - `LimboKill.IDs` lists IDs that will be targeted. Buildings with these IDs will be removed from the game instantly.
 
@@ -474,7 +474,7 @@ Remember that Limbo Delivered buildings don't exist physically! This means they 
 ```
 In `rulesmd.ini`:
 ```ini
-[SOMESW]                        ; Super Weapon
+[SOMESW]                        ; Superweapon
 LimboDelivery.Types=            ; List of BuildingTypes
 LimboDelivery.IDs=              ; List of numeric IDs. -1 cannot be used.
 LimboDelivery.RollChances=      ; List of percentages.
@@ -485,7 +485,7 @@ LimboKill.IDs=                  ; List of numeric IDs.
 
 ### Next
 
-Super Weapons can now launch other superweapons at the same target. Launched types can be additionally randomized using the same rules as with LimboDelivery (see above).
+Superweapons can now launch other superweapons at the same target. Launched types can be additionally randomized using the same rules as with LimboDelivery (see above).
   - `SW.Next.RealLaunch` controls whether the owner who fired the initial superweapon must own all listed superweapons and sufficient funds to support `Money.Amout`. Otherwise they will be launched forcibly.
   - `SW.Next.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of each superweapon, otherwise only non-inhibited superweapons are launched.
   - `SW.Next.IgnoreDesignators` ignores `SW.Designators`/`SW.AnyDesignator` respectively.
@@ -493,7 +493,7 @@ Super Weapons can now launch other superweapons at the same target. Launched typ
 In `rulesmd.ini`:
 ```ini
 [SOMESW]                        ; Super Weapon
-SW.Next=                        ; List of Super Weapons
+SW.Next=                        ; List of Superweapons
 SW.Next.RealLaunch=true         ; boolean
 SW.Next.IgnoreInhibitors=false  ; boolean
 SW.Next.IgnoreDesignators=true  ; boolean

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -245,6 +245,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 New:
 - `Crit.AffectsHouses` for critical hit system (by Starkku)
 - Warhead or weapon detonation at superweapon target cell (by Starkku)
+- Super Weapons launching other Super Weapons (by Morton)
 </details>
 
 
@@ -350,7 +351,6 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
-- Super Weapons launching other Super Weapons (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -350,6 +350,7 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
+- Super Weapons launching other Super Weapons (by Morton)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -101,13 +101,9 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	if (weights.size())
 	{
 		if (this->LimboDelivery_RandomWeightsData.size())
-		{
 			this->LimboDelivery_RandomWeightsData[0] = weights;
-		}
 		else
-		{
 			this->LimboDelivery_RandomWeightsData.push_back(weights);
-		}
 	}
 
 	// SW.Next.RandomWeights
@@ -127,13 +123,9 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	if (weights2.size())
 	{
 		if (this->SW_Next_RandomWeightsData.size())
-		{
 			this->SW_Next_RandomWeightsData[0] = weights2;
-		}
 		else
-		{
 			this->SW_Next_RandomWeightsData.push_back(weights2);
-		}
 	}
 	this->Detonate_Warhead.Read(exINI, pSection, "Detonate.Warhead");
 	this->Detonate_Weapon.Read(exINI, pSection, "Detonate.Weapon", true);

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -36,6 +36,10 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Detonate_Warhead)
 		.Process(this->Detonate_Weapon)
 		.Process(this->Detonate_Damage)
+		.Process(this->SW_Next)
+		.Process(this->SW_Next_IgnoreInhibitors)
+		.Process(this->SW_Next_RandomWeightsData)
+		.Process(this->SW_Next_RollChances)
 		;
 }
 
@@ -69,8 +73,14 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->LimboDelivery_Types.Read(exINI, pSection, "LimboDelivery.Types");
 	this->LimboDelivery_IDs.Read(exINI, pSection, "LimboDelivery.IDs");
 	this->LimboDelivery_RollChances.Read(exINI, pSection, "LimboDelivery.RollChances");
+	this->LimboKill_Affected.Read(exINI, pSection, "LimboKill.Affected");
+	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");
+	this->SW_Next.Read(exINI, pSection, "SW.Next");
+	this->SW_Next_IgnoreInhibitors.Read(exINI, pSection, "SW.Next.IgnoreInhibitors");
+	this->SW_Next_RollChances.Read(exINI, pSection, "SW.Next.RollChances");
 
 	char tempBuffer[32];
+	// LimboDelivery.RandomWeights
 	for (size_t i = 0; ; ++i)
 	{
 		ValueableVector<int> weights;
@@ -85,11 +95,42 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	ValueableVector<int> weights;
 	weights.Read(exINI, pSection, "LimboDelivery.RandomWeights");
 	if (weights.size())
-		this->LimboDelivery_RandomWeightsData[0] = weights;
+	{
+		if (this->LimboDelivery_RandomWeightsData.size())
+		{
+			this->LimboDelivery_RandomWeightsData[0] = weights;
+		}
+		else
+		{
+			this->LimboDelivery_RandomWeightsData.push_back(weights);
+		}
+	}
 
-	this->LimboKill_Affected.Read(exINI, pSection, "LimboKill.Affected");
-	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");
+	// SW.Next.RandomWeights
+	for (size_t i = 0; ; ++i)
+	{
+		ValueableVector<int> weights2;
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "SW.Next.RandomWeights%d", i);
+		weights2.Read(exINI, pSection, tempBuffer);
 
+		if (!weights2.size())
+			break;
+
+		this->SW_Next_RandomWeightsData.push_back(weights2);
+	}
+	ValueableVector<int> weights2;
+	weights2.Read(exINI, pSection, "SW.Next.RandomWeights");
+	if (weights2.size())
+	{
+		if (this->SW_Next_RandomWeightsData.size())
+		{
+			this->SW_Next_RandomWeightsData[0] = weights2;
+		}
+		else
+		{
+			this->SW_Next_RandomWeightsData.push_back(weights2);
+		}
+	}
 	this->Detonate_Warhead.Read(exINI, pSection, "Detonate.Warhead");
 	this->Detonate_Weapon.Read(exINI, pSection, "Detonate.Weapon", true);
 	this->Detonate_Damage.Read(exINI, pSection, "Detonate.Damage");

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -37,7 +37,9 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Detonate_Weapon)
 		.Process(this->Detonate_Damage)
 		.Process(this->SW_Next)
+		.Process(this->SW_Next_RealLaunch)
 		.Process(this->SW_Next_IgnoreInhibitors)
+		.Process(this->SW_Next_IgnoreDesignators)
 		.Process(this->SW_Next_RandomWeightsData)
 		.Process(this->SW_Next_RollChances)
 		;
@@ -76,7 +78,9 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->LimboKill_Affected.Read(exINI, pSection, "LimboKill.Affected");
 	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");
 	this->SW_Next.Read(exINI, pSection, "SW.Next");
+	this->SW_Next_RealLaunch.Read(exINI, pSection, "SW.Next.RealLaunch");
 	this->SW_Next_IgnoreInhibitors.Read(exINI, pSection, "SW.Next.IgnoreInhibitors");
+	this->SW_Next_IgnoreDesignators.Read(exINI, pSection, "SW.Next.IgnoreDesignators");
 	this->SW_Next_RollChances.Read(exINI, pSection, "SW.Next.RollChances");
 
 	char tempBuffer[32];

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -37,12 +37,16 @@ public:
 		Valueable<AffectedHouse> LimboKill_Affected;
 		ValueableVector<int> LimboKill_IDs;
 		Valueable<double> RandomBuffer;
+		ValueableVector<SuperWeaponTypeClass*> SW_Next;
+		Valueable<bool> SW_Next_IgnoreInhibitors;
+		ValueableVector<float> SW_Next_RollChances;
 
 		Nullable<WarheadTypeClass*> Detonate_Warhead;
 		Nullable<WeaponTypeClass*> Detonate_Weapon;
 		Nullable<int> Detonate_Damage;
 
 		ValueableVector<ValueableVector<int>> LimboDelivery_RandomWeightsData;
+		ValueableVector<ValueableVector<int>> SW_Next_RandomWeightsData;
 
 		ExtData(SuperWeaponTypeClass* OwnerObject) : Extension<SuperWeaponTypeClass>(OwnerObject)
 			, Money_Amount { 0 }
@@ -68,6 +72,10 @@ public:
 			, Detonate_Warhead {}
 			, Detonate_Weapon {}
 			, Detonate_Damage {}
+			, SW_Next {}
+			, SW_Next_IgnoreInhibitors{ false }
+			, SW_Next_RollChances {}
+			, SW_Next_RandomWeightsData {}
 		{ }
 
 		// Ares 0.A functions
@@ -85,6 +93,7 @@ public:
 		void ApplyLimboDelivery(HouseClass* pHouse);
 		void ApplyLimboKill(HouseClass* pHouse);
 		void ApplyDetonation(HouseClass* pHouse, const CellStruct& cell);
+		void ApplySWNext(SuperClass* pSW, const CellStruct& cell);
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		virtual ~ExtData() = default;
@@ -94,6 +103,8 @@ public:
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+	private:
+		std::vector<int> WeightedRollsHandler(ValueableVector<float>* chances, ValueableVector<ValueableVector<int>>* weights, size_t size);
 
 		template <typename T>
 		void Serialize(T& Stm);

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -38,7 +38,9 @@ public:
 		ValueableVector<int> LimboKill_IDs;
 		Valueable<double> RandomBuffer;
 		ValueableVector<SuperWeaponTypeClass*> SW_Next;
+		Valueable<bool> SW_Next_RealLaunch;
 		Valueable<bool> SW_Next_IgnoreInhibitors;
+		Valueable<bool> SW_Next_IgnoreDesignators;
 		ValueableVector<float> SW_Next_RollChances;
 
 		Nullable<WarheadTypeClass*> Detonate_Warhead;
@@ -73,7 +75,9 @@ public:
 			, Detonate_Weapon {}
 			, Detonate_Damage {}
 			, SW_Next {}
-			, SW_Next_IgnoreInhibitors{ false }
+			, SW_Next_RealLaunch { true }
+			, SW_Next_IgnoreInhibitors { false }
+			, SW_Next_IgnoreDesignators { true }
 			, SW_Next_RollChances {}
 			, SW_Next_RandomWeightsData {}
 		{ }

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -164,15 +164,24 @@ std::vector<int> SWTypeExt::ExtData::WeightedRollsHandler(ValueableVector<float>
 // SW.Next proper launching mechanic
 void Launch(HouseClass* pHouse, SuperWeaponTypeClass* pLaunchedType, const CellStruct& cell)
 {
-	const auto pLaunched = pHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pLaunchedType));
-	if (!pLaunched)
-		return;
-	const auto pLaunchedTypeExt = SWTypeExt::ExtMap.Find(pLaunchedType);
+	const auto pSuper = pHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pLaunchedType));
 
-	if (pLaunchedTypeExt->SW_Next_IgnoreInhibitors || !pLaunchedTypeExt->HasInhibitor(pHouse, cell))
+	if (!pSuper)
+		return;
+
+	const auto pSuperTypeExt = SWTypeExt::ExtMap.Find(pLaunchedType);
+	if (!pSuperTypeExt->SW_Next_RealLaunch || (pSuperTypeExt && pSuper->IsCharged && pHouse->CanTransactMoney(pSuperTypeExt->Money_Amount)))
 	{
-		// Forcibly fire
-		pLaunched->Launch(cell, true);
+
+		if (pSuperTypeExt->SW_Next_IgnoreInhibitors || !pSuperTypeExt->HasInhibitor(pHouse, cell)
+		&& (pSuperTypeExt->SW_Next_IgnoreDesignators || pSuperTypeExt->HasDesignator(pHouse, cell)))
+		{
+			// Forcibly fire
+			pSuper->Launch(cell, true);
+			if (pSuperTypeExt->SW_Next_RealLaunch)
+				pSuper->Reset();
+		}
+
 	}
 }
 

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -197,8 +197,7 @@ void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 		{
 			if (result < idsSize)
 				id = this->LimboDelivery_IDs[result];
-			if (auto const deliverBldType = this->LimboDelivery_Types[result])
-				LimboCreate(deliverBldType, pHouse, id);
+			LimboCreate(this->LimboDelivery_Types[result], pHouse, id);
 		}
 	}
 	// no randomness mode

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -162,7 +162,7 @@ std::vector<int> SWTypeExt::ExtData::WeightedRollsHandler(ValueableVector<float>
 }
 
 // SW.Next proper launching mechanic
-void Launch(HouseClass* pHouse, SuperWeaponTypeClass* pLaunchedType, const CellStruct& cell)
+void Launch(HouseClass* pHouse, SWTypeExt::ExtData* pLauncherTypeExt, SuperWeaponTypeClass* pLaunchedType, const CellStruct& cell)
 {
 	const auto pSuper = pHouse->Supers.GetItem(SuperWeaponTypeClass::Array->FindItemIndex(pLaunchedType));
 
@@ -170,15 +170,15 @@ void Launch(HouseClass* pHouse, SuperWeaponTypeClass* pLaunchedType, const CellS
 		return;
 
 	const auto pSuperTypeExt = SWTypeExt::ExtMap.Find(pLaunchedType);
-	if (!pSuperTypeExt->SW_Next_RealLaunch || (pSuperTypeExt && pSuper->IsCharged && pHouse->CanTransactMoney(pSuperTypeExt->Money_Amount)))
+	if (!pLauncherTypeExt->SW_Next_RealLaunch || (pSuperTypeExt && pSuper->IsCharged && pHouse->CanTransactMoney(pSuperTypeExt->Money_Amount)))
 	{
 
-		if (pSuperTypeExt->SW_Next_IgnoreInhibitors || !pSuperTypeExt->HasInhibitor(pHouse, cell)
-		&& (pSuperTypeExt->SW_Next_IgnoreDesignators || pSuperTypeExt->HasDesignator(pHouse, cell)))
+		if (pLauncherTypeExt->SW_Next_IgnoreInhibitors || !pSuperTypeExt->HasInhibitor(pHouse, cell)
+		&& (pLauncherTypeExt->SW_Next_IgnoreDesignators || pSuperTypeExt->HasDesignator(pHouse, cell)))
 		{
 			// Forcibly fire
 			pSuper->Launch(cell, true);
-			if (pSuperTypeExt->SW_Next_RealLaunch)
+			if (pLauncherTypeExt->SW_Next_RealLaunch)
 				pSuper->Reset();
 		}
 
@@ -264,13 +264,13 @@ void SWTypeExt::ExtData::ApplySWNext(SuperClass* pSW, const CellStruct& cell)
 	{
 		auto results = this->WeightedRollsHandler(&this->SW_Next_RollChances, &this->SW_Next_RandomWeightsData, this->SW_Next.size());
 		for each (int result in results)
-			Launch(pSW->Owner, this->SW_Next[result], cell);
+			Launch(pSW->Owner, this, this->SW_Next[result], cell);
 	}
 	// no randomness mode
 	else
 	{
 		for each (const auto pSWType in this->SW_Next)
-			Launch(pSW->Owner, pSWType, cell);
+			Launch(pSW->Owner, this, pSWType, cell);
 	}
 }
 

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -174,7 +174,7 @@ void Launch(HouseClass* pHouse, SWTypeExt::ExtData* pLauncherTypeExt, SuperWeapo
 	{
 
 		if (pLauncherTypeExt->SW_Next_IgnoreInhibitors || !pSuperTypeExt->HasInhibitor(pHouse, cell)
-		&& (pLauncherTypeExt->SW_Next_IgnoreDesignators || pSuperTypeExt->HasDesignator(pHouse, cell)))
+			&& (pLauncherTypeExt->SW_Next_IgnoreDesignators || pSuperTypeExt->HasDesignator(pHouse, cell)))
 		{
 			// Forcibly fire
 			pSuper->Launch(cell, true);
@@ -193,10 +193,11 @@ void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 		int id = -1;
 		size_t idsSize = this->LimboDelivery_IDs.size();
 		auto results = this->WeightedRollsHandler(&this->LimboDelivery_RollChances, &this->LimboDelivery_RandomWeightsData, this->LimboDelivery_Types.size());
-		for each (size_t result in results)
+		for (size_t result : results)
 		{
 			if (result < idsSize)
 				id = this->LimboDelivery_IDs[result];
+
 			LimboCreate(this->LimboDelivery_Types[result], pHouse, id);
 		}
 	}
@@ -262,13 +263,13 @@ void SWTypeExt::ExtData::ApplySWNext(SuperClass* pSW, const CellStruct& cell)
 	if (this->SW_Next_RandomWeightsData.size())
 	{
 		auto results = this->WeightedRollsHandler(&this->SW_Next_RollChances, &this->SW_Next_RandomWeightsData, this->SW_Next.size());
-		for each (int result in results)
+		for (int result : results)
 			Launch(pSW->Owner, this, this->SW_Next[result], cell);
 	}
 	// no randomness mode
 	else
 	{
-		for each (const auto pSWType in this->SW_Next)
+		for (const auto pSWType : this->SW_Next)
 			Launch(pSW->Owner, this, pSWType, cell);
 	}
 }

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -2,8 +2,10 @@
 
 #include <SuperClass.h>
 
-//Ares hooked from 0x6CC390 and jumped to this offset
-DEFINE_HOOK(0x6CDE40, SuperClass_Place_FireExt, 0x3)
+//Ares hooked at 0x6CC390 and jumped to 0x6CDE40
+// If a super is not handled by Ares however, we do it at the original entry point
+DEFINE_HOOK_AGAIN(0x6CC390, SuperClass_Place_FireExt, 0x6)
+DEFINE_HOOK(0x6CDE40, SuperClass_Place_FireExt, 0x4)
 {
 	GET(SuperClass* const, pSuper, ECX);
 	GET_STACK(CellStruct const* const, pCell, 0x4);

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -80,14 +80,14 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 			{
 				const auto pSWExt = SWTypeExt::ExtMap.Find(pSuper->Type);
 				const auto cell = CellClass::Coord2Cell(coords);
-				if ((pSWExt && pSuper->IsCharged && pHouse->CanTransactMoney(pSWExt->Money_Amount)) || !this->LaunchSW_RealLaunch)
+				if (!this->LaunchSW_RealLaunch || (pSWExt && pSuper->IsCharged && pHouse->CanTransactMoney(pSWExt->Money_Amount)))
 				{
 					if (this->LaunchSW_IgnoreInhibitors || !pSWExt->HasInhibitor(pHouse, cell)
 					&& (this->LaunchSW_IgnoreDesignators || pSWExt->HasDesignator(pHouse, cell)))
 					{
-						pSuper->SetReadiness(true);
 						pSuper->Launch(cell, true);
-						pSuper->Reset();
+						if (this->LaunchSW_RealLaunch)
+							pSuper->Reset();
 					}
 				}
 			}


### PR DESCRIPTION
### Next

Superweapons can now launch other superweapons at the same target. Launched types can be additionally randomized using the same rules as with LimboDelivery (see above).
  - `SW.Next.RealLaunch` controls whether the owner who fired the initial superweapon must own all listed superweapons and sufficient funds to support `Money.Amout`. Otherwise they will be launched forcibly.
  - `SW.Next.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of each superweapon, otherwise only non-inhibited superweapons are launched.
  - `SW.Next.IgnoreDesignators` ignores `SW.Designators`/`SW.AnyDesignator` respectively.

In `rulesmd.ini`:
```ini
[SOMESW]                        ; Super Weapon
SW.Next=                        ; List of Super Weapons
SW.Next.RealLaunch=true         ; boolean
SW.Next.IgnoreInhibitors=false  ; boolean
SW.Next.IgnoreDesignators=true  ; boolean
SW.Next.RollChances=            ; List of percentages.
SW.Next.RandomWeightsN=         ; List of integers.
```

Additionally, all Phobos SW features should now support every SW `Type`.