### PR TITLE
Fix LimboDelivery buildings counting in AI base center calculations

### DIFF
--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -10,6 +10,13 @@
 template<> const DWORD Extension<HouseClass>::Canary = 0x11111111;
 HouseExt::ExtContainer HouseExt::ExtMap;
 
+bool HouseExt::ExtData::OwnsLimboDeliveredBuilding(BuildingClass const* pBuilding)
+{
+	if (!pBuilding)
+		return false;
+
+	return this->OwnedLimboDeliveredBuildings.count(pBuilding->UniqueID);
+}
 
 int HouseExt::ActiveHarvesterCount(HouseClass* pThis)
 {
@@ -33,12 +40,6 @@ int HouseExt::TotalHarvesterCount(HouseClass* pThis)
 		result += pThis->CountOwnedAndPresent(pType);
 
 	return result;
-}
-
-int HouseExt::CountOwnedLimbo(HouseClass* pThis, BuildingTypeClass const* const pItem)
-{
-	auto pHouseExt = HouseExt::ExtMap.Find(pThis);
-	return pHouseExt->OwnedLimboBuildingTypes.GetItemCount(pItem->ArrayIndex);
 }
 
 // Ares
@@ -80,6 +81,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->BuildingCounter)
+		.Process(this->OwnedLimboDeliveredBuildings)
 		.Process(this->Factory_BuildingType)
 		.Process(this->Factory_InfantryType)
 		.Process(this->Factory_VehicleType)

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -5,7 +5,7 @@
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
 
-#include <Ext/BuildingType/Body.h>
+#include <Ext/Building/Body.h>
 
 #include <map>
 
@@ -17,7 +17,7 @@ public:
 	{
 	public:
 		std::map<BuildingTypeExt::ExtData*, int> BuildingCounter;
-		CounterClass OwnedLimboBuildingTypes;
+		std::map<DWORD, BuildingExt::ExtData*> OwnedLimboDeliveredBuildings;
 
 		BuildingClass* Factory_BuildingType;
 		BuildingClass* Factory_InfantryType;
@@ -26,13 +26,16 @@ public:
 		BuildingClass* Factory_AircraftType;
 
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
-			, OwnedLimboBuildingTypes {}
+			, BuildingCounter {}
+			, OwnedLimboDeliveredBuildings {}
 			, Factory_BuildingType { nullptr }
 			, Factory_InfantryType { nullptr }
 			, Factory_VehicleType { nullptr }
 			, Factory_NavyType { nullptr }
 			, Factory_AircraftType { nullptr }
 		{ }
+
+		bool OwnsLimboDeliveredBuilding(BuildingClass const* pBuilding);
 
 		virtual ~ExtData() = default;
 
@@ -63,8 +66,6 @@ public:
 
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
-
-	static int CountOwnedLimbo(HouseClass* pThis, BuildingTypeClass const* const pItem);
 
 	static int ActiveHarvesterCount(HouseClass* pThis);
 	static int TotalHarvesterCount(HouseClass* pThis);

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -63,3 +63,32 @@ DEFINE_HOOK(0x73E474, UnitClass_Unload_Storage, 0x6)
 
 	return 0;
 }
+
+namespace RecalcCenterTemp
+{
+	HouseExt::ExtData* pExtData;
+}
+
+DEFINE_HOOK(0x4FD166, HouseClass_RecalcCenter_SetContext, 0x5)
+{
+	GET(HouseClass* const, pThis, EDI);
+
+	RecalcCenterTemp::pExtData = HouseExt::ExtMap.Find(pThis);
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x4FD463, HouseClass_RecalcCenter_LimboDelivery, 0x6)
+DEFINE_HOOK(0x4FD1CD, HouseClass_RecalcCenter_LimboDelivery, 0x6)
+{
+	enum { SkipBuilding1 = 0x4FD23B, SkipBuilding2 = 0x4FD4D5 };
+
+	GET(BuildingClass* const, pBuilding, ESI);
+
+	auto const pExt = RecalcCenterTemp::pExtData;
+
+	if (pExt && pExt->OwnsLimboDeliveredBuilding(pBuilding))
+		return R->Origin() == 0x4FD1CD ? SkipBuilding1 : SkipBuilding2;
+
+	return 0;
+}


### PR DESCRIPTION
Fixes an issue where buildings brought into the game via LimboDelivery are considered by AI when calculating its base center. Normally it checks if they are alive and not in limbo, but this check is satisfied by LimboDelivery buildings, so an additional check is required. For this purpose houses now keep track of LimboDelivered buildings they own (a map of BuildingExt::ExtData with AbstractClass->UniqueID as key, ExtData because it saves iterating BuildingClass array and calling ExtMap::Find on LimboKill).