### PR TITLE
Custom single player game speed

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -186,6 +186,7 @@ This page lists all the individual contributions to the project by their author.
   - Super Weapons launching other Super Weapons
   - SpyEffects expansion, launching Super Weapons on building infiltration
   - Real time timers
+  - Defualt campaign game speed override and custom campaign game speed FPS
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -186,7 +186,7 @@ This page lists all the individual contributions to the project by their author.
   - Super Weapons launching other Super Weapons
   - SpyEffects expansion, launching Super Weapons on building infiltration
   - Real time timers
-  - Defualt campaign game speed override and custom campaign game speed FPS
+  - Default campaign game speed override and custom campaign game speed FPS
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -46,7 +46,8 @@
     <ClCompile Include="src\Ext\TEvent\Body.cpp" />
     <ClCompile Include="src\Ext\Trigger\Hooks.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
-    <ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
+    <ClCompile Include="src\Misc\CaptureManager.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
     <ClCompile Include="src\Misc\Hooks.Image.cpp" />
     <ClCompile Include="src\Misc\PhobosToolTip.cpp" />
     <ClCompile Include="src\Misc\TextInput.cpp" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -30,7 +30,7 @@
     <ClCompile Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
     <ClCompile Include="src\Ext\CaptureManager\Hooks.cpp" />
-	<ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
+    <ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
     <ClCompile Include="src\Ext\Scenario\Hooks.Variables.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
     <ClCompile Include="src\Ext\CaptureManager\Hooks.cpp" />
+	<ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
     <ClCompile Include="src\Ext\Scenario\Hooks.Variables.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />
@@ -46,7 +47,6 @@
     <ClCompile Include="src\Ext\TEvent\Body.cpp" />
     <ClCompile Include="src\Ext\Trigger\Hooks.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
-    <ClCompile Include="src\Misc\CaptureManager.cpp" />
     <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
     <ClCompile Include="src\Misc\Hooks.Image.cpp" />
     <ClCompile Include="src\Misc\PhobosToolTip.cpp" />

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -72,7 +72,7 @@ CampaignDefaultGameSpeed=4  ; integer
 
 <details>
 <summary>Click to show the generator</summary>
-<input id="customGameSpeedIn" type=number placeholder="Enter desired FPS" onchange="onInput()">
+<input id="customGameSpeedIn" type=number placeholder="Enter desired FPS" oninput="onInput()">
 <p>Results (remember to replace N with your game speed number!):</p>
 <div id="codeBlockHere1"></div>
 </details>

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -57,13 +57,17 @@ Currently there is no way to set desired FPS directly. Use the generator below t
 In `rulesmd.ini`:
 ```ini
 [General]
-CampaignDefaultGameSpeed=2  ; integer
-
 CustomGS=false              ; boolean
 CustomGSN.ChangeInterval=-1 ; integer >= 1
 CustomGSN.ChangeDelay=N     ; integer between 0 and 6
 CustomGSN.DefaultDelay=N    ; integer between 0 and 6
 ; where N = 0, 1, 2, 3, 4, 5, 6
+```
+
+In `ra2md.ini`:
+```ini
+[Phobos]
+CampaignDefaultGameSpeed=4  ; integer
 ```
 
 <details>

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -37,3 +37,25 @@ Fly      | `{4A582746-9839-11d1-B709-00A024DDAFD1}` |
 Teleport | `{4A582747-9839-11d1-B709-00A024DDAFD1}` |
 Mech     | `{55D141B8-DB94-11d1-AC98-006008055BB5}` |
 Ship     | `{2BEA74E1-7CCA-11d3-BE14-00104B62A16C}` |
+
+## Game Speed
+
+### Single player game speed
+
+- It is now possible to change the default (GS4/Fast/30FPS) campaign game speed with `CampaignDefaultGameSpeed`.
+- It is now possible to change the *values* of single player game speed, by inputing a pair of values. This feature must be enabled with `CustomGS=true`. **Not every number of FPS is possible**.
+  - Custom game speed is achieved by temporarily manipulating the delay between game frames.
+  - `CustomGSN.ChangeInterval` describes the frame interval between applying the effect. I.e. a value of 2 means "every other frame" and 7 means "every 7 frames".
+  - `CustomGSN.ChangeDelay` and `CustomGSN.DefaultDelay` set the delay to use on...
+
+In `rulesmd.ini`:
+```ini
+[General]
+CampaignDefaultGameSpeed=2	; integer
+
+CustomGS=false				; boolean
+CustomGSN.ChangeInterval=-1	; integer >= 1
+CustomGSN.ChangeDelay=N		; integer between 0 and 6
+CustomGSN.DefaultDelay=N	; integer between 0 and 6
+; where N = 0, 1, 2, 3, 4, 5, 6
+```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -102,8 +102,8 @@ ShowPlacementPreview=yes   ; boolean
 
 ### Real time timers
 
-- Timers can now display values in real time, taking game speed into account. This can be enabled with `RealTimeTimers=yes`.
-- By default, time is calculated relative to desired framerate. Enabling `RealTimeTimers.Adaptive=yes` (always on for unlimited FPS) will calculate time relative to *current* FPS, accounting for lag.
+- Timers can now display values in real time, taking game speed into account. This can be enabled with `RealTimeTimers=true`.
+- By default, time is calculated relative to desired framerate. Enabling `RealTimeTimers.Adaptive` (always true for unlimited FPS and custom speeds) will calculate time relative to *current* FPS, accounting for lag.
   - When playing with unlimited FPS (or custom speed above 60 FPS), the timers might constantly change value because of the unstable nature.
 - This option respects custom game speeds.
 
@@ -112,8 +112,8 @@ ShowPlacementPreview=yes   ; boolean
 In `ra2md.ini`:
 ```ini
 [Phobos]
-RealTimeTimers=no           ; boolean
-RealTimeTimers.Adaptive=no  ; boolean
+RealTimeTimers=false            ; boolean
+RealTimeTimers.Adaptive=false   ; boolean
 ```
 
 ### SuperWeapon ShowTimer sorting

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -278,7 +278,7 @@ New:
 - Removal of hardcoded AA & Gattling weapon selection restrictions (by Starkku)
 - Projectile `SubjectToLand/Water` (by Starkku)
 - Real time timers (by Morton)
-- Defualt campaign game speed override and custom campaign game speed FPS (by Morton)
+- Default campaign game speed override and custom campaign game speed FPS (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -278,6 +278,7 @@ New:
 - Removal of hardcoded AA & Gattling weapon selection restrictions (by Starkku)
 - Projectile `SubjectToLand/Water` (by Starkku)
 - Real time timers (by Morton)
+- Defualt campaign game speed override and custom campaign game speed FPS (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/_static/js/ini-block-maker.js
+++ b/docs/_static/js/ini-block-maker.js
@@ -1,0 +1,53 @@
+// Create an INI code block with given `newId` as a child of `parent` node, with an optional `height`
+function makeINICodeBlock(parent, newId, height) {
+	let div1 = document.createElement("div");
+	div1.className = "highlight-ini notranslate";
+	if (height != null) {
+		div1.style.height = `${height}px`;
+		div1.style.overflow = "auto";
+    }
+	let div2 = document.createElement("div");
+	div2.className = "highlight";
+	let pre = document.createElement("pre");
+	pre.id = newId;
+	div2.appendChild(pre);
+	div1.appendChild(div2);
+	parent.appendChild(div1);
+}
+
+// Add an INI line to a code block node (a direct parent <pre> node)
+// An INI line consists of a `key`, `value` and `comment`, all can be null
+function addINILine(codeBlockNode, line) {
+	if (line.key != null) {
+		let na = document.createElement("span");
+		na.className = "na";
+		na.textContent = line.key;
+		codeBlockNode.appendChild(na);
+		let o = document.createElement("span");
+		o.className = "o";
+		o.textContent = "=";
+		codeBlockNode.appendChild(o);
+	}
+	if (line.value != null) {
+		let s = document.createElement("span");
+		s.className = "s";
+		s.textContent = line.value;
+		codeBlockNode.appendChild(s);
+	}
+	if (line.comment != null) {
+		if (line.key != null || line.value != null) {
+			let w = document.createElement("span");
+			w.className = "w";
+			w.textContent = ' ';
+			codeBlockNode.appendChild(w);
+		}
+		let c1 = document.createElement("span");
+		c1.className = "c1";
+		c1.textContent = line.comment;
+		codeBlockNode.appendChild(c1);
+	}
+	let w = document.createElement("span");
+	w.className = "w";
+	w.textContent = '\n';
+	codeBlockNode.appendChild(w);
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="_static/css/index.css" type="text/css" />
   <link rel="stylesheet" href="_static/css/dark.css" media="(prefers-color-scheme: dark)" />
   <script src="_static/js/scheme-switcher.js"></script>
+  <script src="_static/js/ini-block-maker.js"></script>
 {% endblock %}
 
 {% block footer %}

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -2,6 +2,7 @@
 #include <Utilities/Macro.h>
 #include <SessionClass.h>
 #include <GameOptionsClass.h>
+#include <Unsorted.h>
 
 DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 {
@@ -13,6 +14,7 @@ int counter = 0;
 DEFINE_HOOK(0x55E160, SyncDelay_Start, 0x6)
 {
 	constexpr reference<CDTimerClass, 0x887348> FrameTimer;
+	//constexpr reference<CDTimerClass, 0x887328> NFTTimer;
 	if (!Phobos::Misc::CustomGS)
 		return 0;
 	if ((Phobos::Misc::CustomGS_ChangeInterval[FrameTimer->TimeLeft] > 0)
@@ -23,9 +25,10 @@ DEFINE_HOOK(0x55E160, SyncDelay_Start, 0x6)
 	}
 	else
 	{
-		counter += 1;
 		FrameTimer->TimeLeft = Phobos::Misc::CustomGS_DefaultDelay[FrameTimer->TimeLeft];
+		counter++;
 	}
+
 	return 0;
 }
 
@@ -35,3 +38,56 @@ DEFINE_HOOK(0x55E33B, SyncDelay_End, 0x6)
 	FrameTimer->TimeLeft = GameOptionsClass::Instance->GameSpeed;
 	return 0;
 }
+
+// note: currently vanilla code, doesn't do anything, changing PrecalcDesiredFrameRate doesn't effect anything either
+/*
+void SetNetworkFrameRate()
+{
+	static constexpr reference<int, 0xA8B550u> const PrecalcDesiredFrameRate {};
+	switch (GameOptionsClass::Instance->GameSpeed)
+	{
+	case 0:
+		Game::Network.MaxAhead = 40;
+		PrecalcDesiredFrameRate = 60;
+		Game::Network.FrameSendRate = 10;
+		break;
+	case 1:
+		Game::Network.MaxAhead = 40;
+		PrecalcDesiredFrameRate = 45;
+		Game::Network.FrameSendRate = 10;
+		break;
+	case 2:
+		Game::Network.MaxAhead = 30;
+		PrecalcDesiredFrameRate = 30;
+		break;
+	case 3:
+		Game::Network.MaxAhead = 20;
+		PrecalcDesiredFrameRate = 20;
+		break;
+	case 4:
+		Game::Network.MaxAhead = 20;
+		PrecalcDesiredFrameRate = 15;
+		break;
+	case 5:
+		Game::Network.MaxAhead = 20;
+		PrecalcDesiredFrameRate = 12;
+		break;
+	default:
+		Game::Network.MaxAhead = 10;
+		PrecalcDesiredFrameRate = 10;
+		break;
+	}
+}
+
+DEFINE_HOOK(0x5C49A7, MPCooperative_5C46E0_FPS, 0x9)
+{
+	SetNetworkFrameRate();
+	return 0x5C4A40;
+}
+
+DEFINE_HOOK(0x794F7E, Start_Game_Now_FPS, 0x8)
+{
+	SetNetworkFrameRate();
+	return 0x79501F;
+}
+*/

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -1,14 +1,60 @@
 #include <Phobos.h>
 #include <Utilities/Macro.h>
+#include <SessionClass.h>
+#include <GameOptionsClass.h>
 
-DEFINE_HOOK(0x55D774, MainLoop_CampaignGameSpeed, 0xA)
+DEFINE_HOOK(0x55D774, MainLoop_CampaignGameSpeed_NotSpeedControl, 0xA)
 {
-	Options.GameSpeed = Phobos::Config::CampaignDefaultGameSpeed;
+	GameOptionsClass::Instance->GameSpeed = Phobos::Misc::CampaignDefaultGameSpeed;
 	return 0x55D77E;
+}
+
+DEFINE_HOOK(0x55D78C, MainLoop_CampaignGameSpeed_NotSpeedControl2, 0x5)
+{
+	R->ECX(Phobos::Misc::CampaignDefaultGameSpeed);
+	return 0x55D791;
+}
+
+// todo just write to memory there once, this is executed every frame
+DEFINE_HOOK(0x55D79E, MainLoop_CampaignGameSpeed_SpeedControl, 0x6)
+{
+	if (SessionClass::IsCampaign())
+	{
+		R->ESI(Phobos::Misc::CampaignDefaultGameSpeed);
+		return 0x55D7A4;
+	}
+	return 0;
 }
 
 DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 {
-	Options.GameSpeed = Phobos::Config::CampaignDefaultGameSpeed;
+	GameOptionsClass::Instance->GameSpeed = Phobos::Misc::CampaignDefaultGameSpeed;
 	return 0x69BAF1;
+}
+
+int counter = 0;
+DEFINE_HOOK(0x55E160, SyncDelay_Start, 0x6)
+{
+	constexpr reference<CDTimerClass, 0x887348> FrameTimer;
+	if (!Phobos::Misc::CustomGS)
+		return 0;
+	if ((Phobos::Misc::CustomGS_ChangeInterval[FrameTimer->TimeLeft] > 0)
+		&& (counter % Phobos::Misc::CustomGS_ChangeInterval[FrameTimer->TimeLeft] == 0))
+	{
+		FrameTimer->TimeLeft = Phobos::Misc::CustomGS_ChangeDelay[FrameTimer->TimeLeft];
+		counter = 1;
+	}
+	else
+	{
+		counter += 1;
+		FrameTimer->TimeLeft = Phobos::Misc::CustomGS_DefaultDelay[FrameTimer->TimeLeft];
+	}
+	return 0;
+}
+
+DEFINE_HOOK(0x55E33B, SyncDelay_End, 0x6)
+{
+	constexpr reference<CDTimerClass, 0x887348> FrameTimer;
+	FrameTimer->TimeLeft = GameOptionsClass::Instance->GameSpeed;
+	return 0;
 }

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -6,7 +6,7 @@
 
 DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 {
-	GameOptionsClass::Instance->GameSpeed = Phobos::Misc::CampaignDefaultGameSpeed;
+	GameOptionsClass::Instance->GameSpeed = Phobos::Config::CampaignDefaultGameSpeed;
 	return 0x69BAF1;
 }
 

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -1,0 +1,14 @@
+#include <Phobos.h>
+#include <Utilities/Macro.h>
+
+DEFINE_HOOK(0x55D774, MainLoop_CampaignGameSpeed, 0xA)
+{
+	Options.GameSpeed = Phobos::Config::CampaignDefaultGameSpeed;
+	return 0x55D77E;
+}
+
+DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
+{
+	Options.GameSpeed = Phobos::Config::CampaignDefaultGameSpeed;
+	return 0x69BAF1;
+}

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -3,29 +3,6 @@
 #include <SessionClass.h>
 #include <GameOptionsClass.h>
 
-DEFINE_HOOK(0x55D774, MainLoop_CampaignGameSpeed_NotSpeedControl, 0xA)
-{
-	GameOptionsClass::Instance->GameSpeed = Phobos::Misc::CampaignDefaultGameSpeed;
-	return 0x55D77E;
-}
-
-DEFINE_HOOK(0x55D78C, MainLoop_CampaignGameSpeed_NotSpeedControl2, 0x5)
-{
-	R->ECX(Phobos::Misc::CampaignDefaultGameSpeed);
-	return 0x55D791;
-}
-
-// todo just write to memory there once, this is executed every frame
-DEFINE_HOOK(0x55D79E, MainLoop_CampaignGameSpeed_SpeedControl, 0x6)
-{
-	if (SessionClass::IsCampaign())
-	{
-		R->ESI(Phobos::Misc::CampaignDefaultGameSpeed);
-		return 0x55D7A4;
-	}
-	return 0;
-}
-
 DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 {
 	GameOptionsClass::Instance->GameSpeed = Phobos::Misc::CampaignDefaultGameSpeed;

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -4,13 +4,17 @@
 #include <GameOptionsClass.h>
 #include <Unsorted.h>
 
+namespace GameSpeedTemp
+{
+	static int counter = 0;
+}
+
 DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 {
 	GameOptionsClass::Instance->GameSpeed = Phobos::Config::CampaignDefaultGameSpeed;
 	return 0x69BAF1;
 }
 
-int counter = 0;
 DEFINE_HOOK(0x55E160, SyncDelay_Start, 0x6)
 {
 	constexpr reference<CDTimerClass, 0x887348> FrameTimer;
@@ -18,15 +22,15 @@ DEFINE_HOOK(0x55E160, SyncDelay_Start, 0x6)
 	if (!Phobos::Misc::CustomGS)
 		return 0;
 	if ((Phobos::Misc::CustomGS_ChangeInterval[FrameTimer->TimeLeft] > 0)
-		&& (counter % Phobos::Misc::CustomGS_ChangeInterval[FrameTimer->TimeLeft] == 0))
+		&& (GameSpeedTemp::counter % Phobos::Misc::CustomGS_ChangeInterval[FrameTimer->TimeLeft] == 0))
 	{
 		FrameTimer->TimeLeft = Phobos::Misc::CustomGS_ChangeDelay[FrameTimer->TimeLeft];
-		counter = 1;
+		GameSpeedTemp::counter = 1;
 	}
 	else
 	{
 		FrameTimer->TimeLeft = Phobos::Misc::CustomGS_DefaultDelay[FrameTimer->TimeLeft];
-		counter++;
+		GameSpeedTemp::counter++;
 	}
 
 	return 0;

--- a/src/Misc/Hooks.Timers.cpp
+++ b/src/Misc/Hooks.Timers.cpp
@@ -19,7 +19,7 @@ DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical_Start, 0x6)
 
 	if (Phobos::Config::RealTimeTimers_Adaptive
 		|| GameOptionsClass::Instance->GameSpeed == 0
-		|| (false && !SessionClass::IsMultiplayer())) // TODO change when custom game speed gets merged
+		|| (Phobos::Misc::CustomGS && !SessionClass::IsMultiplayer()))
 	{
 		value = (int)((double)value / (std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0));
 		return 0;

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -13,6 +13,7 @@
 #include <BitFont.h>
 #include <BitText.h>
 #include <FPSCounter.h>
+#include <Phobos.h>
 
 #include <Ext/Side/Body.h>
 #include <Ext/Surface/Body.h>
@@ -101,7 +102,7 @@ inline int tickTimeToSeconds(int tickTime)
 
 	if (Phobos::Config::RealTimeTimers_Adaptive
 		|| GameOptionsClass::Instance->GameSpeed == 0
-		|| (false && !SessionClass::IsMultiplayer())) // TODO change when custom game speed gets merged
+		|| (Phobos::Misc::CustomGS && !SessionClass::IsMultiplayer()))
 	{
 		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
 	}

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -278,8 +278,9 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 
 	Phobos::Config::ArtImageSwap = pINI_RULESMD->ReadBool(GameStrings::General, "ArtImageSwap", false);
 
+	// Custom game speeds, 6 - i so that GS6 is index 0, just like in the engine
 	Phobos::Misc::CampaignDefaultGameSpeed = 6 - pINI_RULESMD->ReadInteger(GameStrings::General, "CampaignDefaultGameSpeed", 4);
-	if (Phobos::Misc::CampaignDefaultGameSpeed > 5 || Phobos::Misc::CampaignDefaultGameSpeed < 0)
+	if (Phobos::Misc::CampaignDefaultGameSpeed > 6 || Phobos::Misc::CampaignDefaultGameSpeed < 0)
 		Phobos::Misc::CampaignDefaultGameSpeed = 2;
 	*(BYTE*)(0x55D77A) = (BYTE)Phobos::Misc::CampaignDefaultGameSpeed; // We overwrite the instructions that force GameSpeed to 2 (GS4)
 	*(BYTE*)(0x55D78D) = (BYTE)Phobos::Misc::CampaignDefaultGameSpeed; // when speed control is off. Doesn't need a hook.
@@ -290,7 +291,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	int temp;
 	for (size_t i = 0; i <= 6; ++i)
 	{
-		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.ChangeDelay", 6 - i); // 6 - i so that GS6 is index 0
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.ChangeDelay", 6 - i);
 		temp = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, -1);
 		if (temp >= 0 && temp <= 6)
 			Phobos::Misc::CustomGS_ChangeDelay[i] = 6 - temp;

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -60,6 +60,7 @@ bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::ShowPlacementPreview = false;
 bool Phobos::Config::RealTimeTimers = false;
 bool Phobos::Config::RealTimeTimers_Adaptive = false;
+int Phobos::Config::CampaignDefaultGameSpeed = 2;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -270,6 +271,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	CCINIClass* pINI_RULESMD = Phobos::OpenConfig(GameStrings::RULESMD_INI);
 
 	Phobos::Config::ArtImageSwap = pINI_RULESMD->ReadBool(GameStrings::General, "ArtImageSwap", false);
+	Phobos::Config::CampaignDefaultGameSpeed = pINI_RULESMD->ReadInteger(GameStrings::General, "CampaignDefaultGameSpped", 2);
 
 	if (pINI_RULESMD->ReadBool(GameStrings::General, "FixTransparencyBlitters", true))
 		BlittersFix::Apply();

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -62,6 +62,12 @@ bool Phobos::Config::RealTimeTimers = false;
 bool Phobos::Config::RealTimeTimers_Adaptive = false;
 int Phobos::Config::CampaignDefaultGameSpeed = 2;
 
+int Phobos::Misc::CampaignDefaultGameSpeed = 2;
+bool Phobos::Misc::CustomGS = false;
+int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
+int Phobos::Misc::CustomGS_ChangeDelay[7] = { 0, 1, 2, 3, 4, 5, 6 };
+int Phobos::Misc::CustomGS_DefaultDelay[7] = { 0, 1, 2, 3, 4, 5, 6 };
+
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
 	// > 1 because the exe path itself counts as an argument, too!
@@ -271,7 +277,32 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	CCINIClass* pINI_RULESMD = Phobos::OpenConfig(GameStrings::RULESMD_INI);
 
 	Phobos::Config::ArtImageSwap = pINI_RULESMD->ReadBool(GameStrings::General, "ArtImageSwap", false);
-	Phobos::Config::CampaignDefaultGameSpeed = pINI_RULESMD->ReadInteger(GameStrings::General, "CampaignDefaultGameSpped", 2);
+
+	Phobos::Misc::CampaignDefaultGameSpeed = 6 - pINI_RULESMD->ReadInteger(GameStrings::General, "CampaignDefaultGameSpeed", 4);
+	if (Phobos::Misc::CampaignDefaultGameSpeed > 5 || Phobos::Misc::CampaignDefaultGameSpeed < 0)
+		Phobos::Misc::CampaignDefaultGameSpeed = 2;
+
+	Phobos::Misc::CustomGS = pINI_RULESMD->ReadBool(GameStrings::General, "CustomGS", false);
+
+	char tempBuffer[26];
+	int temp;
+	for (size_t i = 0; i <= 6; ++i)
+	{
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.ChangeDelay", 6 - i); // 6 - i so that GS6 is index 0
+		temp = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, -1);
+		if (temp >= 0 && temp <= 6)
+			Phobos::Misc::CustomGS_ChangeDelay[i] = 6 - temp;
+
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.DefaultDelay", 6 - i);
+		temp = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, -1);
+		if (temp >= 1)
+			Phobos::Misc::CustomGS_DefaultDelay[i] = 6 - temp;
+
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.ChangeInterval", 6 - i);
+		temp = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, -1);
+		if (temp >= 1)
+			Phobos::Misc::CustomGS_ChangeInterval[i] = temp;
+	}
 
 	if (pINI_RULESMD->ReadBool(GameStrings::General, "FixTransparencyBlitters", true))
 		BlittersFix::Apply();

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -62,7 +62,6 @@ bool Phobos::Config::RealTimeTimers = false;
 bool Phobos::Config::RealTimeTimers_Adaptive = false;
 int Phobos::Config::CampaignDefaultGameSpeed = 2;
 
-int Phobos::Misc::CampaignDefaultGameSpeed = 2;
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
 int Phobos::Misc::CustomGS_ChangeDelay[7] = { 0, 1, 2, 3, 4, 5, 6 };
@@ -279,11 +278,11 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::ArtImageSwap = pINI_RULESMD->ReadBool(GameStrings::General, "ArtImageSwap", false);
 
 	// Custom game speeds, 6 - i so that GS6 is index 0, just like in the engine
-	Phobos::Misc::CampaignDefaultGameSpeed = 6 - pINI_RULESMD->ReadInteger(GameStrings::General, "CampaignDefaultGameSpeed", 4);
-	if (Phobos::Misc::CampaignDefaultGameSpeed > 6 || Phobos::Misc::CampaignDefaultGameSpeed < 0)
-		Phobos::Misc::CampaignDefaultGameSpeed = 2;
-	*(BYTE*)(0x55D77A) = (BYTE)Phobos::Misc::CampaignDefaultGameSpeed; // We overwrite the instructions that force GameSpeed to 2 (GS4)
-	*(BYTE*)(0x55D78D) = (BYTE)Phobos::Misc::CampaignDefaultGameSpeed; // when speed control is off. Doesn't need a hook.
+	Phobos::Config::CampaignDefaultGameSpeed = 6 - CCINIClass::INI_RA2MD->ReadInteger("Phobos", "CampaignDefaultGameSpeed", 4);
+	if (Phobos::Config::CampaignDefaultGameSpeed > 6 || Phobos::Config::CampaignDefaultGameSpeed < 0)
+		Phobos::Config::CampaignDefaultGameSpeed = 2;
+	*(BYTE*)(0x55D77A) = (BYTE)Phobos::Config::CampaignDefaultGameSpeed; // We overwrite the instructions that force GameSpeed to 2 (GS4)
+	*(BYTE*)(0x55D78D) = (BYTE)Phobos::Config::CampaignDefaultGameSpeed; // when speed control is off. Doesn't need a hook.
 
 	Phobos::Misc::CustomGS = pINI_RULESMD->ReadBool(GameStrings::General, "CustomGS", false);
 

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -281,6 +281,8 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Misc::CampaignDefaultGameSpeed = 6 - pINI_RULESMD->ReadInteger(GameStrings::General, "CampaignDefaultGameSpeed", 4);
 	if (Phobos::Misc::CampaignDefaultGameSpeed > 5 || Phobos::Misc::CampaignDefaultGameSpeed < 0)
 		Phobos::Misc::CampaignDefaultGameSpeed = 2;
+	*(BYTE*)(0x55D77A) = (BYTE)Phobos::Misc::CampaignDefaultGameSpeed; // We overwrite the instructions that force GameSpeed to 2 (GS4)
+	*(BYTE*)(0x55D78D) = (BYTE)Phobos::Misc::CampaignDefaultGameSpeed; // when speed control is off. Doesn't need a hook.
 
 	Phobos::Misc::CustomGS = pINI_RULESMD->ReadBool(GameStrings::General, "CustomGS", false);
 

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -70,5 +70,6 @@ public:
 		static bool ShowPlacementPreview;
 		static bool RealTimeTimers;
 		static bool RealTimeTimers_Adaptive;
+		static int CampaignDefaultGameSpeed;
 	};
 };

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -70,12 +70,12 @@ public:
 		static bool ShowPlacementPreview;
 		static bool RealTimeTimers;
 		static bool RealTimeTimers_Adaptive;
+		static int CampaignDefaultGameSpeed;
 	};
 
 	class Misc
 	{
 	public:
-		static int CampaignDefaultGameSpeed;
 		static bool CustomGS;
 		static int CustomGS_ChangeInterval[7];
 		static int CustomGS_ChangeDelay[7];

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -70,6 +70,15 @@ public:
 		static bool ShowPlacementPreview;
 		static bool RealTimeTimers;
 		static bool RealTimeTimers_Adaptive;
+	};
+
+	class Misc
+	{
+	public:
 		static int CampaignDefaultGameSpeed;
+		static bool CustomGS;
+		static int CustomGS_ChangeInterval[7];
+		static int CustomGS_ChangeDelay[7];
+		static int CustomGS_DefaultDelay[7];
 	};
 };


### PR DESCRIPTION
Additional reference: https://docs.google.com/spreadsheets/d/1LjHrYXjXZ7vyQSYEno5hEY0VY9XhncPFlXKlWsVaM5k/edit?usp=sharing

### Single player game speed

- It is now possible to change the default (GS4/Fast/30FPS) campaign game speed with `CampaignDefaultGameSpeed`.
- It is now possible to change the *values* of single player game speed, by inputing a pair of values. This feature must be enabled with `CustomGS=true`. **Only values between 10 and 60 FPS can be consistently achieved.**
  - Custom game speed is achieved by periodically manipulating the delay between game frames, thus increasing or decreasing FPS.
  - `CustomGSN.ChangeInterval` describes the frame interval between applying the effect. A value of 2 means "every other frame", 3 means "every 3 frames" etc. Increase of speedup/slowdown is approximately logarithmic.
  - `CustomGSN.ChangeDelay` sets the delay (game speed number) to use every `CustomGSN.ChangeInterval` frames.
  - `CustomGSN.DefaultDelay` sets the delay (game speed number) to use on other frames.
  - Using game speed 6 (Fastest) in either `CustomGSN.ChangeDelay` or `CustomGSN.DefaultDelay` allows to set FPS above 60. **However, the resulting FPS may vary on different machines.**

```{note}
Currently there is no way to set desired FPS directly. Use the generator below to get required values. The generator supports values from 10 to 60.
```

In `rulesmd.ini`:
```ini
[General]
CustomGS=false              ; boolean
CustomGSN.ChangeInterval=-1 ; integer >= 1
CustomGSN.ChangeDelay=N     ; integer between 0 and 6
CustomGSN.DefaultDelay=N    ; integer between 0 and 6
; where N = 0, 1, 2, 3, 4, 5, 6
```

In `ra2md.ini`:
```ini
[Phobos]
CampaignDefaultGameSpeed=4  ; integer
```

(generator omitted)