### PR TITLE
RadialIndicator visible to observer/allies & Different PowerDelta label when power sabotaged

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -189,9 +189,11 @@ This page lists all the individual contributions to the project by their author.
    - Slaves' house customization when owner is killed
    - Campaign AI's base node/SW-delivered/trigger action 125-delivered structures' auto-repairability dehardcode
    - Misc CN doc fix, code refactor
+   - Power delta counter : blackout indication mark
    - Harvester counter
    - Warhead superweapon launch logic
    - "Shield is broken" trigger event
+   - RadialIndicator observer visibility
    - Forbidding parallel AI queues by type
 - **NetsuNegi** - Forbidding parallel AI queues by type
 - **Apollo** - Translucent SHP drawing patches

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -544,3 +544,14 @@ Bolt.Disable1=false    ; boolean
 Bolt.Disable2=false    ; boolean
 Bolt.Disable3=false    ; boolean
 ```
+
+### RadialIndicator visibility
+
+In vanilla game, a structure's radial indicator can be drawn only when it belongs to the player. Now it can also be visible to observer.
+On top of that, you can specify its visibility from other houses.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+RadialIndicatorVisibility=allies  ; list of Affected House Enumeration (owner/self | allies/ally | enemies/enemy | all)
+```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -202,7 +202,8 @@ If you use the vanilla font in your mod, you can use the improved font (v4 and h
 *Power delta Counter in [Assault Amerika](https://www.moddb.com/mods/assault-amerika)*
 
 - An additional counter for your power delta (surplus) can be added near the credits indicator.
-- The counter is displayed with the format of `Label(sign)(Power Delta)`. The label is PowerLabel used in tooltips (by default `⚡ U+26A1`).
+- The counter is displayed with the format of `Label(sign)(Power Delta)`. The label is `PowerLabel` used in `ToolTips` (by default `⚡ U+26A1`).
+- When the power of the player is blacked-out by a spy or force-shield, `PowerBlackoutLabel` in `ToolTips` is displayed instead (by default ⚡❌ `U+26A1 U+274C`), the text color is `Sidebar.PowerDelta.ColorGrey`.
 - You can adjust counter position by `Sidebar.PowerDelta.Offset`, negative means left/up, positive means right/down.
 - You can adjust counter text alignment by `Sidebar.PowerDelta.Align`, acceptable values are left, right, center/centre.
 - By setting `PowerDelta.ConditionYellow` and `PowerDelta.ConditionRed`, the game will warn player by changing the color of counter whenever the percentage of used power exceeds the value (i.e. when drain to output ratio is above 100%, the counter will turn red).
@@ -223,7 +224,8 @@ Sidebar.PowerDelta.Offset=0,0             ; X,Y, pixels relative to default
 Sidebar.PowerDelta.ColorGreen=0,255,0     ; integer - R,G,B
 Sidebar.PowerDelta.ColorYellow=255,255,0  ; integer - R,G,B
 Sidebar.PowerDelta.ColorRed=255,0,0       ; integer - R,G,B
-Sidebar.PowerDelta.Align=left             ; Alignment enumeration - left|center|centre|right
+Sidebar.PowerDelta.ColorGrey=128,128,128  ; integer - R,G,B
+Sidebar.PowerDelta.Align=left             ; Alignment enumeration - left | center/centre | right
 ```
 
 ```{note}
@@ -275,11 +277,12 @@ Sidebar.GDIPositions=  ; boolean
 In `uimd.ini`:
 ```ini
 [ToolTips]
-ExtendedToolTips=false  ; boolean
-CostLabel=<none>        ; CSF entry key
-PowerLabel=<none>       ; CSF entry key
-TimeLabel=<none>        ; CSF entry key
-MaxWidth=0              ; integer, pixels
+ExtendedToolTips=false     ; boolean
+CostLabel=<none>           ; CSF entry key
+PowerLabel=<none>          ; CSF entry key
+PowerBlackoutLabel=<none>  ; CSF entry key
+TimeLabel=<none>           ; CSF entry key
+MaxWidth=0                 ; integer, pixels
 ```
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -391,6 +391,7 @@ Vanilla fixes:
 - Fixed transports recursively put into each other not having a correct killer set after second transport when being killed by something (by Kerbiter)
 - Fixed projectiles with `Inviso=true` suffering from potential inaccuracy problems if combined with `Airburst=yes` or Warhead with `EMEffect=true` (by Starkku)
 - Fixed the bug when `MakeInfantry` logic on BombClass resulted in `Neutral` side infantry (by Otamaa)
+- Observers can also see a building's radial indicator when selecting it (by Trsdy)
 
 Phobos fixes:
 - Fixed shields being able to take damage when the parent TechnoType was under effects of a `Temporal` Warhead (by Starkku)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -77,6 +77,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->RadHasInvoker.Read(exINI, GameStrings::Radiation, "RadHasInvoker");
 	this->MissingCameo.Read(pINI, GameStrings::AudioVisual, "MissingCameo");
 	this->JumpjetTurnToTarget.Read(exINI, "JumpjetControls", "TurnToTarget");
+
 	this->PlacementPreview.Read(exINI, GameStrings::AudioVisual, "PlacementPreview");
 	this->PlacementPreview_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Translucency");
 	this->PlacementGrid_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.Translucency");
@@ -93,6 +94,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->ToolTip_Background_Color.Read(exINI, GameStrings::AudioVisual, "ToolTip.Background.Color");
 	this->ToolTip_Background_Opacity.Read(exINI, GameStrings::AudioVisual, "ToolTip.Background.Opacity");
 	this->ToolTip_Background_BlurSize.Read(exINI, GameStrings::AudioVisual, "ToolTip.Background.BlurSize");
+	this->RadialIndicatorVisibility.Read(exINI, GameStrings::AudioVisual, "RadialIndicatorVisibility");
 
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
 	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
@@ -225,6 +227,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ToolTip_Background_Color)
 		.Process(this->ToolTip_Background_Opacity)
 		.Process(this->ToolTip_Background_BlurSize)
+		.Process(this->RadialIndicatorVisibility)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -6,7 +6,7 @@
 #include <Utilities/Container.h>
 #include <Utilities/Constructs.h>
 #include <Utilities/Template.h>
-
+#include <Utilities/TemplateDef.h>
 #include <Utilities/Debug.h>
 
 
@@ -66,6 +66,8 @@ public:
 		Valueable<int> ToolTip_Background_Opacity;
 		Valueable<float> ToolTip_Background_BlurSize;
 
+		Valueable<AffectedHouse> RadialIndicatorVisibility;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -101,6 +103,7 @@ public:
 			, ToolTip_Background_Color { { 0, 0, 0 } }
 			, ToolTip_Background_Opacity { 100 }
 			, ToolTip_Background_BlurSize { 0.0f }
+			, RadialIndicatorVisibility { AffectedHouse::Allies }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -34,6 +34,7 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Sidebar_PowerDelta_Green.Read(exINI, pSection, "Sidebar.PowerDelta.ColorGreen");
 	this->Sidebar_PowerDelta_Yellow.Read(exINI, pSection, "Sidebar.PowerDelta.ColorYellow");
 	this->Sidebar_PowerDelta_Red.Read(exINI, pSection, "Sidebar.PowerDelta.ColorRed");
+	this->Sidebar_PowerDelta_Grey.Read(exINI, pSection, "Sidebar.PowerDelta.ColorGrey");
 	this->Sidebar_PowerDelta_Align.Read(exINI, pSection, "Sidebar.PowerDelta.Align");
 	this->ToolTip_Background_Color.Read(exINI, pSection, "ToolTip.Background.Color");
 	this->ToolTip_Background_Opacity.Read(exINI, pSection, "ToolTip.Background.Opacity");
@@ -57,6 +58,7 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->Sidebar_PowerDelta_Green)
 		.Process(this->Sidebar_PowerDelta_Yellow)
 		.Process(this->Sidebar_PowerDelta_Red)
+		.Process(this->Sidebar_PowerDelta_Grey)
 		.Process(this->Sidebar_PowerDelta_Align)
 		.Process(this->ToolTip_Background_Color)
 		.Process(this->ToolTip_Background_Opacity)

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -25,6 +25,7 @@ public:
 		Valueable<ColorStruct> Sidebar_PowerDelta_Green;
 		Valueable<ColorStruct> Sidebar_PowerDelta_Yellow;
 		Valueable<ColorStruct> Sidebar_PowerDelta_Red;
+		Valueable<ColorStruct> Sidebar_PowerDelta_Grey;
 		Valueable<TextAlign> Sidebar_PowerDelta_Align;
 		Nullable<ColorStruct> ToolTip_Background_Color;
 		Nullable<int> ToolTip_Background_Opacity;
@@ -43,6 +44,7 @@ public:
 			, Sidebar_PowerDelta_Green { { 0, 255, 0 } }
 			, Sidebar_PowerDelta_Yellow { { 255, 255, 0 } }
 			, Sidebar_PowerDelta_Red { { 255, 0, 0 } }
+			, Sidebar_PowerDelta_Grey { { 0x80,0x80,0x80 } }
 			, Sidebar_PowerDelta_Align { TextAlign::Left }
 			, ToolTip_Background_Color { }
 			, ToolTip_Background_Opacity { }

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -77,7 +77,7 @@ DEFINE_HOOK(0x641EE0, PreviewClass_ReadPreview, 0x6)
 DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 {
 	auto const pPlayer = HouseClass::CurrentPlayer();
-	if (!pPlayer || pPlayer->Defeated)
+	if (pPlayer->Defeated)
 		return 0;
 
 	if (Phobos::UI::ShowHarvesterCounter)
@@ -110,20 +110,28 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 	{
 		auto pSideExt = SideExt::ExtMap.Find(SideClass::Array->GetItem(pPlayer->SideIndex));
 		wchar_t counter[0x20];
-		auto delta = pPlayer->PowerOutput - pPlayer->PowerDrain;
 
-		double percent = pPlayer->PowerOutput != 0
-			? (double)pPlayer->PowerDrain / (double)pPlayer->PowerOutput : pPlayer->PowerDrain != 0
-			? Phobos::UI::PowerDelta_ConditionRed*2.f : Phobos::UI::PowerDelta_ConditionYellow;
+		ColorStruct clrToolTip;
 
-		ColorStruct clrToolTip = percent < Phobos::UI::PowerDelta_ConditionYellow
-			? pSideExt->Sidebar_PowerDelta_Green : LESS_EQUAL(percent, Phobos::UI::PowerDelta_ConditionRed)
-			? pSideExt->Sidebar_PowerDelta_Yellow : pSideExt->Sidebar_PowerDelta_Red;
+		if (pPlayer->PowerBlackoutTimer.InProgress())
+		{
+			clrToolTip = pSideExt->Sidebar_PowerDelta_Grey;
+			swprintf_s(counter, L"%ls", Phobos::UI::PowerBlackoutLabel);
+		}
+		else
+		{
+			int delta = pPlayer->PowerOutput - pPlayer->PowerDrain;
 
-		auto TextFlags = static_cast<TextPrintType>(static_cast<int>(TextPrintType::UseGradPal | TextPrintType::Metal12)
-				| static_cast<int>(pSideExt->Sidebar_PowerDelta_Align.Get()));
+			double percent = pPlayer->PowerOutput != 0
+				? (double)pPlayer->PowerDrain / (double)pPlayer->PowerOutput : pPlayer->PowerDrain != 0
+				? Phobos::UI::PowerDelta_ConditionRed * 2.f : Phobos::UI::PowerDelta_ConditionYellow;
 
-		swprintf_s(counter, L"%ls%+d", Phobos::UI::PowerLabel, delta);
+			clrToolTip = percent < Phobos::UI::PowerDelta_ConditionYellow
+				? pSideExt->Sidebar_PowerDelta_Green : LESS_EQUAL(percent, Phobos::UI::PowerDelta_ConditionRed)
+				? pSideExt->Sidebar_PowerDelta_Yellow : pSideExt->Sidebar_PowerDelta_Red;
+
+			swprintf_s(counter, L"%ls%+d", Phobos::UI::PowerLabel, delta);
+		}
 
 		Point2D vPos = {
 			DSurface::Sidebar->GetWidth() / 2 - 70 + pSideExt->Sidebar_PowerDelta_Offset.Get().X,
@@ -132,6 +140,9 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 
 		RectangleStruct vRect = { 0, 0, 0, 0 };
 		DSurface::Sidebar->GetRect(&vRect);
+
+		auto const TextFlags = static_cast<TextPrintType>(static_cast<int>(TextPrintType::UseGradPal | TextPrintType::Metal12)
+				| static_cast<int>(pSideExt->Sidebar_PowerDelta_Align.Get()));
 
 		DSurface::Sidebar->DrawText(counter, &vRect, &vPos, Drawing::RGB_To_Int(clrToolTip), 0, TextFlags);
 	}
@@ -197,4 +208,19 @@ DEFINE_HOOK(0x6D4684, TacticalClass_Draw_FlyingStrings, 0x6)
 {
 	FlyingStrings::UpdateAll();
 	return 0;
+}
+
+DEFINE_HOOK(0x456776, BuildingClass_DrawRadialIndicator_Visibility, 0x6)
+{
+	enum { ContinueDraw = 0x456789, DoNotDraw = 0x456962 };
+	GET(BuildingClass* const, pThis, ESI);
+
+	if (HouseClass::IsCurrentPlayerObserver() || pThis->Owner->IsControlledByCurrentPlayer())
+		return ContinueDraw;
+
+	AffectedHouse const canSee = RulesExt::Global()->RadialIndicatorVisibility.Get();
+	if (pThis->Owner->IsAlliedWith(HouseClass::CurrentPlayer) ? canSee & AffectedHouse::Allies : canSee & AffectedHouse::Enemies)
+		return ContinueDraw;
+
+	return DoNotDraw;
 }

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -45,6 +45,7 @@ double Phobos::UI::HarvesterCounter_ConditionRed = 0.5;
 bool Phobos::UI::ShowProducingProgress = false;
 const wchar_t* Phobos::UI::CostLabel = L"";
 const wchar_t* Phobos::UI::PowerLabel = L"";
+const wchar_t* Phobos::UI::PowerBlackoutLabel = L"";
 const wchar_t* Phobos::UI::TimeLabel = L"";
 const wchar_t* Phobos::UI::HarvesterLabel = L"";
 bool Phobos::UI::ShowPowerDelta = false;
@@ -226,6 +227,9 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 
 		pINI_UIMD->ReadString(TOOLTIPS_SECTION, "PowerLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::PowerLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u26a1"); // ⚡
+
+		pINI_UIMD->ReadString(TOOLTIPS_SECTION, "PowerBlackoutLabel", NONE_STR, Phobos::readBuffer);
+		Phobos::UI::PowerBlackoutLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u26a1\u274c"); // ⚡❌
 
 		pINI_UIMD->ReadString(TOOLTIPS_SECTION, "TimeLabel", NONE_STR, Phobos::readBuffer);
 		Phobos::UI::TimeLabel = GeneralUtils::LoadStringOrDefault(Phobos::readBuffer, L"\u231a"); // ⌚

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -58,6 +58,7 @@ public:
 
 		static const wchar_t* CostLabel;
 		static const wchar_t* PowerLabel;
+		static const wchar_t* PowerBlackoutLabel;
 		static const wchar_t* TimeLabel;
 		static const wchar_t* HarvesterLabel;
 	};

--- a/src/Utilities/EnumFunctions.cpp
+++ b/src/Utilities/EnumFunctions.cpp
@@ -2,9 +2,11 @@
 
 bool EnumFunctions::CanTargetHouse(AffectedHouse flags, HouseClass* ownerHouse, HouseClass* targetHouse)
 {
-	return (flags & AffectedHouse::Owner) && ownerHouse == targetHouse ||
-		(flags & AffectedHouse::Allies) && ownerHouse != targetHouse && ownerHouse->IsAlliedWith(targetHouse) ||
-		(flags & AffectedHouse::Enemies) && ownerHouse != targetHouse && !ownerHouse->IsAlliedWith(targetHouse);
+	if (ownerHouse == targetHouse)
+		return (flags & AffectedHouse::Owner) != AffectedHouse::None;
+	if (ownerHouse->IsAlliedWith(targetHouse))
+		return (flags & AffectedHouse::Allies) != AffectedHouse::None;
+	return (flags & AffectedHouse::Enemies) != AffectedHouse::None;
 }
 
 bool EnumFunctions::IsCellEligible(CellClass* const pCell, AffectedTarget allowed, bool explicitEmptyCells)


### PR DESCRIPTION
In vanilla game, when the player selects a defense building, the radial indicator is shown only if it belongs to the player. Now the indicator is also drawn for observers. For other houses it can be specified by

In `rulesmd.ini`
```ini
[AudioVisual]
RadialIndicatorVisibility=allies  ; list of Affected House Enumeration (allies/ally | enemies/enemy | all)
```

When your power is sabotaged by a spy, the number given by the power delta counter may look confusing to players. Now I replaced it by ⚡❌, which can also be replaced by

In `uimd.ini`
```ini
[ToolTips]
PowerBlackoutLabel=  ; CSF entry key
```
If `[GlobalControls]->DebugKeysEnabled=yes` power delta is still displayed