### PR TITLE
Level projectile improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -166,6 +166,7 @@ This page lists all the individual contributions to the project by their author.
   - IvanBomb detonation & image display centered on buildings
   - Customizable ROF random delay
   - BibShape drawing during buildup fix
+  - Level projectile improvements
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="src\Ext\BulletType\Body.cpp" />
     <ClCompile Include="src\Ext\Bullet\Body.cpp" />
     <ClCompile Include="src\Ext\Bullet\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Hooks.Obstacles.cpp" />
     <ClCompile Include="src\Ext\House\Body.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.cpp" />
     <ClCompile Include="src\Ext\RadSite\Body.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -89,6 +89,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - IvanBomb images now display and the bombs detonate at center of buildings instead of in top-leftmost cell of the building foundation.
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations.
 - Animation with `Tiled=yes` now supports `CustomPalette`.
+- Weapons with `Level=true` projectile now prompt the firer to move in range if there is an obstacle in between the firer and target where the projectile would be forced to detonate.
 
 ## Animations
 
@@ -185,6 +186,16 @@ Grinding.DisplayRefund.Offset=0,0  ; X,Y, pixels relative to default
 ```
 
 ## Projectiles
+
+### Customizable level projectile force detonation condition
+
+- By default `Level=true` projectiles are forced to detonate when entering cells that belong to a non-water tileset. This condition is now customizable, including options to force detonation on water or ground (which is not exactly same as the default behaviour) or disabling it entirely.
+
+In `rulesmd.ini`:
+```ini
+[SOMEPROJECTILE]                        ; Projectile
+Level.ForceDetonationOn=nonwatertileset ; Level projectile behavior enumeration (nothing|nonwatertileset|water|ground)
+```
 
 ### Customizable projectile gravity
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -254,6 +254,7 @@ New:
 - Forcing specific weapon against cloaked or disguised targets (by Starkku)
 - Customizable ROF random delay (by Starkku)
 - Animation with `Tiled=yes` now supports `CustomPalette` (by ststl)
+- Improvements to `Level` projectile logic (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Bullet/Hooks.Obstacles.cpp
+++ b/src/Ext/Bullet/Hooks.Obstacles.cpp
@@ -1,0 +1,161 @@
+#include "Body.h"
+
+#include <Utilities/Macro.h>
+
+// Ares reimplements the bullet obstacle logic so need to get creative to add any new functionality for that in Phobos.
+// Not named PhobosTrajectoryHelper to avoid confusion with actual custom trajectory logic.
+class BulletObstacleHelper
+{
+public:
+
+	static CellClass* GetObstacle(CellClass* pSourceCell, CellClass* pTargetCell, CellClass* pCurrentCell, CoordStruct currentCoords, HouseClass* pOwner, BulletTypeClass* pBulletType, BulletTypeExt::ExtData*& pBulletTypeExt)
+	{
+		if (CanBeBlockedByObstacles(pBulletType, pBulletTypeExt))
+		{
+			if (pBulletTypeExt->ShouldLevelBulletDetonateOnCell(pCurrentCell))
+				return pCurrentCell;
+		}
+
+		return nullptr;
+	}
+
+	static CellClass* FindFirstObstacle(CoordStruct const& pSourceCoords, CoordStruct const& pTargetCoords, HouseClass* pOwner, BulletTypeClass* pBulletType)
+	{
+		BulletTypeExt::ExtData* pBulletTypeExt = nullptr;
+
+		if (CanBeBlockedByObstacles(pBulletType, pBulletTypeExt))
+		{
+			auto sourceCell = CellClass::Coord2Cell(pSourceCoords);
+			auto const pSourceCell = MapClass::Instance->GetCellAt(sourceCell);
+			auto targetCell = CellClass::Coord2Cell(pTargetCoords);
+			auto const pTargetCell = MapClass::Instance->GetCellAt(targetCell);
+
+			auto const sub = sourceCell - targetCell;
+			auto const delta = CellStruct { (short)std::abs(sub.X), (short)std::abs(sub.Y) };
+			auto const maxDelta = static_cast<size_t>(std::max(delta.X, delta.Y));
+			auto const step = !maxDelta ? CoordStruct::Empty : (pTargetCoords - pSourceCoords) * (1.0 / maxDelta);
+			CoordStruct crdCur = pSourceCoords;
+			auto pCellCur = pSourceCell;
+
+			for (size_t i = 0; i < maxDelta; ++i)
+			{
+				if (auto const pCell = GetObstacle(pSourceCell, pTargetCell, pCellCur, crdCur, pOwner, pBulletType, pBulletTypeExt))
+					return pCell;
+
+				pCellCur = MapClass::Instance->GetCellAt(crdCur);
+				crdCur += step;
+			}
+		}
+
+		return nullptr;
+	}
+
+	static CellClass* FindFirstImpenetrableObstacle(CoordStruct const& pSourceCoords, CoordStruct const& pTargetCoords, WeaponTypeClass* pWeapon, HouseClass* pOwner)
+	{
+		// Does not currently need further checks.
+		return FindFirstObstacle(pSourceCoords, pTargetCoords, pOwner, pWeapon->Projectile);
+	}
+
+	static bool CanBeBlockedByObstacles(BulletTypeClass* pBulletType, BulletTypeExt::ExtData*& pBulletTypeExt)
+	{
+		// Minor performance optimization, if add more conditions move the Level check further down.
+		if (!pBulletType || !pBulletType->Level)
+			return false;
+
+		if (!pBulletTypeExt)
+			pBulletTypeExt = BulletTypeExt::ExtMap.Find(pBulletType);
+
+		if (pBulletTypeExt->Level_ForceDetonationOn != LevelBulletBehavior::Nothing)
+			return true;
+
+		return false;
+	}
+};
+
+// Hooks
+
+DEFINE_HOOK(0x4688A9, BulletClass_Unlimbo_Obstacles, 0x6)
+{
+	enum { SkipGameCode = 0x468A3F, Continue = 0x4688BD };
+
+	GET(BulletClass*, pThis, EBX);
+	GET(CoordStruct const* const, sourceCoords, EDI);
+	REF_STACK(CoordStruct const, targetCoords, STACK_OFFSET(0x54, -0x10));
+
+	if (pThis->Type->Inviso)
+	{
+		auto const pOwner = pThis->Owner ? pThis->Owner->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
+		const auto pObstacleCell = BulletObstacleHelper::FindFirstObstacle(*sourceCoords, targetCoords, pOwner, pThis->Type);
+
+		if (pObstacleCell)
+		{
+			pThis->SetLocation(pObstacleCell->GetCoords());
+			pThis->Speed = 0;
+			pThis->Velocity = BulletVelocity::Empty;
+
+			return SkipGameCode;
+		}
+
+		return Continue;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x468C86, BulletClass_ShouldExplode_Obstacles, 0xA)
+{
+	enum { SkipGameCode = 0x468C90, Explode = 0x468C9F };
+
+	GET(BulletClass*, pThis, ESI);
+
+	BulletTypeExt::ExtData* pBulletTypeExt = nullptr;
+
+	if (BulletObstacleHelper::CanBeBlockedByObstacles(pThis->Type, pBulletTypeExt))
+	{
+		auto const pCellSource = MapClass::Instance->GetCellAt(pThis->SourceCoords);
+		auto const pCellTarget = MapClass::Instance->GetCellAt(pThis->TargetCoords);
+		auto const pCellCurrent = MapClass::Instance->GetCellAt(pThis->LastMapCoords);
+		auto const pOwner = pThis->Owner ? pThis->Owner->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
+		const auto pObstacleCell = BulletObstacleHelper::GetObstacle(pCellSource, pCellTarget, pCellCurrent, pThis->Location, pOwner, pThis->Type, pBulletTypeExt);
+
+		if (pObstacleCell)
+			return Explode;
+	}
+
+
+	// Restore overridden instructions.
+	R->EAX(pThis->GetHeight());
+	return SkipGameCode;
+}
+
+namespace InRangeTemp
+{
+	TechnoClass* Techno = nullptr;
+}
+
+DEFINE_HOOK(0x6F7261, TechnoClass_InRange_SetContext, 0x5)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	InRangeTemp::Techno = pThis;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6F7647, TechnoClass_InRange_Obstacles, 0x5)
+{
+	GET_BASE(WeaponTypeClass*, pWeapon, 0x10);
+	GET(CoordStruct*, pSourceCoords, ESI);
+	REF_STACK(CoordStruct const, targetCoords, STACK_OFFSET(0x3C, -0x1C));
+	GET(CellClass*, pResult, EAX);
+
+	auto pObstacleCell = pResult;
+
+	if (!pObstacleCell)
+		pObstacleCell = BulletObstacleHelper::FindFirstImpenetrableObstacle(*pSourceCoords, targetCoords, pWeapon, InRangeTemp::Techno->Owner);
+
+	InRangeTemp::Techno = nullptr;
+
+	R->EAX(pObstacleCell);
+	return 0;
+}

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -30,6 +30,7 @@ public:
 
 		Valueable<bool> Shrapnel_AffectsGround;
 		Valueable<bool> Shrapnel_AffectsBuildings;
+		Valueable<LevelBulletBehavior> Level_ForceDetonationOn;
 
 		ExtData(BulletTypeClass* OwnerObject) : Extension<BulletTypeClass>(OwnerObject)
 			, Strength { 0 }
@@ -43,9 +44,11 @@ public:
 			, Trajectory_Speed { 100.0 }
 			, Shrapnel_AffectsGround { false }
 			, Shrapnel_AffectsBuildings { false }
+			, Level_ForceDetonationOn { LevelBulletBehavior::NonWaterTileset }
 		{ }
 
 		virtual ~ExtData() = default;
+		bool ShouldLevelBulletDetonateOnCell(CellClass* pCell);
 
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;
 		// virtual void Initialize() override;

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -149,6 +149,14 @@ enum class AutoDeathBehavior
 	Sell = 2,     // buildings only
 };
 
+enum class LevelBulletBehavior
+{
+	Nothing = 0,
+	NonWaterTileset = 1,
+	Water = 2,
+	Ground = 3
+};
+
 enum class SelfHealGainType
 {
 	None = 0,

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -806,6 +806,38 @@ namespace detail
 	}
 
 	template <>
+	inline bool read<LevelBulletBehavior>(LevelBulletBehavior& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			if (_strcmpi(parser.value(), "none") == 0 || _strcmpi(parser.value(), "nothing") == 0)
+			{
+				value = LevelBulletBehavior::Nothing;
+			}
+			else if (_strcmpi(parser.value(), "nonwatertileset") == 0)
+			{
+				value = LevelBulletBehavior::NonWaterTileset;
+			}
+			else if (_strcmpi(parser.value(), "water") == 0)
+			{
+				value = LevelBulletBehavior::Water;
+			}
+			else if (_strcmpi(parser.value(), "ground") == 0)
+			{
+				value = LevelBulletBehavior::Ground;
+			}
+			else
+			{
+				Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a level bullet detonation behavior type");
+				return false;
+			}
+
+			return true;
+		}
+		return false;
+	}
+
+	template <>
 	inline bool read<TextAlign>(TextAlign& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
 	{
 		if (parser.ReadString(pSection, pKey))


### PR DESCRIPTION
- Weapons with `Level=true` projectile now prompt the firer to move in range if there is an obstacle in between the firer and target where the projectile would be forced to detonate.


- By default `Level=true` projectiles are forced to detonate when entering cells that belong to a non-water tileset. This condition is now customizable, including options to force detonation on water or ground (which is not exactly same as the default behaviour) or disabling it entirely.

In `rulesmd.ini`:
```ini
[SOMEPROJECTILE]                        ; Projectile
Level.ForceDetonationOn=nonwatertileset ; Level projectile behavior enumeration (nothing|nonwatertileset|water|ground)
```