### PR TITLE
The option to limit random crate generation only on land + sampling mechanism fix

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -204,7 +204,8 @@ This page lists all the individual contributions to the project by their author.
    - "Shield is broken" trigger event
    - RadialIndicator observer visibility
    - Cloaked objects from allies displaying to player in singleplayer campaigns
-   - Skip `NaturalParticleSystem` displaying from in-map pre-placed structures.
+   - Skip `NaturalParticleSystem` displaying from in-map pre-placed structures
+   - Random crate generation limited to land option, optimization for crates' random sampling
    - `ImmuneToCrit` for shields
    - Forbidding parallel AI queues by type
    - The option to allow DieSound/VoiceDie being played when grinding

--- a/README.md
+++ b/README.md
@@ -101,6 +101,6 @@ Legal and License
 
 The Phobos project is an unofficial open-source community collaboration project to extend the Red Alert 2 Yuri's Revenge engine for modding and compatibility purposes.
 
-As a modification, the project complies with [EA C&C modding guidelines](https://www.ea.com/games/command-and-conquer/command-and-conquer-remastered/modding-faq); should there be conflict between the project's license and modding guidelines - the rules imposed by guidelines shall take precedence (for example, the project should not be commercial or used to make money). 
+As a modification, the project complies with [EA C&C modding guidelines](https://www.ea.com/games/command-and-conquer/command-and-conquer-remastered/modding-faq); should there be conflict between the project's license and modding guidelines - the rules imposed by guidelines shall take precedence (for example, the project should not be commercial or used to make money).
 
 This project has no direct affiliation with Electronic Arts Inc. Command & Conquer, Command & Conquer Red Alert 2, Command & Conquer Yuri's Revenge are registered trademarks of Electronic Arts Inc. All Rights Reserved.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -28,6 +28,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed missing 'no enter' cursor for VehicleTypes being unable to enter a `Grinding` building.
 - Fixed Engineers being able to enter `Grinding` buildings even when they shouldn't (such as ally building at full HP).
 - Allowed usage of `AlternateFLH` of vehicles in `OpenTopped` transport.
+- Improved the statistic distribution of the spawned crates over the visible area of the map so that they will no longer have a higher chance to show up near the edges.
 - SHP debris shadows now respect the `Shadow` tag.
 - Allowed usage of TileSet of 255 and above without making NE-SW broken bridges unrepairable.
 - Added a "Load Game" button to the retry dialog on mission failure.
@@ -621,4 +622,15 @@ In `rulesmd.ini`:
 ```ini
 [AudioVisual]
 RadialIndicatorVisibility=allies  ; list of Affected House Enumeration (owner/self | allies/ally | enemies/enemy | all)
+```
+
+## Crate generation
+
+The statistic distribution of the randomly generated crates is now more uniform within the visible map region by using an optimized sampling procedure.
+- You can now limit the crates' spawn region to land only.
+
+In `rulesmd.ini`:
+```ini
+[CrateRules]
+CrateOnlyOnLand=no  ; boolean
 ```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -255,6 +255,7 @@ New:
 - Animation with `Tiled=yes` now supports `CustomPalette` (by ststl)
 - Toggleable DieSound when grinding (by Trsdy)
 - Shields can inherit Techno ArmorType (by Starkku)
+- Allow random crates to be generated only on lands (by Trsdy)
 - Iron-curtain effects on infantries and organic units (by ststl)
 - Custom `SlavesFreeSound` (by TwinkleStar)
 - Allows jumpjet to crash without rotation (by TwinkleStar)
@@ -263,6 +264,7 @@ New:
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
 - Allow usage of `AlternateFLH%d` of vehicles in `OpenTopped` transport. (by Trsdy)
+- Improved the statistic distribution of the spawned crates over the visible area of the map. (by Trsdy, based on TwinkleStar's work)
 - Teams spawned by trigger action 7,80,107 can use IFV and `OpenTopped` logic normally (by Trsdy)
 - Prevented units from retaining previous order after ownership change (by Trsdy)
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations (by Starkku)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -107,6 +107,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->IronCurtain_EffectOnOrganics.Read(exINI, GameStrings::CombatDamage, "IronCurtain.EffectOnOrganics");
 	this->IronCurtain_KillOrganicsWarhead.Read(exINI, GameStrings::CombatDamage, "IronCurtain.KillOrganicsWarhead");
 
+	this->CrateOnlyOnLand.Read(exINI, GameStrings::CrateRules, "CrateOnlyOnLand");
+
 	this->ROF_RandomDelay.Read(exINI, GameStrings::CombatDamage, "ROF.RandomDelay");
 
 	// Section AITargetTypes
@@ -216,6 +218,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ToolTip_Background_Color)
 		.Process(this->ToolTip_Background_Opacity)
 		.Process(this->ToolTip_Background_BlurSize)
+		.Process(this->CrateOnlyOnLand)
 		.Process(this->RadialIndicatorVisibility)
 		;
 }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -72,6 +72,7 @@ public:
 		Valueable<int> ToolTip_Background_Opacity;
 		Valueable<float> ToolTip_Background_BlurSize;
 
+		Valueable<bool> CrateOnlyOnLand;
 		Valueable<AffectedHouse> RadialIndicatorVisibility;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
@@ -113,6 +114,7 @@ public:
 			, ToolTip_Background_Color { { 0, 0, 0 } }
 			, ToolTip_Background_Opacity { 100 }
 			, ToolTip_Background_BlurSize { 0.0f }
+			, CrateOnlyOnLand { false }
 			, RadialIndicatorVisibility { AffectedHouse::Allies }
 		{ }
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -608,3 +608,34 @@ DEFINE_HOOK(0x70BCE6, TechnoClass_GetTargetCoords_BuildingFix, 0x6)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x56BD8B, MapClass_PlaceRandomCrate_Sampling, 0x5)
+{
+	enum { SpawnCrate = 0x56BE7B, SkipSpawn = 0x56BE91 };
+
+	int XP = 2 * MapClass::Instance->VisibleRect.X - MapClass::Instance->MapRect.Width
+		+ ScenarioClass::Instance->Random.RandomRanged(0, 2 * MapClass::Instance->VisibleRect.Width);
+	int YP = 2 * MapClass::Instance->VisibleRect.Y + MapClass::Instance->MapRect.Width
+		+ ScenarioClass::Instance->Random.RandomRanged(0, 2 * MapClass::Instance->VisibleRect.Height + 2);
+	CellStruct candidate { (short)((XP + YP) / 2),(short)((YP - XP) / 2) };
+
+	auto pCell = MapClass::Instance->TryGetCellAt(candidate);
+	if (!pCell)
+		return SkipSpawn;
+
+	if (!MapClass::Instance->IsWithinUsableArea(pCell, true))
+		return SkipSpawn;
+
+	bool isWater = pCell->LandType == LandType::Water;
+	if (isWater && RulesExt::Global()->CrateOnlyOnLand.Get())
+		return SkipSpawn;
+
+	REF_STACK(CellStruct, cell, STACK_OFFSET(0x28, -0x18));
+	cell = MapClass::Instance->NearByLocation(pCell->MapCoords,
+		isWater ? SpeedType::Float : SpeedType::Track,
+		-1, MovementZone::Normal, false, 1, 1, false, false, false, true, CellStruct::Empty, false, false);
+
+	R->EAX(&cell);
+
+	return SpawnCrate;
+}


### PR DESCRIPTION
This should fix the theoretical flaw of #809 
A histogram proving a more uniform distribution will be uploaded later

The game uses [rejection sampling](https://en.wikipedia.org/wiki/Rejection_sampling) for the random generation of crates.
- You can now limit the crates' spawn region to land only.

In `rulesmd.ini`:
```ini
[CrateRules]
CrateOnlyOnLand=no  ; boolean
```
