### PR TITLE
Separate AI naval vehicle production from regular vehicle production

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -186,6 +186,7 @@ This page lists all the individual contributions to the project by their author.
   - Option to center pause menu background
   - Disguise logic improvements
   - Custom insignias
+  - AI naval vehicle production fix
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption
@@ -260,7 +261,7 @@ This page lists all the individual contributions to the project by their author.
 - **E1 Elite** - TileSet 255 and above bridge repair fix
 - **AutoGavy** - interceptor logic, Warhead critical hit logic
 - **Chasheen (Chasheenburg)** - CN docs help
-- **Ares developers** - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares, unfinished RadTypes code, prototype deployer fixes, Superweapon launch site & availability code
+- **Ares developers** - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares, unfinished RadTypes code, prototype deployer fixes, Superweapon launch site & availability code, AI vehicle production update code
 - **tomsons26** - all-around help, assistance and guidance in reverse-engineering, YR binary mappings
 - **CCHyper** - all-around help, current project logo, assistance and guidance in reverse-engineering, YR binary mappings
 - **AlexB** - Original FlyingStrings implementation

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -73,6 +73,7 @@
     <ClCompile Include="src\Ext\Bullet\Hooks.Obstacles.cpp" />
     <ClCompile Include="src\Ext\House\Body.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.cpp" />
+    <ClCompile Include="src\Ext\House\Hooks.AINavalProduction.cpp" />
     <ClCompile Include="src\Ext\RadSite\Body.cpp" />
     <ClCompile Include="src\Ext\RadSite\Hooks.cpp" />
     <ClCompile Include="src\Ext\Scenario\Body.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -122,6 +122,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and passengers firing out no longer have the passenger firing offset shift lateral position based on burst index.
 - Fixed disguised infantry not using custom palette for drawing the disguise when needed.
 - Disguised infantry now show appropriate insignia when disguise is visible, based on the disguise type and house. Original unit's insignia is always shown to observers and if disguise blinking is enabled for the current player by `[General]`->`DisguiseBlinkingVisibility`.
+- AI players can now build `Naval=true` and `Naval=false` vehicles concurrently like human players do
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -340,6 +340,7 @@ Vanilla fixes:
 - Fixed disguised infantry not using custom palette for drawing the disguise when needed (by Starkku)
 - Reenabled the obsolete `[General] WarpIn` as default anim type when units are warping in (by Trsdy)
 - Fixed permanent health bar display for units targeted by temporal weapons upon mouse hover (by Trsdy)
+- AI players can now build `Naval=true` and `Naval=false` vehicles concurrently like human players do (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -345,7 +345,7 @@ Vanilla fixes:
 - Fixed permanent health bar display for units targeted by temporal weapons upon mouse hover (by Trsdy)
 - Buildings with superweapons no longer display `SuperAnimThree` at beginning of match if pre-placed on the map (by Starkku)
 - AI players can now build `Naval=true` and `Naval=false` vehicles concurrently like human players do (by Starkku)
-  
+
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)
 - Add `ImmuneToCrit` for shields (by Trsdy)

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -10,12 +10,264 @@
 template<> const DWORD Extension<HouseClass>::Canary = 0x11111111;
 HouseExt::ExtContainer HouseExt::ExtMap;
 
+std::vector<int> HouseExt::AIProduction_CreationFrames;
+std::vector<int> HouseExt::AIProduction_Values;
+std::vector<int> HouseExt::AIProduction_BestChoices;
+std::vector<int> HouseExt::AIProduction_BestChoicesNaval;
+
+// Based on Ares' rewrite of 0x4FEA60.
+void HouseExt::ExtData::UpdateVehicleProduction()
+{
+	auto pThis = this->OwnerObject();
+	auto const AIDifficulty = static_cast<int>(pThis->GetAIDifficultyIndex());
+	bool skipGround = pThis->ProducingUnitTypeIndex != -1;
+	bool skipNaval = this->ProducingNavalUnitTypeIndex != -1;
+
+	if (skipGround && skipNaval)
+		return;
+
+	if (!skipGround)
+	{
+		auto const idxParentCountry = pThis->Type->FindParentCountryIndex();
+		auto const pHarvester = HouseExt::FindOwned(pThis, idxParentCountry, make_iterator(RulesClass::Instance->HarvesterUnit));
+
+		if (pHarvester)
+		{
+			//Buildable harvester found
+			auto const harvesters = pThis->CountResourceGatherers;
+
+			auto maxHarvesters = HouseExt::FindBuildable(
+				pThis, idxParentCountry, make_iterator(RulesClass::Instance->BuildRefinery))
+				? RulesClass::Instance->HarvestersPerRefinery[AIDifficulty] * pThis->CountResourceDestinations
+				: RulesClass::Instance->AISlaveMinerNumber[AIDifficulty];
+
+			if (pThis->IQLevel2 >= RulesClass::Instance->Harvester && !pThis->IsTiberiumShort
+				&& !pThis->IsControlledByHuman() && harvesters < maxHarvesters
+				&& pThis->TechLevel >= pHarvester->TechLevel)
+			{
+				pThis->ProducingUnitTypeIndex = pHarvester->ArrayIndex;
+				return;
+			}
+		}
+		else
+		{
+			//No buildable harvester found
+			auto const maxHarvesters = RulesClass::Instance->AISlaveMinerNumber[AIDifficulty];
+
+			if (pThis->CountResourceGatherers < maxHarvesters)
+			{
+				auto const pRefinery = HouseExt::FindBuildable(
+					pThis, idxParentCountry, make_iterator(RulesClass::Instance->BuildRefinery));
+
+				if (pRefinery)
+				{
+					//awesome way to find out whether this building is a slave miner, isn't it? ...
+					if (auto const pSlaveMiner = pRefinery->UndeploysInto)
+					{
+						pThis->ProducingUnitTypeIndex = pSlaveMiner->ArrayIndex;
+						return;
+					}
+				}
+			}
+		}
+	}
+
+	auto& creationFrames = HouseExt::AIProduction_CreationFrames;
+	auto& values = HouseExt::AIProduction_Values;
+	auto& bestChoices = HouseExt::AIProduction_BestChoices;
+	auto& bestChoicesNaval = HouseExt::AIProduction_BestChoicesNaval;
+
+	auto const count = static_cast<unsigned int>(UnitTypeClass::Array->Count);
+	creationFrames.assign(count, 0x7FFFFFFF);
+	values.assign(count, 0);
+
+	for (auto currentTeam : *TeamClass::Array)
+	{
+		if (!currentTeam || currentTeam->Owner != pThis)
+			continue;
+
+		int teamCreationFrame = currentTeam->CreationFrame;
+
+		if ((!currentTeam->Type->Reinforce || currentTeam->IsFullStrength)
+			&& (currentTeam->IsForcedActive || currentTeam->IsHasBeen))
+		{
+			continue;
+		}
+
+		DynamicVectorClass<TechnoTypeClass*> taskForceMembers;
+		currentTeam->GetTaskForceMissingMemberTypes(taskForceMembers);
+
+		for (auto currentMember : taskForceMembers)
+		{
+			if (currentMember->WhatAmI() != UnitTypeClass::AbsID ||
+				(skipGround && !currentMember->Naval) ||
+				(skipNaval && currentMember->Naval))
+				continue;
+
+			auto const index = static_cast<unsigned int>(currentMember->GetArrayIndex());
+			++values[index];
+
+			if (teamCreationFrame < creationFrames[index])
+				creationFrames[index] = teamCreationFrame;
+		}
+	}
+
+	for (auto unit : *UnitClass::Array)
+	{
+		auto const index = static_cast<unsigned int>(unit->GetType()->GetArrayIndex());
+
+		if (values[index] > 0 && unit->CanBeRecruited(pThis))
+			--values[index];
+	}
+
+	bestChoices.clear();
+	bestChoicesNaval.clear();
+
+	int bestValue = -1;
+	int bestValueNaval = -1;
+	int earliestTypenameIndex = -1;
+	int earliestTypenameIndexNaval = -1;
+	int earliestFrame = 0x7FFFFFFF;
+	int earliestFrameNaval = 0x7FFFFFFF;
+
+	for (auto i = 0u; i < count; ++i)
+	{
+		auto const type = UnitTypeClass::Array->Items[static_cast<int>(i)];
+		int currentValue = values[i];
+
+		if (currentValue <= 0 || pThis->CanBuild(type, false, false) == CanBuildResult::Unbuildable
+			|| type->GetActualCost(pThis) > pThis->Available_Money())
+		{
+			continue;
+		}
+
+		bool isNaval = type->Naval;
+		int* cBestValue = !isNaval ? &bestValue : &bestValueNaval;
+		std::vector<int>* cBestChoices = !isNaval ? &bestChoices : &bestChoicesNaval;
+
+		if (*cBestValue < currentValue || *cBestValue == -1)
+		{
+			*cBestValue = currentValue;
+			cBestChoices->clear();
+		}
+
+		cBestChoices->push_back(static_cast<int>(i));
+
+		int* cEarliestTypeNameIndex = !isNaval ? &earliestTypenameIndex : &earliestTypenameIndexNaval;
+		int* cEarliestFrame = !isNaval ? &earliestFrame : &earliestFrameNaval;
+
+		if (*cEarliestFrame > creationFrames[i] || *cEarliestTypeNameIndex == -1)
+		{
+			*cEarliestTypeNameIndex = static_cast<int>(i);
+			*cEarliestFrame = creationFrames[i];
+		}
+	}
+
+	int earliestOdds = RulesClass::Instance->FillEarliestTeamProbability[AIDifficulty];
+
+	if (!skipGround)
+	{
+		if (ScenarioClass::Instance->Random.RandomRanged(0, 99) < earliestOdds)
+		{
+			pThis->ProducingUnitTypeIndex = earliestTypenameIndex;
+		}
+		else if (auto const size = static_cast<int>(bestChoices.size()))
+		{
+			int randomChoice = ScenarioClass::Instance->Random.RandomRanged(0, size - 1);
+			pThis->ProducingUnitTypeIndex = bestChoices[static_cast<unsigned int>(randomChoice)];
+		}
+	}
+
+	if (!skipNaval)
+	{
+		if (ScenarioClass::Instance->Random.RandomRanged(0, 99) < earliestOdds)
+		{
+			this->ProducingNavalUnitTypeIndex = earliestTypenameIndexNaval;
+		}
+		else if (auto const size = static_cast<int>(bestChoicesNaval.size()))
+		{
+			int randomChoice = ScenarioClass::Instance->Random.RandomRanged(0, size - 1);
+			this->ProducingNavalUnitTypeIndex = bestChoicesNaval[static_cast<unsigned int>(randomChoice)];
+		}
+	}
+}
+
 bool HouseExt::ExtData::OwnsLimboDeliveredBuilding(BuildingClass* pBuilding)
 {
 	if (!pBuilding)
 		return false;
 
 	return this->OwnedLimboDeliveredBuildings.count(pBuilding);
+}
+
+size_t HouseExt::FindOwnedIndex(
+	HouseClass const* const, int const idxParentCountry,
+	Iterator<TechnoTypeClass const*> const items, size_t const start)
+{
+	auto const bitOwner = 1u << idxParentCountry;
+
+	for (auto i = start; i < items.size(); ++i)
+	{
+		auto const pItem = items[i];
+
+		if (pItem->InOwners(bitOwner))
+		{
+			return i;
+		}
+	}
+
+	return items.size();
+}
+
+bool HouseExt::IsDisabledFromShell(
+	HouseClass const* const pHouse, BuildingTypeClass const* const pItem)
+{
+	// SWAllowed does not apply to campaigns any more
+	if (SessionClass::Instance->GameMode == GameMode::Campaign
+		|| GameModeOptionsClass::Instance->SWAllowed)
+	{
+		return false;
+	}
+
+	if (pItem->SuperWeapon != -1)
+	{
+		// allow SWs only if not disableable from shell
+		auto const pItem2 = const_cast<BuildingTypeClass*>(pItem);
+		auto const& BuildTech = RulesClass::Instance->BuildTech;
+		if (BuildTech.FindItemIndex(pItem2) == -1)
+		{
+			auto const pSuper = pHouse->Supers[pItem->SuperWeapon];
+			if (pSuper->Type->DisableableFromShell)
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+size_t HouseExt::FindBuildableIndex(
+	HouseClass const* const pHouse, int const idxParentCountry,
+	Iterator<TechnoTypeClass const*> const items, size_t const start)
+{
+	for (auto i = start; i < items.size(); ++i)
+	{
+		auto const pItem = items[i];
+
+		if (pHouse->CanExpectToBuild(pItem, idxParentCountry))
+		{
+			auto const pBld = abstract_cast<const BuildingTypeClass*>(pItem);
+			if (pBld && HouseExt::IsDisabledFromShell(pHouse, pBld))
+			{
+				continue;
+			}
+
+			return i;
+		}
+	}
+
+	return items.size();
 }
 
 int HouseExt::ActiveHarvesterCount(HouseClass* pThis)
@@ -45,7 +297,8 @@ int HouseExt::TotalHarvesterCount(HouseClass* pThis)
 // Ares
 HouseClass* HouseExt::GetHouseKind(OwnerHouseKind const kind, bool const allowRandom, HouseClass* const pDefault, HouseClass* const pInvoker, HouseClass* const pVictim)
 {
-	switch (kind) {
+	switch (kind)
+	{
 	case OwnerHouseKind::Invoker:
 	case OwnerHouseKind::Killer:
 		return pInvoker ? pInvoker : pDefault;
@@ -128,6 +381,8 @@ void HouseExt::ExtData::Serialize(T& Stm)
 		.Process(this->Factory_NavyType)
 		.Process(this->Factory_AircraftType)
 		.Process(this->RepairBaseNodes)
+		.Process(this->LastBuiltNavalVehicleType)
+		.Process(this->ProducingNavalUnitTypeIndex)
 		;
 }
 
@@ -158,7 +413,8 @@ bool HouseExt::SaveGlobals(PhobosStreamWriter& Stm)
 // =============================
 // container
 
-HouseExt::ExtContainer::ExtContainer() : Container("HouseClass") {
+HouseExt::ExtContainer::ExtContainer() : Container("HouseClass")
+{
 }
 
 HouseExt::ExtContainer::~ExtContainer() = default;

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -56,10 +56,12 @@ void HouseExt::ExtData::UpdateVehicleProduction()
 
 		for (auto currentMember : taskForceMembers)
 		{
-			if (currentMember->WhatAmI() != UnitTypeClass::AbsID ||
-				(skipGround && !currentMember->Naval) ||
-				(skipNaval && currentMember->Naval))
+			if (currentMember->WhatAmI() != UnitTypeClass::AbsID
+				|| (skipGround && !currentMember->Naval)
+				|| (skipNaval && currentMember->Naval))
+			{
 				continue;
+			}
 
 			auto const index = static_cast<unsigned int>(currentMember->GetArrayIndex());
 			++values[index];
@@ -92,7 +94,8 @@ void HouseExt::ExtData::UpdateVehicleProduction()
 		auto const type = UnitTypeClass::Array->Items[static_cast<int>(i)];
 		int currentValue = values[i];
 
-		if (currentValue <= 0 || pThis->CanBuild(type, false, false) == CanBuildResult::Unbuildable
+		if (currentValue <= 0
+			|| pThis->CanBuild(type, false, false) == CanBuildResult::Unbuildable
 			|| type->GetActualCost(pThis) > pThis->Available_Money())
 		{
 			continue;
@@ -217,9 +220,7 @@ size_t HouseExt::FindOwnedIndex(
 		auto const pItem = items[i];
 
 		if (pItem->InOwners(bitOwner))
-		{
 			return i;
-		}
 	}
 
 	return items.size();
@@ -245,9 +246,7 @@ bool HouseExt::IsDisabledFromShell(
 		{
 			auto const pSuper = pHouse->Supers[pItem->SuperWeapon];
 			if (pSuper->Type->DisableableFromShell)
-			{
 				return true;
-			}
 		}
 	}
 
@@ -266,9 +265,7 @@ size_t HouseExt::FindBuildableIndex(
 		{
 			auto const pBld = abstract_cast<const BuildingTypeClass*>(pItem);
 			if (pBld && HouseExt::IsDisabledFromShell(pHouse, pBld))
-			{
 				continue;
-			}
 
 			return i;
 		}

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -29,6 +29,9 @@ public:
 		//Read from INI
 		bool RepairBaseNodes[3];
 
+		int LastBuiltNavalVehicleType;
+		int ProducingNavalUnitTypeIndex;
+
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, BuildingCounter {}
 			, OwnedLimboDeliveredBuildings {}
@@ -39,6 +42,8 @@ public:
 			, Factory_NavyType { nullptr }
 			, Factory_AircraftType { nullptr }
 			, RepairBaseNodes { false,false,false }
+			, LastBuiltNavalVehicleType { -1 }
+			, ProducingNavalUnitTypeIndex { -1 }
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding);
@@ -57,8 +62,11 @@ public:
 			AnnounceInvalidPointer(Factory_BuildingType, ptr);
 		}
 
+		void UpdateVehicleProduction();
+
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
 	private:
 		template <typename T>
 		void Serialize(T& Stm);
@@ -78,4 +86,38 @@ public:
 	static int ActiveHarvesterCount(HouseClass* pThis);
 	static int TotalHarvesterCount(HouseClass* pThis);
 	static HouseClass* GetHouseKind(OwnerHouseKind kind, bool allowRandom, HouseClass* pDefault, HouseClass* pInvoker = nullptr, HouseClass* pVictim = nullptr);
+
+	static bool IsDisabledFromShell(
+	HouseClass const* pHouse, BuildingTypeClass const* pItem);
+
+	static size_t FindOwnedIndex(
+	HouseClass const* pHouse, int idxParentCountry,
+	Iterator<TechnoTypeClass const*> items, size_t start = 0);
+
+	static size_t FindBuildableIndex(
+		HouseClass const* pHouse, int idxParentCountry,
+		Iterator<TechnoTypeClass const*> items, size_t start = 0);
+
+	template <typename T>
+	static T* FindOwned(
+		HouseClass const* const pHouse, int const idxParent,
+		Iterator<T*> const items, size_t const start = 0)
+	{
+		auto const index = FindOwnedIndex(pHouse, idxParent, items, start);
+		return index < items.size() ? items[index] : nullptr;
+	}
+
+	template <typename T>
+	static T* FindBuildable(
+		HouseClass const* const pHouse, int const idxParent,
+		Iterator<T*> const items, size_t const start = 0)
+	{
+		auto const index = FindBuildableIndex(pHouse, idxParent, items, start);
+		return index < items.size() ? items[index] : nullptr;
+	}
+
+	static std::vector<int> AIProduction_CreationFrames;
+	static std::vector<int> AIProduction_Values;
+	static std::vector<int> AIProduction_BestChoices;
+	static std::vector<int> AIProduction_BestChoicesNaval;
 };

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -70,6 +70,7 @@ public:
 	private:
 		template <typename T>
 		void Serialize(T& Stm);
+		bool UpdateHarvesterProduction();
 	};
 
 	class ExtContainer final : public Container<HouseExt> {

--- a/src/Ext/House/Hooks.AINavalProduction.cpp
+++ b/src/Ext/House/Hooks.AINavalProduction.cpp
@@ -1,0 +1,198 @@
+#include "Body.h"
+
+#include <FactoryClass.h>
+#include <TEventClass.h>
+
+// AI Naval queue bugfix hooks
+
+namespace ExitObjectTemp
+{
+	int ProducingUnitIndex = -1;
+}
+
+DEFINE_HOOK(0x444113, BuildingClass_ExitObject_NavalProductionFix1, 0x6)
+{
+	GET(BuildingClass* const, pThis, ESI);
+	GET(FootClass* const, pObject, EDI);
+
+	auto const pHouse = pThis->Owner;
+
+	if (pObject->WhatAmI() == AbstractType::Unit && pObject->GetTechnoType()->Naval)
+	{
+		if (auto const pHouseExt = HouseExt::ExtMap.Find(pHouse))
+			pHouseExt->ProducingNavalUnitTypeIndex = -1;
+
+		ExitObjectTemp::ProducingUnitIndex = pHouse->ProducingUnitTypeIndex;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x444137, BuildingClass_ExitObject_NavalProductionFix2, 0x6)
+{
+	GET(BuildingClass* const, pThis, ESI);
+	GET(FootClass* const, pObject, EDI);
+
+	auto const pHouse = pThis->Owner;
+
+	if (pObject->WhatAmI() == AbstractType::Unit && pObject->GetTechnoType()->Naval)
+		pHouse->ProducingUnitTypeIndex = ExitObjectTemp::ProducingUnitIndex;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x450319, BuildingClass_AI_Factory_NavalProductionFix, 0x6)
+{
+	enum { SkipGameCode = 0x450332 };
+
+	GET(BuildingClass* const, pThis, ESI);
+
+	auto pHouse = pThis->Owner;
+	TechnoTypeClass* pTechnoType = nullptr;
+	int index = -1;
+
+	switch (pThis->Type->Factory)
+	{
+	case AbstractType::Aircraft:
+	case AbstractType::AircraftType:
+		index = pHouse->ProducingAircraftTypeIndex;
+
+		if (index >= 0)
+			pTechnoType = AircraftTypeClass::Array->GetItem(index);
+
+		break;
+
+	case AbstractType::Building:
+	case AbstractType::BuildingType:
+		index = pHouse->ProducingBuildingTypeIndex;
+
+		if (index >= 0)
+			pTechnoType = BuildingTypeClass::Array->GetItem(index);
+
+		break;
+
+	case AbstractType::Infantry:
+	case AbstractType::InfantryType:
+		index = pHouse->ProducingInfantryTypeIndex;
+
+		if (index >= 0)
+			pTechnoType = InfantryTypeClass::Array->GetItem(index);
+
+		break;
+
+	case AbstractType::Unit:
+	case AbstractType::UnitType:
+		index = !pThis->Type->Naval ? pHouse->ProducingUnitTypeIndex : HouseExt::ExtMap.Find(pHouse)->ProducingNavalUnitTypeIndex;
+
+		if (index >= 0)
+			pTechnoType = UnitTypeClass::Array->GetItem(index);
+
+		break;
+	}
+
+	R->EAX(pTechnoType);
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x4CA08B, FactoryClass_Abandon_NavalProductionFix, 0x5)
+{
+	enum { SkipOtherChecks = 0x4CA0E3 };
+
+	GET(FactoryClass* const, pThis, ESI);
+
+	if (pThis->Object->WhatAmI() == AbstractType::Unit && pThis->Object->GetTechnoType()->Naval)
+	{
+		if (auto const pHouseExt = HouseExt::ExtMap.Find(pThis->Owner))
+		{
+			pHouseExt->ProducingNavalUnitTypeIndex = -1;
+			return SkipOtherChecks;
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x4F91A4, HouseClass_AI_BuildingProductionCheck, 0x6)
+{
+	enum { SkipGameCode = 0x4CA0E3, CheckBuildingProduction = 0x4F9240 };
+
+	GET(HouseClass* const, pThis, ESI);
+
+	auto const pExt = HouseExt::ExtMap.Find(pThis);
+
+	bool cantBuild = pThis->ProducingUnitTypeIndex == -1 && pThis->ProducingInfantryTypeIndex == -1 &&
+		pThis->ProducingAircraftTypeIndex == -1 && pExt->ProducingNavalUnitTypeIndex == -1;
+
+	int index = pExt->ProducingNavalUnitTypeIndex;
+	if (index != -1 && !UnitTypeClass::Array->GetItem(index)->FindFactory(true, true, true, pThis))
+		cantBuild = true;
+
+	index = pThis->ProducingUnitTypeIndex;
+	if (index != -1 && !UnitTypeClass::Array->GetItem(index)->FindFactory(true, true, true, pThis))
+		cantBuild = true;
+
+	index = pThis->ProducingInfantryTypeIndex;
+	if (index != -1 && !InfantryTypeClass::Array->GetItem(index)->FindFactory(true, true, true, pThis))
+		cantBuild = true;
+
+	index = pThis->ProducingAircraftTypeIndex;
+	if ((index != -1 && !InfantryTypeClass::Array->GetItem(index)->FindFactory(true, true, true, pThis)) || cantBuild)
+		return CheckBuildingProduction;
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x4FE0A3, HouseClass_AI_RaiseMoney_NavalProductionFix, 0x6)
+{
+	GET(HouseClass* const, pThis, ESI);
+
+	if (auto const pExt = HouseExt::ExtMap.Find(pThis))
+		pExt->ProducingNavalUnitTypeIndex = -1;
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x4F90F0, HouseClass_AI_NavalProductionFix, 0x7)
+DEFINE_HOOK(0x4F9250, HouseClass_AI_NavalProductionFix, 0x7)
+{
+	enum { SkipGameCodeOne = 0x4F9257, SkipGameCodeTwo = 0x4F90F7 };
+
+	GET(HouseClass* const, pThis, ESI);
+
+	HouseExt::ExtMap.Find(pThis)->UpdateVehicleProduction();
+
+	return R->Origin() == 0x4F9250 ? SkipGameCodeOne : SkipGameCodeTwo;
+}
+
+DEFINE_HOOK(0x4FB6FC, HouseClass_JustBuilt_NavalProductionFix, 0x6)
+{
+	enum { SkipGameCode = 0x4FB702 };
+
+	GET(HouseClass* const, pThis, EDI);
+	GET(UnitTypeClass* const, pUnitType, EDX);
+	GET(int const, ID, EAX);
+
+	if (pUnitType->Naval)
+	{
+		HouseExt::ExtMap.Find(pThis)->LastBuiltNavalVehicleType = ID;
+		return SkipGameCode;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x71F003, TEventClass_Execute_NavalProductionFix, 0x6)
+{
+	enum { Execute = 0x71F014, Skip = 0x71F163 };
+
+	GET(TEventClass* const, pThis, EBP);
+	GET(HouseClass* const, pHouse, EAX);
+
+	if (pHouse->LastBuiltVehicleType != pThis->Value &&
+		HouseExt::ExtMap.Find(pHouse)->LastBuiltNavalVehicleType != pThis->Value)
+	{
+		return Skip;
+	}
+
+	return Execute;
+}

--- a/src/Ext/House/Hooks.AINavalProduction.cpp
+++ b/src/Ext/House/Hooks.AINavalProduction.cpp
@@ -94,9 +94,9 @@ DEFINE_HOOK(0x450319, BuildingClass_AI_Factory_NavalProductionFix, 0x6)
 	return SkipGameCode;
 }
 
-DEFINE_HOOK(0x4CA08B, FactoryClass_Abandon_NavalProductionFix, 0x5)
+DEFINE_HOOK(0x4CA0A1, FactoryClass_Abandon_NavalProductionFix, 0x5)
 {
-	enum { SkipOtherChecks = 0x4CA0E3 };
+	enum { SkipUnitTypeCheck = 0x4CA0B7 };
 
 	GET(FactoryClass* const, pThis, ESI);
 
@@ -105,7 +105,7 @@ DEFINE_HOOK(0x4CA08B, FactoryClass_Abandon_NavalProductionFix, 0x5)
 		if (auto const pHouseExt = HouseExt::ExtMap.Find(pThis->Owner))
 		{
 			pHouseExt->ProducingNavalUnitTypeIndex = -1;
-			return SkipOtherChecks;
+			return SkipUnitTypeCheck;
 		}
 	}
 

--- a/src/Ext/House/Hooks.AINavalProduction.cpp
+++ b/src/Ext/House/Hooks.AINavalProduction.cpp
@@ -114,7 +114,7 @@ DEFINE_HOOK(0x4CA0A1, FactoryClass_Abandon_NavalProductionFix, 0x5)
 
 DEFINE_HOOK(0x4F91A4, HouseClass_AI_BuildingProductionCheck, 0x6)
 {
-	enum { SkipGameCode = 0x4CA0E3, CheckBuildingProduction = 0x4F9240 };
+	enum { SkipGameCode = 0x4F9265, CheckBuildingProduction = 0x4F9240 };
 
 	GET(HouseClass* const, pThis, ESI);
 

--- a/src/Ext/House/Hooks.AINavalProduction.cpp
+++ b/src/Ext/House/Hooks.AINavalProduction.cpp
@@ -136,7 +136,7 @@ DEFINE_HOOK(0x4F91A4, HouseClass_AI_BuildingProductionCheck, 0x6)
 		cantBuild = true;
 
 	index = pThis->ProducingAircraftTypeIndex;
-	if ((index != -1 && !InfantryTypeClass::Array->GetItem(index)->FindFactory(true, true, true, pThis)) || cantBuild)
+	if ((index != -1 && !AircraftTypeClass::Array->GetItem(index)->FindFactory(true, true, true, pThis)) || cantBuild)
 		return CheckBuildingProduction;
 
 	return SkipGameCode;


### PR DESCRIPTION
By default, while game has separate FactoryClass instances and queues for regular and naval vehicles, game still keeps track of which VehicleType to build and which one was last built using only one reference each in HouseClass. This PR decouples this for ground and naval vehicles, allowing AI to produce both simultaneously.

Because Ares reimplements the HouseClass unit production update function (`0x4FEA60`) and this feature/fix is impossible to implement without touching that function, it has been reimplemented here again using [Ares 0.A version of the function](https://github.com/Ares-Developers/Ares/blob/4f1d929920aca31924c6cd4d3dfa849daa65252a/src/Ext/House/Hooks.100.cpp#L25) as a reference. However as it stands, I have no reliable way of telling if it has been altered to any significant degree in time since that and 3.0. It is possible that this PR uses less optimized code, or in worst-case, faulty or partial. **I would appreciate help of a more experienced reverse-engineer with this.**