### PR TITLE
Allow `DieSound/VoiceDie` not being played when being grinded

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -206,6 +206,7 @@ This page lists all the individual contributions to the project by their author.
    - Skip `NaturalParticleSystem` displaying from in-map pre-placed structures.
    - `ImmuneToCrit` for shields
    - Forbidding parallel AI queues by type
+   - The option to allow DieSound/VoiceDie being played when grinding
    - Allow iron-curtain effects on infantries
 - **FlyStar**
    - Campaign load screen PCX support

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -169,6 +169,7 @@ AllowAirstrike=  ; boolean
   - `Grinding.AllowOwner` changes whether or not to allow units to enter your own buildings.
   - `Grinding.AllowTypes` can be used to define InfantryTypes and VehicleTypes that can be grinded by the building. Listing any will disable grinding for all types except those listed.
   - `Grinding.DisallowTypes` can be used to exclude InfantryTypes or VehicleTypes from being able to enter the grinder building.
+  - `Grinding.PlayDieSound` controls if the units' `DieSound` and `VoiceDie` are played when entering the grinder. Default to `yes`.
   - `Grinding.Sound` is a sound played by when object is grinded by the building. If not set, defaults to `[AudioVisual]`->`EnterGrinderSound`.
   - `Grinding.Weapon` is a weapon fired at the building & by the building when it grinds an object. Will only be fired if at least weapon's `ROF` amount of frames have passed since it was last fired.
   - `Grinding.DisplayRefund` can be set to display the amount of credits acquired upon grinding on the building. Multiple refunded objects within a short period of time have their refund amounts coalesced into single display.
@@ -182,6 +183,7 @@ Grinding.AllowAllies=false         ; boolean
 Grinding.AllowOwner=true           ; boolean
 Grinding.AllowTypes=               ; List of InfantryTypes / VehicleTypes
 Grinding.DisallowTypes=            ; List of InfantryTypes / VehicleTypes
+Grinding.PlayDieSound=true         ; boolean
 Grinding.Sound=                    ; Sound
 Grinding.Weapon=                   ; WeaponType
 Grinding.DisplayRefund=false       ; boolean

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -253,6 +253,7 @@ New:
 - Forcing specific weapon against cloaked or disguised targets (by Starkku)
 - Customizable ROF random delay (by Starkku)
 - Animation with `Tiled=yes` now supports `CustomPalette` (by ststl)
+- Toggleable DieSound when grinding (by Trsdy)
 - Shields can inherit Techno ArmorType (by Starkku)
 - Iron-curtain effects on infantries and organic units (by ststl)
 

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -137,6 +137,7 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Grinding_AllowTypes.Read(exINI, pSection, "Grinding.AllowTypes");
 	this->Grinding_DisallowTypes.Read(exINI, pSection, "Grinding.DisallowTypes");
 	this->Grinding_Sound.Read(exINI, pSection, "Grinding.Sound");
+	this->Grinding_PlayDieSound.Read(exINI, pSection, "Grinding.PlayDieSound");
 	this->Grinding_Weapon.Read(exINI, pSection, "Grinding.Weapon", true);
 	this->Grinding_DisplayRefund.Read(exINI, pSection, "Grinding.DisplayRefund");
 	this->Grinding_DisplayRefund_Houses.Read(exINI, pSection, "Grinding.DisplayRefund.Houses");
@@ -207,6 +208,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Grinding_DisallowTypes)
 		.Process(this->Grinding_Sound)
 		.Process(this->Grinding_Weapon)
+		.Process(this->Grinding_PlayDieSound)
 		.Process(this->Grinding_DisplayRefund)
 		.Process(this->Grinding_DisplayRefund_Houses)
 		.Process(this->Grinding_DisplayRefund_Offset)

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -35,6 +35,7 @@ public:
 		ValueableVector<TechnoTypeClass*> Grinding_DisallowTypes;
 		NullableIdx<VocClass> Grinding_Sound;
 		Nullable<WeaponTypeClass*> Grinding_Weapon;
+		Valueable<bool> Grinding_PlayDieSound;
 		Valueable<bool> Grinding_DisplayRefund;
 		Valueable<AffectedHouse> Grinding_DisplayRefund_Houses;
 		Valueable<Point2D> Grinding_DisplayRefund_Offset;
@@ -67,6 +68,7 @@ public:
 			, Grinding_AllowTypes {}
 			, Grinding_DisallowTypes {}
 			, Grinding_Sound {}
+			, Grinding_PlayDieSound { true }
 			, Grinding_Weapon {}
 			, Grinding_DisplayRefund { false }
 			, Grinding_DisplayRefund_Houses { AffectedHouse::All }


### PR DESCRIPTION
When an infantry/unit enters a grinder, the `DieSound`/`VoiceDie` are always played.
You can now disable that per grinder

```ini
[SOMEBUILDING]
Grinding.PlayDieSound=yes
```

Can merge this only after v0.3 being merged into develop