### PR TITLE
Skip `NaturalParticleSystem` displaying from in-map pre-placed structures

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -200,6 +200,7 @@ This page lists all the individual contributions to the project by their author.
    - "Shield is broken" trigger event
    - RadialIndicator observer visibility
    - Cloaked objects from allies displaying to player in singleplayer campaigns
+   - Skip `NaturalParticleSystem` displaying from in-map pre-placed structures.
    - Forbidding parallel AI queues by type
 - **FlyStar**
    - Campaign load screen PCX support

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -16,6 +16,7 @@ RepairBaseNodes=no,no,no ; 3 booleans indicating whether AI repair basenodes in 
 ```
 - Teams spawned by trigger action 7,80,107 can use IFV and opentopped logic normally.
   - `InitialPayload` logic from Ares is not supported yet.
+- If a pre-placed building has a `NaturalParticleSystem`, it used to always be created when the game starts. This has been removed.
 
 ## Script Actions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -90,6 +90,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - IvanBomb images now display and the bombs detonate at center of buildings instead of in top-leftmost cell of the building foundation.
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations.
 - Animation with `Tiled=yes` now supports `CustomPalette`.
+- Fixed buildings' `NaturalParticleSystem` being created for in-map pre-placed structures.
+
 
 ## Animations
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -260,6 +260,7 @@ Vanilla fixes:
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations (by Starkku)
 - Cloaked objects displaying to observers (by Starkku)
 - Cloaked objects from allies displaying to player in single player missions (by Trsdy)
+- Skip `NaturalParticleSystem` displaying from in-map pre-placed structures (by Trsdy)
 - Made sure that `Suicide=yes` weapon does kill the firer (by Trsdy)
 - Made sure that vxl units being flipped over get killed instead of rotating up and down (by Trsdy)
 

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -335,6 +335,7 @@ void BuildingExt::ExtData::Serialize(T& Stm)
 	Stm
 		.Process(this->TypeExtData)
 		.Process(this->DeployedTechno)
+		.Process(this->IsCreatedFromMapFile)
 		.Process(this->LimboID)
 		.Process(this->GrindingWeapon_LastFiredFrame)
 		.Process(this->CurrentAirFactory)

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -23,6 +23,7 @@ public:
 	public:
 		BuildingTypeExt::ExtData* TypeExtData;
 		bool DeployedTechno;
+		bool IsCreatedFromMapFile;
 		int LimboID;
 		int GrindingWeapon_LastFiredFrame;
 		BuildingClass* CurrentAirFactory;
@@ -31,6 +32,7 @@ public:
 		ExtData(BuildingClass* OwnerObject) : Extension<BuildingClass>(OwnerObject)
 			, TypeExtData { nullptr }
 			, DeployedTechno { false }
+			, IsCreatedFromMapFile { false }
 			, LimboID { -1 }
 			, GrindingWeapon_LastFiredFrame { 0 }
 			, CurrentAirFactory { nullptr }

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -172,4 +172,3 @@ DEFINE_HOOK(0x51EAF2, TechnoClass_WhatAction_AllowAirstrike, 0x6)
 
 	return SkipGameCode;
 }
-

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -1,5 +1,4 @@
 #include "Body.h"
-#include <GameOptionsClass.h>
 #include "../Techno/Body.h"
 #include "../Building/Body.h"
 #include <unordered_map>
@@ -62,20 +61,4 @@ DEFINE_HOOK(0x73E474, UnitClass_Unload_Storage, 0x6)
 	}
 
 	return 0;
-}
-
-DEFINE_HOOK(0x440B4F, BuildingClass_Unlimbo_SetShouldRebuild, 0x5)
-{
-	enum { ContinueCheck = 0x440B58, SkipCheck = 0x440B81 };
-
-	GET(BuildingClass* const, pThis, ESI);
-
-	if (SessionClass::IsCampaign())
-	{
-		if (!pThis->BeingProduced ||
-			!HouseExt::ExtMap.Find(pThis->Owner)->RepairBaseNodes[GameOptionsClass::Instance->Difficulty])
-			return SkipCheck;
-	}
-
-	return ContinueCheck;
 }


### PR DESCRIPTION
`[SOMEBUILDING]->NaturalParticleSystem` creates smoke particles when a building is built and placed. However it was also played for those already placed structures in the map files, which make the intro of a campaign visually strange since those buildings should not be considered to be built on the scene by players.

This PR adds a check for all buildings to see if it's preplaced on the map file, and if yes, skip the particle creation process

This PR also fixes a similar issue for AI-Structure repairability introduced by #722 but broken by d451f0194458c370af3a34a8e0c1710f10b2ba95

Must be merged before b34