### PR TITLE
Warhead / weapon detonation at superweapon target cell

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -160,6 +160,7 @@ This page lists all the individual contributions to the project by their author.
   - Warhead detonation on all objects on map
   - Animated TerrainTypes extension
   - Exploding unit passenger killing customization
+  - Warhead / weapon detonation at superweapon target cell
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -194,7 +194,7 @@ This page lists all the individual contributions to the project by their author.
 - **E1 Elite** - TileSet 255 and above bridge repair fix
 - **AutoGavy** - interceptor logic, Warhead critical hit logic
 - **Chasheen (Chasheenburg)** - CN docs help
-- **Ares developers** - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares, unfinished RadTypes code, prototype deployer fixes
+- **Ares developers** - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares, unfinished RadTypes code, prototype deployer fixes, Superweapon launch site & availability code
 - **tomsons26** - all-around help, assistance and guidance in reverse-engineering, YR binary mappings
 - **CCHyper** - all-around help, current project logo, assistance and guidance in reverse-engineering, YR binary mappings
 - **AlexB** - Original FlyingStrings implementation

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -483,6 +483,21 @@ LimboKill.Affects=self          ; Affected House Enumeration (none|owner/self|al
 LimboKill.IDs=                  ; List of numeric IDs.
 ```
 
+### Warhead or Weapon detonation at target cell
+
+- Any superweapon can now detonate a Warhead or a weapon at superweapon's target cell.
+  - If both `Detonate.Warhead` and `Detonate.Weapon` are set, latter takes precedence.
+  - `Detonate.Damage`, if not set, defaults to weapon ´Damage` for `Detonate.Weapon` and 0 for `Detonate.Warhead`.
+  - Both the weapon and Warhead behave as if fired by whatever building fired the Superweapon. This respects controls like `SW.RangeMinimum/Maximum` (similar to Ares' GenericWarhead superweapon in this regard).
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]           ; Super Weapon
+Detonate.Warhead=  ; Warhead
+Detonate.Weapon=   ; WeaponType
+Detonate.Damage=   ; integer
+```
+
 ## Technos
 
 ### Automatic passenger deletion

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -487,7 +487,7 @@ LimboKill.IDs=                  ; List of numeric IDs.
 
 - Any superweapon can now detonate a Warhead or a weapon at superweapon's target cell.
   - If both `Detonate.Warhead` and `Detonate.Weapon` are set, latter takes precedence.
-  - `Detonate.Damage`, if not set, defaults to weapon ´Damage` for `Detonate.Weapon` and 0 for `Detonate.Warhead`.
+  - `Detonate.Damage`, if not set, defaults to weapon `Damage` for `Detonate.Weapon` and 0 for `Detonate.Warhead`.
   - Both the weapon and Warhead behave as if fired by whatever building fired the Superweapon. This respects controls like `SW.RangeMinimum/Maximum` (similar to Ares' GenericWarhead superweapon in this regard).
 
 In `rulesmd.ini`:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -241,6 +241,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 New:
 - `Crit.AffectsHouses` for critical hit system (by Starkku)
+- Warhead or weapon detonation at superweapon target cell (by Starkku)
 
 ### 0.3
 
@@ -344,7 +345,6 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
-- Warhead or weapon detonation at superweapon target cell (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -344,6 +344,7 @@ New:
 - Implemented support for PCX images for observer loading screen (by Uranusian)
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
+- Warhead or weapon detonation at superweapon target cell (by Starkku)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -30,6 +30,43 @@ void BuildingExt::ExtData::DisplayGrinderRefund()
 	}
 }
 
+bool BuildingExt::ExtData::HasSuperWeapon(const int index, const bool withUpgrades) const
+{
+	const auto pThis = this->OwnerObject();
+	const auto pExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+
+	const auto count = pExt->GetSuperWeaponCount();
+	for (auto i = 0; i < count; ++i)
+	{
+		const auto idxSW = pExt->GetSuperWeaponIndex(i, pThis->Owner);
+		if (idxSW == index)
+		{
+			return true;
+		}
+	}
+
+	if (withUpgrades)
+	{
+		for (auto const& pUpgrade : pThis->Upgrades)
+		{
+			if (const auto pUpgradeExt = BuildingTypeExt::ExtMap.Find(pUpgrade))
+			{
+				const auto countUpgrade = pUpgradeExt->GetSuperWeaponCount();
+				for (auto i = 0; i < countUpgrade; ++i)
+				{
+					const auto idxSW = pUpgradeExt->GetSuperWeaponIndex(i, pThis->Owner);
+					if (idxSW == index)
+					{
+						return true;
+					}
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
 void BuildingExt::StoreTiberium(BuildingClass* pThis, float amount, int idxTiberiumType, int idxStorageTiberiumType)
 {
 	auto const pDepositableTiberium = TiberiumClass::Array->GetItem(idxStorageTiberiumType);
@@ -242,6 +279,14 @@ bool BuildingExt::DoGrindingExtras(BuildingClass* pBuilding, TechnoClass* pTechn
 	}
 
 	return false;
+}
+
+CoordStruct BuildingExt::GetCenterCoords(BuildingClass* pBuilding, bool includeBib)
+{
+	CoordStruct ret = pBuilding->GetCoords();
+	ret.X += pBuilding->Type->GetFoundationWidth() / 2;
+	ret.Y += pBuilding->Type->GetFoundationHeight(includeBib) / 2;
+	return ret;
 }
 
 // Building only or allow units too?

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -39,10 +39,9 @@ bool BuildingExt::ExtData::HasSuperWeapon(const int index, const bool withUpgrad
 	for (auto i = 0; i < count; ++i)
 	{
 		const auto idxSW = pExt->GetSuperWeaponIndex(i, pThis->Owner);
+
 		if (idxSW == index)
-		{
 			return true;
-		}
 	}
 
 	if (withUpgrades)
@@ -55,10 +54,9 @@ bool BuildingExt::ExtData::HasSuperWeapon(const int index, const bool withUpgrad
 				for (auto i = 0; i < countUpgrade; ++i)
 				{
 					const auto idxSW = pUpgradeExt->GetSuperWeaponIndex(i, pThis->Owner);
+
 					if (idxSW == index)
-					{
 						return true;
-					}
 				}
 			}
 		}
@@ -279,14 +277,6 @@ bool BuildingExt::DoGrindingExtras(BuildingClass* pBuilding, TechnoClass* pTechn
 	}
 
 	return false;
-}
-
-CoordStruct BuildingExt::GetCenterCoords(BuildingClass* pBuilding, bool includeBib)
-{
-	CoordStruct ret = pBuilding->GetCoords();
-	ret.X += pBuilding->Type->GetFoundationWidth() / 2;
-	ret.Y += pBuilding->Type->GetFoundationHeight(includeBib) / 2;
-	return ret;
 }
 
 // Building only or allow units too?

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -89,5 +89,4 @@ public:
 	static bool HasFreeDocks(BuildingClass* pBuilding);
 	static bool CanGrindTechno(BuildingClass* pBuilding, TechnoClass* pTechno);
 	static bool DoGrindingExtras(BuildingClass* pBuilding, TechnoClass* pTechno);
-	static CoordStruct GetCenterCoords(BuildingClass* pThis, bool includeBib = false);
 };

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -39,6 +39,7 @@ public:
 
 		void DisplayGrinderRefund();
 		void ApplyPoweredKillSpawns();
+		bool HasSuperWeapon(int index, bool withUpgrades) const;
 
 		virtual ~ExtData() = default;
 
@@ -88,4 +89,5 @@ public:
 	static bool HasFreeDocks(BuildingClass* pBuilding);
 	static bool CanGrindTechno(BuildingClass* pBuilding, TechnoClass* pTechno);
 	static bool DoGrindingExtras(BuildingClass* pBuilding, TechnoClass* pTechno);
+	static CoordStruct GetCenterCoords(BuildingClass* pThis, bool includeBib = false);
 };

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -2,9 +2,47 @@
 
 #include <Ext/House/Body.h>
 #include <Utilities/GeneralUtils.h>
+#include <Ext/SWType/Body.h>
 
 template<> const DWORD Extension<BuildingTypeClass>::Canary = 0x11111111;
 BuildingTypeExt::ExtContainer BuildingTypeExt::ExtMap;
+
+int BuildingTypeExt::ExtData::GetSuperWeaponCount() const
+{
+	return 2 + this->SuperWeapons.Count;
+}
+
+int BuildingTypeExt::ExtData::GetSuperWeaponIndex(const int index, HouseClass* pHouse) const
+{
+	auto idxSW = this->GetSuperWeaponIndex(index);
+
+	if (auto pSuper = pHouse->Supers.GetItemOrDefault(idxSW))
+	{
+		auto pExt = SWTypeExt::ExtMap.Find(pSuper->Type);
+		if (!pExt->IsAvailable(pHouse))
+		{
+			return -1;
+		}
+	}
+
+	return idxSW;
+}
+
+int BuildingTypeExt::ExtData::GetSuperWeaponIndex(const int index) const
+{
+	const auto pThis = this->OwnerObject();
+
+	if (index < 2)
+	{
+		return !index ? pThis->SuperWeapon : pThis->SuperWeapon2;
+	}
+	else if (index - 2 < this->SuperWeapons.Count)
+	{
+		return this->SuperWeapons[index - 2]->ArrayIndex;
+	}
+
+	return -1;
+}
 
 int BuildingTypeExt::GetEnhancedPower(BuildingClass* pBuilding, HouseClass* pHouse)
 {

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -9,6 +9,7 @@ BuildingTypeExt::ExtContainer BuildingTypeExt::ExtMap;
 
 int BuildingTypeExt::ExtData::GetSuperWeaponCount() const
 {
+	// 2 = SuperWeapon & SuperWeapon2
 	return 2 + this->SuperWeapons.Count;
 }
 
@@ -19,10 +20,9 @@ int BuildingTypeExt::ExtData::GetSuperWeaponIndex(const int index, HouseClass* p
 	if (auto pSuper = pHouse->Supers.GetItemOrDefault(idxSW))
 	{
 		auto pExt = SWTypeExt::ExtMap.Find(pSuper->Type);
+
 		if (!pExt->IsAvailable(pHouse))
-		{
 			return -1;
-		}
 	}
 
 	return idxSW;
@@ -32,14 +32,11 @@ int BuildingTypeExt::ExtData::GetSuperWeaponIndex(const int index) const
 {
 	const auto pThis = this->OwnerObject();
 
+	// 2 = SuperWeapon & SuperWeapon2
 	if (index < 2)
-	{
 		return !index ? pThis->SuperWeapon : pThis->SuperWeapon2;
-	}
 	else if (index - 2 < this->SuperWeapons.Count)
-	{
 		return this->SuperWeapons[index - 2]->ArrayIndex;
-	}
 
 	return -1;
 }

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -72,6 +72,7 @@ public:
 			, PlacementPreview_Translucency {}
 		{ }
 
+		// Ares 0.A functions
 		int GetSuperWeaponCount() const;
 		int GetSuperWeaponIndex(int index, HouseClass* pHouse) const;
 		int GetSuperWeaponIndex(int index) const;

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <BuildingTypeClass.h>
+#include <SuperClass.h>
 #include <SuperWeaponTypeClass.h>
 
 #include <Helpers/Macro.h>
@@ -70,6 +71,10 @@ public:
 			, PlacementPreview_Palette {}
 			, PlacementPreview_Translucency {}
 		{ }
+
+		int GetSuperWeaponCount() const;
+		int GetSuperWeaponIndex(int index, HouseClass* pHouse) const;
+		int GetSuperWeaponIndex(int index) const;
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -10,13 +10,20 @@ SWTypeExt::ExtContainer SWTypeExt::ExtMap;
 // load / save
 
 template <typename T>
-void SWTypeExt::ExtData::Serialize(T& Stm) {
+void SWTypeExt::ExtData::Serialize(T& Stm)
+{
 	Stm
 		.Process(this->Money_Amount)
 		.Process(this->SW_Inhibitors)
 		.Process(this->SW_AnyInhibitor)
 		.Process(this->SW_Designators)
 		.Process(this->SW_AnyDesignator)
+		.Process(this->SW_RangeMinimum)
+		.Process(this->SW_RangeMaximum)
+		.Process(this->SW_RequiredHouses)
+		.Process(this->SW_ForbiddenHouses)
+		.Process(this->SW_AuxBuildings)
+		.Process(this->SW_NegBuildings)
 		.Process(this->UIDescription)
 		.Process(this->CameoPriority)
 		.Process(this->LimboDelivery_Types)
@@ -26,14 +33,19 @@ void SWTypeExt::ExtData::Serialize(T& Stm) {
 		.Process(this->LimboKill_Affected)
 		.Process(this->LimboKill_IDs)
 		.Process(this->RandomBuffer)
+		.Process(this->Detonate_Warhead)
+		.Process(this->Detonate_Weapon)
+		.Process(this->Detonate_Damage)
 		;
 }
 
-void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
+void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
+{
 	auto pThis = this->OwnerObject();
 	const char* pSection = pThis->ID;
 
-	if (!pINI->GetSection(pSection)) {
+	if (!pINI->GetSection(pSection))
+	{
 		return;
 	}
 
@@ -45,6 +57,12 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->SW_AnyInhibitor.Read(exINI, pSection, "SW.AnyInhibitor");
 	this->SW_Designators.Read(exINI, pSection, "SW.Designators");
 	this->SW_AnyDesignator.Read(exINI, pSection, "SW.AnyDesignator");
+	this->SW_RangeMinimum.Read(exINI, pSection, "SW.RangeMinimum");
+	this->SW_RangeMaximum.Read(exINI, pSection, "SW.RangeMaximum");
+	this->SW_RequiredHouses = pINI->ReadHouseTypesList(pSection, "SW.RequiredHouses", this->SW_RequiredHouses);
+	this->SW_ForbiddenHouses = pINI->ReadHouseTypesList(pSection, "SW.ForbiddenHouses", this->SW_ForbiddenHouses);
+	this->SW_AuxBuildings.Read(exINI, pSection, "SW.AuxBuildings");
+	this->SW_NegBuildings.Read(exINI, pSection, "SW.NegBuildings");
 
 	this->UIDescription.Read(exINI, pSection, "UIDescription");
 	this->CameoPriority.Read(exINI, pSection, "CameoPriority");
@@ -72,24 +90,31 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI) {
 	this->LimboKill_Affected.Read(exINI, pSection, "LimboKill.Affected");
 	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");
 
+	this->Detonate_Warhead.Read(exINI, pSection, "Detonate.Warhead");
+	this->Detonate_Weapon.Read(exINI, pSection, "Detonate.Weapon", true);
+	this->Detonate_Damage.Read(exINI, pSection, "Detonate.Damage");
 }
 
-void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm) {
+void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
+{
 	Extension<SuperWeaponTypeClass>::LoadFromStream(Stm);
 	this->Serialize(Stm);
 }
 
-void SWTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm) {
+void SWTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
+{
 	Extension<SuperWeaponTypeClass>::SaveToStream(Stm);
 	this->Serialize(Stm);
 }
 
-bool SWTypeExt::LoadGlobals(PhobosStreamReader& Stm) {
+bool SWTypeExt::LoadGlobals(PhobosStreamReader& Stm)
+{
 	return Stm
 		.Success();
 }
 
-bool SWTypeExt::SaveGlobals(PhobosStreamWriter& Stm) {
+bool SWTypeExt::SaveGlobals(PhobosStreamWriter& Stm)
+{
 	return Stm
 		.Success();
 }
@@ -97,7 +122,8 @@ bool SWTypeExt::SaveGlobals(PhobosStreamWriter& Stm) {
 // =============================
 // container
 
-SWTypeExt::ExtContainer::ExtContainer() : Container("SuperWeaponTypeClass") {
+SWTypeExt::ExtContainer::ExtContainer() : Container("SuperWeaponTypeClass")
+{
 }
 
 SWTypeExt::ExtContainer::~ExtContainer() = default;

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <WarheadTypeClass.h>
+#include <WeaponTypeClass.h>
 #include <SuperWeaponTypeClass.h>
 
 #include <Helpers/Macro.h>
@@ -20,6 +22,12 @@ public:
 		Valueable<bool> SW_AnyInhibitor;
 		ValueableVector<TechnoTypeClass*> SW_Designators;
 		Valueable<bool> SW_AnyDesignator;
+		Valueable<double> SW_RangeMinimum;
+		Valueable<double> SW_RangeMaximum;
+		DWORD SW_RequiredHouses;
+		DWORD SW_ForbiddenHouses;
+		ValueableVector<BuildingTypeClass*> SW_AuxBuildings;
+		ValueableVector<BuildingTypeClass*> SW_NegBuildings;
 
 		Valueable<CSFText> UIDescription;
 		Valueable<int> CameoPriority;
@@ -30,6 +38,9 @@ public:
 		ValueableVector<int> LimboKill_IDs;
 		Valueable<double> RandomBuffer;
 
+		Nullable<WarheadTypeClass*> Detonate_Warhead;
+		Nullable<WeaponTypeClass*> Detonate_Weapon;
+		Nullable<int> Detonate_Damage;
 
 		ValueableVector<ValueableVector<int>> LimboDelivery_RandomWeightsData;
 
@@ -39,6 +50,12 @@ public:
 			, SW_AnyInhibitor { false }
 			, SW_Designators { }
 			, SW_AnyDesignator { false }
+			, SW_RangeMinimum { -1.0 }
+			, SW_RangeMaximum { -1.0 }
+			, SW_RequiredHouses { 0xFFFFFFFFu }
+			, SW_ForbiddenHouses { 0u }
+			, SW_AuxBuildings {}
+			, SW_NegBuildings {}
 			, UIDescription {}
 			, CameoPriority { 0 }
 			, LimboDelivery_Types {}
@@ -48,19 +65,26 @@ public:
 			, LimboKill_Affected { AffectedHouse::Owner }
 			, LimboKill_IDs {}
 			, RandomBuffer { 0.0 }
+			, Detonate_Warhead {}
+			, Detonate_Weapon {}
+			, Detonate_Damage {}
 		{ }
 
 		// Ares 0.A functions
 		bool IsInhibitor(HouseClass* pOwner, TechnoClass* pTechno) const;
 		bool HasInhibitor(HouseClass* pOwner, const CellStruct& coords) const;
 		bool IsInhibitorEligible(HouseClass* pOwner, const CellStruct& coords, TechnoClass* pTechno) const;
-
 		bool IsDesignator(HouseClass* pOwner, TechnoClass* pTechno) const;
 		bool HasDesignator(HouseClass* pOwner, const CellStruct& coords) const;
 		bool IsDesignatorEligible(HouseClass* pOwner, const CellStruct& coords, TechnoClass* pTechno) const;
+		bool IsLaunchSiteEligible(const CellStruct& Coords, BuildingClass* pBuilding, bool ignoreRange) const;
+		bool IsLaunchSite(BuildingClass* pBuilding) const;
+		std::pair<double, double> GetLaunchSiteRange(BuildingClass* pBuilding = nullptr) const;
+		bool IsAvailable(HouseClass* pHouse) const;
 
 		void ApplyLimboDelivery(HouseClass* pHouse);
 		void ApplyLimboKill(HouseClass* pHouse);
+		void ApplyDetonation(HouseClass* pHouse, const CellStruct& cell);
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		virtual ~ExtData() = default;

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -120,9 +120,7 @@ void SWTypeExt::FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell)
 			pTypeExt->ApplyLimboKill(pSW->Owner);
 
 		if (pTypeExt->Detonate_Warhead.isset() || pTypeExt->Detonate_Weapon.isset())
-		{
 			pTypeExt->ApplyDetonation(pSW->Owner, cell);
-		}
 	}
 }
 
@@ -325,21 +323,21 @@ bool SWTypeExt::ExtData::HasDesignator(HouseClass* pOwner, const CellStruct& coo
 bool SWTypeExt::ExtData::IsLaunchSiteEligible(const CellStruct& Coords, BuildingClass* pBuilding, bool ignoreRange) const
 {
 	if (!this->IsLaunchSite(pBuilding))
-	{
 		return false;
-	}
 
 	if (ignoreRange)
-	{
 		return true;
-	}
 
 	// get the range for this building
 	auto range = this->GetLaunchSiteRange(pBuilding);
 	const auto& minRange = range.first;
 	const auto& maxRange = range.second;
 
-	const auto center = CellClass::Coord2Cell(BuildingExt::GetCenterCoords(pBuilding));
+	CoordStruct coords = pBuilding->GetCoords();
+	coords.X += pBuilding->Type->GetFoundationWidth() / 2;
+	coords.Y += pBuilding->Type->GetFoundationHeight(false) / 2;
+
+	const auto center = CellClass::Coord2Cell(coords);
 	const auto distance = Coords.DistanceFrom(center);
 
 	// negative range values just pass the test
@@ -369,16 +367,13 @@ bool SWTypeExt::ExtData::IsAvailable(HouseClass* pHouse) const
 
 	// check whether the optional aux building exists
 	if (pThis->AuxBuilding && pHouse->CountOwnedAndPresent(pThis->AuxBuilding) <= 0)
-	{
 		return false;
-	}
 
 	// allow only certain houses, disallow forbidden houses
 	const auto OwnerBits = 1u << pHouse->Type->ArrayIndex;
+
 	if (!(this->SW_RequiredHouses & OwnerBits) || (this->SW_ForbiddenHouses & OwnerBits))
-	{
 		return false;
-	}
 
 	// check that any aux building exist and no neg building
 	auto IsBuildingPresent = [pHouse](BuildingTypeClass* pType)
@@ -387,16 +382,14 @@ bool SWTypeExt::ExtData::IsAvailable(HouseClass* pHouse) const
 	};
 
 	const auto& Aux = this->SW_AuxBuildings;
+
 	if (!Aux.empty() && std::none_of(Aux.begin(), Aux.end(), IsBuildingPresent))
-	{
 		return false;
-	}
 
 	const auto& Neg = this->SW_NegBuildings;
+
 	if (std::any_of(Neg.begin(), Neg.end(), IsBuildingPresent))
-	{
 		return false;
-	}
 
 	return true;
 }

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -9,6 +9,8 @@
 #include <Utilities/GeneralUtils.h>
 #include "Ext/Building/Body.h"
 #include "Ext/House/Body.h"
+#include "Ext/WarheadType/Body.h"
+#include "Ext/WeaponType/Body.h"
 
 inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 {
@@ -116,6 +118,11 @@ void SWTypeExt::FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell)
 
 		if (pTypeExt->LimboKill_IDs.size() > 0)
 			pTypeExt->ApplyLimboKill(pSW->Owner);
+
+		if (pTypeExt->Detonate_Warhead.isset() || pTypeExt->Detonate_Weapon.isset())
+		{
+			pTypeExt->ApplyDetonation(pSW->Owner, cell);
+		}
 	}
 }
 
@@ -192,6 +199,28 @@ void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
 			}
 		}
 	}
+}
+
+void SWTypeExt::ExtData::ApplyDetonation(HouseClass* pHouse, const CellStruct& cell)
+{
+	const auto coords = MapClass::Instance->GetCellAt(cell)->GetCoords();
+	BuildingClass* pFirer = nullptr;
+
+	for (auto const& pBld : pHouse->Buildings)
+	{
+		if (this->IsLaunchSiteEligible(cell, pBld, false))
+		{
+			pFirer = pBld;
+			break;
+		}
+	}
+
+	const auto pWeapon = this->Detonate_Weapon.isset() ? this->Detonate_Weapon.Get() : nullptr;
+
+	if (pWeapon)
+		WeaponTypeExt::DetonateAt(pWeapon, coords, pFirer, this->Detonate_Damage.Get(pWeapon->Damage));
+	else
+		WarheadTypeExt::DetonateAt(this->Detonate_Warhead.Get(), coords, pFirer, this->Detonate_Damage.Get(0));
 }
 
 // =============================
@@ -293,3 +322,81 @@ bool SWTypeExt::ExtData::HasDesignator(HouseClass* pOwner, const CellStruct& coo
 		{ return this->IsDesignatorEligible(pOwner, coords, pTechno); });
 }
 
+bool SWTypeExt::ExtData::IsLaunchSiteEligible(const CellStruct& Coords, BuildingClass* pBuilding, bool ignoreRange) const
+{
+	if (!this->IsLaunchSite(pBuilding))
+	{
+		return false;
+	}
+
+	if (ignoreRange)
+	{
+		return true;
+	}
+
+	// get the range for this building
+	auto range = this->GetLaunchSiteRange(pBuilding);
+	const auto& minRange = range.first;
+	const auto& maxRange = range.second;
+
+	const auto center = CellClass::Coord2Cell(BuildingExt::GetCenterCoords(pBuilding));
+	const auto distance = Coords.DistanceFrom(center);
+
+	// negative range values just pass the test
+	return (minRange < 0.0 || distance >= minRange)
+		&& (maxRange < 0.0 || distance <= maxRange);
+}
+
+bool SWTypeExt::ExtData::IsLaunchSite(BuildingClass* pBuilding) const
+{
+	if (pBuilding->IsAlive && pBuilding->Health && !pBuilding->InLimbo && pBuilding->IsPowerOnline())
+	{
+		auto const pExt = BuildingExt::ExtMap.Find(pBuilding);
+		return pExt->HasSuperWeapon(this->OwnerObject()->ArrayIndex, true);
+	}
+
+	return false;
+}
+
+std::pair<double, double> SWTypeExt::ExtData::GetLaunchSiteRange(BuildingClass* pBuilding) const
+{
+	return std::make_pair(this->SW_RangeMinimum.Get(), this->SW_RangeMaximum.Get());
+}
+
+bool SWTypeExt::ExtData::IsAvailable(HouseClass* pHouse) const
+{
+	const auto pThis = this->OwnerObject();
+
+	// check whether the optional aux building exists
+	if (pThis->AuxBuilding && pHouse->CountOwnedAndPresent(pThis->AuxBuilding) <= 0)
+	{
+		return false;
+	}
+
+	// allow only certain houses, disallow forbidden houses
+	const auto OwnerBits = 1u << pHouse->Type->ArrayIndex;
+	if (!(this->SW_RequiredHouses & OwnerBits) || (this->SW_ForbiddenHouses & OwnerBits))
+	{
+		return false;
+	}
+
+	// check that any aux building exist and no neg building
+	auto IsBuildingPresent = [pHouse](BuildingTypeClass* pType)
+	{
+		return pType && pHouse->CountOwnedAndPresent(pType) > 0;
+	};
+
+	const auto& Aux = this->SW_AuxBuildings;
+	if (!Aux.empty() && std::none_of(Aux.begin(), Aux.end(), IsBuildingPresent))
+	{
+		return false;
+	}
+
+	const auto& Neg = this->SW_NegBuildings;
+	if (std::any_of(Neg.begin(), Neg.end(), IsBuildingPresent))
+	{
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
GenericWarhead SW substitute (that works in tandem with any SW type) with proper support for all weapon / warhead features.

Code for the feature itself is pretty simple, however proper support for determining which building fired the SW required porting over large amount of helper functions from Ares 0.A though. As a result the weapon / warhead is considered to be fired by the building that fired the SW, which supports `SW.RangeMinimum/Maximum` etc (same as GenericWarhead SW).

-------------

### Warhead or Weapon detonation at target cell

- Any superweapon can now detonate a Warhead or a weapon at superweapon's target cell.
  - If both `Detonate.Warhead` and `Detonate.Weapon` are set, latter takes precedence.
  - `Detonate.Damage`, if not set, defaults to weapon ´Damage` for `Detonate.Weapon` and 0 for `Detonate.Warhead`.
  - Both the weapon and Warhead behave as if fired by whatever building fired the Superweapon. This respects controls like `SW.RangeMinimum/Maximum` (similar to Ares' GenericWarhead superweapon in this regard).

In `rulesmd.ini`:
```ini
[SOMESW]           ; Super Weapon
Detonate.Warhead=  ; Warhead
Detonate.Weapon=   ; WeaponType
Detonate.Damage=   ; integer
```