### PR TITLE
Fix weapon effects (beams/railguns/bolts etc) interaction with obstacles

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -217,6 +217,7 @@ This page lists all the individual contributions to the project by their author.
   - Negative damage `Verses/PercentAtMax` toggle
   - Misc. singleplayer mission improvements
   - Weapon effect obstacle interaction fix
+  - Fire particle rotation coordinate adjust toggle
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -218,6 +218,7 @@ This page lists all the individual contributions to the project by their author.
   - Misc. singleplayer mission improvements
   - Weapon effect obstacle interaction fix
   - Fire particle rotation coordinate adjust toggle
+  - `AmbientDamage` warhead & main target ignore customization
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -216,6 +216,7 @@ This page lists all the individual contributions to the project by their author.
   - Airstrike & spy plane fixed spawn distance & height
   - Negative damage `Verses/PercentAtMax` toggle
   - Misc. singleplayer mission improvements
+  - Weapon effect obstacle interaction fix
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -125,7 +125,7 @@
     <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Unload.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.EffectTargetCoordsFix.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.WeaponEffects.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />
     <ClCompile Include="src\Ext\VoxelAnimType\Body.cpp" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="src\Ext\House\Hooks.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.AINavalProduction.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.UnitFromFactory.cpp" />
+    <ClCompile Include="src\Ext\ParticleSystemType\Body.cpp" />
     <ClCompile Include="src\Ext\RadSite\Body.cpp" />
     <ClCompile Include="src\Ext\RadSite\Hooks.cpp" />
     <ClCompile Include="src\Ext\Scenario\Body.cpp" />
@@ -215,6 +216,7 @@
     <ClInclude Include="src\Ext\BulletType\Body.h" />
     <ClInclude Include="src\Ext\Bullet\Body.h" />
     <ClInclude Include="src\Ext\House\Body.h" />
+    <ClInclude Include="src\Ext\ParticleSystemType\Body.h" />
     <ClInclude Include="src\Ext\RadSite\Body.h" />
     <ClInclude Include="src\Ext\Scenario\Body.h" />
     <ClInclude Include="src\Ext\Script\Body.h" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -125,6 +125,7 @@
     <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Unload.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.EffectTargetCoordsFix.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />
     <ClCompile Include="src\Ext\VoxelAnimType\Body.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -306,6 +306,18 @@ In `rulesmd.ini`:
 SellBuildupLength=23  ; integer, number of buildup frames to play
 ```
 
+## Particle systems
+
+### Fire particle target coordinate adjustment when firer rotates
+
+- By default particle systems with `BehavesLike=Fire` shift their target coordinates if the object that created the particle system (e.g firer of a weapon) is rotating. This behavior can now be disabled per particle system type.
+
+In `rulesmd.ini`:
+```ini
+[SOMEPARTICLESYSTEM]               ; ParticleSystemType
+AdjustTargetCoordsOnRotation=true  ; boolean
+```
+
 ## Projectiles
 
 ### Cluster scatter distance customization

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -143,8 +143,9 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fix [EIP 00529A14](https://modenc.renegadeprojects.com/Internal_Error/YR#eip_00529A14) when attempting to read `[Header]` section of campaign maps.
 - Units will no longer rotate its turret under EMP.
 - Jumpjets will no longer wobble under EMP.
-- Fixed weapon effects like railguns, lasers, beams, bolts and waves drawing beyond where Warhead detonates if it hits an obstacle like wall. Note that this is not necessarily same as the actual projectile travel path if it is not `Inviso=true` projectile.
 - Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by elevation changes.
+- Fixed railgun and fire particles being cut off by elevation changes.
+
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -143,6 +143,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fix [EIP 00529A14](https://modenc.renegadeprojects.com/Internal_Error/YR#eip_00529A14) when attempting to read `[Header]` section of campaign maps.
 - Units will no longer rotate its turret under EMP.
 - Jumpjets will no longer wobble under EMP.
+- Fixed weapon effects like railguns, lasers, beams, bolts and waves drawing beyond where Warhead detonates if it hits an obstacle like wall.
+- Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by elevation changes.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -143,7 +143,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fix [EIP 00529A14](https://modenc.renegadeprojects.com/Internal_Error/YR#eip_00529A14) when attempting to read `[Header]` section of campaign maps.
 - Units will no longer rotate its turret under EMP.
 - Jumpjets will no longer wobble under EMP.
-- Fixed weapon effects like railguns, lasers, beams, bolts and waves drawing beyond where Warhead detonates if it hits an obstacle like wall.
+- Fixed weapon effects like railguns, lasers, beams, bolts and waves drawing beyond where Warhead detonates if it hits an obstacle like wall. Note that this is not necessarily same as the actual projectile travel path if it is not `Inviso=true` projectile.
 - Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by elevation changes.
 
 ## Fixes / interactions with other extensions

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -897,6 +897,17 @@ ShakeIsLocal=false  ; boolean
 
 ## Weapons
 
+### AmbientDamage customizations
+
+- You can now specify separate Warhead used for `AmbientDamage` via `AmbientDamage.Warhead` or make it never apply to weapon's main target by setting `AmbientDamage.IgnoreTarget` to true.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWEAPON]                      ; WeaponType
+AmbientDamage.Warhead=            ; WarheadType
+AmbientDamage.IgnoreTarget=false  ; boolean
+```
+
 ### Customizable disk laser radius
 
 ![image](_static/images/disklaser-radius-values-01.gif)

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -643,7 +643,7 @@ SW.Next.RandomWeightsN=         ; List of integers.
 In `rulesmd.ini`:
 ```ini
 [SOMESW]                ; Super Weapon
-Detonate.Warhead=       ; Warhead
+Detonate.Warhead=       ; WarheadType
 Detonate.Weapon=        ; WeaponType
 Detonate.Damage=        ; integer
 Detonate.AtFirer=false  ; boolean

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -354,6 +354,7 @@ New:
 - Allow setting mission par times and related messages in `missionmd.ini` (by Starkku)
 - Allow setting default singleplayer map loading screen and briefing offsets (by Starkku)
 - Allow toggling whether or not fire particle systems adjust target coordinates when firer rotates (by Starkku)
+- `AmbientDamage` warhead & main target ignore customization (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -353,6 +353,7 @@ New:
 - Show briefing screen on singleplayer mission start (by Starkku)
 - Allow setting mission par times and related messages in `missionmd.ini` (by Starkku)
 - Allow setting default singleplayer map loading screen and briefing offsets (by Starkku)
+- Allow toggling whether or not fire particle systems adjust target coordinates when firer rotates (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -403,6 +403,8 @@ Vanilla fixes:
 - Fixed a glitch related to incorrect target setting for missiles (by Belonit)
 - Skipped parsing `[Header]` section of compaign maps which led to occasional crashes on Linux (by Trsdy)
 - Fixed units' turret rotation and jumpjet wobble under EMP (by Trsdy)
+- Fixed weapon effects like railguns, lasers, beams, bolts and waves drawing beyond where Warhead detonates if it hits an obstacle like wall (by Starkku)
+- Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by elevation changes (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -403,8 +403,8 @@ Vanilla fixes:
 - Fixed a glitch related to incorrect target setting for missiles (by Belonit)
 - Skipped parsing `[Header]` section of compaign maps which led to occasional crashes on Linux (by Trsdy)
 - Fixed units' turret rotation and jumpjet wobble under EMP (by Trsdy)
-- Fixed weapon effects like railguns, lasers, beams, bolts and waves drawing beyond where Warhead detonates if it hits an obstacle like wall (by Starkku)
 - Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by elevation changes (by Starkku)
+- Fixed railgun and fire particles being cut off by elevation changes (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/ParticleSystemType/Body.cpp
+++ b/src/Ext/ParticleSystemType/Body.cpp
@@ -68,9 +68,9 @@ DEFINE_HOOK(0x644215, ParticleSystemTypeClass_CTOR, 0x7)
 	return 0;
 }
 
-DEFINE_HOOK(0x644256, ParticleSystemTypeClass_DTOR, 0x6)
+DEFINE_HOOK(0x644986, ParticleSystemTypeClass_SDDTOR, 0x6)
 {
-	GET(ParticleSystemTypeClass*, pItem, ECX);
+	GET(ParticleSystemTypeClass*, pItem, ESI);
 
 	ParticleSystemTypeExt::ExtMap.Remove(pItem);
 

--- a/src/Ext/ParticleSystemType/Body.cpp
+++ b/src/Ext/ParticleSystemType/Body.cpp
@@ -1,0 +1,114 @@
+#include "Body.h"
+
+ParticleSystemTypeExt::ExtContainer ParticleSystemTypeExt::ExtMap;
+
+// =============================
+// load / save
+
+template <typename T>
+void ParticleSystemTypeExt::ExtData::Serialize(T& Stm)
+{
+	Stm
+		.Process(this->AdjustTargetCoordsOnRotation)
+		;
+}
+
+void ParticleSystemTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
+{
+	auto pThis = this->OwnerObject();
+	const char* pSection = pThis->ID;
+
+	if (!pINI->GetSection(pSection))
+		return;
+
+	INI_EX exINI(pINI);
+
+	this->AdjustTargetCoordsOnRotation.Read(exINI, pSection, "AdjustTargetCoordsOnRotation");
+}
+
+void ParticleSystemTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
+{
+	Extension<ParticleSystemTypeClass>::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void ParticleSystemTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
+{
+	Extension<ParticleSystemTypeClass>::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+bool ParticleSystemTypeExt::LoadGlobals(PhobosStreamReader& Stm)
+{
+	return Stm
+		.Success();
+}
+
+bool ParticleSystemTypeExt::SaveGlobals(PhobosStreamWriter& Stm)
+{
+	return Stm
+		.Success();
+}
+
+// =============================
+// container
+
+ParticleSystemTypeExt::ExtContainer::ExtContainer() : Container("ParticleSystemTypeClass") { }
+ParticleSystemTypeExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// container hooks
+
+DEFINE_HOOK(0x644215, ParticleSystemTypeClass_CTOR, 0x7)
+{
+	GET(ParticleSystemTypeClass*, pItem, ESI);
+
+	ParticleSystemTypeExt::ExtMap.TryAllocate(pItem);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x644256, ParticleSystemTypeClass_DTOR, 0x6)
+{
+	GET(ParticleSystemTypeClass*, pItem, ECX);
+
+	ParticleSystemTypeExt::ExtMap.Remove(pItem);
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x644830, ParticleSystemTypeClass_SaveLoad_Prefix, 0x8)
+DEFINE_HOOK(0x6447E0, ParticleSystemTypeClass_SaveLoad_Prefix, 0x5)
+{
+	GET_STACK(ParticleSystemTypeClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	ParticleSystemTypeExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x64481F, ParticleSystemTypeClass_Load_Suffix, 0x6)
+{
+	ParticleSystemTypeExt::ExtMap.LoadStatic();
+
+	return 0;
+}
+
+DEFINE_HOOK(0x644844, ParticleSystemTypeClass_Save_Suffix, 0x5)
+{
+	ParticleSystemTypeExt::ExtMap.SaveStatic();
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x644615, ParticleSystemTypeClass_LoadFromINI, 0x5)
+DEFINE_HOOK(0x644620, ParticleSystemTypeClass_LoadFromINI, 0x5)
+{
+	GET(ParticleSystemTypeClass*, pItem, ESI);
+	GET_STACK(CCINIClass*, pINI, STACK_OFFSET(0x64, 0x4));
+
+	ParticleSystemTypeExt::ExtMap.LoadFromINI(pItem, pINI);
+
+	return 0;
+}

--- a/src/Ext/ParticleSystemType/Body.h
+++ b/src/Ext/ParticleSystemType/Body.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <ParticleSystemTypeClass.h>
+
+#include <Helpers/Macro.h>
+#include <Utilities/Container.h>
+#include <Utilities/TemplateDef.h>
+#include <Utilities/Macro.h>
+#include <Utilities/GeneralUtils.h>
+
+class ParticleSystemTypeExt
+{
+public:
+	using base_type = ParticleSystemTypeClass;
+
+	static constexpr DWORD Canary = 0xF9984EFE;
+	static constexpr size_t ExtPointerOffset = 0x18;
+
+	class ExtData final : public Extension<ParticleSystemTypeClass>
+	{
+	public:
+		Valueable<bool> AdjustTargetCoordsOnRotation;
+
+		ExtData(ParticleSystemTypeClass* OwnerObject) : Extension<ParticleSystemTypeClass>(OwnerObject)
+			, AdjustTargetCoordsOnRotation { true }
+		{ }
+
+		virtual ~ExtData() = default;
+
+		virtual void LoadFromINIFile(CCINIClass* pINI) override;
+
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
+
+		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+	private:
+		template <typename T>
+		void Serialize(T& Stm);
+	};
+
+	class ExtContainer final : public Container<ParticleSystemTypeExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+	};
+
+	static ExtContainer ExtMap;
+
+	static bool LoadGlobals(PhobosStreamReader& Stm);
+	static bool SaveGlobals(PhobosStreamWriter& Stm);
+};

--- a/src/Ext/Techno/Hooks.EffectTargetCoordsFix.cpp
+++ b/src/Ext/Techno/Hooks.EffectTargetCoordsFix.cpp
@@ -1,0 +1,136 @@
+#include <BuildingClass.h>
+#include <CellClass.h>
+#include <MapClass.h>
+#include <ParticleSystemClass.h>
+#include <FootClass.h>
+
+#include <Utilities/Macro.h>
+
+// Contains hooks that fix weapon graphical effects like lasers, railguns, electric bolts, beams and waves not interacting
+// correctly with obstacles between firer and target, as well as railgun / railgun particles being cut off by elevation.
+
+namespace FireAtTemp
+{
+	CoordStruct originalTargetCoords;
+	CellClass* pObstacleCell = nullptr;
+	AbstractClass* pOriginalTarget = nullptr;
+}
+
+// Set obstacle cell.
+DEFINE_HOOK(0x6FF15F, TechnoClass_FireAt_ObstacleCellSet, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET(WeaponTypeClass*, pWeapon, EBX);
+	GET_BASE(AbstractClass*, pTarget, 0x8);
+	LEA_STACK(CoordStruct*, pSourceCoords, STACK_OFFSET(0xB0, -0x6C));
+
+	auto coords = pTarget->GetCenterCoords();
+
+	if (const auto pBuilding = abstract_cast<BuildingClass*>(pTarget))
+		coords = pBuilding->GetTargetCoords();
+
+	FireAtTemp::pObstacleCell = TrajectoryHelper::FindFirstObstacle(*pSourceCoords, coords, pWeapon->Projectile, pThis->Owner);
+
+	return 0;
+}
+
+// Fix railgun target coordinates potentially differing from actual target coords.
+DEFINE_HOOK(0x70C6B5, TechnoClass_Railgun_TargetCoords, 0x5)
+{
+	GET(AbstractClass*, pTarget, EBX);
+
+	auto coords = pTarget->GetCenterCoords();
+
+	if (const auto pBuilding = abstract_cast<BuildingClass*>(pTarget))
+		coords = pBuilding->GetTargetCoords();
+	else if (const auto pCell = abstract_cast<CellClass*>(pTarget))
+		coords = pCell->GetCoordsWithBridge();
+
+	R->EAX(&coords);
+	return 0;
+}
+
+// Cut railgun logic off at obstacle coordinates.
+DEFINE_HOOK(0x70CA64, TechnoClass_Railgun_Obstacles, 0x5)
+{
+	enum { Continue = 0x70CA79, Stop = 0x70CAD8 };
+
+	REF_STACK(CoordStruct const, coords, STACK_OFFSET(0xC0, -0x80));
+
+	auto pCell = MapClass::Instance->GetCellAt(coords);
+
+	if (pCell == FireAtTemp::pObstacleCell)
+		return Stop;
+
+	return Continue;
+}
+
+// Do not adjust map coordinates for railgun particles that are below cell coordinates.
+DEFINE_HOOK(0x62B8BC, ParticleClass_CTOR_RailgunCoordAdjust, 0x6)
+{
+	enum { SkipCoordAdjust = 0x62B8CB };
+
+	GET(ParticleClass*, pThis, ESI);
+
+	if (pThis->ParticleSystem && pThis->ParticleSystem->Type->BehavesLike == BehavesLike::Railgun)
+		return SkipCoordAdjust;
+
+	return 0;
+}
+
+// Adjust target coordinates for laser drawing.
+DEFINE_HOOK(0x6FD38D, TechnoClass_LaserZap_Obstacles, 0x7)
+{
+	GET(CoordStruct*, pTargetCoords, EAX);
+
+	auto coords = *pTargetCoords;
+	auto pObstacleCell = FireAtTemp::pObstacleCell;
+
+	if (pObstacleCell)
+		coords = pObstacleCell->GetCoordsWithBridge();
+
+	R->EAX(&coords);
+	return 0;
+}
+
+// Adjust target for bolt / beam / wave drawing.
+DEFINE_HOOK(0x6FF57D, TechnoClass_FireAt_TargetSet, 0x6)
+{
+	LEA_STACK(CoordStruct*, pTargetCoords, STACK_OFFSET(0xB0, -0x28));
+	GET(AbstractClass*, pTarget, EDI);
+
+	FireAtTemp::originalTargetCoords = *pTargetCoords;
+	FireAtTemp::pOriginalTarget = pTarget;
+
+	if (FireAtTemp::pObstacleCell)
+	{
+		auto coords = FireAtTemp::pObstacleCell->GetCoordsWithBridge();
+		pTargetCoords->X = coords.X;
+		pTargetCoords->Y = coords.Y;
+		pTargetCoords->Z = coords.Z;
+
+		R->EDI(FireAtTemp::pObstacleCell);
+	}
+
+	return 0;
+}
+
+// Restore original target values and unset obstacle cell.
+DEFINE_HOOK(0x6FF660, TechnoClass_FireAt_ObstacleCellUnset, 0x6)
+{
+	LEA_STACK(CoordStruct*, pTargetCoords, STACK_OFFSET(0xB0, -0x28));
+
+	auto coords = FireAtTemp::originalTargetCoords;
+	pTargetCoords->X = coords.X;
+	pTargetCoords->Y = coords.Y;
+	pTargetCoords->Z = coords.Z;
+	auto target = FireAtTemp::pOriginalTarget;
+
+	FireAtTemp::originalTargetCoords = CoordStruct::Empty;
+	FireAtTemp::pObstacleCell = nullptr;
+	FireAtTemp::pOriginalTarget = nullptr;
+
+	R->EDI(target);
+
+	return 0;
+}

--- a/src/Ext/Techno/Hooks.WeaponEffects.cpp
+++ b/src/Ext/Techno/Hooks.WeaponEffects.cpp
@@ -68,11 +68,10 @@ DEFINE_HOOK(0x62FA20, ParticleSystemClass_FireAI_TargetCoords, 0x6)
 	return Continue;
 }
 
-//
-DEFINE_HOOK_AGAIN(0x62D685, ParticleSystemClass_Fire_Coords, 0x5)
-DEFINE_HOOK(0x62D596, ParticleSystemClass_Fire_Coords, 0x5)
+// Fix fire particles being disallowed from going upwards.
+DEFINE_HOOK(0x62D685, ParticleSystemClass_Fire_Coords, 0x5)
 {
-	enum { SkipGameCode1 = 0x62D5C8, SkipGameCode2 = 0x62D6B7 };
+	enum { SkipGameCode = 0x62D6B7 };
 
 	// Game checks if MapClass::GetCellFloorHeight() for currentCoords is larger than for previousCoords and sets the flags on ParticleClass to
 	// remove it if so. Below is an attempt to create a smarter check that allows upwards movement and does not needlessly collide with elevation
@@ -98,7 +97,7 @@ DEFINE_HOOK(0x62D596, ParticleSystemClass_Fire_Coords, 0x5)
 	}
 	*/
 
-	return R->Origin() == 0x62D596 ? SkipGameCode1 : SkipGameCode2;
+	return SkipGameCode;
 }
 
 // Fix railgun target coordinates potentially differing from actual target coords.

--- a/src/Ext/Techno/Hooks.WeaponEffects.cpp
+++ b/src/Ext/Techno/Hooks.WeaponEffects.cpp
@@ -4,6 +4,7 @@
 #include <ParticleSystemClass.h>
 #include <FootClass.h>
 
+#include <Ext/WeaponType/Body.h>
 #include <Utilities/Macro.h>
 
 // Contains hooks that fix weapon graphical effects like lasers, railguns, electric bolts, beams and waves not interacting
@@ -131,6 +132,24 @@ DEFINE_HOOK(0x6FF660, TechnoClass_FireAt_ObstacleCellUnset, 0x6)
 	FireAtTemp::pOriginalTarget = nullptr;
 
 	R->EDI(target);
+
+	return 0;
+}
+
+// Allow drawing single color lasers with thickness.
+DEFINE_HOOK(0x6FD446, TechnoClass_LaserZap_IsSingleColor, 0x7)
+{
+	GET(WeaponTypeClass* const, pWeapon, ECX);
+	GET(LaserDrawClass* const, pLaser, EAX);
+
+	if (auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon))
+	{
+		if (!pLaser->IsHouseColor && pWeaponExt->Laser_IsSingleColor)
+			pLaser->IsHouseColor = true;
+	}
+
+	// Fixes drawing thick lasers for non-PrismSupport building-fired lasers.
+	pLaser->IsSupported = pLaser->Thickness > 3;
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.WeaponEffects.cpp
+++ b/src/Ext/Techno/Hooks.WeaponEffects.cpp
@@ -181,8 +181,12 @@ DEFINE_HOOK(0x62B8BC, ParticleClass_CTOR_CoordAdjust, 0x6)
 
 	GET(ParticleClass*, pThis, ESI);
 
-	if (pThis->ParticleSystem && (pThis->ParticleSystem->Type->BehavesLike == BehavesLike::Railgun || pThis->ParticleSystem->Type->BehavesLike == BehavesLike::Fire))
+	if (pThis->ParticleSystem
+		&& (pThis->ParticleSystem->Type->BehavesLike == BehavesLike::Railgun
+			|| pThis->ParticleSystem->Type->BehavesLike == BehavesLike::Fire))
+	{
 		return SkipCoordAdjust;
+	}
 
 	return 0;
 }
@@ -214,9 +218,7 @@ DEFINE_HOOK(0x6FF43F, TechnoClass_FireAt_TargetSet, 0x6)
 	if (FireAtTemp::pObstacleCell)
 	{
 		auto coords = FireAtTemp::pObstacleCell->GetCoordsWithBridge();
-		pTargetCoords->X = coords.X;
-		pTargetCoords->Y = coords.Y;
-		pTargetCoords->Z = coords.Z;
+		pTargetCoords = &coords;
 		R->EDI(FireAtTemp::pObstacleCell);
 	}
 
@@ -229,9 +231,7 @@ DEFINE_HOOK(0x6FF660, TechnoClass_FireAt_ObstacleCellUnset, 0x6)
 	LEA_STACK(CoordStruct*, pTargetCoords, STACK_OFFSET(0xB0, -0x28));
 
 	auto coords = FireAtTemp::originalTargetCoords;
-	pTargetCoords->X = coords.X;
-	pTargetCoords->Y = coords.Y;
-	pTargetCoords->Z = coords.Z;
+	pTargetCoords = &coords;
 	auto target = FireAtTemp::pOriginalTarget;
 
 	FireAtTemp::originalTargetCoords = CoordStruct::Empty;

--- a/src/Ext/Techno/Hooks.WeaponEffects.cpp
+++ b/src/Ext/Techno/Hooks.WeaponEffects.cpp
@@ -4,6 +4,7 @@
 #include <ParticleSystemClass.h>
 #include <FootClass.h>
 
+#include <Ext/ParticleSystemType/Body.h>
 #include <Ext/WeaponType/Body.h>
 #include <Utilities/Macro.h>
 
@@ -60,6 +61,11 @@ DEFINE_HOOK(0x62FA20, ParticleSystemClass_FireAI_TargetCoords, 0x6)
 
 	if (pOwner->PrimaryFacing.IsRotating())
 	{
+		auto const pTypeExt = ParticleSystemTypeExt::ExtMap.Find(pThis->Type);
+
+		if (!pTypeExt->AdjustTargetCoordsOnRotation)
+			return Continue;
+
 		auto coords = pThis->TargetCoords;
 		R->EAX(&coords);
 		return SkipGameCode;

--- a/src/Ext/Techno/Hooks.WeaponEffects.cpp
+++ b/src/Ext/Techno/Hooks.WeaponEffects.cpp
@@ -137,6 +137,43 @@ DEFINE_HOOK(0x70CA64, TechnoClass_Railgun_Obstacles, 0x5)
 	return Continue;
 }
 
+DEFINE_HOOK(0x70C862, TechnoClass_Railgun_AmbientDamageIgnoreTarget1, 0x5)
+{
+	enum { IgnoreTarget = 0x70CA59 };
+
+	GET_BASE(WeaponTypeClass*, pWeapon, 0x14);
+
+	if (WeaponTypeExt::ExtMap.Find(pWeapon)->AmbientDamage_IgnoreTarget)
+		return IgnoreTarget;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x70CA8B, TechnoClass_Railgun_AmbientDamageIgnoreTarget2, 0x6)
+{
+	enum { IgnoreTarget = 0x70CBB0 };
+
+	GET_BASE(WeaponTypeClass*, pWeapon, 0x14);
+	REF_STACK(DynamicVectorClass<ObjectClass*>, objects, STACK_OFFSET(0xC0, -0xAC));
+
+	if (WeaponTypeExt::ExtMap.Find(pWeapon)->AmbientDamage_IgnoreTarget)
+	{
+		R->EAX(objects.Count);
+		return IgnoreTarget;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x70CBE0, TechnoClass_Railgun_AmbientDamageWarhead, 0x5)
+{
+	GET(WeaponTypeClass*, pWeapon, EDI);
+
+	R->EDX(WeaponTypeExt::ExtMap.Find(pWeapon)->AmbientDamage_Warhead.Get(pWeapon->Warhead));
+
+	return 0;
+}
+
 // Do not adjust map coordinates for railgun or fire stream particles that are below cell coordinates.
 DEFINE_HOOK(0x62B8BC, ParticleClass_CTOR_CoordAdjust, 0x6)
 {

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -276,19 +276,6 @@ DEFINE_HOOK(0x4D7221, FootClass_Unlimbo_LaserTrails, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x6FD446, TechnoClass_LaserZap_IsSingleColor, 0x7)
-{
-	GET(WeaponTypeClass* const, pWeapon, ECX);
-	GET(LaserDrawClass* const, pLaser, EAX);
-
-	if (auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon))
-	{
-		if (!pLaser->IsHouseColor && pWeaponExt->Laser_IsSingleColor)
-			pLaser->IsHouseColor = true;
-	}
-
-	// Fixes drawing thick lasers for non-PrismSupport building-fired lasers.
-	pLaser->IsSupported = pLaser->Thickness > 3;
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -276,10 +276,6 @@ DEFINE_HOOK(0x4D7221, FootClass_Unlimbo_LaserTrails, 0x6)
 	return 0;
 }
 
-
-	return 0;
-}
-
 DEFINE_HOOK_AGAIN(0x703789, TechnoClass_CloakUpdateMCAnim, 0x6) // TechnoClass_Do_Cloak
 DEFINE_HOOK(0x6FB9D7, TechnoClass_CloakUpdateMCAnim, 0x6)       // TechnoClass_Cloaking_AI
 {

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -59,6 +59,8 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->OmniFire_TurnToTarget.Read(exINI, pSection, "OmniFire.TurnToTarget");
 	this->ExtraWarheads.Read(exINI, pSection, "ExtraWarheads");
 	this->ExtraWarheads_DamageOverrides.Read(exINI, pSection, "ExtraWarheads.DamageOverrides");
+	this->AmbientDamage_Warhead.Read(exINI, pSection, "AmbientDamage.Warhead");
+	this->AmbientDamage_IgnoreTarget.Read(exINI, pSection, "AmbientDamage.IgnoreTarget");
 }
 
 template <typename T>
@@ -84,6 +86,8 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->OmniFire_TurnToTarget)
 		.Process(this->ExtraWarheads)
 		.Process(this->ExtraWarheads_DamageOverrides)
+		.Process(this->AmbientDamage_Warhead)
+		.Process(this->AmbientDamage_IgnoreTarget)
 		;
 };
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -39,6 +39,8 @@ public:
 		Valueable<bool> OmniFire_TurnToTarget;
 		ValueableVector<WarheadTypeClass*> ExtraWarheads;
 		ValueableVector<int> ExtraWarheads_DamageOverrides;
+		Nullable<WarheadTypeClass*> AmbientDamage_Warhead;
+		Valueable<bool> AmbientDamage_IgnoreTarget;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius { DiskLaserClass::Radius }
@@ -60,6 +62,8 @@ public:
 			, OmniFire_TurnToTarget { false }
 			, ExtraWarheads {}
 			, ExtraWarheads_DamageOverrides {}
+			, AmbientDamage_Warhead {}
+			, AmbientDamage_IgnoreTarget { false }
 		{ }
 
 		int GetBurstDelay(int burstIndex);

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -14,6 +14,7 @@
 #include <FlyLocomotionClass.h>
 #include <JumpjetLocomotionClass.h>
 #include <BombClass.h>
+#include <ParticleSystemClass.h>
 #include <WarheadTypeClass.h>
 
 #include <Ext/Rules/Body.h>
@@ -542,23 +543,6 @@ DEFINE_HOOK(0x43D874, BuildingClass_Draw_BuildupBibShape, 0x6)
 
 	return 0;
 }
-
-// Fix railgun target coordinates potentially differing from actual target coords.
-DEFINE_HOOK(0x70C6B5, TechnoClass_Railgun_TargetCoords, 0x5)
-{
-	GET(AbstractClass*, pTarget, EBX);
-
-	auto coords = pTarget->GetCenterCoords();
-
-	if (const auto pBuilding = abstract_cast<BuildingClass*>(pTarget))
-		coords = pBuilding->GetTargetCoords();
-	else if (const auto pCell = abstract_cast<CellClass*>(pTarget))
-		coords = pCell->GetCoordsWithBridge();
-
-	R->EAX(&coords);
-	return 0;
-}
-
 // Fix techno target coordinates (used for fire angle calculations, target lines etc) to take building target coordinate offsets into accord.
 // This, for an example, fixes a vanilla bug where Destroyer has trouble targeting Naval Yards with its cannon weapon from certain angles.
 DEFINE_HOOK(0x70BCE6, TechnoClass_GetTargetCoords_BuildingFix, 0x6)

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -11,6 +11,7 @@
 #include <Ext/BulletType/Body.h>
 #include <Ext/House/Body.h>
 #include <Ext/OverlayType/Body.h>
+#include <Ext/ParticleSystemType/Body.h>
 #include <Ext/RadSite/Body.h>
 #include <Ext/Rules/Body.h>
 #include <Ext/Scenario/Body.h>
@@ -199,6 +200,7 @@ using PhobosTypeRegistry = TypeRegistry<
 	BulletTypeExt,
 	HouseExt,
 	OverlayTypeExt,
+	ParticleSystemTypeExt,
 	RadSiteExt,
 	RulesExt,
 	ScenarioExt,


### PR DESCRIPTION
Prevents weapon effects like lasers, railgun particles, rad beams, electric bolts and waves from being drawn beyond where the projectile detonates (walls, solid buildings etc).

In addition particles spawned by `BehavesLike=Railgun` particle system as well as `AmbientDamage` are no longer cut off by elevation changes along trajectory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new options for customizing fire particle systems and ambient damage effects.
	- Introduced the ability to show a briefing screen at the start of singleplayer missions.
	- Enhanced missile targeting, turret rotation, and jumpjet stability under EMP conditions.
	- Added customization options for disk laser radius and cluster scatter distance in projectiles.

- **Bug Fixes**
	- Fixed graphical issues with weapon effects not interacting correctly with obstacles.
	- Resolved problems with railgun and fire particles being cut off by elevation changes.
	- Corrected behavior of `AmbientDamage` with `IsRailgun=yes` to prevent cutoff by elevation.

- **Documentation**
	- Updated documentation to reflect new features and bug fixes.
	- Renamed the `Detonate.Warhead` property to `Detonate.WarheadType` in configuration files for clarity.

- **Refactor**
	- Removed outdated laser drawing logic to streamline weapon effect processing.

- **Chores**
	- Integrated new source files for the `ParticleSystemType` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->