### PR TITLE
Multiple Burst shots during same infantry firing sequence

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1012,16 +1012,21 @@ In `rulesmd.ini`:
 AreaFire.Target=base ; AreaFire Target Enumeration (base|self|random)
 ```
 
-### Burst.Delays
+### Burst delay customizations
 
-- Allows specifying weapon-specific burst shot delays. Takes precedence over the old `BurstDelayX` logic available on VehicleTypes, functions with Infantry & BuildingType weapons (AircraftTypes are not supported due to their weapon firing system being completely different) and allows every shot of `Burst` to have a separate delay instead of only first four shots.
-- If no delay is defined for a shot, it falls back to last delay value defined (f.ex `Burst=3` and `Burst.Delays=10` would use 10 as delay for all shots).
-- Using `-1` as delay reverts back to old logic (`BurstDelay0-3` for VehicleTypes if available or random value between 3-5 otherwise) for that shot.
+- `Burst.Delays` allows specifying weapon-specific burst shot delays. Takes precedence over the old `BurstDelayX` logic available on VehicleTypes, functions with Infantry & BuildingType weapons (AircraftTypes are not supported due to their weapon firing system being completely different) and allows every shot of `Burst` to have a separate delay instead of only first four shots.
+  - If no delay is defined for a shot, it falls back to last delay value defined (f.ex `Burst=3` and `Burst.Delays=10` would use 10 as delay for all shots).
+  - Using `-1` as delay reverts back to old logic (`BurstDelay0-3` for VehicleTypes if available or random value between 3-5 otherwise) for that shot.
+- `Burst.FireWithinSequence` is only used if the weapon is fired by InfantryTypes, and setting it to true allows infantry to fire multiple `Burst` shots within same firing sequence.
+  - First shot is always fired at sequence frame determined by firing frame controls on InfantryType image (`FireUp` et al).
+  - Following shots come at intervals determined by `Burst.Delays` (with minimum delay of 1 frame) or random delay between 3 to 5 frames if not defined. Note that if next shot would be fired at a frame that is beyond the firing sequence's length, burst shot count is reset and weapon starts reloading.
+  - Burst shot counter is not immediately reset if firing is ceased mid-sequence after at least one shot, but the frame at which each burst shot is fired will not be influenced by this (in other words, resuming firing afterward without weapon reload taking place would restart firing sequence but no firing will take place until the frame at which next burst shot should be fired is hit).
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWEAPON]     ; WeaponType
-Burst.Delays=-1  ; integer - burst delays (comma-separated) for shots in order from first to last.
+[SOMEWEAPON]                    ; WeaponType
+Burst.Delays=-1                 ; integer - burst delays (comma-separated) for shots in order from first to last.
+Burst.FireWithinSequence=false  ; boolean
 ```
 
 ### Feedback weapon

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -19,7 +19,8 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 #### From pre-0.3 devbuilds
 
 - `Trajectory.Speed` is now defined on projectile instead of weapon.
-- `Gravity=0` is not supported anymore as it will cause the projectile to fly backwards and be unable to hit the target which is not at the same height. Use `Straight` Trajectory instead. See [here](New-or-Enhanced-Logics.md#projectile-trajectories).
+- `Gravity=0` is not supportint burstDelay = pWeaponExt->GetBurstDelay(pThis->CurrentBurstIndex);
+ed anymore as it will cause the projectile to fly backwards and be unable to hit the target which is not at the same height. Use `Straight` Trajectory instead. See [here](New-or-Enhanced-Logics.md#projectile-trajectories).
 - Automatic self-destruction logic logic has been reimplemented, `Death.NoAmmo`, `Death.Countdown` and `Death.Peaceful` tags have been remade/renamed and require adjustments to function.
 - `DetachedFromOwner` on weapons is deprecated. This has been replaced by `AllowDamageOnSelf` on warheads.
 - Timed jump script actions now take the time measured in ingame seconds instead of frames. Divide your value by 15 to accomodate to this change.
@@ -265,6 +266,7 @@ New:
 - Customizable FlakScatter distance (by Starkku)
 - Customizable debris & meteor impact and warhead detonation behaviour (by Starkku, Otamaa)
 - Custom warhead debris animations (by Starkku)
+- Multiple burst shots / burst delay within infantry firing sequence (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1066,6 +1066,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->CurrentLaserWeaponIndex)
 		.Process(this->IsInTunnel)
 		.Process(this->DeployFireTimer)
+		.Process(this->ForceFullRearmDelay)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -34,6 +34,7 @@ public:
 		OptionalStruct<int, true> CurrentLaserWeaponIndex;
 		bool IsInTunnel;
 		CDTimerClass DeployFireTimer;
+		bool ForceFullRearmDelay;
 
 		// Used for Passengers.SyncOwner.RevertOnExit instead of TechnoClass::InitialOwner / OriginallyOwnedByHouse,
 		// as neither is guaranteed to point to the house the TechnoClass had prior to entering transport and cannot be safely overridden.
@@ -56,6 +57,7 @@ public:
 			, CurrentLaserWeaponIndex {}
 			, IsInTunnel { false }
 			, DeployFireTimer {}
+			, ForceFullRearmDelay { false }
 		{ }
 
 		void ApplyInterceptor();

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -143,6 +143,29 @@ DEFINE_HOOK(0x6FD0B5, TechnoClass_RearmDelay_RandomDelay, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x6FD054, TechnoClass_RearmDelay_ForceFullDelay, 0x6)
+{
+	enum { ApplyFullRearmDelay = 0x6FD09E };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	// Currently only used with infantry, so a performance saving measure.
+	if (pThis->WhatAmI() == AbstractType::Infantry)
+	{
+		if (const auto pExt = TechnoExt::ExtMap.Find(pThis))
+		{
+			if (pExt->ForceFullRearmDelay)
+			{
+				pExt->ForceFullRearmDelay = false;
+				pThis->CurrentBurstIndex = 0;
+				return ApplyFullRearmDelay;
+			}
+		}
+	}
+
+	return 0;
+}
+
 // Issue #271: Separate burst delay for weapon type
 // Author: Starkku
 DEFINE_HOOK(0x6FD05E, TechnoClass_RearmDelay_BurstDelays, 0x7)
@@ -151,12 +174,7 @@ DEFINE_HOOK(0x6FD05E, TechnoClass_RearmDelay_BurstDelays, 0x7)
 	GET(WeaponTypeClass*, pWeapon, EDI);
 
 	const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
-	int burstDelay = -1;
-
-	if (pWeaponExt->Burst_Delays.size() > (unsigned)pThis->CurrentBurstIndex)
-		burstDelay = pWeaponExt->Burst_Delays[pThis->CurrentBurstIndex - 1];
-	else if (pWeaponExt->Burst_Delays.size() > 0)
-		burstDelay = pWeaponExt->Burst_Delays[pWeaponExt->Burst_Delays.size() - 1];
+	int burstDelay = pWeaponExt->GetBurstDelay(pThis->CurrentBurstIndex);
 
 	if (burstDelay >= 0)
 	{
@@ -167,6 +185,68 @@ DEFINE_HOOK(0x6FD05E, TechnoClass_RearmDelay_BurstDelays, 0x7)
 	// Restore overridden instructions
 	GET(int, idxCurrentBurst, ECX);
 	return idxCurrentBurst <= 0 || idxCurrentBurst > 4 ? 0x6FD084 : 0x6FD067;
+}
+
+DEFINE_HOOK(0x5209A7, InfantryClass_FiringAI_BurstDelays, 0x8)
+{
+	enum { Continue = 0x5209CD, ReturnFromFunction = 0x520AD9 };
+
+	GET(InfantryClass*, pThis, EBP);
+	GET(int, firingFrame, EDX);
+
+	int weaponIndex = pThis->SelectWeapon(pThis->Target);
+	const auto pWeapon = pThis->GetWeapon(weaponIndex)->WeaponType;
+
+	if (!pWeapon)
+		return ReturnFromFunction;
+
+	const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
+	int cumulativeDelay = 0;
+	int projectedDelay = 0;
+
+	// Calculate cumulative burst delay as well cumulative delay after next shot (projected delay).
+	if (pWeaponExt->Burst_FireWithinSequence)
+	{
+		for (int i = 0; i <= pThis->CurrentBurstIndex; i++)
+		{
+			int burstDelay = pWeaponExt->GetBurstDelay(i);
+			int delay = 0;
+
+			if (burstDelay > -1)
+				delay = burstDelay;
+			else
+				delay = ScenarioClass::Instance->Random.RandomRanged(3, 5);
+
+			// Other than initial delay, treat 0 frame delays as 1 frame delay due to per-frame processing.
+			if (i != 0)
+				delay = Math::max(delay, 1);
+
+			cumulativeDelay += delay;
+
+			if (i == pThis->CurrentBurstIndex)
+				projectedDelay = cumulativeDelay + delay;
+		}
+	}
+
+	if (pThis->IsFiring && pThis->Animation.Value == firingFrame + cumulativeDelay)
+	{
+		if (pWeaponExt->Burst_FireWithinSequence)
+		{
+			int frameCount = pThis->Type->Sequence->GetSequence(pThis->SequenceAnim).CountFrames;
+
+			// If projected frame for firing next shot goes beyond the sequence frame count, cease firing after this shot and start rearm timer.
+			if (firingFrame + projectedDelay > frameCount)
+			{
+				const auto pExt = TechnoExt::ExtMap.Find(pThis);
+				pExt->ForceFullRearmDelay = true;
+			}
+		}
+
+		R->EAX(weaponIndex); // Reuse the weapon index to save some time.
+		return Continue;
+	}
+
+	return ReturnFromFunction;
 }
 
 DEFINE_HOOK(0x6F3B37, TechnoClass_Transform_6F3AD0_BurstFLH_1, 0x7)

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -9,6 +9,20 @@ void WeaponTypeExt::ExtData::Initialize()
 	this->RadType = RadTypeClass::FindOrAllocate(GameStrings::Radiation);
 }
 
+int WeaponTypeExt::ExtData::GetBurstDelay(int burstIndex)
+{
+	int burstDelay = -1;
+
+	if (burstIndex == 0)
+		return 0;
+	else if (this->Burst_Delays.size() > (unsigned)burstIndex)
+		burstDelay = this->Burst_Delays[burstIndex - 1];
+	else if (this->Burst_Delays.size() > 0)
+		burstDelay = this->Burst_Delays[this->Burst_Delays.size() - 1];
+
+	return burstDelay;
+}
+
 // =============================
 // load / save
 
@@ -35,6 +49,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->CanTarget.Read(exINI, pSection, "CanTarget");
 	this->CanTargetHouses.Read(exINI, pSection, "CanTargetHouses");
 	this->Burst_Delays.Read(exINI, pSection, "Burst.Delays");
+	this->Burst_FireWithinSequence.Read(exINI, pSection, "Burst.FireWithinSequence");
 	this->AreaFire_Target.Read(exINI, pSection, "AreaFire.Target");
 	this->FeedbackWeapon.Read(exINI, pSection, "FeedbackWeapon", true);
 	this->Laser_IsSingleColor.Read(exINI, pSection, "IsSingleColor");
@@ -55,6 +70,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->CanTargetHouses)
 		.Process(this->RadType)
 		.Process(this->Burst_Delays)
+		.Process(this->Burst_FireWithinSequence)
 		.Process(this->AreaFire_Target)
 		.Process(this->FeedbackWeapon)
 		.Process(this->Laser_IsSingleColor)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -27,6 +27,7 @@ public:
 		Valueable<AffectedTarget> CanTarget;
 		Valueable<AffectedHouse> CanTargetHouses;
 		ValueableVector<int> Burst_Delays;
+		Valueable<bool> Burst_FireWithinSequence;
 		Valueable<AreaFireTarget> AreaFire_Target;
 		Nullable<WeaponTypeClass*> FeedbackWeapon;
 		Valueable<bool> Laser_IsSingleColor;
@@ -43,11 +44,14 @@ public:
 			, CanTarget { AffectedTarget::All }
 			, CanTargetHouses { AffectedHouse::All }
 			, Burst_Delays {}
+			, Burst_FireWithinSequence { false }
 			, AreaFire_Target { AreaFireTarget::Base }
 			, FeedbackWeapon {}
 			, Laser_IsSingleColor { false }
 			, ROF_RandomDelay {}
 		{ }
+
+		int GetBurstDelay(int burstIndex);
 
 		virtual ~ExtData() = default;
 


### PR DESCRIPTION
- `Burst.FireWithinSequence` is only used if the weapon is fired by InfantryTypes, and setting it to true allows infantry to fire multiple `Burst` shots within same firing sequence.
  - First shot is always fired at sequence frame determined by firing frame controls on InfantryType image (`FireUp` et al).
  - Following shots come at intervals determined by `Burst.Delays` (with minimum delay of 1 frame) or random delay between 3 to 5 frames if not defined. Note that if next shot would be fired at a frame that is beyond the firing sequence's length, burst shot count is reset and weapon starts reloading.
  - Burst shot counter is not immediately reset if firing is ceased mid-sequence after at least one shot, but the frame at which each burst shot is fired will not be influenced by this (in other words, resuming firing afterward without weapon reload taking place would restart firing sequence but no firing will take place until the frame at which next burst shot should be fired is hit).

In `rulesmd.ini`:
```ini
[SOMEWEAPON]                    ; WeaponType
Burst.FireWithinSequence=false  ; boolean
```