### PR TITLE
Projectile obstacle logic additions

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -176,6 +176,7 @@ This page lists all the individual contributions to the project by their author.
   - Custom warhead debris animations
   - Attached particle system for animations
   - Removal of hardcoded AA & Gattling weapon selection restrictions
+  - Projectile obstacle logic additions
 - **Morton (MortonPL)**:
   - `XDrawOffset`
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -65,6 +65,7 @@
     <ClCompile Include="src\Ext\BulletType\Body.cpp" />
     <ClCompile Include="src\Ext\Bullet\Body.cpp" />
     <ClCompile Include="src\Ext\Bullet\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Hooks.Obstacles.cpp" />
     <ClCompile Include="src\Ext\House\Body.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.cpp" />
     <ClCompile Include="src\Ext\RadSite\Body.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -103,6 +103,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed `LandTargeting=1` not preventing from targeting TerrainTypes (trees etc.) on land.
 - Fixed `NavalTargeting=6` not preventing from targeting empty water cells or TerrainTypes (trees etc.) on water.
 - Fixed `NavalTargeting=7` and/or `LandTargeting=2` resulting in still targeting TerrainTypes (trees etc.) on land with `Primary` weapon.
+- Weapons with projectiles with `Level=true` now consider targets behind obstacles that cause the projectile to detonate (tiles belonging to non-water tilesets) as out of range and will attempt to reposition before firing.
 
 ## Animations
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -492,6 +492,20 @@ Shrapnel.AffectsGround=false     ; boolean
 Shrapnel.AffectsBuildings=false  ; boolean
 ```
 
+### Projectiles blocked by land or water
+
+- It is now possible to make projectiles consider either land or water as obstacles that block their path by setting `SubjectToLand/Water` to true, respectively. Weapons firing such projectiles will consider targets blocked by such obstacles as out of range and will attempt to reposition themselves so they can fire without being blocked by the said obstacles before firing and if `SubjectToLand/Water.Detonate` is set to true, the projectiles will detonate if they somehow manage to collide with the said obstacles.
+  - In a special case, `Level=true` projectiles by default, if neither `SubjectToLand` or `SubjectToWater` are set, consider tiles belonging to non-water tilesets as obstacles, but this behaviour can be overridden by setting these keys.
+
+In `rulesmd.ini`:
+```ini
+[SOMEPROJECTILE]              ; Projectile
+SubjectToLand=                ; boolean
+SubjectToLand.Detonate=true   ; boolean
+SubjectToWater=               ; boolean
+SubjectToWater.Detonate=true  ; boolean
+```
+
 ## Super Weapons
 
 ### LimboDelivery

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -269,6 +269,7 @@ New:
 - Multiple burst shots / burst delay within infantry firing sequence (by Starkku)
 - Attached particle system for animations (by Starkku)
 - Removal of hardcoded AA & Gattling weapon selection restrictions (by Starkku)
+- Projectile `SubjectToLand/Water` (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Bullet/Hooks.Obstacles.cpp
+++ b/src/Ext/Bullet/Hooks.Obstacles.cpp
@@ -1,0 +1,175 @@
+#include "Body.h"
+
+#include <Utilities/Macro.h>
+
+// Ares reimplements the bullet obstacle logic so need to get creative to add any new functionality for that in Phobos.
+// Not named PhobosTrajectoryHelper to avoid confusion with actual custom trajectory logic.
+class BulletObstacleHelper
+{
+public:
+
+	static CellClass* GetObstacle(CellClass* pSourceCell, CellClass* pTargetCell, CellClass* pCurrentCell, CoordStruct currentCoords, AbstractClass const* const pSource,
+		AbstractClass const* const pTarget, HouseClass* pOwner, BulletTypeClass* pBulletType, BulletTypeExt::ExtData*& pBulletTypeExt, bool isTargetingCheck = false)
+	{
+		CellClass* pObstacleCell = nullptr;
+
+		if (SubjectToObstacles(pBulletType, pBulletTypeExt))
+		{
+			if (SubjectToTerrain(pCurrentCell, pBulletType, pBulletTypeExt, isTargetingCheck))
+				pObstacleCell = pCurrentCell;
+		}
+
+		return pObstacleCell;
+	}
+
+	static CellClass* FindFirstObstacle(CoordStruct const& pSourceCoords, CoordStruct const& pTargetCoords, AbstractClass const* const pSource,
+		AbstractClass const* const pTarget, HouseClass* pOwner, BulletTypeClass* pBulletType, bool isTargetingCheck = false)
+	{
+		BulletTypeExt::ExtData* pBulletTypeExt = BulletTypeExt::ExtMap.Find(pBulletType);
+
+		if (SubjectToObstacles(pBulletType, pBulletTypeExt))
+		{
+			auto sourceCell = CellClass::Coord2Cell(pSourceCoords);
+			auto const pSourceCell = MapClass::Instance->GetCellAt(sourceCell);
+			auto targetCell = CellClass::Coord2Cell(pTargetCoords);
+			auto const pTargetCell = MapClass::Instance->GetCellAt(targetCell);
+
+			auto const sub = sourceCell - targetCell;
+			auto const delta = CellStruct { (short)std::abs(sub.X), (short)std::abs(sub.Y) };
+			auto const maxDelta = static_cast<size_t>(std::max(delta.X, delta.Y));
+			auto const step = !maxDelta ? CoordStruct::Empty : (pTargetCoords - pSourceCoords) * (1.0 / maxDelta);
+			CoordStruct crdCur = pSourceCoords;
+			auto pCellCur = pSourceCell;
+
+			for (size_t i = 0; i < maxDelta + isTargetingCheck; ++i)
+			{
+				if (auto const pCell = GetObstacle(pSourceCell, pTargetCell, pCellCur, crdCur, pSource, pTarget, pOwner, pBulletType, pBulletTypeExt, isTargetingCheck))
+					return pCell;
+
+				crdCur += step;
+				pCellCur = MapClass::Instance->GetCellAt(crdCur);
+			}
+		}
+
+		return nullptr;
+	}
+
+	static CellClass* FindFirstImpenetrableObstacle(CoordStruct const& pSourceCoords, CoordStruct const& pTargetCoords, AbstractClass const* const pSource,
+		AbstractClass const* const pTarget, HouseClass* pOwner, WeaponTypeClass* pWeapon, bool isTargetingCheck = false)
+	{
+		// Does not currently need further checks.
+		return FindFirstObstacle(pSourceCoords, pTargetCoords, pSource, pTarget, pOwner, pWeapon->Projectile, isTargetingCheck);
+	}
+
+	static bool SubjectToObstacles(BulletTypeClass* pBulletType, BulletTypeExt::ExtData*& pBulletTypeExt)
+	{
+		bool subjectToTerrain = pBulletTypeExt->SubjectToLand.isset() || pBulletTypeExt->SubjectToWater.isset();
+
+		return subjectToTerrain ? true : pBulletType->Level;
+	}
+
+	static bool SubjectToTerrain(CellClass* pCurrentCell, BulletTypeClass* pBulletType, BulletTypeExt::ExtData*& pBulletTypeExt, bool isTargetingCheck)
+	{
+		bool isCellWater = pCurrentCell->LandType == LandType::Water || pCurrentCell->LandType == LandType::Beach;
+		bool isLevel = pBulletType->Level ? pCurrentCell->IsOnFloor() : false;
+
+		if (isLevel && !pBulletTypeExt->SubjectToLand.isset() && !pBulletTypeExt->SubjectToWater.isset())
+			return true;
+		else if (!isCellWater && pBulletTypeExt->SubjectToLand.Get(false))
+			return !isTargetingCheck ? pBulletTypeExt->SubjectToLand_Detonate : true;
+		else if (isCellWater && pBulletTypeExt->SubjectToWater.Get(false))
+			return !isTargetingCheck ? pBulletTypeExt->SubjectToWater_Detonate : true;
+
+		return false;
+	}
+};
+
+// Hooks
+
+DEFINE_HOOK(0x4688A9, BulletClass_Unlimbo_Obstacles, 0x6)
+{
+	enum { SkipGameCode = 0x468A3F, Continue = 0x4688BD };
+
+	GET(BulletClass*, pThis, EBX);
+	GET(CoordStruct const* const, sourceCoords, EDI);
+	REF_STACK(CoordStruct const, targetCoords, STACK_OFFSET(0x54, -0x10));
+
+	if (pThis->Type->Inviso)
+	{
+		auto const pOwner = pThis->Owner ? pThis->Owner->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
+		const auto pObstacleCell = BulletObstacleHelper::FindFirstObstacle(*sourceCoords, targetCoords, pThis->Owner, pThis->Target, pOwner, pThis->Type, false);
+
+		if (pObstacleCell)
+		{
+			pThis->SetLocation(pObstacleCell->GetCoords());
+			pThis->Speed = 0;
+			pThis->Velocity = BulletVelocity::Empty;
+
+			return SkipGameCode;
+		}
+
+		return Continue;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x468C86, BulletClass_ShouldExplode_Obstacles, 0xA)
+{
+	enum { SkipGameCode = 0x468C90, Explode = 0x468C9F };
+
+	GET(BulletClass*, pThis, ESI);
+
+	BulletTypeExt::ExtData* pBulletTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type);
+
+	if (BulletObstacleHelper::SubjectToObstacles(pThis->Type, pBulletTypeExt))
+	{
+		auto const pCellSource = MapClass::Instance->GetCellAt(pThis->SourceCoords);
+		auto const pCellTarget = MapClass::Instance->GetCellAt(pThis->TargetCoords);
+		auto const pCellCurrent = MapClass::Instance->GetCellAt(pThis->LastMapCoords);
+		auto const pOwner = pThis->Owner ? pThis->Owner->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
+		const auto pObstacleCell = BulletObstacleHelper::GetObstacle(pCellSource, pCellTarget, pCellCurrent, pThis->Location, pThis->Owner, pThis->Target, pOwner, pThis->Type, pBulletTypeExt, false);
+
+		if (pObstacleCell)
+			return Explode;
+	}
+
+
+	// Restore overridden instructions.
+	R->EAX(pThis->GetHeight());
+	return SkipGameCode;
+}
+
+namespace InRangeTemp
+{
+	TechnoClass* Techno = nullptr;
+}
+
+DEFINE_HOOK(0x6F7261, TechnoClass_InRange_SetContext, 0x5)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	InRangeTemp::Techno = pThis;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6F7647, TechnoClass_InRange_Obstacles, 0x5)
+{
+	GET_BASE(WeaponTypeClass*, pWeapon, 0x10);
+	GET(CoordStruct const* const, pSourceCoords, ESI);
+	REF_STACK(CoordStruct const, targetCoords, STACK_OFFSET(0x3C, -0x1C));
+	GET_BASE(AbstractClass* const, pTarget, 0xC);
+	GET(CellClass*, pResult, EAX);
+
+	auto pObstacleCell = pResult;
+	auto pTechno = InRangeTemp::Techno;
+
+	if (!pObstacleCell)
+		pObstacleCell = BulletObstacleHelper::FindFirstImpenetrableObstacle(*pSourceCoords, targetCoords, pTechno, pTarget, pTechno->Owner, pWeapon, true);
+
+	InRangeTemp::Techno = nullptr;
+
+	R->EAX(pObstacleCell);
+	return 0;
+}

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -4,6 +4,7 @@
 #include <Ext/WarheadType/Body.h>
 #include <Ext/BulletType/Body.h>
 #include <Ext/CaptureManager/Body.h>
+#include <Utilities/Macro.h>
 
 #include <AnimClass.h>
 #include <AircraftClass.h>
@@ -487,3 +488,6 @@ DEFINE_HOOK(0x469E34, BulletClass_Logics_DebrisAnims, 0x5)
 
 	return SkipGameCode;
 }
+
+// Skip a forced detonation check for Level=true projectiles that is now handled in Hooks.Obstacles.cpp.
+DEFINE_JUMP(LJMP, 0x468D08, 0x468D2F);

--- a/src/Ext/BulletType/Body.cpp
+++ b/src/Ext/BulletType/Body.cpp
@@ -46,6 +46,11 @@ void BulletTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Shrapnel_AffectsBuildings.Read(exINI, pSection, "Shrapnel.AffectsBuildings");
 	this->ClusterScatter_Min.Read(exINI, pSection, "ClusterScatter.Min");
 	this->ClusterScatter_Max.Read(exINI, pSection, "ClusterScatter.Max");
+	this->SubjectToLand.Read(exINI, pSection, "SubjectToLand");
+	this->SubjectToLand_Detonate.Read(exINI, pSection, "SubjectToLand.Detonate");
+	this->SubjectToWater.Read(exINI, pSection, "SubjectToWater");
+	this->SubjectToWater_Detonate.Read(exINI, pSection, "SubjectToWater.Detonate");
+
 
 	// Ares 0.7
 	this->BallisticScatter_Min.Read(exINI, pSection, "BallisticScatter.Min");
@@ -76,6 +81,10 @@ void BulletTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ClusterScatter_Max)
 		.Process(this->BallisticScatter_Min)
 		.Process(this->BallisticScatter_Max)
+		.Process(this->SubjectToLand)
+		.Process(this->SubjectToLand_Detonate)
+		.Process(this->SubjectToWater)
+		.Process(this->SubjectToWater_Detonate)
 		;
 
 	this->TrajectoryType = PhobosTrajectoryType::ProcessFromStream(Stm, this->TrajectoryType);

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -30,6 +30,10 @@ public:
 
 		Valueable<bool> Shrapnel_AffectsGround;
 		Valueable<bool> Shrapnel_AffectsBuildings;
+		Nullable<bool> SubjectToLand;
+		Valueable<bool> SubjectToLand_Detonate;
+		Nullable<bool> SubjectToWater;
+		Valueable<bool> SubjectToWater_Detonate;
 
 		Nullable<Leptons> ClusterScatter_Min;
 		Nullable<Leptons> ClusterScatter_Max;
@@ -53,6 +57,10 @@ public:
 			, ClusterScatter_Max {}
 			, BallisticScatter_Min {}
 			, BallisticScatter_Max {}
+			, SubjectToLand {}
+			, SubjectToLand_Detonate { true }
+			, SubjectToWater {}
+			, SubjectToWater_Detonate { true }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
Additional obstacle logic for projectiles.

### Fixes

- Weapons with projectiles with `Level=true` now consider targets behind obstacles that cause the projectile to detonate (tiles belonging to non-water tilesets) as out of range and will attempt to reposition before firing.

### Projectiles blocked by land or water

- It is now possible to make projectiles consider either land or water as obstacles that block their path by setting `SubjectToLand/Water` to true, respectively. Weapons firing such projectiles will consider targets blocked by such obstacles as out of range and will attempt to reposition themselves so they can fire without being blocked by the said obstacles before firing and if `SubjectToLand/Water.Detonate` is set to true, the projectiles will detonate if they somehow manage to collide with the said obstacles.
  - In a special case, `Level=true` projectiles by default, if neither `SubjectToLand` or `SubjectToWater` are set, consider tiles belonging to non-water tilesets as obstacles, but this behaviour can be overridden by setting these keys.

In `rulesmd.ini`:
```ini
[SOMEPROJECTILE]              ; Projectile
SubjectToLand=                ; boolean
SubjectToLand.Detonate=true   ; boolean
SubjectToWater=               ; boolean
SubjectToWater.Detonate=true  ; boolean
```