### PR TITLE
Fix organic units wrongly show unit self heal pip

### DIFF
--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -741,7 +741,7 @@ void TechnoExt::DrawSelfHealPips(TechnoClass* pThis, Point2D* pLocation, Rectang
 			selfHealFrames = RulesClass::Instance->SelfHealInfantryFrames;
 			isInfantryHeal = true;
 		}
-		else if (pThis->Owner->UnitsSelfHeal > 0 && (hasUnitSelfHeal || pThis->WhatAmI() == AbstractType::Unit))
+		else if (pThis->Owner->UnitsSelfHeal > 0 && (hasUnitSelfHeal || (pThis->WhatAmI() == AbstractType::Unit && !isOrganic)))
 		{
 			drawPip = true;
 			selfHealFrames = RulesClass::Instance->SelfHealUnitFrames;


### PR DESCRIPTION
It is just a display bug.
before:
![Snipaste_2022-09-24_17-28-52](https://user-images.githubusercontent.com/55939089/192091260-9816bdda-1dfc-4656-8ca2-bab1f4581132.jpg)

after:
![Snipaste_2022-09-24_17-36-30](https://user-images.githubusercontent.com/55939089/192091255-f3170645-04a6-4997-9061-1ac42e9d23e5.jpg)
![Snipaste_2022-09-24_17-41-32](https://user-images.githubusercontent.com/55939089/192091327-d1c02822-906a-4177-b8b5-34d77377f65e.jpg)

