### PR TITLE
[Minor] Make ExtMap iterable

### DIFF
--- a/src/Ext/Bullet/Body.cpp
+++ b/src/Ext/Bullet/Body.cpp
@@ -80,30 +80,30 @@ void BulletExt::ExtData::InterceptBullet(TechnoClass* pSource, WeaponTypeClass* 
 void BulletExt::ExtData::ApplyRadiationToCell(CellStruct Cell, int Spread, int RadLevel)
 {
 	auto const pThis = this->OwnerObject();
-	auto const& Instances = RadSiteExt::Array;
+
 	auto const pWeapon = pThis->GetWeaponType();
 	auto const pWeaponExt = WeaponTypeExt::ExtMap.FindOrAllocate(pWeapon);
 	auto const pRadType = pWeaponExt->RadType;
 	auto const pThisHouse = pThis->Owner ? pThis->Owner->Owner : this->FirerHouse;
 
-	if (Instances.Count > 0)
+	if (RadSiteExt::ExtMap.size() > 0)
 	{
-		auto const it = std::find_if(Instances.begin(), Instances.end(),
-			[=](RadSiteExt::ExtData* const pSite) // Lambda
+		auto const it = std::find_if(RadSiteExt::ExtMap.begin(), RadSiteExt::ExtMap.end(),
+			[=](std::pair<RadSiteClass*, RadSiteExt::ExtData*> const& pair) // Lambda
 			{// find
-				return pSite->Type == pRadType &&
-					pSite->OwnerObject()->BaseCell == Cell &&
-					Spread == pSite->OwnerObject()->Spread;
+				return pair.second->Type == pRadType &&
+					pair.first->BaseCell == Cell &&
+					Spread == pair.first->Spread;
 			});
 
-		if (it == Instances.end())
+		if (it == RadSiteExt::ExtMap.end())
 		{
 			RadSiteExt::CreateInstance(Cell, Spread, RadLevel, pWeaponExt, pThisHouse, pThis->Owner);
 		}
 		else
 		{
-			auto const pRadExt = *it;
-			auto const pRadSite = pRadExt->OwnerObject();
+			//auto const pRadExt = it->second;
+			auto const pRadSite = it->first;
 
 			if (pRadSite->GetRadLevel() + RadLevel > pRadType->GetLevelMax())
 			{

--- a/src/Ext/RadSite/Body.cpp
+++ b/src/Ext/RadSite/Body.cpp
@@ -7,8 +7,6 @@
 template<> const DWORD Extension<RadSiteClass>::Canary = 0x87654321;
 RadSiteExt::ExtContainer RadSiteExt::ExtMap;
 
-DynamicVectorClass<RadSiteExt::ExtData*> RadSiteExt::Array;
-
 void RadSiteExt::ExtData::Initialize()
 {
 	this->Type = RadTypeClass::FindOrAllocate(GameStrings::Radiation);
@@ -56,8 +54,6 @@ void RadSiteExt::CreateInstance(CellStruct location, int spread, int amount, Wea
 	pRadSite->SetSpread(spread);
 	RadSiteExt::SetRadLevel(pRadSite, amount);
 	RadSiteExt::CreateLight(pRadSite);
-
-	Array.AddUnique(pRadExt);
 }
 
 //RadSiteClass Activate , Rewritten
@@ -185,9 +181,7 @@ RadSiteExt::ExtContainer::~ExtContainer() = default;
 DEFINE_HOOK(0x65B28D, RadSiteClass_CTOR, 0x6)
 {
 	GET(RadSiteClass*, pThis, ESI);
-	auto pRadSiteExt = RadSiteExt::ExtMap.FindOrAllocate(pThis);
-
-	RadSiteExt::Array.AddUnique(pRadSiteExt);
+	RadSiteExt::ExtMap.FindOrAllocate(pThis);
 
 	return 0;
 }
@@ -195,10 +189,8 @@ DEFINE_HOOK(0x65B28D, RadSiteClass_CTOR, 0x6)
 DEFINE_HOOK(0x65B2F4, RadSiteClass_DTOR, 0x5)
 {
 	GET(RadSiteClass*, pThis, ECX);
-	auto pRadExt = RadSiteExt::ExtMap.Find(pThis);
 
 	RadSiteExt::ExtMap.Remove(pThis);
-	RadSiteExt::Array.Remove(pRadExt);
 
 	return 0;
 }

--- a/src/Ext/RadSite/Body.h
+++ b/src/Ext/RadSite/Body.h
@@ -53,8 +53,6 @@ public:
 		void Serialize(T& Stm);
 	};
 
-	static DynamicVectorClass<RadSiteExt::ExtData*> Array;
-
 	static void CreateInstance(CellStruct location, int spread, int amount, WeaponTypeExt::ExtData* pWeaponExt, HouseClass* const pOwner, TechnoClass* const pInvoker);
 	static void CreateLight(RadSiteClass* pThis);
 	static void Add(RadSiteClass* pThis,int amount);

--- a/src/Ext/RadSite/Hooks.cpp
+++ b/src/Ext/RadSite/Hooks.cpp
@@ -62,18 +62,18 @@ DEFINE_HOOK(0x5213E3, InfantryClass_AIDeployment_CheckRad, 0x4)
 	int radLevel = 0;
 	if (RadSiteExt::ExtMap.size() > 0 && pWeapon)
 	{
-		auto const pWeaponExt = WeaponTypeExt::ExtMap.FindOrAllocate(pWeapon);
+		auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
 		auto const pRadType = pWeaponExt->RadType;
 		auto const warhead = pWeapon->Warhead;
 		auto currentCoord = pInf->GetCell()->MapCoords;
 
 		auto const it = std::find_if(RadSiteExt::ExtMap.begin(), RadSiteExt::ExtMap.end(),
-			[=](std::pair<RadSiteClass*,RadSiteExt::ExtData*> const& pSite)
+			[=](std::pair<RadSiteClass* const, RadSiteExt::ExtData* const> const& pair)
 			{
 				return
-					pSite.second->Type == pRadType &&
-					pSite.first->BaseCell == currentCoord &&
-					pSite.first->Spread == Game::F2I(warhead->CellSpread)
+					pair.second->Type == pRadType &&
+					pair.first->BaseCell == currentCoord &&
+					pair.first->Spread == Game::F2I(warhead->CellSpread)
 					;
 			});
 

--- a/src/Ext/RadSite/Hooks.cpp
+++ b/src/Ext/RadSite/Hooks.cpp
@@ -60,27 +60,27 @@ DEFINE_HOOK(0x5213E3, InfantryClass_AIDeployment_CheckRad, 0x4)
 	auto const pWeapon = pInf->GetDeployWeapon()->WeaponType;
 
 	int radLevel = 0;
-	if (RadSiteExt::Array.Count > 0 && pWeapon)
+	if (RadSiteExt::ExtMap.size() > 0 && pWeapon)
 	{
 		auto const pWeaponExt = WeaponTypeExt::ExtMap.FindOrAllocate(pWeapon);
 		auto const pRadType = pWeaponExt->RadType;
 		auto const warhead = pWeapon->Warhead;
 		auto currentCoord = pInf->GetCell()->MapCoords;
 
-		auto const it = std::find_if(RadSiteExt::Array.begin(), RadSiteExt::Array.end(),
-			[=](RadSiteExt::ExtData* const pSite)
+		auto const it = std::find_if(RadSiteExt::ExtMap.begin(), RadSiteExt::ExtMap.end(),
+			[=](std::pair<RadSiteClass*,RadSiteExt::ExtData*> const& pSite)
 			{
 				return
-					pSite->Type == pRadType &&
-					pSite->OwnerObject()->BaseCell == currentCoord &&
-					pSite->OwnerObject()->Spread == Game::F2I(warhead->CellSpread)
+					pSite.second->Type == pRadType &&
+					pSite.first->BaseCell == currentCoord &&
+					pSite.first->Spread == Game::F2I(warhead->CellSpread)
 					;
 			});
 
-		if (it != RadSiteExt::Array.end())
+		if (it != RadSiteExt::ExtMap.end())
 		{
-			auto pRadExt = *it;
-			auto pRadSite = pRadExt->OwnerObject();
+			//auto pRadExt = it->second;
+			auto pRadSite = it->first;
 			radLevel = pRadSite->GetRadLevel();
 		}
 	}
@@ -136,9 +136,8 @@ DEFINE_HOOK(0x43FB23, BuildingClass_AI_Radiation, 0x5)
 	{
 		CellStruct nCurrentCoord = buildingCoords + *pFoundation;
 
-		for (auto& pRadExt : RadSiteExt::Array)
+		for (auto& [pRadSite,pRadExt] : RadSiteExt::ExtMap)
 		{
-			RadSiteClass* pRadSite = pRadExt->OwnerObject();
 			RadTypeClass* pType = pRadExt->Type;
 
 			// Check the distance, if not in range, just skip this one
@@ -187,10 +186,8 @@ DEFINE_HOOK(0x4DA59F, FootClass_AI_Radiation, 0x5)
 		CellStruct CurrentCoord = pFoot->GetCell()->MapCoords;
 
 		// Loop for each different radiation stored in the RadSites container
-		for (auto& pRadExt : RadSiteExt::Array)
+		for (auto& [pRadSite,pRadExt] : RadSiteExt::ExtMap)
 		{
-			RadSiteClass* pRadSite = pRadExt->OwnerObject();
-
 			// Check the distance, if not in range, just skip this one
 			double orDistance = pRadSite->BaseCell.DistanceFrom(CurrentCoord);
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -30,7 +30,7 @@ void TechnoExt::ExtData::ApplyInterceptor()
 	{
 		BulletClass* pTargetBullet = nullptr;
 
-		for (auto const& pBullet : *BulletClass::Array)
+		for (auto const& [pBullet,pBulletExt] : BulletExt::ExtMap)
 		{
 			const auto& guardRange = pTypeExt->Interceptor_GuardRange.Get(pThis);
 			const auto& minguardRange = pTypeExt->Interceptor_MinimumGuardRange.Get(pThis);
@@ -40,7 +40,6 @@ void TechnoExt::ExtData::ApplyInterceptor()
 			if (distance > guardRange || distance < minguardRange)
 				continue;
 
-			auto pBulletExt = BulletExt::ExtMap.Find(pBullet);
 			auto pBulletTypeExt = pBulletExt->TypeExtData;
 
 			if (!pBulletTypeExt || !pBulletTypeExt->Interceptable)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -506,9 +506,8 @@ DEFINE_HOOK(0x679CAF, RulesClass_LoadAfterTypeData_CompleteInitialization, 0x5)
 {
 	//GET(CCINIClass*, pINI, ESI);
 
-	for (auto const& pType : *BuildingTypeClass::Array)
+	for (auto const& [pType,pExt] : BuildingTypeExt::ExtMap)
 	{
-		auto const pExt = BuildingTypeExt::ExtMap.Find(pType);
 		pExt->CompleteInitialization();
 	}
 

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -307,9 +307,8 @@ void WarheadTypeExt::ExtData::InterceptBullets(TechnoClass* pOwner, WeaponTypeCl
 	}
 	else
 	{
-		for (auto const& pBullet : *BulletClass::Array)
+		for (auto const& [pBullet,pExt] : BulletExt::ExtMap)
 		{
-			auto const pExt = BulletExt::ExtMap.Find(pBullet);
 			auto const pTypeExt = pExt->TypeExtData;
 
 			// Cells don't know about bullets that may or may not be located on them so it has to be this way.

--- a/src/Utilities/Container.h
+++ b/src/Utilities/Container.h
@@ -413,17 +413,17 @@ public:
 		this->SavingStream = nullptr;
 	}
 
-	decltype(auto) begin()
+	decltype(auto) begin() const
 	{
 		return this->Items.begin();
 	}
 
-	decltype(auto) end()
+	decltype(auto) end() const
 	{
 		return this->Items.end();
 	}
 
-	size_t size()
+	size_t size() const
 	{
 		return this->Items.size();
 	}

--- a/src/Utilities/Container.h
+++ b/src/Utilities/Container.h
@@ -413,6 +413,21 @@ public:
 		this->SavingStream = nullptr;
 	}
 
+	decltype(auto) begin()
+	{
+		return this->Items.begin();
+	}
+
+	decltype(auto) end()
+	{
+		return this->Items.end();
+	}
+
+	size_t size()
+	{
+		return this->Items.size();
+	}
+
 protected:
 	// override this method to do type-specific stuff
 	virtual bool Save(key_type key, IStream* pStm)


### PR DESCRIPTION
I don't think using `DynamicVectorClass` is a good idea.
This removes the `Array` from `RadExt`
and should make it simpler and perhaps faster for something like
```cpp
for( auto pObj : *SomeClass::Array)
{
    auto pExt = SomeExt::ExtMap.Find(pObj);
```
by using
```cpp
for(auto& [pObj, pExt] : SomeExt::ExtMap)
```
I'm not familiar with STL yet so need help on the format
Need testing if everything else such as Radiation or Interceptor work as usual
