### PR TITLE
Fix subterranean transports in "Move To..." script actions

### DIFF
--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -277,7 +277,6 @@ void ScriptExt::LoadIntoTransports(TeamClass* pTeam)
 					&& pUnitType->Size <= pTransportType->SizeLimit
 					&& pUnitType->Size <= pTransportType->Passengers - pTransport->Passengers.GetTotalSize())
 				{
-					pUnit->IsTeamLeader = true;
 					// All fine
 					if (pUnit->GetCurrentMission() != Mission::Enter)
 					{
@@ -296,6 +295,13 @@ void ScriptExt::LoadIntoTransports(TeamClass* pTeam)
 	for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
 		if (pUnit->GetCurrentMission() == Mission::Enter)
 			return;
+
+	auto pExt = TeamExt::ExtMap.Find(pTeam);
+	if (pExt)
+	{
+		FootClass* pLeaderUnit = FindTheTeamLeader(pTeam);
+		pExt->TeamLeader = pLeaderUnit;
+	}
 
 	// This action finished
 	if (pTeam->CurrentScript->HasNextMission())
@@ -336,9 +342,9 @@ void ScriptExt::WaitUntilFullAmmoAction(TeamClass* pTeam)
 	pTeam->StepCompleted = true;
 }
 
-void ScriptExt::Mission_Gather_NearTheLeader(TeamClass *pTeam, int countdown = -1)
+void ScriptExt::Mission_Gather_NearTheLeader(TeamClass* pTeam, int countdown = -1)
 {
-	FootClass *pLeaderUnit = nullptr;
+	FootClass* pLeaderUnit = nullptr;
 	int initialCountdown = pTeam->CurrentScript->Type->ScriptActions[pTeam->CurrentScript->CurrentMission].Argument;
 	bool gatherUnits = false;
 	auto pExt = TeamExt::ExtMap.Find(pTeam);
@@ -398,7 +404,8 @@ void ScriptExt::Mission_Gather_NearTheLeader(TeamClass *pTeam, int countdown = -
 			|| !pLeaderUnit->IsAlive
 			|| pLeaderUnit->Health <= 0
 			|| pLeaderUnit->InLimbo
-			|| !pLeaderUnit->IsOnMap
+			|| !(pLeaderUnit->IsOnMap || (pLeaderUnit->GetTechnoType()->IsSubterranean))
+			|| pLeaderUnit->Transporter
 			|| pLeaderUnit->Absorbed)
 		{
 			pLeaderUnit = FindTheTeamLeader(pTeam);
@@ -469,7 +476,7 @@ void ScriptExt::Mission_Gather_NearTheLeader(TeamClass *pTeam, int countdown = -
 
 				nUnits++;
 
-				if (pUnit->DistanceFrom(pLeaderUnit) / 256.0 > closeEnough)
+				if ((pUnit->DistanceFrom(pLeaderUnit) / 256.0) > closeEnough)
 				{
 					// Leader's location is too far from me. Regroup
 					if (pUnit->Destination != pLeaderUnit)
@@ -564,6 +571,7 @@ void ScriptExt::Mission_Attack(TeamClass *pTeam, bool repeatAction = true, int c
 		|| pFocus->Health <= 0
 		|| pFocus->InLimbo
 		|| !pFocus->IsOnMap
+		|| pFocus->Transporter
 		|| pFocus->Absorbed)
 	{
 		pTeam->Focus = nullptr;
@@ -672,7 +680,8 @@ void ScriptExt::Mission_Attack(TeamClass *pTeam, bool repeatAction = true, int c
 		|| !pLeaderUnit->IsAlive
 		|| pLeaderUnit->Health <= 0
 		|| pLeaderUnit->InLimbo
-		|| !pLeaderUnit->IsOnMap
+		|| !(pLeaderUnit->IsOnMap || (pLeaderUnit->GetTechnoType()->IsSubterranean))
+		|| pLeaderUnit->Transporter
 		|| pLeaderUnit->Absorbed)
 	{
 		pLeaderUnit = FindTheTeamLeader(pTeam);
@@ -2034,13 +2043,13 @@ void ScriptExt::Mission_Attack_List(TeamClass *pTeam, bool repeatAction, int cal
 	}
 }
 
-void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pickAllies = false, int attackAITargetType = -1, int idxAITargetTypeItem = -1)
+void ScriptExt::Mission_Move(TeamClass* pTeam, int calcThreatMode = 0, bool pickAllies = false, int attackAITargetType = -1, int idxAITargetTypeItem = -1)
 {
 	auto pScript = pTeam->CurrentScript;
 	int scriptArgument = pScript->Type->ScriptActions[pScript->CurrentMission].Argument; // This is the target type
 	TechnoClass* selectedTarget = nullptr;
 	bool noWaitLoop = false;
-	FootClass *pLeaderUnit = nullptr;
+	FootClass* pLeaderUnit = nullptr;
 	TechnoTypeClass* pLeaderUnitType = nullptr;
 	bool bAircraftsWithoutAmmo = false;
 	TechnoClass* pFocus = nullptr;
@@ -2109,7 +2118,8 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 		|| !pLeaderUnit->IsAlive
 		|| pLeaderUnit->Health <= 0
 		|| pLeaderUnit->InLimbo
-		|| !pLeaderUnit->IsOnMap
+		|| !(pLeaderUnit->IsOnMap || (pLeaderUnit->GetTechnoType()->IsSubterranean))
+		|| pLeaderUnit->Transporter
 		|| pLeaderUnit->Absorbed)
 	{
 		pLeaderUnit = FindTheTeamLeader(pTeam);
@@ -2148,7 +2158,7 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 
 		if (selectedTarget)
 		{
-			Debug::Log("DEBUG: [%s] [%s] (line: %d = %d,%d) Leader [%s] (UID: %lu) selected [%s] (UID: %lu) as target.\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pLeaderUnit->GetTechnoType()->get_ID(), pLeaderUnit->UniqueID, selectedTarget->GetTechnoType()->get_ID(), selectedTarget->UniqueID);
+			Debug::Log("DEBUG: [%s] [%s] (line: %d = %d,%d) Leader [%s] (UID: %lu) selected [%s] (UID: %lu) as destination target.\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pLeaderUnit->GetTechnoType()->get_ID(), pLeaderUnit->UniqueID, selectedTarget->GetTechnoType()->get_ID(), selectedTarget->UniqueID);
 
 			pTeam->Focus = selectedTarget;
 			pTeamData->WaitNoTargetAttempts = 0; // Disable Script Waits if there are any because a new target was selected
@@ -2158,8 +2168,9 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 			for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
 			{
 				if (pUnit->IsAlive
-					&& pUnit->IsOnMap
-					&& !pUnit->InLimbo)
+					&& (pUnit->IsOnMap || (pUnit->GetTechnoType()->IsSubterranean))
+					&& !pUnit->InLimbo
+					&& !pUnit->Transporter)
 				{
 					auto pUnitType = pUnit->GetTechnoType();
 
@@ -2179,21 +2190,21 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 							continue;
 						}
 
-						pUnit->SetDestination(selectedTarget, false);
+						// Reset previous command
+						pUnit->SetTarget(nullptr);
+						pUnit->SetFocus(nullptr);
+						pUnit->SetDestination(nullptr, false);
+						pUnit->ForceMission(Mission::Guard);
+
+						// Get a cell near the target
+						pUnit->QueueMission(Mission::Move, false);
+						CoordStruct coord = TechnoExt::PassengerKickOutLocation(selectedTarget, pUnit);
+						CellClass* pCellDestination = MapClass::Instance->TryGetCellAt(coord);
+						pUnit->SetDestination(pCellDestination, true);
 
 						// Aircraft hack. I hate how this game auto-manages the aircraft missions.
 						if (pUnitType->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo > 0 && pUnit->GetHeight() <= 0)
 							pUnit->QueueMission(Mission::Move, false);
-
-						// Aircraft hack. I hate how this game auto-manages the aircraft missions.
-						if (pUnitType->WhatAmI() != AbstractType::AircraftType)
-						{
-							pUnit->QueueMission(Mission::Move, false);
-							pUnit->ObjectClickedAction(Action::Move, selectedTarget, false);
-
-							if (pUnit->GetCurrentMission() != Mission::Move)
-								pUnit->Mission_Move();
-						}
 					}
 				}
 			}
@@ -2232,7 +2243,6 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 	else
 	{
 		// This part of the code is used for updating the "Move" mission in each team unit
-
 		int moveDestinationMode = 0;
 		moveDestinationMode = pTeamData->MoveMissionEndMode;
 		bool bForceNextAction = ScriptExt::MoveMissionEndStatus(pTeam, pFocus, pLeaderUnit, moveDestinationMode);
@@ -2254,9 +2264,9 @@ void ScriptExt::Mission_Move(TeamClass *pTeam, int calcThreatMode = 0, bool pick
 	}
 }
 
-TechnoClass* ScriptExt::FindBestObject(TechnoClass *pTechno, int method, int calcThreatMode = 0, bool pickAllies = false, int attackAITargetType = -1, int idxAITargetTypeItem = -1)
+TechnoClass* ScriptExt::FindBestObject(TechnoClass* pTechno, int method, int calcThreatMode = 0, bool pickAllies = false, int attackAITargetType = -1, int idxAITargetTypeItem = -1)
 {
-	TechnoClass *bestObject = nullptr;
+	TechnoClass* bestObject = nullptr;
 	double bestVal = -1;
 	HouseClass* enemyHouse = nullptr;
 
@@ -2268,11 +2278,8 @@ TechnoClass* ScriptExt::FindBestObject(TechnoClass *pTechno, int method, int cal
 		{
 			int enemyHouseIndex = pFoot->Team->FirstUnit->Owner->EnemyHouseIndex;
 
-			if (pFoot->Team->Type->OnlyTargetHouseEnemy
-				&& enemyHouseIndex >= 0)
-			{
+			if (pFoot->Team->Type->OnlyTargetHouseEnemy	&& enemyHouseIndex >= 0)
 				enemyHouse = HouseClass::Array->GetItem(enemyHouseIndex);
-			}
 		}
 	}
 
@@ -2318,6 +2325,7 @@ TechnoClass* ScriptExt::FindBestObject(TechnoClass *pTechno, int method, int cal
 			&& object->IsAlive
 			&& !object->InLimbo
 			&& object->IsOnMap
+			&& !object->Transporter
 			&& !object->Absorbed
 			&& ((pickAllies && pTechno->Owner->IsAlliedWith(object))
 				|| (!pickAllies && !pTechno->Owner->IsAlliedWith(object))))
@@ -2632,29 +2640,26 @@ bool ScriptExt::MoveMissionEndStatus(TeamClass* pTeam, TechnoClass* pFocus, Foot
 	if (pTeamData && pTeamData->CloseEnough > 0)
 		closeEnough = pTeamData->CloseEnough;
 
-	bool bForceNextAction;
+	bool bForceNextAction = false;
 
 	if (mode == 2)
 		bForceNextAction = true;
-	else
-		bForceNextAction = false;
 
 	// Team already have a focused target
 	for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
 	{
 		if (pUnit
 			&& pUnit->IsAlive
+			&& pUnit->Health > 0
 			&& !pUnit->InLimbo
 			&& !pUnit->TemporalTargetingMe
-			&& !pUnit->BeingWarpedOut)
+			&& !pUnit->BeingWarpedOut
+			&& !pUnit->Transporter)
 		{
-			if (!pUnit->Locomotor->Is_Moving_Now())
-				pUnit->SetDestination(pFocus, false);
-
 			if (mode == 2)
 			{
 				// Default mode: all members in range
-				if (pUnit->DistanceFrom(pUnit->Destination) / 256.0 > closeEnough)
+				if ((pUnit->DistanceFrom(pFocus->GetCell()) / 256.0) > closeEnough)
 				{
 					bForceNextAction = false;
 
@@ -2679,7 +2684,7 @@ bool ScriptExt::MoveMissionEndStatus(TeamClass* pTeam, TechnoClass* pFocus, Foot
 				if (mode == 1)
 				{
 					// Any member in range
-					if (pUnit->DistanceFrom(pUnit->Destination) / 256.0 > closeEnough)
+					if ((pUnit->DistanceFrom(pFocus->GetCell()) / 256.0) > closeEnough)
 					{
 						if (pUnit->GetTechnoType()->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo > 0)
 							pUnit->QueueMission(Mission::Move, false);
@@ -2704,7 +2709,7 @@ bool ScriptExt::MoveMissionEndStatus(TeamClass* pTeam, TechnoClass* pFocus, Foot
 					// All other cases: Team Leader mode in range
 					if (pLeader)
 					{
-						if (pUnit->DistanceFrom(pUnit->Destination) / 256.0 > closeEnough)
+						if ((pUnit->DistanceFrom(pFocus->GetCell()) / 256.0) > closeEnough)
 						{
 							if (pUnit->GetTechnoType()->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo > 0)
 								pUnit->QueueMission(Mission::Move, false);
@@ -2713,7 +2718,7 @@ bool ScriptExt::MoveMissionEndStatus(TeamClass* pTeam, TechnoClass* pFocus, Foot
 						}
 						else
 						{
-							if (pUnit == pLeader)
+							if (pUnit->IsTeamLeader)
 								bForceNextAction = true;
 
 							if (pUnit->GetTechnoType()->WhatAmI() == AbstractType::AircraftType && pUnit->Ammo <= 0)
@@ -2736,7 +2741,6 @@ bool ScriptExt::MoveMissionEndStatus(TeamClass* pTeam, TechnoClass* pFocus, Foot
 
 	return bForceNextAction;
 }
-
 
 void ScriptExt::SkipNextAction(TeamClass* pTeam, int successPercentage = 0)
 {
@@ -2975,9 +2979,7 @@ FootClass* ScriptExt::FindTheTeamLeader(TeamClass* pTeam)
 	bool teamLeaderFound = false;
 
 	if (!pTeam)
-	{
 		return pLeaderUnit;
-	}
 
 	// Find the Leader or promote a new one
 	for (auto pUnit = pTeam->FirstUnit; pUnit; pUnit = pUnit->NextTeamMember)
@@ -2985,41 +2987,38 @@ FootClass* ScriptExt::FindTheTeamLeader(TeamClass* pTeam)
 		if (!pUnit)
 			continue;
 
+		bool isValidUnit = pUnit->IsAlive
+			&& pUnit->Health > 0
+			&& !pUnit->InLimbo
+			&& (pUnit->IsOnMap || (pUnit->GetTechnoType()->IsSubterranean))
+			&& !pUnit->Transporter
+			&& !pUnit->Absorbed;
+
 		// Preventing >1 leaders in teams
-		if (teamLeaderFound)
+		if (teamLeaderFound || !isValidUnit)
 		{
 			pUnit->IsTeamLeader = false;
 			continue;
 		}
 
-		if (pUnit->IsAlive
-			&& pUnit->Health > 0
-			&& !pUnit->InLimbo
-			&& pUnit->IsOnMap
-			&& !pUnit->Absorbed)
+		if (pUnit->IsTeamLeader)
 		{
-			if (pUnit->IsTeamLeader)
-			{
-				pLeaderUnit = pUnit;
-				teamLeaderFound = true;
-				continue;
-			}
+			pLeaderUnit = pUnit;
+			teamLeaderFound = true;
 
-			auto pUnitType = pUnit->GetTechnoType();
-			if (pUnitType)
-			{
-				// The team Leader will be used for selecting targets, if there are living Team Members then always exists 1 Leader.
-				int unitLeadershipRating = pUnitType->LeadershipRating;
-				if (unitLeadershipRating > bestUnitLeadershipValue)
-				{
-					pLeaderUnit = pUnit;
-					bestUnitLeadershipValue = unitLeadershipRating;
-				}
-			}
+			continue;
 		}
-		else
+
+		auto pUnitType = pUnit->GetTechnoType();
+		if (!pUnitType)
+			continue;
+
+		// The team Leader will be used for selecting targets, if there are living Team Members then always exists 1 Leader.
+		int unitLeadershipRating = pUnitType->LeadershipRating;
+		if (unitLeadershipRating > bestUnitLeadershipValue)
 		{
-			pUnit->IsTeamLeader = false;
+			pLeaderUnit = pUnit;
+			bestUnitLeadershipValue = unitLeadershipRating;
 		}
 	}
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -878,6 +878,36 @@ void TechnoExt::DisplayDamageNumberString(TechnoClass* pThis, int damage, bool i
 	pExt->DamageNumberOffset = pExt->DamageNumberOffset + width;
 }
 
+CoordStruct TechnoExt::PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger)
+{
+	if (!pThis || !pPassenger)
+		return CoordStruct::Empty;
+
+	auto pTypePassenger = pPassenger->GetTechnoType();
+	CoordStruct finalLocation = CoordStruct::Empty;
+	short extraDistanceX = 1;
+	short extraDistanceY = 1;
+	SpeedType speedType = pTypePassenger->SpeedType;
+	MovementZone movementZone = pTypePassenger->MovementZone;
+
+	if (pTypePassenger->WhatAmI() == AbstractType::AircraftType)
+	{
+		speedType = SpeedType::Track;
+		movementZone = MovementZone::Normal;
+	}
+
+	CellStruct placeCoords = pThis->GetCell()->MapCoords - CellStruct { (short)(extraDistanceX / 2), (short)(extraDistanceY / 2) };
+	placeCoords = MapClass::Instance->NearByLocation(placeCoords, speedType, -1, movementZone, false, extraDistanceX, extraDistanceY, true, false, false, false, CellStruct::Empty, false, false);
+
+	if (auto pCell = MapClass::Instance->TryGetCellAt(placeCoords))
+	{
+		pPassenger->OnBridge = pCell->ContainsBridge();
+		finalLocation = pCell->GetCoordsWithBridge();
+	}
+
+	return finalLocation;
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -116,4 +116,5 @@ public:
 	static void DrawSelfHealPips(TechnoClass* pThis, Point2D* pLocation, RectangleStruct* pBounds);
 	static void ApplyGainedSelfHeal(TechnoClass* pThis);
 	static void SyncIronCurtainStatus(TechnoClass* pFrom, TechnoClass* pTo);
+	static CoordStruct PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger);
 };


### PR DESCRIPTION
- "Move to" actions set for using the end mode 0 (the one that ends the action when the Team leader reaches the destination) ended as soon as the subterranean transport traveled underground. For the action it was like if the transport wasn't in the map.
- Some Subterranean transports moved on the surface instead of using subterranean tunnels.