### PR TITLE
JumpjetTurnToTarget: The correct fix, and OmniFire.TurnToTarget

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -184,11 +184,12 @@ This page lists all the individual contributions to the project by their author.
    - Laser fixes prototype
 - **Trsdy**
    - Preserve IronCurtain status upon DeploysInto/UndeploysInto
-   - Misc jumpjet fixes:
-      - Facing towards target fix
+   - Several jumpjet fixes:
+      - Facing towards target even if not omni-firing
       - Turret direction in idle state fix
       - Sensor fix
       - Allow to tilt on ground
+   - OmniFire.TurnToTarget
    - Object Self-destruction logic
    - Misc vanilla suicidal behavior fix
    - Post-type-conversion update

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -22,6 +22,10 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug when occupied building's `MuzzleFlashX` is drawn on the center of the building when `X` goes past 10.
 - Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead.
 - Fixed jumpjet units being unable to turn to the target when firing from a different direction.
+
+![image](_static/images/jumpjet-turning.gif)
+*Jumpjet turning to target applied in [Robot Storm X](https://www.moddb.com/mods/cc-robot-storm-x)*
+
 - Fixed turreted jumpjet units always facing bottom-right direction when motion stops.
 - Fixed jumpjet objects being unable to use `Sensors`.
 - Fixed interaction of `UnitAbsorb` & `InfantryAbsorb` with `Grinding` buildings. The keys will now make the building only accept appropriate types of objects.
@@ -338,25 +342,6 @@ AllowLayerDeviation=true         ; boolean
 
 [SOMETECHNO]                     ; TechnoType
 JumpjetAllowLayerDeviation=true  ; boolean
-```
-
-### Jumpjet turning to target
-
-![image](_static/images/jumpjet-turning.gif)
-*Jumpjet turning to target applied in [Robot Storm X](https://www.moddb.com/mods/cc-robot-storm-x)*
-
-- Allows jumpjet units to face towards the target when firing from different directions. Set `[JumpjetControls] -> TurnToTarget=yes` to enable it for all jumpjet locomotor units. This behavior can be overriden by setting `[UnitType] -> JumpjetTurnToTarget` for specific units.
-
-In `rulesmd.ini`:
-```ini
-[JumpjetControls]
-TurnToTarget=false     ; boolean
-
-[SOMEUNITTYPE]         ; UnitType with jumpjet locomotor
-JumpjetTurnToTarget=   ; boolean, override the tag in JumpjetControls
-```
-```{warning}
-This option will be deprecated in future versions.
 ```
 
 ### Jumpjet rotating on crashing toggle

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -659,6 +659,17 @@ ForceWeapon.Cloaked=-1          ; integer. 0 for primary weapon, 1 for secondary
 ForceWeapon.Disguised=-1        ; integer. 0 for primary weapon, 1 for secondary weapon, -1 to disable
 ```
 
+### Make units try turning to target when firing with `OmniFire=yes`
+- The unit will try to turn the body to target even firing with `OmniFire=yes`
+  - Recommended for jumpjets if you want it to turn to target when firing.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWEAPONTYPE]          ; WeaponType
+OmniFire=yes
+OmniFire.TurnToTarget=no  ; boolean
+```
+
 ### Initial strength for TechnoTypes and cloned infantry
 
 ![image](_static/images/initialstrength.cloning-01.png)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -16,6 +16,11 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 ### From older Phobos versions
 
+### From 0.3
+
+- `[JumpjetControls]->TurnToTarget` and `JumpjetTurnToTarget` are obsolete. Jumpjet units who fire `OmniFire=no` weapons **always** turn to targets as other units do.
+  - `OmniFire.TurnToTarget` is recommended for jumpjet units' omnifiring weapons for facing turning.
+
 #### From pre-0.3 devbuilds
 
 - `Trajectory.Speed` is now defined on projectile instead of weapon.

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -76,7 +76,6 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->RadHasInvoker.Read(exINI, GameStrings::Radiation, "RadHasInvoker");
 	this->MissingCameo.Read(pINI, GameStrings::AudioVisual, "MissingCameo");
 	this->JumpjetAllowLayerDeviation.Read(exINI, GameStrings::JumpjetControls, "AllowLayerDeviation");
-	this->JumpjetTurnToTarget.Read(exINI, GameStrings::JumpjetControls, "TurnToTarget");
 
 	this->PlacementPreview.Read(exINI, GameStrings::AudioVisual, "PlacementPreview");
 	this->PlacementPreview_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Translucency");
@@ -188,7 +187,6 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->JumpjetAllowLayerDeviation)
-		.Process(this->JumpjetTurnToTarget)
 		.Process(this->MissingCameo)
 		.Process(this->PlacementGrid_Translucency)
 		.Process(this->PlacementPreview)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -40,7 +40,7 @@ public:
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;
 		Valueable<bool> JumpjetAllowLayerDeviation;
-		Valueable<bool> JumpjetTurnToTarget;
+
 		PhobosFixedString<32u> MissingCameo;
 		TranslucencyLevel PlacementGrid_Translucency;
 		Valueable<bool> PlacementPreview;
@@ -86,7 +86,6 @@ public:
 			, JumpjetCrash { 5.0 }
 			, JumpjetNoWobbles { false }
 			, JumpjetAllowLayerDeviation { true }
-			, JumpjetTurnToTarget { false }
 			, MissingCameo { "xxicon.shp" }
 			, PlacementGrid_Translucency { 0 }
 			, PlacementPreview { false }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -197,8 +197,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->NoSecondaryWeaponFallback.Read(exINI, pSection, "NoSecondaryWeaponFallback");
 
 	this->JumpjetAllowLayerDeviation.Read(exINI, pSection, "JumpjetAllowLayerDeviation");
-	this->JumpjetTurnToTarget.Read(exINI, pSection, "JumpjetTurnToTarget");
 	this->JumpjetRotateOnCrash.Read(exINI, pSection, "JumpjetRotateOnCrash");
+
 	this->DeployingAnim_AllowAnyDirection.Read(exINI, pSection, "DeployingAnim.AllowAnyDirection");
 	this->DeployingAnim_KeepUnitVisible.Read(exINI, pSection, "DeployingAnim.KeepUnitVisible");
 	this->DeployingAnim_ReverseForUndeploy.Read(exINI, pSection, "DeployingAnim.ReverseForUndeploy");
@@ -371,7 +371,6 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->NoAmmoWeapon)
 		.Process(this->NoAmmoAmount)
 		.Process(this->JumpjetAllowLayerDeviation)
-		.Process(this->JumpjetTurnToTarget)
 		.Process(this->JumpjetRotateOnCrash)
 
 		.Process(this->DeployingAnim_AllowAnyDirection)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -111,7 +111,6 @@ public:
 		Valueable<int> NoAmmoAmount;
 
 		Nullable<bool> JumpjetAllowLayerDeviation;
-		Nullable<bool> JumpjetTurnToTarget;
 		Valueable<bool> JumpjetRotateOnCrash;
 
 		Valueable<bool> DeployingAnim_AllowAnyDirection;
@@ -236,7 +235,6 @@ public:
 			, NoAmmoWeapon { -1 }
 			, NoAmmoAmount { 0 }
 			, JumpjetAllowLayerDeviation {}
-			, JumpjetTurnToTarget {}
 			, JumpjetRotateOnCrash { true }
 
 			, DeployingAnim_AllowAnyDirection { false }

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -34,8 +34,11 @@ DEFINE_HOOK(0x736F78, UnitClass_UpdateFiring_FireErrorIsFACING, 0x6)
 	CoordStruct& source = pThis->Location;
 	CoordStruct target = pThis->Target->GetCoords(); // Target checked so it's not null here
 	DirStruct tgtDir { Math::atan2(source.Y - target.Y, target.X - source.X) };
+
 	if (pType->Turret && !pType->HasTurret) // 0x736F92
+	{
 		pThis->SecondaryFacing.SetDesired(tgtDir);
+	}
 	else // 0x736FB6
 	{
 		if (auto jjLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -42,7 +42,8 @@ DEFINE_HOOK(0x736F78, UnitClass_UpdateFiring_FireErrorIsFACING, 0x6)
 	else // 0x736FB6
 	{
 		if (auto jjLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
-		{	//wrong destination check and wrong Is_Moving usage for jumpjets, should have used Is_Moving_Now
+		{
+			//wrong destination check and wrong Is_Moving usage for jumpjets, should have used Is_Moving_Now
 			if (jjLoco->State != JumpjetLocomotionClass::State::Cruising)
 			{
 				jjLoco->LocomotionFacing.SetDesired(tgtDir);

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -2,6 +2,7 @@
 #include <UnitClass.h>
 
 #include <Ext/TechnoType/Body.h>
+#include <Ext/WeaponType/Body.h>
 
 DEFINE_HOOK(0x54B8E9, JumpjetLocomotionClass_In_Which_Layer_Deviation, 0x6)
 {
@@ -23,34 +24,73 @@ DEFINE_HOOK(0x54B8E9, JumpjetLocomotionClass_In_Which_Layer_Deviation, 0x6)
 }
 
 // Bugfix: Jumpjet turn to target when attacking
-// The way vanilla game handles facing turning is a total mess, so even though this is not the most correct place to do it, given that 0x54BF5B has something similar, I just do it here too
-// TODO : The correct fix : 0x736FC4 for stucking at FireError::FACING, 0x736EE9 for something else like OmniFire etc.
-DEFINE_HOOK(0x54BD93, JumpjetLocomotionClass_State2_TurnToTarget, 0x6)
+
+// Jumpjets stuck at FireError::FACING because WW didn't use a correct facing
+DEFINE_HOOK(0x736F78, UnitClass_UpdateFiring_FireErrorIsFACING, 0x6)
 {
-	enum { ContinueNoTarget = 0x54BDA1, EndFunction = 0x54BFDE };
-	GET(JumpjetLocomotionClass* const, pLoco, ESI);
-	GET(FootClass* const, pLinkedTo, EDI);
+	GET(UnitClass* const, pThis, ESI);
 
-	const auto pTarget = pLinkedTo->Target;
-	if (!pTarget)
-		return ContinueNoTarget;
-
-	if (const auto pThis = abstract_cast<UnitClass*>(pLinkedTo))
+	auto pType = pThis->Type;
+	CoordStruct& source = pThis->Location;
+	CoordStruct target = pThis->Target->GetCoords(); // Target checked so it's not null here
+	DirStruct tgtDir { Math::atan2(source.Y - target.Y, target.X - source.X) };
+	if (pType->Turret && !pType->HasTurret) // 0x736F92
+		pThis->SecondaryFacing.SetDesired(tgtDir);
+	else // 0x736FB6
 	{
-		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
-		if (pTypeExt->JumpjetTurnToTarget.Get(RulesExt::Global()->JumpjetTurnToTarget))
+		if (auto jjLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
+		{	//wrong destination check and wrong Is_Moving usage for jumpjets, should have used Is_Moving_Now
+			if (jjLoco->State != JumpjetLocomotionClass::State::Cruising)
+			{
+				jjLoco->LocomotionFacing.SetDesired(tgtDir);
+				pThis->PrimaryFacing.SetDesired(tgtDir);
+				pThis->SecondaryFacing.SetDesired(tgtDir);
+			}
+		}
+		else if (!pThis->Destination && !pThis->Locomotor->Is_Moving())
 		{
-			CoordStruct& source = pThis->Location;
-			CoordStruct target = pTarget->GetCoords();
-			DirStruct tgtDir { Math::atan2(source.Y - target.Y, target.X - source.X) };
-
-			if (pThis->GetRealFacing() != tgtDir)
-				pLoco->LocomotionFacing.SetDesired(tgtDir);
+			pThis->PrimaryFacing.SetDesired(tgtDir);
+			pThis->SecondaryFacing.SetDesired(tgtDir);
 		}
 	}
 
-	R->EAX(pTarget);
-	return EndFunction;
+	return 0x736FB1;
+}
+
+// For compatibility with previous builds
+DEFINE_HOOK(0x736EE9, UnitClass_UpdateFiring_FireErrorIsOK, 0x6)
+{
+	GET(UnitClass* const, pThis, ESI);
+	GET(int const, wpIdx, EDI);
+	auto pType = pThis->Type;
+
+	if ((pType->Turret && !pType->HasTurret) || pType->TurretSpins)
+		return 0;
+
+	if ((pType->DeployFire || pType->DeployFireWeapon == wpIdx) && pThis->CurrentMission == Mission::Unload)
+		return 0;
+
+	auto const pWpn = pThis->GetWeapon(wpIdx)->WeaponType;
+	if (pWpn->OmniFire)
+	{
+		const auto pTypeExt = WeaponTypeExt::ExtMap.Find(pWpn);
+		if (pTypeExt->OmniFire_TurnToTarget.Get() && !pThis->Locomotor->Is_Moving_Now())
+		{
+			CoordStruct& source = pThis->Location;
+			CoordStruct target = pThis->Target->GetCoords();
+			DirStruct tgtDir { Math::atan2(source.Y - target.Y, target.X - source.X) };
+
+			if (pThis->GetRealFacing() != tgtDir)
+			{
+				if (auto const pLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
+					pLoco->LocomotionFacing.SetDesired(tgtDir);
+				else
+					pThis->PrimaryFacing.SetDesired(tgtDir);
+			}
+		}
+	}
+
+	return 0;
 }
 
 // Bugfix: Align jumpjet turret's facing with body's

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -39,6 +39,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->FeedbackWeapon.Read(exINI, pSection, "FeedbackWeapon", true);
 	this->Laser_IsSingleColor.Read(exINI, pSection, "IsSingleColor");
 	this->ROF_RandomDelay.Read(exINI, pSection, "ROF.RandomDelay");
+	this->OmniFire_TurnToTarget.Read(exINI, pSection, "OmniFire.TurnToTarget");
 }
 
 template <typename T>
@@ -59,6 +60,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->FeedbackWeapon)
 		.Process(this->Laser_IsSingleColor)
 		.Process(this->ROF_RandomDelay)
+		.Process(this->OmniFire_TurnToTarget)
 		;
 };
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -31,6 +31,7 @@ public:
 		Nullable<WeaponTypeClass*> FeedbackWeapon;
 		Valueable<bool> Laser_IsSingleColor;
 		Nullable<PartialVector2D<int>> ROF_RandomDelay;
+		Valueable<bool> OmniFire_TurnToTarget;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius { DiskLaserClass::Radius }
@@ -47,6 +48,7 @@ public:
 			, FeedbackWeapon {}
 			, Laser_IsSingleColor { false }
 			, ROF_RandomDelay {}
+			, OmniFire_TurnToTarget { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
# This is finally the **correct** fix for the jumpjet facing bug

Basically: 
## `JumpjetTurnToTarget` and `[JumpjetControl]->TurnToTarget` are **obsolete**
###  If `OmniFire=no`, jumpjet units now **always** turn to the target as other locomotors do
**No additional tags needed** since it was actually a bug

besides, according to @Metadorius 's suggestion
### Make units try turning to target when firing with `OmniFire=yes`
Recommended for jumpjets' omnifiring weapons
In `rulesmd.ini`:
```ini
[SOMEWEAPON]                ; WeaponType
OmniFire=yes                      ; condition
OmniFire.TurnToTarget=no  ; boolean
```

This should finally close the concern starting from 
#215 
#443 
#608 
#626
#639 
#738 
#744 
There were 2 causes of the bug: 
1. When jumpjets arrived at their `FootClass::Destination`, they seem stuck at the Move mission, and this pointer is not nullified unlike other locomotors. This prevents the body facing from changing in most cases
2.  Jumpjets use the facing in its loco instead of techno, no synchronization was implemented

**Warning for DP-Kratos users**: You should better not using it together with its `JumpjetFacingTarget` related tags

Voxel units always **have and only have 32 facings**.
