### PR TITLE
Allow to only grant `SpyEffects.InfiltratorSuperWeapon` instead of launching directly on site

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -205,6 +205,7 @@ This page lists all the individual contributions to the project by their author.
    - Cloaked objects from allies displaying to player in singleplayer campaigns
    - Skip `NaturalParticleSystem` displaying from in-map pre-placed structures.
    - `ImmuneToCrit` for shields
+   - SpyEffects expansion: launching SuperWeapon on building infiltration
    - Forbidding parallel AI queues by type
    - Allow iron-curtain effects on infantries
 - **FlyStar**

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -287,13 +287,15 @@ PowerPlantEnhancer.Factor=1.0      ; floating point value
 - Additional espionage bonuses can be toggled with `SpyEffects.Custom`.
   - `SpyEffects.VictimSuperWeapon` instantly launches a Super Weapon for the owner of the infiltrated building at building's coordinates.
   - `SpyEffects.InfiltratorSuperWeapon` behaves the same as above, with the Super Weapon's owner being the owner of the spying unit.
+   - `SpyEffects.InfiltratorSuperWeapon.JustGrant` only grants the superweapon instead of launching on site.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEBUILDING]                     ; BuildingType
-SpyEffects.Custom=false            ; boolean
-SpyEffects.VictimSuperWeapon=      ; SuperWeaponType
-SpyEffects.InfiltratorSuperWeapon= ; SuperWeaponType
+[SOMEBUILDING]                                     ; BuildingType
+SpyEffects.Custom=false                            ; boolean
+SpyEffects.VictimSuperWeapon=                      ; SuperWeaponType
+SpyEffects.InfiltratorSuperWeapon=                 ; SuperWeaponType
+SpyEffects.InfiltratorSuperWeapon.JustGrant=false  ; boolean
 ```
 
 ## Infantry

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -287,7 +287,7 @@ PowerPlantEnhancer.Factor=1.0      ; floating point value
 - Additional espionage bonuses can be toggled with `SpyEffects.Custom`.
   - `SpyEffects.VictimSuperWeapon` instantly launches a Super Weapon for the owner of the infiltrated building at building's coordinates.
   - `SpyEffects.InfiltratorSuperWeapon` behaves the same as above, with the Super Weapon's owner being the owner of the spying unit.
-   - `SpyEffects.InfiltratorSuperWeapon.JustGrant` only grants the superweapon instead of launching on site.
+   - `SpyEffects.InfiltratorSuperWeapon.JustGrant` only grants the superweapon instead of launching on site. If the SW is already granted, the infiltration makes it charged to 100%.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -247,7 +247,7 @@ New:
 - `Crit.AffectsHouses` for critical hit system (by Starkku)
 - Warhead or weapon detonation at superweapon target cell (by Starkku)
 - Super Weapons launching other Super Weapons (by Morton)
-- Launching Super Weapons on building infiltration (by Morton)
+- Launching Super Weapons on building infiltration (by Morton & Trsdy)
 - Building airstrike target eligibility customization (by Starkku)
 - IvanBomb detonation & image display centered on buildings (by Starkku)
 - Forcing specific weapon against cloaked or disguised targets (by Starkku)

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -297,18 +297,21 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 	auto pVictimHouse = pBuilding->Owner;
 	if (pInfiltratorHouse != pVictimHouse)
 	{
-		// I assume you were not launching for real, Morton
-		auto launchTheSWHere = [pBuilding](int const idx, HouseClass* const pHouse)
+		// Did you mean for not launching for real or not, Morton?
+		auto launchTheSWHere = [pBuilding](int const idx, HouseClass* const pHouse, bool realLaunch = false)
 		{
 			if (const auto pSuper = pHouse->Supers.GetItem(idx))
 			{
-				int oldstart = pSuper->RechargeTimer.StartTime;
-				int oldleft = pSuper->RechargeTimer.TimeLeft;
-				pSuper->SetReadiness(true);
-				pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pHouse->IsCurrentPlayer());
-				pSuper->Reset();
-				pSuper->RechargeTimer.StartTime = oldstart;
-				pSuper->RechargeTimer.TimeLeft = oldleft;
+				if (!realLaunch || (pSuper->Granted && pSuper->IsCharged && !pSuper->IsOnHold))
+				{
+					int oldstart = pSuper->RechargeTimer.StartTime;
+					int oldleft = pSuper->RechargeTimer.TimeLeft;
+					pSuper->SetReadiness(true);
+					pSuper->Launch(CellClass::Coord2Cell(pBuilding->GetCenterCoords()), pHouse->IsCurrentPlayer());
+					pSuper->Reset();
+					pSuper->RechargeTimer.StartTime = oldstart;
+					pSuper->RechargeTimer.TimeLeft = oldleft;
+				}
 			}
 		};
 
@@ -317,7 +320,7 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 			if (const auto pSuper = pHouse->Supers.GetItem(idx))
 			{
 				if (pSuper->Granted)
-					pSuper->SetReadiness(true);
+					pSuper->SetCharge(100);
 				else
 				{
 					pSuper->Grant(true, false, false);
@@ -329,9 +332,8 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 		};
 
 		if (pTypeExt->SpyEffect_VictimSuperWeapon.isset() && !pVictimHouse->IsNeutral())
-		{
-			launchTheSWHere(pTypeExt->SpyEffect_VictimSuperWeapon.Get(), pVictimHouse);
-		}
+			launchTheSWHere(pTypeExt->SpyEffect_VictimSuperWeapon.Get(), pVictimHouse, pTypeExt->SpyEffect_VictimSW_RealLaunch.Get());
+
 
 		if (pTypeExt->SpyEffect_InfiltratorSuperWeapon.isset())
 		{

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -310,7 +310,22 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 			pSuper->RechargeTimer.TimeLeft = oldleft;
 		};
 
-		if (pTypeExt->SpyEffect_VictimSuperWeapon.isset())
+		auto justGrantTheSW = [](SuperClass* const pSuper, HouseClass* const pHouse)
+		{
+			if (pSuper->Granted)
+				pSuper->SetReadiness(true);
+			else
+			{
+				pSuper->Grant(true, false, false);
+				if (pHouse->IsCurrentPlayer())
+				{
+					SidebarClass::Instance->AddCameo(AbstractType::Special, pSuper->Type->ArrayIndex);
+					SidebarClass::Instance->RepaintSidebar(1);
+				}
+			}
+		};
+
+		if (pTypeExt->SpyEffect_VictimSuperWeapon.isset() && !pVictimHouse->IsNeutral())
 		{
 			if (const auto pSuper = pVictimHouse->Supers.GetItem(pTypeExt->SpyEffect_VictimSuperWeapon.Get()))
 				launchTheSWHere(pSuper, pVictimHouse);
@@ -319,7 +334,12 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 		if (pTypeExt->SpyEffect_InfiltratorSuperWeapon.isset())
 		{
 			if (const auto pSuper = pInfiltratorHouse->Supers.GetItem(pTypeExt->SpyEffect_InfiltratorSuperWeapon.Get()))
-				launchTheSWHere(pSuper, pInfiltratorHouse);
+			{
+				if (pTypeExt->SpyEffect_InfiltratorSW_JustGrant.Get())
+					justGrantTheSW(pSuper, pInfiltratorHouse);
+				else
+					launchTheSWHere(pSuper, pInfiltratorHouse);
+			}
 		}
 	}
 

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -322,11 +322,9 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 				{
 					pSuper->Grant(true, false, false);
 					if (pHouse->IsCurrentPlayer())
-					{
 						SidebarClass::Instance->AddCameo(AbstractType::Special, idx);
-						SidebarClass::Instance->RepaintSidebar(1);
-					}
 				}
+				SidebarClass::Instance->RepaintSidebar(1);
 			}
 		};
 

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -298,48 +298,50 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 	if (pInfiltratorHouse != pVictimHouse)
 	{
 		// I assume you were not launching for real, Morton
-
-		auto launchTheSWHere = [pBuilding](SuperClass* const pSuper, HouseClass* const pHouse)
+		auto launchTheSWHere = [pBuilding](int const idx, HouseClass* const pHouse)
 		{
-			int oldstart = pSuper->RechargeTimer.StartTime;
-			int oldleft = pSuper->RechargeTimer.TimeLeft;
-			pSuper->SetReadiness(true);
-			pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pHouse->IsCurrentPlayer());
-			pSuper->Reset();
-			pSuper->RechargeTimer.StartTime = oldstart;
-			pSuper->RechargeTimer.TimeLeft = oldleft;
+			if (const auto pSuper = pHouse->Supers.GetItem(idx))
+			{
+				int oldstart = pSuper->RechargeTimer.StartTime;
+				int oldleft = pSuper->RechargeTimer.TimeLeft;
+				pSuper->SetReadiness(true);
+				pSuper->Launch(CellClass::Coord2Cell(pBuilding->Location), pHouse->IsCurrentPlayer());
+				pSuper->Reset();
+				pSuper->RechargeTimer.StartTime = oldstart;
+				pSuper->RechargeTimer.TimeLeft = oldleft;
+			}
 		};
 
-		auto justGrantTheSW = [](SuperClass* const pSuper, HouseClass* const pHouse)
+		auto justGrantTheSW = [](int const idx, HouseClass* const pHouse)
 		{
-			if (pSuper->Granted)
-				pSuper->SetReadiness(true);
-			else
+			if (const auto pSuper = pHouse->Supers.GetItem(idx))
 			{
-				pSuper->Grant(true, false, false);
-				if (pHouse->IsCurrentPlayer())
+				if (pSuper->Granted)
+					pSuper->SetReadiness(true);
+				else
 				{
-					SidebarClass::Instance->AddCameo(AbstractType::Special, pSuper->Type->ArrayIndex);
-					SidebarClass::Instance->RepaintSidebar(1);
+					pSuper->Grant(true, false, false);
+					if (pHouse->IsCurrentPlayer())
+					{
+						SidebarClass::Instance->AddCameo(AbstractType::Special, idx);
+						SidebarClass::Instance->RepaintSidebar(1);
+					}
 				}
 			}
 		};
 
 		if (pTypeExt->SpyEffect_VictimSuperWeapon.isset() && !pVictimHouse->IsNeutral())
 		{
-			if (const auto pSuper = pVictimHouse->Supers.GetItem(pTypeExt->SpyEffect_VictimSuperWeapon.Get()))
-				launchTheSWHere(pSuper, pVictimHouse);
+			launchTheSWHere(pTypeExt->SpyEffect_VictimSuperWeapon.Get(), pVictimHouse);
 		}
 
 		if (pTypeExt->SpyEffect_InfiltratorSuperWeapon.isset())
 		{
-			if (const auto pSuper = pInfiltratorHouse->Supers.GetItem(pTypeExt->SpyEffect_InfiltratorSuperWeapon.Get()))
-			{
-				if (pTypeExt->SpyEffect_InfiltratorSW_JustGrant.Get())
-					justGrantTheSW(pSuper, pInfiltratorHouse);
-				else
-					launchTheSWHere(pSuper, pInfiltratorHouse);
-			}
+			const int swidx = pTypeExt->SpyEffect_InfiltratorSuperWeapon.Get();
+			if (pTypeExt->SpyEffect_InfiltratorSW_JustGrant.Get())
+				justGrantTheSW(swidx, pInfiltratorHouse);
+			else
+				launchTheSWHere(swidx, pInfiltratorHouse);
 		}
 	}
 

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -148,10 +148,16 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	{
 		this->SuperWeapons.Read(exINI, pSection, "SuperWeapons");
 
-		this->SpyEffect_VictimSuperWeapon.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon");
-		this->SpyEffect_InfiltratorSuperWeapon.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon");
-		if (this->SpyEffect_InfiltratorSuperWeapon.isset())
-			this->SpyEffect_InfiltratorSW_JustGrant.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon.JustGrant");
+		if (this->SpyEffect_Custom.Get())
+		{
+			this->SpyEffect_VictimSuperWeapon.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon");
+			if (this->SpyEffect_VictimSuperWeapon.isset())
+				this->SpyEffect_VictimSW_RealLaunch.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon.RealLaunch");
+
+			this->SpyEffect_InfiltratorSuperWeapon.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon");
+			if (this->SpyEffect_InfiltratorSuperWeapon.isset())
+				this->SpyEffect_InfiltratorSW_JustGrant.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon.JustGrant");
+		}
 	}
 
 	if (pThis->MaxNumberOccupants > 10)
@@ -220,6 +226,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PlacementPreview_Palette)
 		.Process(this->PlacementPreview_Translucency)
 		.Process(this->SpyEffect_Custom)
+		.Process(this->SpyEffect_VictimSW_RealLaunch)
 		.Process(this->SpyEffect_VictimSuperWeapon)
 		.Process(this->SpyEffect_InfiltratorSW_JustGrant)
 		.Process(this->SpyEffect_InfiltratorSuperWeapon)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -150,6 +150,8 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 		this->SpyEffect_VictimSuperWeapon.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon");
 		this->SpyEffect_InfiltratorSuperWeapon.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon");
+		if (this->SpyEffect_InfiltratorSuperWeapon.isset())
+			this->SpyEffect_InfiltratorSW_JustGrant.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon.JustGrant");
 	}
 
 	if (pThis->MaxNumberOccupants > 10)
@@ -219,6 +221,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PlacementPreview_Translucency)
 		.Process(this->SpyEffect_Custom)
 		.Process(this->SpyEffect_VictimSuperWeapon)
+		.Process(this->SpyEffect_InfiltratorSW_JustGrant)
 		.Process(this->SpyEffect_InfiltratorSuperWeapon)
 		;
 }

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -51,6 +51,7 @@ public:
 		Valueable<bool> SpyEffect_InfiltratorSW_JustGrant;
 		NullableIdx<SuperWeaponTypeClass> SpyEffect_VictimSuperWeapon;
 		NullableIdx<SuperWeaponTypeClass> SpyEffect_InfiltratorSuperWeapon;
+		Valueable<bool> SpyEffect_VictimSW_RealLaunch;
 
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
@@ -81,6 +82,7 @@ public:
 			, PlacementPreview_Translucency {}
 			, SpyEffect_Custom { false }
 			, SpyEffect_VictimSuperWeapon {}
+			, SpyEffect_VictimSW_RealLaunch { false }
 			, SpyEffect_InfiltratorSuperWeapon {}
 			, SpyEffect_InfiltratorSW_JustGrant{ false }
 		{ }

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -48,6 +48,7 @@ public:
 		Nullable<TranslucencyLevel> PlacementPreview_Translucency;
 
 		Valueable<bool> SpyEffect_Custom;
+		Valueable<bool> SpyEffect_InfiltratorSW_JustGrant;
 		NullableIdx<SuperWeaponTypeClass> SpyEffect_VictimSuperWeapon;
 		NullableIdx<SuperWeaponTypeClass> SpyEffect_InfiltratorSuperWeapon;
 
@@ -81,6 +82,7 @@ public:
 			, SpyEffect_Custom { false }
 			, SpyEffect_VictimSuperWeapon {}
 			, SpyEffect_InfiltratorSuperWeapon {}
+			, SpyEffect_InfiltratorSW_JustGrant{ false }
 		{ }
 
 		// Ares 0.A functions


### PR DESCRIPTION
In `rulesmd.ini`:
```ini
[SOMEBUILDING]                                     ; BuildingType
SpyEffect.Custom=false                            ; boolean
SpyEffect.VictimSuperWeapon=                      ; SuperWeaponType
SpyEffect.InfiltratorSuperWeapon=                 ; SuperWeaponType

; Added by this PR
SpyEffect.VictimSuperWeapon.RealLaunch=false   ; boolean
SpyEffect.InfiltratorSuperWeapon.JustGrant=false  ; boolean
```

https://user-images.githubusercontent.com/9932846/209951713-7490a5c8-5565-45ec-92c6-a5dc03b13711.mp4


