### PR TITLE
Allow UnitTypes to use `AlternateFLH` in opentopped transport

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -190,6 +190,7 @@ This page lists all the individual contributions to the project by their author.
       - Misc vanilla suicidal behavior fix
    - Post-type-conversion update
    - Building EVA_StructureSold and SellSound dehardcode
+   - `AlternateFLH` of vehicles in `OpenTopped` transport.
    - Slaves' house customization when owner is killed
    - Trigger Action spawned team IFV/Opentopped logic fix
    - Singleplayer Campaign AI's base node/SW-delivered/trigger action 125-delivered structures' auto-repairability dehardcode

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -26,7 +26,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed interaction of `UnitAbsorb` & `InfantryAbsorb` with `Grinding` buildings. The keys will now make the building only accept appropriate types of objects.
 - Fixed missing 'no enter' cursor for VehicleTypes being unable to enter a `Grinding` building.
 - Fixed Engineers being able to enter `Grinding` buildings even when they shouldn't (such as ally building at full HP).
-
+- Allowed usage of `AlternateFLH` of vehicles in `OpenTopped` transport.
 - SHP debris shadows now respect the `Shadow` tag.
 - Allowed usage of TileSet of 255 and above without making NE-SW broken bridges unrepairable.
 - Added a "Load Game" button to the retry dialog on mission failure.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -257,6 +257,7 @@ New:
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
+- Allowed usage of `AlternateFLH%d` of vehicles in `OpenTopped` transport. (by Trsdy)
 - Teams spawned by trigger action 7,80,107 can use IFV and `OpenTopped` logic normally (by Trsdy)
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations (by Starkku)
 - Cloaked objects displaying to observers (by Starkku)

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -5,7 +5,7 @@
 #include <Helpers/Macro.h>
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
-
+#include <Utilities/Macro.h>
 #include <New/Entity/ShieldClass.h>
 #include <New/Entity/LaserTrailClass.h>
 

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -409,3 +409,10 @@ DEFINE_HOOK(0x6FF4CC, TechnoClass_FireAt_ToggleLaserWeaponIndex, 0x6)
 
 	return 0;
 }
+
+
+// Feature: Allow Units using AlternateFLHs - by Trsdy
+// I don't want to rewrite something new, so I use the Infantry one directly
+// afaik it has no check for infantry-specific stuff here so far
+// and neither Ares nor Phobos has touched it, even that crawling flh one was in TechnoClass
+DEFINE_JUMP(VTABLE, 0x7F5D20, 0x523250);// Redirect UnitClass::GetFLH to InfantryClass::GetFLH (used to be TechnoClass::GetFLH)

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2,7 +2,7 @@
 #include <ScenarioClass.h>
 #include <GameStrings.h>
 #include "Body.h"
-#include <Utilities/Macro.h>
+
 #include <Ext/TechnoType/Body.h>
 #include <Ext/WarheadType/Body.h>
 #include <Ext/WeaponType/Body.h>


### PR DESCRIPTION
Was closed by accident