### PR TITLE
AttachEffect / Custom tints / Revenge weapons / Warhead effect Verses requirement change

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -224,6 +224,9 @@ This page lists all the individual contributions to the project by their author.
   - Aircraft landing / docking direction
   - `DeploysInto` cursor desync fix
   - Minor crate logic improvements
+  - Custom tint effects
+  - Revenge weapons
+  - AttachEffect
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -18,6 +18,8 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\New\Entity\AttachEffectClass.cpp" />
+    <ClCompile Include="src\New\Type\AttachEffectTypeClass.cpp" />
     <ClCompile Include="src\Commands\Commands.cpp" />
     <ClCompile Include="src\Commands\DamageDisplay.cpp" />
     <ClCompile Include="src\Commands\FrameByFrame.cpp" />
@@ -131,7 +133,10 @@
     <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Unload.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.AttachEffect.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.WeaponEffects.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Tint.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.WeaponRange.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />
     <ClCompile Include="src\Ext\VoxelAnimType\Body.cpp" />
@@ -178,6 +183,8 @@
     <ClCompile Include="YRpp\StaticInits.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\New\Entity\AttachEffectClass.h" />
+    <ClInclude Include="src\New\Type\AttachEffectTypeClass.h" />
     <ClInclude Include="src\Commands\FrameByFrame.h" />
     <ClInclude Include="src\Commands\FrameStep.h" />
     <ClInclude Include="src\Commands\NextIdleHarvester.h" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -153,6 +153,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `PowerUpN` building animations can now use `Powered` & `PoweredLight/Effect/Special` keys.
 - Fixed a desync potentially caused by displaying of cursor over selected `DeploysInto` units.
 - Skipped drawing rally point line when undeploying a factory.
+- Tint effects are now correctly applied to SHP vehicles and all types of aircraft as well as building animations regardless of their position.
+- Iron Curtained / Force Shielded objects now always use the correct tint color.
  
 ## Fixes / interactions with other extensions
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -14,6 +14,7 @@ This page describes all the engine features that are either new and introduced b
     - `entry`: Discard on exiting the map when entering transports or buildings etc.
     - `move`: Discard when the object the effect is attached on moves. Ignored if the object is a building.
     - `stationary`: Discard when the object the effect is attached on stops moving. Ignored if the object is a building.
+    - `drain`: Discard when the object is being affected by a weapon with `DrainWeapon=true`.
   - If `PenetratesIronCurtain` is not set to true, the effect is not applied on currently invulnerable objects (Iron Curtain / Force Shield).
   - `Animation` defines animation to play in an indefinite loop for as long as the effect is active on the object it is attached to.
     - If `Animation.ResetOnReapply` is set to true, the animation playback is reset every time the effect is applied if `Cumulative=false`.
@@ -60,7 +61,7 @@ Duration=0                                   ; integer - game frames or negative
 Cumulative=false                             ; boolean
 Cumulative.MaxCount=-1                       ; integer
 Powered=false                                ; boolean
-DiscardOn=none                               ; list of discard condition enumeration (none|entry|move|stationary)
+DiscardOn=none                               ; list of discard condition enumeration (none|entry|move|stationary|drain)
 PenetratesIronCurtain=false                  ; boolean
 Animation=                                   ; Animation
 Animation.ResetOnReapply=false               ; boolean

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -26,8 +26,8 @@ This page describes all the engine features that are either new and introduced b
   - `WeaponRange.Multiplier` and `WeaponRange.ExtraRange` can be used to multiply the weapon firing range of the object the effect is attached to, or give it an increase / decrease (measured in cells), respectively. `ExtraRange` is cumulatively applied from all attached effects after all `Multiplier` values have been applied.
     - `WeaponRange.AllowWeapons` can be used to list only weapons that can benefit from this range bonus and `WeaponRange.DisallowWeapons` weapons that are not allowed to, respectively.
     - On TechnoTypes with `OpenTopped=true`, `OpenTopped.UseTransportRangeModifiers` can be set to true to make passengers firing out use the transport's active range bonuses instead.
-  - `CritMultiplier` can be used to multiply the [critical hit](#chance-based-extra-damage-or-warhead-detonation--critical-hits) chance of the object the effect is attached to.
-    - `CritMultiplier.AllowWarheads` can be used to list only Warheads that can benefit from this critical hit chance multiplier and `CritMultiplier.DisallowWarheads` weapons that are not allowed to, respectively.
+  - `Crit.Multiplier` and `Crit.ExtraChance` can be used to multiply the [critical hit](#chance-based-extra-damage-or-warhead-detonation--critical-hits) chance or grant a fixed bonus to it for the object the effect is attached to, respectively.
+    - `Crit.AllowWarheads` can be used to list only Warheads that can benefit from this critical hit chance multiplier and `Crit.DisallowWarheads` weapons that are not allowed to, respectively.
   - `RevengeWeapon` can be used to temporarily grant the specified weapon as a [revenge weapon](#revenge-weapon) for the attached object.
     - `RevengeWeapon.AffectsHouses` customizes which houses can trigger the revenge weapon.
 
@@ -76,9 +76,10 @@ WeaponRange.Multiplier=1.0                   ; floating point value
 WeaponRange.ExtraRange=0.0                   ; floating point value
 WeaponRange.AllowWeapons=                    ; list of WeaponTypes
 WeaponRange.DisallowWeapons=                 ; list of WeaponTypes
-CritMultiplier=1.0                           ; floating point value
-CritMultiplier.AllowWarheads=                ; list of WarheadTypes
-CritMultiplier.DisallowWarheads=             ; list of WarheadTypes
+Crit.Multiplier=1.0                          ; floating point value
+Crit.ExtraChance=0.0                         ; floating point value
+Crit.AllowWarheads=                          ; list of WarheadTypes
+Crit.DisallowWarheads=                       ; list of WarheadTypes
 RevengeWeapon=                               ; WeaponType
 RevengeWeapon.AffectsHouses=all              ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -33,6 +33,7 @@ This page describes all the engine features that are either new and introduced b
     - `Crit.AllowWarheads` can be used to list only Warheads that can benefit from this critical hit chance multiplier and `Crit.DisallowWarheads` weapons that are not allowed to, respectively.
   - `RevengeWeapon` can be used to temporarily grant the specified weapon as a [revenge weapon](#revenge-weapon) for the attached object.
     - `RevengeWeapon.AffectsHouses` customizes which houses can trigger the revenge weapon.
+  - `DisableWeapons` can be used to disable ability to fire any and all weapons.
 
 - AttachEffectTypes can be attached to TechnoTypes using `AttachEffect.AttachTypes`.
   - `AttachEffect.DurationOverrides` can be used to override the default durations. Duration matching the position in `AttachTypes` is used for that type, or the last listed duration if not available.
@@ -86,6 +87,7 @@ Crit.AllowWarheads=                          ; list of WarheadTypes
 Crit.DisallowWarheads=                       ; list of WarheadTypes
 RevengeWeapon=                               ; WeaponType
 RevengeWeapon.AffectsHouses=all              ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+DisableWeapons=false                         ; boolean
 
 [SOMETECHNO]                                 ; TechnoType
 AttachEffect.AttachTypes=                    ; List of AttachEffectTypes

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -23,8 +23,8 @@ This page describes all the engine features that are either new and introduced b
     - If `ROFMultiplier.ApplyOnCurrentTimer` is set to true, `ROFMultiplier` is applied on currently running reload timer (if any) when the effect is first applied.
   - If `Cloakable` is set to true, the object the effect is attached to is granted ability to cloak itself for duration of the effect.
   - `ForceDecloak`, if set to true, will uncloak and make the object the effect is attached to unable to cloak itself for duration of the effect.
-  - `WeaponRangeBonus` can be used to give the object the effect is attached an increase or decrease to weapon range, defined in cells.
-    - `WeaponRangeBonus.AllowWeapons` can be used to list only weapons that can benefit from this range bonus and `WeaponRangeBonus.DisallowWeapons` weapons that are not allowed to, respectively.
+  - `WeaponRange.Multiplier` and `WeaponRange.ExtraRange` can be used to multiply the weapon firing range of the object the effect is attached to, or give it an increase / decrease (measured in cells), respectively. `ExtraRange` is cumulatively applied from all attached effects after all `Multiplier` values have been applied.
+    - `WeaponRange.AllowWeapons` can be used to list only weapons that can benefit from this range bonus and `WeaponRange.DisallowWeapons` weapons that are not allowed to, respectively.
     - On TechnoTypes with `OpenTopped=true`, `OpenTopped.UseTransportRangeModifiers` can be set to true to make passengers firing out use the transport's active range bonuses instead.
   - `RevengeWeapon` can be used to temporarily grant the specified weapon as a [revenge weapon](#revenge-weapon) for the attached object.
     - `RevengeWeapon.AffectsHouses` customizes which houses can trigger the revenge weapon.
@@ -70,9 +70,10 @@ ROFMultiplier=1.0                            ; floating point value
 ROFMultiplier.ApplyOnCurrentTimer=true       ; boolean
 Cloakable=false                              ; boolean
 ForceDecloak=false                           ; boolean
-WeaponRangeBonus=0.0                         ; floating point value
-WeaponRangeBonus.AllowWeapons=               ; list of WeaponTypes
-WeaponRangeBonus.DisallowWeapons=            ; list of WeaponTypes
+WeaponRange.Multiplier=1.0                   ; floating point value
+WeaponRange.ExtraRange=0.0                   ; floating point value
+WeaponRange.AllowWeapons=                    ; list of WeaponTypes
+WeaponRange.DisallowWeapons=                 ; list of WeaponTypes
 RevengeWeapon=                               ; WeaponType
 RevengeWeapon.AffectsHouses=all              ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -44,6 +44,7 @@ This page describes all the engine features that are either new and introduced b
 - Weapons can require attached effects on target to fire, or be prevented by firing if specific attached effects are applied.
   - `AttachEffect.RequiredTypes` can be used to list attached effects required to be on target to fire, all listed effect types must be present to allow firing.
   - `AttachEffect.DisallowedTypes` can be used to list attached effects that when present prevent the weapon from firing, any of the listed effect types will prevent firing if present.
+  - `AttachEffect.IgnoreFromSameSource` can be set to true to ignore effects that have been attached by the firer of the weapon and its Warhead.
 
 In `rulesmd.ini`:
 ```ini
@@ -94,6 +95,7 @@ OpenTopped.UseTransportRangeModifiers=false  ; boolean
 [SOMEWEAPON]                                 ; WeaponType
 AttachEffect.RequiredTypes=                  ; List of AttachEffectTypes
 AttachEffect.DisallowedTypes=                ; List of AttachEffectTypes
+AttachEffect.IgnoreFromSameSource=false      ; boolean
 
 [SOMEWARHEAD]
 AttachEffect.AttachTypes=                    ; List of AttachEffectTypes

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -10,7 +10,10 @@ This page describes all the engine features that are either new and introduced b
   - `Duration` determines how long the effect lasts for. It can be overriden by `DurationOverrides` on TechnoTypes and Warheads.
   - `Cumulative`, if set to true, allows the same type of effect to be applied on same object multiple times, up to `Cumulative.MaxCount` number or with no limit if `Cumulative.MaxCount` is a negative number.
   - `Powered` controls whether or not the effect is rendered inactive if the object it is attached to is deactivated (`PoweredUnit` or affected by EMP) or on low power. What happens to animation is controlled by `Animation.OfflineAction`.
-  - If `DiscardOnEntry` is set to true, the effect is removed when the object it is attached to exits map (enters transport or a building, etc).
+  - `DiscardOn` accepts a list of values corresponding to conditions where the attached effect should be discarded. Defaults to `none`, meaning it is never discarded.
+    - `entry`: Discard on exiting the map when entering transports or buildings etc.
+    - `move`: Discard when the object the effect is attached on moves. Ignored if the object is a building.
+    - `stationary`: Discard when the object the effect is attached on stops moving. Ignored if the object is a building.
   - If `PenetratesIronCurtain` is not set to true, the effect is not applied on currently invulnerable objects (Iron Curtain / Force Shield).
   - `Animation` defines animation to play in an indefinite loop for as long as the effect is active on the object it is attached to.
     - If `Animation.ResetOnReapply` is set to true, the animation playback is reset every time the effect is applied if `Cumulative=false`.
@@ -56,7 +59,7 @@ Duration=0                                   ; integer - game frames or negative
 Cumulative=false                             ; boolean
 Cumulative.MaxCount=-1                       ; integer
 Powered=false                                ; boolean
-DiscardOnEntry=false                         ; boolean
+DiscardOn=none                               ; list of discard condition enumeration (none|entry|move|stationary)
 PenetratesIronCurtain=false                  ; boolean
 Animation=                                   ; Animation
 Animation.ResetOnReapply=false               ; boolean

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -35,6 +35,8 @@ This page describes all the engine features that are either new and introduced b
   - `RevengeWeapon` can be used to temporarily grant the specified weapon as a [revenge weapon](#revenge-weapon) for the attached object.
     - `RevengeWeapon.AffectsHouses` customizes which houses can trigger the revenge weapon.
   - `DisableWeapons` can be used to disable ability to fire any and all weapons.
+  - It is possible to set groups for attach effect types by defining strings in `Groups`.
+    - Groups can be used instead of types for removing effects and weapon filters.
 
 - AttachEffectTypes can be attached to TechnoTypes using `AttachEffect.AttachTypes`.
   - `AttachEffect.DurationOverrides` can be used to override the default durations. Duration matching the position in `AttachTypes` is used for that type, or the last listed duration if not available.
@@ -44,11 +46,12 @@ This page describes all the engine features that are either new and introduced b
 
 - AttachEffectTypes can be attached to objects via Warheads using `AttachEffect.AttachTypes`.
   - `AttachEffect.DurationOverrides` can be used to override the default durations. Duration matching the position in `AttachTypes` is used for that type, or the last listed duration if not available.
-  - Attached effects can be removed from objects by Warheads using `AttachEffect.RemoveTypes`.
+  - Attached effects can be removed from objects by Warheads using `AttachEffect.RemoveTypes` or `AttachEffect.RemoveGroups`.
 
 - Weapons can require attached effects on target to fire, or be prevented by firing if specific attached effects are applied.
   - `AttachEffect.RequiredTypes` can be used to list attached effects required to be on target to fire, all listed effect types must be present to allow firing.
   - `AttachEffect.DisallowedTypes` can be used to list attached effects that when present prevent the weapon from firing, any of the listed effect types will prevent firing if present.
+  - `AttachEffect.Required/DisallowedGroups` have the same effect except applied with/to all types that have one of the listed groups in their `Groups` listing.
   - `AttachEffect.IgnoreFromSameSource` can be set to true to ignore effects that have been attached by the firer of the weapon and its Warhead.
 
 In `rulesmd.ini`:
@@ -89,6 +92,7 @@ Crit.DisallowWarheads=                       ; list of WarheadTypes
 RevengeWeapon=                               ; WeaponType
 RevengeWeapon.AffectsHouses=all              ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 DisableWeapons=false                         ; boolean
+Groups=                                      ; comma-separated list of strings (group IDs)
 
 [SOMETECHNO]                                 ; TechnoType
 AttachEffect.AttachTypes=                    ; List of AttachEffectTypes
@@ -101,11 +105,14 @@ OpenTopped.UseTransportRangeModifiers=false  ; boolean
 [SOMEWEAPON]                                 ; WeaponType
 AttachEffect.RequiredTypes=                  ; List of AttachEffectTypes
 AttachEffect.DisallowedTypes=                ; List of AttachEffectTypes
+AttachEffect.RequiredGroups=                 ; comma-separated list of strings (group IDs)
+AttachEffect.DisallowedGroups=               ; comma-separated list of strings (group IDs)
 AttachEffect.IgnoreFromSameSource=false      ; boolean
 
 [SOMEWARHEAD]
 AttachEffect.AttachTypes=                    ; List of AttachEffectTypes
 AttachEffect.RemoveTypes=                    ; List of AttachEffectTypes
+AttachEffect.RemoveGroups=                   ; comma-separated list of strings (group IDs)
 AttachEffect.DurationOverrides=              ; integer - duration overrides (comma-separated) for AttachTypes in order from first to last.
 ```
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -22,6 +22,9 @@ This page describes all the engine features that are either new and introduced b
     - `Animation.TemporalAction` determines what happens to the animation when the attached object is under effect of `Temporal=true` Warhead.
     - `Animation.UseInvokerAsOwner` can be used to set the house and TechnoType that created the effect (e.g firer of the weapon that applied it) as the animation's owner & invoker instead of the object the effect is attached to.
   - `CumulativeAnimations` can be used to declare a list of animations used for `Cumulative=true` types instead of `Animation`. An animation is picked from the list in order matching the number of active instances of the type on the object, with last listed animation used if number is higher than the number of listed animations. This animation is only displayed once, on the first active instance of the effect found attached and is updated and restarted if the number of active instances changed.
+  - Attached effect can fire off a weapon when expired / removed / object dies by setting `ExpireWeapon`.
+    - `ExpireWeapon.TriggerOn` determines the exact conditions upon which the weapon is fired, defaults to `expire` which means only if the effect naturally expires.
+    - `ExpireWeapon.CumulativeOnlyOnce`, if set to true, makes it so that `Cumulative=true` attached effects only detonate the weapon once period, instead of once per active instance. On `remove` and `expire` condition this means it will only detonate after last instance has expired or been removed.
   - `Tint.Color` & `Tint.Intensity` can be used to set a color tint effect and additive lighting increase/decrease on the object the effect is attached to, respectively.
     - `Tint.VisibleToHouses` can be used to control which houses can see the tint effect.
   - `FirepowerMultiplier`, `ArmorMultiplier`, `SpeedMultiplier` and `ROFMultiplier` can be used to modify the object's firepower, armor strength, movement speed and weapon reload rate, respectively.
@@ -76,6 +79,9 @@ Animation.OfflineAction=Hides                ; AttachedAnimFlag (None, Hides, Te
 Animation.TemporalAction=None                ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
 Animation.UseInvokerAsOwner=false            ; boolean
 CumulativeAnimations=                        ; list of animations
+ExpireWeapon=
+ExpireWeapon.TriggerOn=expire                ; List of expire weapon trigger condition enumeration (none|expire|remove|death|all)
+ExpireWeapon.CumulativeOnlyOnce=false        ; boolean
 Tint.Color=                                  ; integer - R,G,B
 Tint.Intensity=                              ; floating point value
 Tint.VisibleToHouses=all                     ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -21,6 +21,7 @@ This page describes all the engine features that are either new and introduced b
     - `Animation.OfflineAction` determines what happens to the animation when the attached object is deactivated or not powered. Only applies if `Powered=true`.
     - `Animation.TemporalAction` determines what happens to the animation when the attached object is under effect of `Temporal=true` Warhead.
     - `Animation.UseInvokerAsOwner` can be used to set the house and TechnoType that created the effect (e.g firer of the weapon that applied it) as the animation's owner & invoker instead of the object the effect is attached to.
+  - `CumulativeAnimations` can be used to declare a list of animations used for `Cumulative=true` types instead of `Animation`. An animation is picked from the list in order matching the number of active instances of the type on the object, with last listed animation used if number is higher than the number of listed animations. This animation is only displayed once, on the first active instance of the effect found attached and is updated and restarted if the number of active instances changed.
   - `Tint.Color` & `Tint.Intensity` can be used to set a color tint effect and additive lighting increase/decrease on the object the effect is attached to, respectively.
     - `Tint.VisibleToHouses` can be used to control which houses can see the tint effect.
   - `FirepowerMultiplier`, `ArmorMultiplier`, `SpeedMultiplier` and `ROFMultiplier` can be used to modify the object's firepower, armor strength, movement speed and weapon reload rate, respectively.
@@ -47,11 +48,14 @@ This page describes all the engine features that are either new and introduced b
 - AttachEffectTypes can be attached to objects via Warheads using `AttachEffect.AttachTypes`.
   - `AttachEffect.DurationOverrides` can be used to override the default durations. Duration matching the position in `AttachTypes` is used for that type, or the last listed duration if not available.
   - Attached effects can be removed from objects by Warheads using `AttachEffect.RemoveTypes` or `AttachEffect.RemoveGroups`.
+    - `AttachEffect.CumulativeRemoveMinCounts` sets minimum number of active instaces per `RemoveTypes`/`RemoveGroups` required for `Cumulative=true` types to be removed.
+    - `AttachEffect.CumulativeRemoveMaxCounts` sets maximum number of active instaces per `RemoveTypes`/`RemoveGroups` for `Cumulative=true` that are removed at once by this Warhead.
 
 - Weapons can require attached effects on target to fire, or be prevented by firing if specific attached effects are applied.
   - `AttachEffect.RequiredTypes` can be used to list attached effects required to be on target to fire, all listed effect types must be present to allow firing.
   - `AttachEffect.DisallowedTypes` can be used to list attached effects that when present prevent the weapon from firing, any of the listed effect types will prevent firing if present.
   - `AttachEffect.Required/DisallowedGroups` have the same effect except applied with/to all types that have one of the listed groups in their `Groups` listing.
+  - `AttachEffect.(Required|Disallowed)MinCounts & (Required|Disallowed)MaxCounts` can be used to set the minimum and maximum number of instances required / disallowed to be on the Techno for `Cumulative=true` types (ignored for other types) respectively.
   - `AttachEffect.IgnoreFromSameSource` can be set to true to ignore effects that have been attached by the firer of the weapon and its Warhead.
 
 In `rulesmd.ini`:
@@ -71,6 +75,7 @@ Animation.ResetOnReapply=false               ; boolean
 Animation.OfflineAction=Hides                ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
 Animation.TemporalAction=None                ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
 Animation.UseInvokerAsOwner=false            ; boolean
+CumulativeAnimations=                        ; list of animations
 Tint.Color=                                  ; integer - R,G,B
 Tint.Intensity=                              ; floating point value
 Tint.VisibleToHouses=all                     ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
@@ -107,12 +112,18 @@ AttachEffect.RequiredTypes=                  ; List of AttachEffectTypes
 AttachEffect.DisallowedTypes=                ; List of AttachEffectTypes
 AttachEffect.RequiredGroups=                 ; comma-separated list of strings (group IDs)
 AttachEffect.DisallowedGroups=               ; comma-separated list of strings (group IDs)
+AttachEffect.RequiredMinCounts=              ; integer - minimum required instance count (comma-separated) for cumulative types in order from first to last.
+AttachEffect.RequiredMaxCounts=              ; integer - maximum required instance count (comma-separated) for cumulative types in order from first to last.
+AttachEffect.DisallowedMinCounts=            ; integer - minimum disallowed instance count (comma-separated) for cumulative types in order from first to last.
+AttachEffect.DisallowedMaxCounts=            ; integer - maximum disallowed instance count (comma-separated) for cumulative types in order from first to last.
 AttachEffect.IgnoreFromSameSource=false      ; boolean
 
 [SOMEWARHEAD]
 AttachEffect.AttachTypes=                    ; List of AttachEffectTypes
 AttachEffect.RemoveTypes=                    ; List of AttachEffectTypes
 AttachEffect.RemoveGroups=                   ; comma-separated list of strings (group IDs)
+AttachEffect.CumulativeRemoveMinCounts=      ; integer - minimum required instance count (comma-separated) for cumulative types in order from first to last.
+AttachEffect.CumulativeRemoveMaxCounts=      ; integer - maximum removed instance count (comma-separated) for cumulative types in order from first to last.
 AttachEffect.DurationOverrides=              ; integer - duration overrides (comma-separated) for AttachTypes in order from first to last.
 ```
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -221,7 +221,7 @@ Shield.InheritStateOnReplace=false          ; boolean
   - `Pips.Shield.Building.Empty` can be used to set the frame of `pips.shp` displayed for empty building strength pips, defaults to 1st frame of `pips.shp`.
   - The above customizations are also available on per ShieldType basis, e.g `[ShieldType]`->`Pips` instead of `[AudioVisual]`->`Pips.Shield` and so on. ShieldType settings take precedence over the global ones, but will fall back to them if not set.
   - `BracketDelta` can be used as additional vertical offset (negative shifts it up) for shield strength bar. Much like `PixelSelectionBracketDelta`, it is not applied on buildings.
-- Warheads have new options that interact with shields.
+- Warheads have new options that interact with shields. Note that all of these that do not by their very nature require ability to target the shield (such as modifiers like `Shield.Break` or removing / attaching) still require Warhead `Verses` to affect the target unless `EffectsRequireVerses` is set to false on the Warhead.
   - `Shield.Penetrate` allows the warhead ignore the shield and always deal full damage to the TechnoType itself. It also allows targeting the TechnoType as if shield doesn't exist.
   - `Shield.Break` allows the warhead to always break shields of TechnoTypes. This is done before damage is dealt.
   - `Shield.BreakAnim` will be displayed instead of ShieldType `BreakAnim` if the shield is broken by the Warhead, either through damage or `Shield.Break`.
@@ -1024,9 +1024,10 @@ DestroySound=      ; Sound
 ## Warheads
 
 ```{hint}
-All new warhead effects
-- can be used with CellSpread and Ares' GenericWarhead superweapon where applicable.
-- cannot be used with `MindControl.Permanent=yes` of Ares.
+All new Warhead effects
+- Can be used with CellSpread and Ares' GenericWarhead superweapon where applicable.
+- Cannot be used with `MindControl.Permanent=yes` of Ares.
+- Respect `Verses` where applicable unless `EffectsRequireVerses` is set to false. If target has an active shield, its armor type is used instead unless warhead can penetrate the shield.
 ```
 
 ### Break Mind Control on impact

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -252,6 +252,9 @@ ReceivedDamage.Maximum=2147483647           ; integer
 AllowTransfer=                              ; boolean
 ImmuneToBerserk=no                          ; boolean
 ImmuneToCrit=no                             ; boolean
+Tint.Color=                                 ; integer - R,G,B
+Tint.Intensity=0.0                          ; floating point value
+Tint.VisibleToHouses=all                    ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 
 [SOMETECHNO]                                ; TechnoType
 ShieldType=SOMESHIELDTYPE                   ; ShieldType; none by default
@@ -319,6 +322,9 @@ Shield.InheritStateOnReplace=false          ; boolean
 - `ReceivedDamage.Minimum` & `ReceivedDamage.Maximum` control the minimum and maximum amount of damage that can be dealt to shield in a single hit. This is applied after armor type and `AbsorbPercent` adjustments. If `AbsorbOverDamage=false`, the residual damage dealt to the TechnoType is still based on the original damage before the clamping to the range.
 - `AllowTransfer` controls whether or not the shield can be transferred if the TechnoType changes (such as `(Un)DeploysInto` or Ares type conversion). If not set, defaults to true if shield was attached via `Shield.AttachTypes`, otherwise false.
 - `ImmuneToBerserk` gives the immunity against `Psychedelic=yes` warhead. Otherwise the berserk effect penetrates shields by default. Note that this shouldn't prevent the unit from targeting at the shielded object. `Versus.shieldArmor=0%` is still required in this case.
+- A tint effect similar to that used by Iron Curtain / Force Shield or `Psychedelic=true` Warheads can be applied to to TechnoTypes with shields by setting `Tint.Color` and/or `Tint Intensity`.
+  - `Tint.Intensity` is additive lighting increase/decrease - 1.0 is the default object lighting.
+  - `Tint.VisibleToHouses` can be used to customize which houses can see the tint effect.
 - A TechnoType with a shield will show its shield Strength. An empty shield strength bar will be left after destroyed if it is respawnable. Several customizations are available for the shield strength pips.
   - By default, buildings use the 6th frame of `pips.shp` to display the shield strength while others use the 17th frame.
   - `Pips.Shield` can be used to specify which pip frame should be used as shield strength. If only 1 digit is set, then it will always display that frame, or if 3 digits are set, it will use those if shield's current strength is at or below `ConditionYellow` and `ConditionRed`, respectively. `Pips.Shield.Building` is used for BuildingTypes. -1 as value will use the default frame, whether it is fallback to first value or the aforementioned hardcoded defaults.
@@ -1093,7 +1099,7 @@ WarpOutWeapon=                          ; WeaponType
 - A tint effect similar to that used by Iron Curtain / Force Shield or `Psychedelic=true` Warheads can be applied to TechnoTypes naturally by setting `Tint.Color` and/or `Tint Intensity`.
   - `Tint.Intensity` is additive lighting increase/decrease - 1.0 is the default object lighting.
   - `Tint.VisibleToHouses` can be used to customize which houses can see the tint effect.
-  - Tint effects can also be applied by [attached effects](#attached-effects).
+  - Tint effects can also be applied by [attached effects](#attached-effects) and on shields.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -26,6 +26,8 @@ This page describes all the engine features that are either new and introduced b
   - `WeaponRange.Multiplier` and `WeaponRange.ExtraRange` can be used to multiply the weapon firing range of the object the effect is attached to, or give it an increase / decrease (measured in cells), respectively. `ExtraRange` is cumulatively applied from all attached effects after all `Multiplier` values have been applied.
     - `WeaponRange.AllowWeapons` can be used to list only weapons that can benefit from this range bonus and `WeaponRange.DisallowWeapons` weapons that are not allowed to, respectively.
     - On TechnoTypes with `OpenTopped=true`, `OpenTopped.UseTransportRangeModifiers` can be set to true to make passengers firing out use the transport's active range bonuses instead.
+  - `CritMultiplier` can be used to multiply the [critical hit](#chance-based-extra-damage-or-warhead-detonation--critical-hits) chance of the object the effect is attached to.
+    - `CritMultiplier.AllowWarheads` can be used to list only Warheads that can benefit from this critical hit chance multiplier and `CritMultiplier.DisallowWarheads` weapons that are not allowed to, respectively.
   - `RevengeWeapon` can be used to temporarily grant the specified weapon as a [revenge weapon](#revenge-weapon) for the attached object.
     - `RevengeWeapon.AffectsHouses` customizes which houses can trigger the revenge weapon.
 
@@ -74,6 +76,9 @@ WeaponRange.Multiplier=1.0                   ; floating point value
 WeaponRange.ExtraRange=0.0                   ; floating point value
 WeaponRange.AllowWeapons=                    ; list of WeaponTypes
 WeaponRange.DisallowWeapons=                 ; list of WeaponTypes
+CritMultiplier=1.0                           ; floating point value
+CritMultiplier.AllowWarheads=                ; list of WarheadTypes
+CritMultiplier.DisallowWarheads=             ; list of WarheadTypes
 RevengeWeapon=                               ; WeaponType
 RevengeWeapon.AffectsHouses=all              ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -664,7 +664,7 @@ Trajectory.Bombard.Height=0.0  ; double
 *Shrapnel appearing against ground & buildings* ([Project Phantom](https://www.moddb.com/mods/project-phantom))
 
 - `ShrapnelWeapon` can now be triggered against ground & buildings via `Shrapnel.AffectsGround` and `Shrapnel.AffectsBuildings`.
-- Setting `Shrapnel.UseWeaponTargeting` now allows weapon target filtering to be enabled for `ShrapnelWeapon`. Target's `LegalTarget` setting, Warhead `Verses` against `Armor` as well as `ShrapnelWeapon` [weapon targeting filters](#weapon-targeting-filter) will be checked.
+- Setting `Shrapnel.UseWeaponTargeting` now allows weapon target filtering to be enabled for `ShrapnelWeapon`. Target's `LegalTarget` setting, Warhead `Verses` against `Armor` as well as `ShrapnelWeapon` [weapon targeting filters](#weapon-targeting-filter) & [AttachEffect filters](#attached-effects) will be checked.
   - Do note that this overrides the normal check of only allowing shrapnels to hit non-allied objects. Use `CanTargetHouses=enemies` to manually enable this behaviour again.
   
 In `rulesmd.ini`:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -399,7 +399,10 @@ New:
 - Restore functionality of `[CrateRules]` -> `FreeMCV` with customizable credits threshold (by Starkku)
 - Allow customizing the number of vehicles required for unit crates to turn into money crates (by Starkku)
 - Per-VehicleType reroll chance for `CrateGoodie=true` (by Starkku)
-- Warheads spawning powerup crates (by Starkku)
+- Warheads spawning powerup crates (by Starkku)- Custom tint on TechnoTypes (by Starkku)
+- Custom tint on TechnoTypes (by Starkku)
+- Revenge weapon (by Starkku)
+- AttachEffect types with new features like custom tint and weapon range modifier (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
@@ -461,6 +464,8 @@ Vanilla fixes:
 - Fixed jumpjet crash speed when crashing onto buildings (by NetsuNegi)
 - Fixed a desync potentially caused by displaying of cursor over selected `DeploysInto` units (by Starkku)
 - Skipped drawing the rally point line when undeploying a factory (by Trsdy)
+- Tint effects are now correctly applied to SHP vehicles and all types of aircraft as well as building animations regardless of their position (by Starkku)
+- Iron Curtained / Force Shielded objects now always use the correct tint color (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -28,6 +28,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 #### From 0.3
 
+- Phobos-introduced Warhead effects like shield modifiers, critical hits, disguise & mind control removal now require Warhead `Verses` to affect target to apply unless `EffectsRequireVerses` is set to false. Shield armor type is used if target has an active shield that cannot be penetrated by the Warhead.
 - `Trajectory=Straight` projectiles can now snap on targets within 0.5 cells from their detonation point, this distance can be customized via `Trajectory.Straight.TargetSnapDistance`.
 - `LaunchSW.RealLaunch=false` now checks if firing house has enough credits to satisfy SW's `Money.Amount` in order to be fired.
 - `CreateUnit` now creates the units by default at animation's height (even if `CreateUnit.ConsiderPathfinding` is enabled) instead of always at ground level. This behaviour can be restored by setting `CreateUnit.AlwaysSpawnOnGround` to true.

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -202,6 +202,7 @@ void AnimExt::ExtData::Serialize(T& Stm)
 		.Process(this->Invoker)
 		.Process(this->InvokerHouse)
 		.Process(this->AttachedSystem)
+		.Process(this->ParentBuilding)
 		;
 }
 

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -25,7 +25,7 @@ public:
 		TechnoClass* Invoker;
 		HouseClass* InvokerHouse;
 		ParticleSystemClass* AttachedSystem;
-		BuildingClass* ParentBuilding; // This is a failsafe that is only set if this is a building animation and the building is not on same cell as the animation.
+		BuildingClass* ParentBuilding; // Only set on building anims, used for tinting the anims etc. especially when not on same cell as building
 
 		ExtData(AnimClass* OwnerObject) : Extension<AnimClass>(OwnerObject)
 			, DeathUnitFacing { 0 }

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -25,6 +25,7 @@ public:
 		TechnoClass* Invoker;
 		HouseClass* InvokerHouse;
 		ParticleSystemClass* AttachedSystem;
+		BuildingClass* ParentBuilding; // This is a failsafe that is only set if this is a building animation and the building is not on same cell as the animation.
 
 		ExtData(AnimClass* OwnerObject) : Extension<AnimClass>(OwnerObject)
 			, DeathUnitFacing { 0 }
@@ -34,6 +35,7 @@ public:
 			, Invoker {}
 			, InvokerHouse {}
 			, AttachedSystem {}
+			, ParentBuilding {}
 		{ }
 
 		void SetInvoker(TechnoClass* pInvoker);
@@ -51,6 +53,7 @@ public:
 			AnnounceInvalidPointer(this->Invoker, ptr);
 			AnnounceInvalidPointer(this->InvokerHouse, ptr);
 			AnnounceInvalidPointer(this->AttachedSystem, ptr);
+			AnnounceInvalidPointer(ParentBuilding, ptr);
 		}
 
 		virtual void InitializeConstants() override;

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -4,6 +4,7 @@
 #include <UnitClass.h>
 #include <SuperClass.h>
 #include <GameOptionsClass.h>
+#include <Ext/Anim/Body.h>
 #include <Ext/House/Body.h>
 #include <Ext/WarheadType/Body.h>
 #include <TacticalClass.h>
@@ -391,6 +392,22 @@ DEFINE_HOOK(0x4575A2, BuildingClass_Infiltrate_AfterAres, 0xE)
 	GET(BuildingClass*, pBuilding, ECX);
 
 	BuildingExt::HandleInfiltrate(pBuilding, pInfiltratorHouse);
+	return 0;
+}
+
+DEFINE_HOOK(0x4519A2, BuildingClass_UpdateAnim_SetParentBuilding, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+	GET(AnimClass*, pAnim , EBP);
+
+	auto const pCell = MapClass::Instance->GetCellAt(pAnim->GetCenterCoords());
+
+	if (pCell && pCell->GetBuilding() != pThis)
+	{
+		auto const pAnimExt = AnimExt::ExtMap.Find(pAnim);
+		pAnimExt->ParentBuilding = pThis;
+	}
+
 	return 0;
 }
 

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -398,15 +398,10 @@ DEFINE_HOOK(0x4575A2, BuildingClass_Infiltrate_AfterAres, 0xE)
 DEFINE_HOOK(0x4519A2, BuildingClass_UpdateAnim_SetParentBuilding, 0x6)
 {
 	GET(BuildingClass*, pThis, ESI);
-	GET(AnimClass*, pAnim , EBP);
+	GET(AnimClass*, pAnim, EBP);
 
-	auto const pCell = MapClass::Instance->GetCellAt(pAnim->GetCenterCoords());
-
-	if (pCell && pCell->GetBuilding() != pThis)
-	{
-		auto const pAnimExt = AnimExt::ExtMap.Find(pAnim);
-		pAnimExt->ParentBuilding = pThis;
-	}
+	auto const pAnimExt = AnimExt::ExtMap.Find(pAnim);
+	pAnimExt->ParentBuilding = pThis;
 
 	return 0;
 }

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -250,6 +250,9 @@ DEFINE_HOOK(0x46A4FB, BulletClass_Shrapnel_Targeting, 0x6)
 
 			if (!EnumFunctions::IsTechnoEligible(pTechno, pWeaponExt->CanTarget))
 				return SkipObject;
+
+			if (!pWeaponExt->HasRequiredAttachedEffects(pTechno, pSource))
+				return SkipObject;
 		}
 
 	}

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -8,6 +8,7 @@
 #include <New/Type/ShieldTypeClass.h>
 #include <New/Type/LaserTrailTypeClass.h>
 #include <New/Type/DigitalDisplayTypeClass.h>
+#include <New/Type/AttachEffectTypeClass.h>
 
 std::unique_ptr<RulesExt::ExtData> RulesExt::Data = nullptr;
 
@@ -32,6 +33,7 @@ void RulesExt::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	RadTypeClass::LoadFromINIList(pINI);
 	ShieldTypeClass::LoadFromINIList(pINI);
 	LaserTrailTypeClass::LoadFromINIList(&CCINIClass::INI_Art.get());
+	AttachEffectTypeClass::LoadFromINIList(pINI);
 
 	Data->LoadBeforeTypeData(pThis, pINI);
 }

--- a/src/Ext/Script/Mission.Attack.cpp
+++ b/src/Ext/Script/Mission.Attack.cpp
@@ -2,6 +2,7 @@
 
 #include <Ext/Building/Body.h>
 #include <Ext/Techno/Body.h>
+#include <Ext/WeaponType/Body.h>
 
 // Contains ScriptExt::Mission_Attack and its helper functions.
 
@@ -704,8 +705,8 @@ bool ScriptExt::EvaluateObjectWithMask(TechnoClass* pTechno, int mask, int attac
 			// Then check if this possible target is too near of the Team Leader
 			distanceToTarget = pTeamLeader->DistanceFrom(pTechno) / 256.0;
 
-			bool primaryCheck = pWeaponPrimary && distanceToTarget <= (pWeaponPrimary->Range / 256.0 * 4.0);
-			bool secondaryCheck = pWeaponSecondary && distanceToTarget <= (pWeaponSecondary->Range / 256.0 * 4.0);
+			bool primaryCheck = pWeaponPrimary && distanceToTarget <= (WeaponTypeExt::GetRangeWithModifiers(pWeaponPrimary, pTechno) / 256.0 * 4.0);
+			bool secondaryCheck = pWeaponSecondary && distanceToTarget <= (WeaponTypeExt::GetRangeWithModifiers(pWeaponSecondary, pTechno) / 256.0 * 4.0);
 			bool guardRangeCheck = pTeamLeader->GetTechnoType()->GuardRange > 0 && distanceToTarget <= (pTeamLeader->GetTechnoType()->GuardRange / 256.0 * 2.0);
 
 			if (!pTechno->Owner->IsNeutral() && (primaryCheck || secondaryCheck || guardRangeCheck))

--- a/src/Ext/Techno/Body.Internal.cpp
+++ b/src/Ext/Techno/Body.Internal.cpp
@@ -1,5 +1,7 @@
 #include "Body.h"
 
+#include <AirstrikeClass.h>
+
 #include <Utilities/EnumFunctions.h>
 
 // Unsorted methods

--- a/src/Ext/Techno/Body.Internal.cpp
+++ b/src/Ext/Techno/Body.Internal.cpp
@@ -149,6 +149,87 @@ CoordStruct TechnoExt::GetSimpleFLH(InfantryClass* pThis, int weaponIndex, bool&
 	return FLH;
 }
 
+void TechnoExt::ExtData::InitializeAttachEffects()
+{
+	if (auto pTypeExt = this->TypeExtData)
+	{
+		if (pTypeExt->AttachEffect_AttachTypes.size() < 1)
+			return;
+
+		auto const pThis = this->OwnerObject();
+
+		AttachEffectClass::Attach(pTypeExt->AttachEffect_AttachTypes, pThis, pThis->Owner, pThis, pThis,
+			pTypeExt->AttachEffect_DurationOverrides, pTypeExt->AttachEffect_Delays, pTypeExt->AttachEffect_InitialDelays, pTypeExt->AttachEffect_RecreationDelays);
+	}
+}
+
+// Gets tint colors for invulnerability, airstrike laser target and berserk, depending on parameters.
+int TechnoExt::GetTintColor(TechnoClass* pThis, bool invulnerability, bool airstrike, bool berserk)
+{
+	int tintColor = 0;
+
+	if (pThis)
+	{
+		if (invulnerability && pThis->IsIronCurtained())
+			tintColor |= GeneralUtils::GetColorFromColorAdd(pThis->ForceShielded ? RulesClass::Instance->ForceShieldColor : RulesClass::Instance->IronCurtainColor);
+		if (airstrike && pThis->Airstrike && pThis->Airstrike->Target == pThis)
+			tintColor |= GeneralUtils::GetColorFromColorAdd(RulesClass::Instance->LaserTargetColor);
+		if (berserk && pThis->Berzerk)
+			tintColor |= GeneralUtils::GetColorFromColorAdd(RulesClass::Instance->BerserkColor);
+	}
+
+	return tintColor;
+}
+
+// Gets custom tint color from TechnoTypes & Warheads.
+int TechnoExt::GetCustomTintColor(TechnoClass* pThis)
+{
+	int dummy = 0;
+	int color = 0;
+	TechnoExt::ApplyCustomTintValues(pThis, color, dummy);
+	return color;
+}
+
+// Gets custom tint intensity from TechnoTypes & Warheads.
+int TechnoExt::GetCustomTintIntensity(TechnoClass* pThis)
+{
+	int dummy = 0;
+	int intensity = 0;
+	TechnoExt::ApplyCustomTintValues(pThis, dummy, intensity);
+	return intensity;
+}
+
+// Applies custom tint color and intensity from TechnoTypes & Warheads on provided values.
+void TechnoExt::ApplyCustomTintValues(TechnoClass* pThis, int& color, int& intensity)
+{
+	if (!pThis)
+		return;
+
+	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+	if ((pTypeExt->Tint_Color.isset() || pTypeExt->Tint_Intensity != 0.0) && EnumFunctions::CanTargetHouse(pTypeExt->Tint_VisibleToHouses, pThis->Owner, HouseClass::CurrentPlayer))
+	{
+		color |= Drawing::RGB_To_Int(pTypeExt->Tint_Color.Get(ColorStruct { 0,0,0 }));
+		intensity += static_cast<int>(pTypeExt->Tint_Intensity * 1000);
+	}
+
+	const auto pExt = TechnoExt::ExtMap.Find(pThis);
+
+	for (auto const& attachEffect : pExt->AttachedEffects)
+	{
+		auto const type = attachEffect->GetType();
+
+		if (!attachEffect->IsActive() || !type->HasTint())
+			continue;
+
+		if (!EnumFunctions::CanTargetHouse(type->Tint_VisibleToHouses, pThis->Owner, HouseClass::CurrentPlayer))
+			continue;
+
+		color |= Drawing::RGB_To_Int(type->Tint_Color);
+		intensity += static_cast<int>(type->Tint_Intensity * 1000);
+	}
+}
+
 // This is still not even correct, but let's see how far this can help us
 void TechnoExt::ChangeOwnerMissionFix(FootClass* pThis)
 {

--- a/src/Ext/Techno/Body.Internal.cpp
+++ b/src/Ext/Techno/Body.Internal.cpp
@@ -225,8 +225,19 @@ void TechnoExt::ApplyCustomTintValues(TechnoClass* pThis, int& color, int& inten
 		if (!EnumFunctions::CanTargetHouse(type->Tint_VisibleToHouses, pThis->Owner, HouseClass::CurrentPlayer))
 			continue;
 
-		color |= Drawing::RGB_To_Int(type->Tint_Color);
+		color |= Drawing::RGB_To_Int(type->Tint_Color.Get(ColorStruct { 0,0,0 }));
 		intensity += static_cast<int>(type->Tint_Intensity * 1000);
+	}
+
+	if (pExt->Shield && pExt->Shield->IsActive())
+	{
+		auto const pShieldType = pExt->Shield->GetType();
+
+		if (pShieldType->Tint_Color.isset())
+			color |= Drawing::RGB_To_Int(pShieldType->Tint_Color);
+
+		if (pShieldType->Tint_Intensity != 0.0)
+			intensity += static_cast<int>(pShieldType->Tint_Intensity * 1000);
 	}
 }
 

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -759,3 +759,85 @@ void TechnoExt::UpdateSharedAmmo(TechnoClass* pThis)
 		}
 	}
 }
+
+void TechnoExt::ExtData::UpdateTemporal()
+{
+	if (const auto pShieldData = this->Shield.get())
+	{
+		if (pShieldData->IsAvailable())
+			pShieldData->AI_Temporal();
+	}
+
+	for (auto const& ae : this->AttachedEffects)
+		ae->AI_Temporal();
+}
+
+void TechnoExt::ExtData::UpdateAttachEffects()
+{
+	bool markForRedraw = false;
+	std::vector<std::unique_ptr<AttachEffectClass>>::iterator it;
+
+	for (it = this->AttachedEffects.begin(); it != this->AttachedEffects.end(); )
+	{
+		auto const attachEffect = it->get();
+
+		if (!this->IsInTunnel && !this->IsBurrowed)
+			attachEffect->SetAnimationVisibility(true);
+
+		attachEffect->AI();
+
+		if (attachEffect->HasExpired())
+		{
+			if (attachEffect->GetType()->HasTint())
+				markForRedraw = true;
+
+			it = this->AttachedEffects.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	this->RecalculateStatMultipliers();
+
+	if (markForRedraw)
+		this->OwnerObject()->MarkForRedraw();
+}
+
+void TechnoExt::ExtData::RecalculateStatMultipliers()
+{
+	auto const pThis = this->OwnerObject();
+
+	double firepower = 1.0;
+	double armor = 1.0;
+	double speed = 1.0;
+	double ROF = 1.0;
+	bool cloak = pThis->Cloakable;
+	bool forceDecloak = false;
+
+	for (const auto& attachEffect : this->AttachedEffects)
+	{
+		if (!attachEffect->IsActive())
+			continue;
+
+		auto const type = attachEffect->GetType();
+		firepower *= type->FirepowerMultiplier;
+		speed *= type->SpeedMultiplier;
+		armor *= type->ArmorMultiplier;
+		ROF *= type->ROFMultiplier;
+		cloak |= type->Cloakable;
+		forceDecloak |= type->ForceDecloak;
+	}
+
+	this->AE_FirepowerMultiplier = firepower;
+	this->AE_ArmorMultiplier = armor;
+	this->AE_SpeedMultiplier = speed;
+	this->AE_ROFMultiplier = ROF;
+	pThis->Cloakable = cloak;
+	this->AE_ForceDecloak = forceDecloak;
+
+	if (forceDecloak && pThis->CloakState == CloakState::Cloaked)
+		pThis->Uncloak(true);
+}
+

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -786,10 +786,16 @@ void TechnoExt::ExtData::UpdateAttachEffects()
 
 		attachEffect->AI();
 
-		if (attachEffect->HasExpired())
+		if (attachEffect->HasExpired() || (attachEffect->IsActive() && !attachEffect->AllowedToBeActive()))
 		{
 			if (attachEffect->GetType()->HasTint())
 				markForRedraw = true;
+
+			if (!attachEffect->AllowedToBeActive() && attachEffect->ResetIfRecreatable())
+			{
+				++it;
+				continue;
+			}
 
 			it = this->AttachedEffects.erase(it);
 		}

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -789,10 +789,18 @@ void TechnoExt::ExtData::UpdateAttachEffects()
 
 		if (attachEffect->HasExpired() || (attachEffect->IsActive() && !attachEffect->AllowedToBeActive()))
 		{
-			if (attachEffect->GetType()->HasTint())
+			auto const pType = attachEffect->GetType();
+
+			if (pType->HasTint())
 				markForRedraw = true;
 
 			this->UpdateCumulativeAttachEffects(attachEffect->GetType());
+
+			if (pType->ExpireWeapon.isset() && (pType->ExpireWeapon_TriggerOn & ExpireWeaponCondition::Expire) != ExpireWeaponCondition::None)
+			{
+				if (!pType->Cumulative || !pType->ExpireWeapon_CumulativeOnlyOnce || this->GetAttachedEffectCumulativeCount(pType) < 1)
+					attachEffect->ExpireWeapon();
+			}
 
 			if (!attachEffect->AllowedToBeActive() && attachEffect->ResetIfRecreatable())
 			{

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -821,6 +821,7 @@ void TechnoExt::ExtData::RecalculateStatMultipliers()
 	double ROF = 1.0;
 	bool cloak = pThis->Cloakable;
 	bool forceDecloak = false;
+	bool disableWeapons = false;
 
 	for (const auto& attachEffect : this->AttachedEffects)
 	{
@@ -834,6 +835,7 @@ void TechnoExt::ExtData::RecalculateStatMultipliers()
 		ROF *= type->ROFMultiplier;
 		cloak |= type->Cloakable;
 		forceDecloak |= type->ForceDecloak;
+		disableWeapons |= type->DisableWeapons;
 	}
 
 	this->AE_FirepowerMultiplier = firepower;
@@ -842,6 +844,7 @@ void TechnoExt::ExtData::RecalculateStatMultipliers()
 	this->AE_ROFMultiplier = ROF;
 	pThis->Cloakable = cloak;
 	this->AE_ForceDecloak = forceDecloak;
+	this->AE_DisableWeapons = disableWeapons;
 
 	if (forceDecloak && pThis->CloakState == CloakState::Cloaked)
 		pThis->Uncloak(true);

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -430,6 +430,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->AE_ROFMultiplier)
 		.Process(this->AE_Cloakable)
 		.Process(this->AE_ForceDecloak)
+		.Process(this->AE_DisableWeapons)
 		;
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -110,7 +110,9 @@ double TechnoExt::GetCurrentSpeedMultiplier(FootClass* pThis)
 	else
 		houseMultiplier = pThis->Owner->Type->SpeedUnitsMult;
 
-	return pThis->SpeedMultiplier * houseMultiplier *
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+
+	return pThis->SpeedMultiplier * houseMultiplier * pExt->AE_SpeedMultiplier *
 		(pThis->HasAbility(Ability::Faster) ? RulesClass::Instance->VeteranSpeed : 1.0);
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -421,6 +421,13 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->DeployFireTimer)
 		.Process(this->ForceFullRearmDelay)
 		.Process(this->WHAnimRemainingCreationInterval)
+		.Process(this->AttachedEffects)
+		.Process(this->AE_FirepowerMultiplier)
+		.Process(this->AE_ArmorMultiplier)
+		.Process(this->AE_SpeedMultiplier)
+		.Process(this->AE_ROFMultiplier)
+		.Process(this->AE_Cloakable)
+		.Process(this->AE_ForceDecloak)
 		;
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -362,7 +362,7 @@ bool TechnoExt::IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource)
 	return false;
 }
 
-bool TechnoExt::ExtData::HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll)
+bool TechnoExt::ExtData::HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource)
 {
 	unsigned int foundCount = 0;
 	unsigned int typeCounter = 1;
@@ -373,6 +373,9 @@ bool TechnoExt::ExtData::HasAttachedEffects(std::vector<AttachEffectTypeClass*> 
 		{
 			if (attachEffect->GetType() == type)
 			{
+				if (ignoreSameSource && pInvoker && pSource && attachEffect->IsFromSource(pInvoker, pSource))
+					continue;
+
 				// Only need to find one match, can stop here.
 				if (!requireAll)
 					return true;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -362,6 +362,39 @@ bool TechnoExt::IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource)
 	return false;
 }
 
+bool TechnoExt::ExtData::HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll)
+{
+	unsigned int foundCount = 0;
+	unsigned int typeCounter = 1;
+
+	for (auto const& type : attachEffectTypes)
+	{
+		for (auto const& attachEffect : this->AttachedEffects)
+		{
+			if (attachEffect->GetType() == type)
+			{
+				// Only need to find one match, can stop here.
+				if (!requireAll)
+					return true;
+
+				foundCount++;
+				break;
+			}
+		}
+
+		// One of the required types was not found, can stop here.
+		if (requireAll && foundCount < typeCounter)
+			return false;
+
+		typeCounter++;
+	}
+
+	if (requireAll && foundCount == attachEffectTypes.size())
+		return true;
+
+	return false;
+}
+
 // =============================
 // load / save
 
@@ -380,6 +413,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->MindControlRingAnimType)
 		.Process(this->OriginalPassengerOwner)
 		.Process(this->IsInTunnel)
+		.Process(this->IsBurrowed)
 		.Process(this->HasBeenPlacedOnMap)
 		.Process(this->DeployFireTimer)
 		.Process(this->ForceFullRearmDelay)

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -98,12 +98,14 @@ public:
 		void UpdateTypeData(TechnoTypeClass* currentType);
 		void UpdateLaserTrails();
 		void UpdateAttachEffects();
+		void UpdateCumulativeAttachEffects(AttachEffectTypeClass* pAttachEffectType);
 		void RecalculateStatMultipliers();
 		void UpdateTemporal();
 		void UpdateMindControlAnim();
 		void InitializeLaserTrails();
 		void InitializeAttachEffects();
-		bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource);
+		bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource, std::vector<int> const& minCounts, std::vector<int> const& maxCounts);
+		int GetAttachedEffectCumulativeCount(AttachEffectTypeClass* pAttachEffectType, bool ignoreSameSource = false, TechnoClass* pInvoker = nullptr, AbstractClass* pSource = nullptr);
 
 		virtual ~ExtData() override;
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -54,6 +54,7 @@ public:
 		double AE_ROFMultiplier;
 		bool AE_Cloakable;
 		bool AE_ForceDecloak;
+		bool AE_DisableWeapons;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
@@ -82,6 +83,7 @@ public:
 			, AE_ROFMultiplier { 1.0 }
 			, AE_Cloakable { false }
 			, AE_ForceDecloak { false }
+			, AE_DisableWeapons { false }
 		{ }
 
 		void OnEarlyUpdate();

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -8,6 +8,7 @@
 #include <Utilities/Macro.h>
 #include <New/Entity/ShieldClass.h>
 #include <New/Entity/LaserTrailClass.h>
+#include <New/Entity/AttachEffectClass.h>
 
 class BulletClass;
 
@@ -34,15 +35,25 @@ public:
 		AnimTypeClass* MindControlRingAnimType;
 		int DamageNumberOffset;
 		bool IsInTunnel;
+		bool IsBurrowed;
 		bool HasBeenPlacedOnMap; // Set to true on first Unlimbo() call.
 		CDTimerClass DeployFireTimer;
 		bool ForceFullRearmDelay;
 		int WHAnimRemainingCreationInterval;
 		bool CanCurrentlyDeployIntoBuilding; // Only set on UnitClass technos with DeploysInto set in multiplayer games, recalculated once per frame so no need to serialize.
+		std::vector<std::unique_ptr<AttachEffectClass>> AttachedEffects;
 
 		// Used for Passengers.SyncOwner.RevertOnExit instead of TechnoClass::InitialOwner / OriginallyOwnedByHouse,
 		// as neither is guaranteed to point to the house the TechnoClass had prior to entering transport and cannot be safely overridden.
 		HouseClass* OriginalPassengerOwner;
+
+		// AttachEffect stuff.
+		double AE_FirepowerMultiplier;
+		double AE_ArmorMultiplier;
+		double AE_SpeedMultiplier;
+		double AE_ROFMultiplier;
+		bool AE_Cloakable;
+		bool AE_ForceDecloak;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
@@ -58,11 +69,19 @@ public:
 			, DamageNumberOffset { INT32_MIN }
 			, OriginalPassengerOwner {}
 			, IsInTunnel { false }
+			, IsBurrowed { false }
 			, HasBeenPlacedOnMap { false }
 			, DeployFireTimer {}
 			, ForceFullRearmDelay { false }
 			, WHAnimRemainingCreationInterval { 0 }
 			, CanCurrentlyDeployIntoBuilding { false }
+			, AttachedEffects {}
+			, AE_FirepowerMultiplier { 1.0 }
+			, AE_ArmorMultiplier { 1.0 }
+			, AE_SpeedMultiplier { 1.0 }
+			, AE_ROFMultiplier { 1.0 }
+			, AE_Cloakable { false }
+			, AE_ForceDecloak { false }
 		{ }
 
 		void OnEarlyUpdate();
@@ -76,8 +95,13 @@ public:
 		void ApplySpawnLimitRange();
 		void UpdateTypeData(TechnoTypeClass* currentType);
 		void UpdateLaserTrails();
-		void InitializeLaserTrails();
+		void UpdateAttachEffects();
+		void RecalculateStatMultipliers();
+		void UpdateTemporal();
 		void UpdateMindControlAnim();
+		void InitializeLaserTrails();
+		void InitializeAttachEffects();
+		bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll);
 
 		virtual ~ExtData() override;
 
@@ -146,6 +170,10 @@ public:
 	static bool ConvertToType(FootClass* pThis, TechnoTypeClass* toType);
 	static bool CanDeployIntoBuilding(UnitClass* pThis, bool noDeploysIntoDefaultValue = false);
 	static bool IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource);
+	static int GetTintColor(TechnoClass* pThis, bool invulnerability, bool airstrike, bool berserk);
+	static int GetCustomTintColor(TechnoClass* pThis);
+	static int GetCustomTintIntensity(TechnoClass* pThis);
+	static void ApplyCustomTintValues(TechnoClass* pThis, int& color, int& intensity);
 
 	// WeaponHelpers.cpp
 	static int PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, AbstractClass* pTarget, int weaponIndexOne, int weaponIndexTwo, bool allowFallback = true, bool allowAAFallback = true);

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -101,7 +101,7 @@ public:
 		void UpdateMindControlAnim();
 		void InitializeLaserTrails();
 		void InitializeAttachEffects();
-		bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll);
+		bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource);
 
 		virtual ~ExtData() override;
 

--- a/src/Ext/Techno/Hooks.AttachEffect.cpp
+++ b/src/Ext/Techno/Hooks.AttachEffect.cpp
@@ -155,3 +155,29 @@ bool __fastcall TechnoClass_Limbo_Wrapper(TechnoClass* pThis)
 DEFINE_JUMP(VTABLE, 0x7F4A34, GET_OFFSET(TechnoClass_Limbo_Wrapper)); // TechnoClass
 DEFINE_JUMP(CALL, 0x4DB3B1, GET_OFFSET(TechnoClass_Limbo_Wrapper));   // FootClass
 DEFINE_JUMP(CALL, 0x445DDA, GET_OFFSET(TechnoClass_Limbo_Wrapper))    // BuildingClass
+
+DEFINE_HOOK(0x702050, TechnoClass_TakeDamage_AttachEffectExpireWeapon, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	std::set<AttachEffectTypeClass*> cumulativeTypes;
+
+	for (auto const& attachEffect : pExt->AttachedEffects)
+	{
+		auto const pType = attachEffect->GetType();
+
+		if (pType->ExpireWeapon.isset() && (pType->ExpireWeapon_TriggerOn & ExpireWeaponCondition::Death) != ExpireWeaponCondition::None)
+		{
+			if (!pType->Cumulative || !pType->ExpireWeapon_CumulativeOnlyOnce || !cumulativeTypes.contains(pType))
+			{
+				if (pType->Cumulative && pType->ExpireWeapon_CumulativeOnlyOnce)
+					cumulativeTypes.insert(pType);
+
+				attachEffect->ExpireWeapon();
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/Techno/Hooks.AttachEffect.cpp
+++ b/src/Ext/Techno/Hooks.AttachEffect.cpp
@@ -122,12 +122,18 @@ bool __fastcall TechnoClass_Limbo_Wrapper(TechnoClass* pThis)
 	{
 		auto const attachEffect = it->get();
 
-		if (attachEffect->GetType()->DiscardOnEntry)
+		if ((attachEffect->GetType()->DiscardOn & DiscardCondition::Entry) != DiscardCondition::None)
 		{
 			altered = true;
 
 			if (attachEffect->GetType()->HasTint())
 				markForRedraw = true;
+
+			if (attachEffect->ResetIfRecreatable())
+			{
+				++it;
+				continue;
+			}
 
 			it = pExt->AttachedEffects.erase(it);
 		}

--- a/src/Ext/Techno/Hooks.AttachEffect.cpp
+++ b/src/Ext/Techno/Hooks.AttachEffect.cpp
@@ -1,0 +1,151 @@
+#include "Body.h"
+
+DEFINE_HOOK(0x4DB218, FootClass_GetMovementSpeed_SpeedMultiplier, 0x6)
+{
+	GET(FootClass*, pThis, ESI);
+	GET(int, speed, EAX);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	speed = static_cast<int>(speed * pExt->AE_SpeedMultiplier);
+	R->EAX(speed);
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x6FDC87, TechnoClass_ArmorMultiplier, 0x6) // TechnoClass_AdjustDamage
+DEFINE_HOOK(0x701966, TechnoClass_ArmorMultiplier, 0x6)       // TechnoClass_ReceiveDamage
+{
+	TechnoClass* pThis = R->Origin() == 0x701966 ? R->ESI<TechnoClass*>() : R->EDI<TechnoClass*>();
+	GET(int, damage, EAX);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	damage = static_cast<int>(damage / pExt->AE_ArmorMultiplier);
+	R->EAX(damage);
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x6FDBE2, TechnoClass_FirepowerMultiplier, 0x6) // TechnoClass_AdjustDamage
+DEFINE_HOOK(0x6FE352, TechnoClass_FirepowerMultiplier, 0x8)       // TechnoClass_FireAt
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET(int, damage, EAX);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	damage = static_cast<int>(damage * pExt->AE_FirepowerMultiplier);
+	R->EAX(damage);
+
+	return 0;
+}
+
+bool __fastcall TechnoClass_IsReadyToCloak_Wrapper(TechnoClass* pThis)
+{
+	bool cloak = pThis->Cloakable;
+	TechnoExt::ExtData* pExt = nullptr;
+
+	if (!pThis->Cloakable)
+	{
+		pExt = TechnoExt::ExtMap.Find(pThis);
+		pThis->Cloakable = pExt->AE_Cloakable;
+	}
+
+	bool retVal = pThis->TechnoClass::IsReadyToCloak();
+	pThis->Cloakable = cloak;
+
+	if (retVal)
+	{
+		if (!pExt)
+			pExt = TechnoExt::ExtMap.Find(pThis);
+
+		if (pExt->AE_ForceDecloak)
+			return false;
+	}
+
+	return retVal;
+}
+
+bool __fastcall TechnoClass_ShouldNotCloak_Wrapper(TechnoClass* pThis)
+{
+	bool cloak = pThis->Cloakable;
+	TechnoExt::ExtData* pExt = nullptr;
+
+	if (!pThis->Cloakable)
+	{
+		pExt = TechnoExt::ExtMap.Find(pThis);
+		pThis->Cloakable = pExt->AE_Cloakable;
+	}
+
+	bool retVal = pThis->TechnoClass::ShouldNotBeCloaked();
+	pThis->Cloakable = cloak;
+
+	if (retVal)
+	{
+		if (!pExt)
+			pExt = TechnoExt::ExtMap.Find(pThis);
+
+		if (pExt->AE_ForceDecloak)
+			return true;
+	}
+
+	return retVal;
+}
+
+DEFINE_JUMP(VTABLE, 0x7E2544, GET_OFFSET(TechnoClass_IsReadyToCloak_Wrapper)); // AircraftClass
+DEFINE_JUMP(VTABLE, 0x7E8F34, GET_OFFSET(TechnoClass_IsReadyToCloak_Wrapper)); // FootClass
+DEFINE_JUMP(VTABLE, 0x7EB2F8, GET_OFFSET(TechnoClass_IsReadyToCloak_Wrapper)); // InfantryClass
+DEFINE_JUMP(VTABLE, 0x7F4C00, GET_OFFSET(TechnoClass_IsReadyToCloak_Wrapper)); // TechnoClass
+DEFINE_JUMP(VTABLE, 0x7F5F10, GET_OFFSET(TechnoClass_IsReadyToCloak_Wrapper)); // UnitClass
+DEFINE_JUMP(CALL, 0x457779, GET_OFFSET(TechnoClass_IsReadyToCloak_Wrapper))    // BuildingClass
+
+DEFINE_JUMP(VTABLE, 0x7E2548, GET_OFFSET(TechnoClass_ShouldNotCloak_Wrapper)); // AircraftClass
+DEFINE_JUMP(VTABLE, 0x7E8F38, GET_OFFSET(TechnoClass_ShouldNotCloak_Wrapper)); // FootClass
+DEFINE_JUMP(VTABLE, 0x7EB2FC, GET_OFFSET(TechnoClass_ShouldNotCloak_Wrapper)); // InfantryClass
+DEFINE_JUMP(VTABLE, 0x7F4C04, GET_OFFSET(TechnoClass_ShouldNotCloak_Wrapper)); // TechnoClass
+DEFINE_JUMP(VTABLE, 0x7F5F14, GET_OFFSET(TechnoClass_ShouldNotCloak_Wrapper)); // UnitClass
+DEFINE_JUMP(CALL, 0x4578C9, GET_OFFSET(TechnoClass_ShouldNotCloak_Wrapper));   // BuildingClass
+
+bool __fastcall TechnoClass_Limbo_Wrapper(TechnoClass* pThis)
+{
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	bool markForRedraw = false;
+	bool altered = false;
+	std::vector<std::unique_ptr<AttachEffectClass>>::iterator it;
+
+	// Do not remove attached effects from undeploying buildings.
+	if (auto const pBuilding = abstract_cast<BuildingClass*>(pThis))
+	{
+		if (pBuilding->Type->UndeploysInto && pBuilding->CurrentMission == Mission::Selling && pBuilding->MissionStatus == 2)
+			return pThis->TechnoClass::Limbo();
+	}
+
+	for (it = pExt->AttachedEffects.begin(); it != pExt->AttachedEffects.end(); )
+	{
+		auto const attachEffect = it->get();
+
+		if (attachEffect->GetType()->DiscardOnEntry)
+		{
+			altered = true;
+
+			if (attachEffect->GetType()->HasTint())
+				markForRedraw = true;
+
+			it = pExt->AttachedEffects.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	if (altered)
+		pExt->RecalculateStatMultipliers();
+
+	if (markForRedraw)
+		pExt->OwnerObject()->MarkForRedraw();
+
+	return pThis->TechnoClass::Limbo();
+}
+
+DEFINE_JUMP(VTABLE, 0x7F4A34, GET_OFFSET(TechnoClass_Limbo_Wrapper)); // TechnoClass
+DEFINE_JUMP(CALL, 0x4DB3B1, GET_OFFSET(TechnoClass_Limbo_Wrapper));   // FootClass
+DEFINE_JUMP(CALL, 0x445DDA, GET_OFFSET(TechnoClass_Limbo_Wrapper))    // BuildingClass

--- a/src/Ext/Techno/Hooks.DeploysInto.cpp
+++ b/src/Ext/Techno/Hooks.DeploysInto.cpp
@@ -76,6 +76,7 @@ DEFINE_HOOK(0x739956, UnitClass_Deploy_Transfer, 0x6)
 	TechnoExt::TransferMindControlOnDeploy(pUnit, pStructure);
 	ShieldClass::SyncShieldToAnother(pUnit, pStructure);
 	TechnoExt::SyncIronCurtainStatus(pUnit, pStructure);
+	AttachEffectClass::TransferAttachedEffects(pUnit, pStructure);
 
 	return 0;
 }
@@ -88,6 +89,7 @@ DEFINE_HOOK(0x44A03C, BuildingClass_Mi_Selling_Transfer, 0x6)
 	TechnoExt::TransferMindControlOnDeploy(pStructure, pUnit);
 	ShieldClass::SyncShieldToAnother(pStructure, pUnit);
 	TechnoExt::SyncIronCurtainStatus(pStructure, pUnit);
+	AttachEffectClass::TransferAttachedEffects(pStructure, pUnit);
 
 	pUnit->QueueMission(Mission::Hunt, true);
 	//Why?

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -309,7 +309,7 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 				return CannotFire;
 			}
 
-			if (!pWeaponExt->HasRequiredAttachedEffects(pTechno))
+			if (!pWeaponExt->HasRequiredAttachedEffects(pTechno, pThis))
 				return CannotFire;
 		}
 	}

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -619,15 +619,22 @@ DEFINE_HOOK(0x70E1A0, TechnoClass_GetTurretWeapon_LaserWeapon, 0x5)
 	return 0;
 }
 
-DEFINE_HOOK(0x6FD0B5, TechnoClass_RearmDelay_RandomDelay, 0x6)
+DEFINE_HOOK(0x6FD0B5, TechnoClass_RearmDelay_ROF, 0x6)
 {
+	enum { SkipGameCode = 0x6FD0BB };
+
+	GET(TechnoClass*, pThis, ESI);
 	GET(WeaponTypeClass*, pWeapon, EDI);
 
-	const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
+	auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
+	auto const pTechnoExt = TechnoExt::ExtMap.Find(pThis);
 	auto range = pWeaponExt->ROF_RandomDelay.Get(RulesExt::Global()->ROF_RandomDelay);
+	double rof = pWeapon->ROF * pTechnoExt->AE_ROFMultiplier;
 
 	R->EAX(GeneralUtils::GetRangedRandomOrSingleValue(range));
-	return 0;
+	__asm { fld rof };
+
+	return SkipGameCode;
 }
 
 DEFINE_HOOK(0x6FD054, TechnoClass_RearmDelay_ForceFullDelay, 0x6)

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -317,6 +317,23 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x6FC0C5, TechnoClass_CanFire_DisableWeapons, 0x6)
+{
+	enum { OutOfRange = 0x6FC0DF, Illegal = 0x6FC86A, Continue = 0x6FC0D3 };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	if (pThis->SlaveOwner)
+		return Illegal;
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+
+	if (pExt->AE_DisableWeapons)
+		return OutOfRange;
+
+	return Continue;
+}
+
 DEFINE_HOOK(0x6FC587, TechnoClass_CanFire_OpenTopped, 0x6)
 {
 	enum { DisallowFiring = 0x6FC86A };

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -71,3 +71,4 @@ DEFINE_HOOK(0x6B73AD, SpawnManagerClass_AI_SpawnTimer, 0x5)
 
 	return 0;
 }
+

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -1,7 +1,6 @@
 #include "Body.h"
 #include <InfantryClass.h>
 #include <SpecificStructures.h>
-#include <TunnelLocomotionClass.h>
 #include <Utilities/Macro.h>
 #include <Utilities/GeneralUtils.h>
 #include <Ext/TechnoType/Body.h>
@@ -97,26 +96,6 @@ DEFINE_HOOK(0x708AEB, TechnoClass_ReplaceArmorWithShields, 0x6) //TechnoClass_Sh
 	return 0;
 }
 
-// Ares-hook jmp to this offset
-DEFINE_HOOK(0x71A88D, TemporalClass_AI_Shield, 0x0)
-{
-	GET(TemporalClass*, pThis, ESI);
-	if (auto const pTarget = pThis->Target)
-	{
-		pTarget->IsMouseHovering = false;
-		const auto pExt = TechnoExt::ExtMap.Find(pTarget);
-
-		if (const auto pShieldData = pExt->Shield.get())
-		{
-			if (pShieldData->IsAvailable())
-				pShieldData->AI_Temporal();
-		}
-	}
-
-	// Recovering vanilla instructions that were broken by a hook call
-	return R->EAX<int>() <= 0 ? 0x71A895 : 0x71AB08;
-}
-
 DEFINE_HOOK(0x6F6AC4, TechnoClass_Remove_Shield, 0x5)
 {
 	GET(TechnoClass*, pThis, ECX);
@@ -167,36 +146,6 @@ DEFINE_HOOK(0x6F683C, TechnoClass_DrawHealthBar_DrawOtherShieldBar, 0x7)
 	}
 
 	TechnoExt::ProcessDigitalDisplays(pThis);
-
-	return 0;
-}
-
-DEFINE_HOOK(0x728F74, TunnelLocomotionClass_Process_KillAnims, 0x5)
-{
-	GET(ILocomotion*, pThis, ESI);
-
-	const auto pLoco = static_cast<TunnelLocomotionClass*>(pThis);
-	const auto pExt = TechnoExt::ExtMap.Find(pLoco->LinkedTo);
-
-	if (const auto pShieldData = pExt->Shield.get())
-		pShieldData->SetAnimationVisibility(false);
-
-	return 0;
-}
-
-DEFINE_HOOK(0x728E5F, TunnelLocomotionClass_Process_RestoreAnims, 0x7)
-{
-	GET(ILocomotion*, pThis, ESI);
-
-	const auto pLoco = static_cast<TunnelLocomotionClass*>(pThis);
-
-	if (pLoco->State == TunnelLocomotionClass::State::PreDigOut)
-	{
-		const auto pExt = TechnoExt::ExtMap.Find(pLoco->LinkedTo);
-
-		if (const auto pShieldData = pExt->Shield.get())
-			pShieldData->SetAnimationVisibility(true);
-	}
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.Tint.cpp
+++ b/src/Ext/Techno/Hooks.Tint.cpp
@@ -4,6 +4,65 @@
 
 #include <Ext/Anim/Body.h>
 
+#pragma region ICColorBugFix
+
+DEFINE_HOOK(0x43D442, BuildingClass_Draw_ICFSColor, 0x7)
+{
+	enum { SkipGameCode = 0x43D45B };
+
+	GET(BuildingClass*, pThis, ESI);
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->ECX(rules);
+	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x43DCE1, BuildingClass_Draw2_ICFSColor, 0x7)
+{
+	enum { SkipGameCode = 0x43DCFA };
+
+	GET(BuildingClass*, pThis, EBP);
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->ECX(rules);
+	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x73BFBF, UnitClass_DrawAsVoxel_ICFSColor, 0x6)
+{
+	enum { SkipGameCode = 0x73BFC5 };
+
+	GET(UnitClass*, pThis, EBP);
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x423519, AnimClass_Draw_ICFSColor, 0x6)
+{
+	enum { SkipGameCode = 0x423525 };
+
+	GET(BuildingClass*, pBuilding, ECX);
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->ECX(rules);
+	R->EAX(pBuilding->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+#pragma endregion
+
 DEFINE_HOOK(0x706389, TechnoClass_DrawObject_TintColor, 0x6)
 {
 	GET(TechnoClass*, pThis, ESI);
@@ -42,20 +101,6 @@ DEFINE_HOOK(0x7067E4, TechnoClass_DrawVoxel_TintColor, 0x8)
 	return 0;
 }
 
-DEFINE_HOOK(0x43D442, BuildingClass_Draw_ForceShieldICColor, 0x7)
-{
-	enum { SkipGameCode = 0x43D45B };
-
-	GET(BuildingClass*, pThis, ESI);
-
-	RulesClass* rules = RulesClass::Instance;
-
-	R->ECX(rules);
-	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
-
-	return SkipGameCode;
-}
-
 DEFINE_HOOK(0x43D4EB, BuildingClass_Draw_TintColor, 0x6)
 {
 	GET(BuildingClass*, pThis, ESI);
@@ -65,20 +110,6 @@ DEFINE_HOOK(0x43D4EB, BuildingClass_Draw_TintColor, 0x6)
 	R->EDI(color);
 
 	return 0;
-}
-
-DEFINE_HOOK(0x43DCE1, BuildingClass_Draw2_ForceShieldICColor, 0x7)
-{
-	enum { SkipGameCode = 0x43DCFA };
-
-	GET(BuildingClass*, pThis, EBP);
-
-	RulesClass* rules = RulesClass::Instance;
-
-	R->ECX(rules);
-	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
-
-	return SkipGameCode;
 }
 
 DEFINE_HOOK(0x43DD8E, BuildingClass_Draw2_TintColor, 0xA)
@@ -125,19 +156,6 @@ DEFINE_HOOK(0x51946D, InfantryClass_Draw_TintIntensity, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x73BFBF, UnitClass_DrawAsVoxel_ForceShieldICColor, 0x6)
-{
-	enum { SkipGameCode = 0x73BFC5 };
-
-	GET(UnitClass*, pThis, EBP);
-
-	RulesClass* rules = RulesClass::Instance;
-
-	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
-
-	return SkipGameCode;
-}
-
 DEFINE_HOOK(0x73C083, UnitClass_DrawAsVoxel_TintColor, 0x6)
 {
 	GET(UnitClass*, pThis, EBP);
@@ -160,20 +178,6 @@ DEFINE_HOOK(0x0423420, AnimClass_Draw_ParentBuildingCheck, 0x6)
 		R->EAX(AnimExt::ExtMap.Find(pThis)->ParentBuilding);
 
 	return 0;
-}
-
-DEFINE_HOOK(0x423519, AnimClass_Draw_ForceShieldICColor, 0x6)
-{
-	enum { SkipGameCode = 0x423525 };
-
-	GET(BuildingClass*, pBuilding, ECX);
-
-	RulesClass* rules = RulesClass::Instance;
-
-	R->ECX(rules);
-	R->EAX(pBuilding->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
-
-	return SkipGameCode;
 }
 
 DEFINE_HOOK(0x4235D3, AnimClass_Draw_TintColor, 0x6)

--- a/src/Ext/Techno/Hooks.Tint.cpp
+++ b/src/Ext/Techno/Hooks.Tint.cpp
@@ -4,11 +4,6 @@
 
 #include <Ext/Anim/Body.h>
 
-namespace AnimDrawTemp
-{
-	BuildingClass* pParentBuilding = nullptr;
-}
-
 DEFINE_HOOK(0x706389, TechnoClass_DrawObject_TintColor, 0x6)
 {
 	GET(TechnoClass*, pThis, ESI);
@@ -161,23 +156,17 @@ DEFINE_HOOK(0x0423420, AnimClass_Draw_ParentBuildingCheck, 0x6)
 	GET(AnimClass*, pThis, ESI);
 	GET(BuildingClass*, pBuilding, EAX);
 
-	AnimDrawTemp::pParentBuilding = pBuilding;
-
 	if (!pBuilding)
-	{
-		auto const pExt = AnimExt::ExtMap.Find(pThis);
-		R->EAX(pExt->ParentBuilding);
-		AnimDrawTemp::pParentBuilding = pExt->ParentBuilding;
-	}
+		R->EAX(AnimExt::ExtMap.Find(pThis)->ParentBuilding);
 
 	return 0;
 }
 
-DEFINE_HOOK(0x423508, AnimClass_Draw_ForceShieldICColor, 0xB)
+DEFINE_HOOK(0x423519, AnimClass_Draw_ForceShieldICColor, 0x6)
 {
 	enum { SkipGameCode = 0x423525 };
 
-	auto const pBuilding = AnimDrawTemp::pParentBuilding;
+	GET(BuildingClass*, pBuilding, ECX);
 
 	RulesClass* rules = RulesClass::Instance;
 
@@ -193,14 +182,13 @@ DEFINE_HOOK(0x4235D3, AnimClass_Draw_TintColor, 0x6)
 	GET(int, color, EBP);
 	REF_STACK(int, intensity, STACK_OFFSET(0x110, -0xD8));
 
-	auto const pBuilding = AnimDrawTemp::pParentBuilding;
+	auto const pBuilding = AnimExt::ExtMap.Find(pThis)->ParentBuilding;
 
 	if (!pBuilding)
 		return 0;
 
 	int dummy = 0;
 	TechnoExt::ApplyCustomTintValues(pBuilding, color, !pThis->Type->UseNormalLight ? intensity : dummy);
-	AnimDrawTemp::pParentBuilding = nullptr;
 	R->EBP(color);
 
 	return 0;

--- a/src/Ext/Techno/Hooks.Tint.cpp
+++ b/src/Ext/Techno/Hooks.Tint.cpp
@@ -1,0 +1,207 @@
+#include <InfantryClass.h>
+
+#include "Body.h"
+
+#include <Ext/Anim/Body.h>
+
+namespace AnimDrawTemp
+{
+	BuildingClass* pParentBuilding = nullptr;
+}
+
+DEFINE_HOOK(0x706389, TechnoClass_DrawObject_TintColor, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET(int, intensity, EBP);
+	REF_STACK(int, color, STACK_OFFSET(0x54, 0x2C));
+
+	bool isVehicle = pThis->WhatAmI() == AbstractType::Unit;
+	bool isAircraft = pThis->WhatAmI() == AbstractType::Aircraft;
+
+	// SHP vehicles and aircraft
+	if (isVehicle || isAircraft)
+	{
+		color |= TechnoExt::GetTintColor(pThis, true, false, !isAircraft);
+		TechnoExt::ApplyCustomTintValues(pThis, color, intensity);
+	}
+	else if (pThis->WhatAmI() != AbstractType::Infantry)
+	{
+		intensity += TechnoExt::GetCustomTintIntensity(pThis);
+	}
+
+	R->EBP(intensity);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7067E4, TechnoClass_DrawVoxel_TintColor, 0x8)
+{
+	GET(TechnoClass*, pThis, EBP);
+	GET(int, intensity, EDI);
+	REF_STACK(int, color, STACK_OFFSET(0x50, 0x24));
+
+	color |= TechnoExt::GetTintColor(pThis, true, false, true);
+	TechnoExt::ApplyCustomTintValues(pThis, color, intensity);
+	R->EDI(intensity);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x43D442, BuildingClass_Draw_ForceShieldICColor, 0x7)
+{
+	enum { SkipGameCode = 0x43D45B };
+
+	GET(BuildingClass*, pThis, ESI);
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->ECX(rules);
+	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x43D4EB, BuildingClass_Draw_TintColor, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+	GET(int, color, EDI);
+
+	color |= TechnoExt::GetCustomTintColor(pThis);
+	R->EDI(color);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x43DCE1, BuildingClass_Draw2_ForceShieldICColor, 0x7)
+{
+	enum { SkipGameCode = 0x43DCFA };
+
+	GET(BuildingClass*, pThis, EBP);
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->ECX(rules);
+	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x43DD8E, BuildingClass_Draw2_TintColor, 0xA)
+{
+	GET(BuildingClass*, pThis, EBP);
+	REF_STACK(int, color, STACK_OFFSET(0x12C, -0x110));
+
+	color |= TechnoExt::GetCustomTintColor(pThis);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x43FA19, BuildingClass_Mark_TintIntensity, 0x7)
+{
+	GET(BuildingClass*, pThis, EDI);
+	GET(int, intensity, ESI);
+
+	intensity += TechnoExt::GetCustomTintIntensity(pThis);
+	R->ESI(intensity);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x519082, InfantryClass_Draw_TintColor, 0x7)
+{
+	GET(InfantryClass*, pThis, EBP);
+	REF_STACK(int, color, STACK_OFFSET(0x54, -0x40));
+
+	color |= TechnoExt::GetTintColor(pThis, true, false, false);
+	color |= TechnoExt::GetCustomTintColor(pThis);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x51946D, InfantryClass_Draw_TintIntensity, 0x6)
+{
+	GET(InfantryClass*, pThis, EBP);
+	GET(int, intensity, ESI);
+
+	intensity = pThis->GetEffectTintIntensity(intensity);
+	intensity += TechnoExt::GetCustomTintIntensity(pThis);
+	R->ESI(intensity);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x73BFBF, UnitClass_DrawAsVoxel_ForceShieldICColor, 0x6)
+{
+	enum { SkipGameCode = 0x73BFC5 };
+
+	GET(UnitClass*, pThis, EBP);
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->EAX(pThis->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x73C083, UnitClass_DrawAsVoxel_TintColor, 0x6)
+{
+	GET(UnitClass*, pThis, EBP);
+	GET(int, color, ESI);
+	REF_STACK(int, intensity, STACK_OFFSET(0x1D0, 0x10));
+
+	TechnoExt::ApplyCustomTintValues(pThis, color, intensity);
+
+	R->ESI(color);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x0423420, AnimClass_Draw_ParentBuildingCheck, 0x6)
+{
+	GET(AnimClass*, pThis, ESI);
+	GET(BuildingClass*, pBuilding, EAX);
+
+	AnimDrawTemp::pParentBuilding = pBuilding;
+
+	if (!pBuilding)
+	{
+		auto const pExt = AnimExt::ExtMap.Find(pThis);
+		R->EAX(pExt->ParentBuilding);
+		AnimDrawTemp::pParentBuilding = pExt->ParentBuilding;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x423508, AnimClass_Draw_ForceShieldICColor, 0xB)
+{
+	enum { SkipGameCode = 0x423525 };
+
+	auto const pBuilding = AnimDrawTemp::pParentBuilding;
+
+	RulesClass* rules = RulesClass::Instance;
+
+	R->ECX(rules);
+	R->EAX(pBuilding->ForceShielded ? rules->ForceShieldColor : rules->IronCurtainColor);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x4235D3, AnimClass_Draw_TintColor, 0x6)
+{
+	GET(AnimClass*, pThis, ESI);
+	GET(int, color, EBP);
+	REF_STACK(int, intensity, STACK_OFFSET(0x110, -0xD8));
+
+	auto const pBuilding = AnimDrawTemp::pParentBuilding;
+
+	if (!pBuilding)
+		return 0;
+
+	int dummy = 0;
+	TechnoExt::ApplyCustomTintValues(pBuilding, color, !pThis->Type->UseNormalLight ? intensity : dummy);
+	AnimDrawTemp::pParentBuilding = nullptr;
+	R->EBP(color);
+
+	return 0;
+}

--- a/src/Ext/Techno/Hooks.WeaponRange.cpp
+++ b/src/Ext/Techno/Hooks.WeaponRange.cpp
@@ -1,0 +1,168 @@
+#include "Body.h"
+
+#include <AircraftClass.h>
+
+#include <Ext/WeaponType/Body.h>
+
+// Reimplements the game function with few changes / optimizations
+DEFINE_HOOK(0x7012C2, TechnoClass_WeaponRange, 0x8)
+{
+	enum { ReturnResult = 0x70138F };
+
+	GET(TechnoClass*, pThis, ECX);
+	GET_STACK(int, weaponIndex, STACK_OFFSET(0x8, 0x4));
+
+	int result = 0;
+	auto pWeapon = pThis->GetWeapon(weaponIndex)->WeaponType;
+
+	if (pWeapon)
+	{
+		result = WeaponTypeExt::GetRangeWithModifiers(pWeapon, pThis);
+		auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+		if (pThis->GetTechnoType()->OpenTopped && !pTypeExt->OpenTopped_IgnoreRangefinding)
+		{
+			int smallestRange = INT32_MAX;
+			auto pPassenger = pThis->Passengers.FirstPassenger;
+
+			while (pPassenger && (pPassenger->AbstractFlags & AbstractFlags::Foot) != AbstractFlags::None)
+			{
+				int openTWeaponIndex = pPassenger->GetTechnoType()->OpenTransportWeapon;
+				int tWeaponIndex = 0;
+
+				if (openTWeaponIndex != -1)
+					tWeaponIndex = openTWeaponIndex;
+				else
+					tWeaponIndex = pPassenger->SelectWeapon(pThis->Target);
+
+				WeaponTypeClass* pTWeapon = pPassenger->GetWeapon(tWeaponIndex)->WeaponType;
+
+				if (pTWeapon && pTWeapon->FireInTransport)
+				{
+					int range = WeaponTypeExt::GetRangeWithModifiers(pTWeapon, pPassenger);
+
+					if (range < smallestRange)
+						smallestRange = range;
+				}
+
+				pPassenger = abstract_cast<FootClass*>(pPassenger->NextObject);
+			}
+
+			if (result > smallestRange)
+				result = smallestRange;
+		}
+	}
+
+	R->EBX(result);
+	return ReturnResult;
+}
+
+DEFINE_HOOK(0x6F7248, TechnoClass_InRange_WeaponRange, 0x6)
+{
+	enum { SkipGameCode = 0x6F724E };
+
+	GET(TechnoClass*, pThis, ESI);
+	GET(WeaponTypeClass*, pWeapon, EBX);
+
+	R->EDI(WeaponTypeExt::GetRangeWithModifiers(pWeapon, pThis));
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x6F7294, TechnoClass_InRange_OccupyRange, 0x5)
+{
+	enum { SkipGameCode = 0x6F729F };
+
+	GET(TechnoClass*, pThis, ESI);
+	GET(int, range, EDI);
+
+	int occupyRange = WeaponTypeExt::GetRangeWithModifiers(nullptr, pThis);
+	occupyRange /= Unsorted::LeptonsPerCell;
+
+	R->EDI(range + occupyRange);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x6FC3A1, TechnoClass_CanFire_InBunkerRangeCheck, 0x5)
+{
+	enum { ContinueChecks = 0x6FC3C5, CannotFire = 0x6FC86A };
+
+	GET(TechnoClass*, pThis, EBP);
+	GET(WeaponTypeClass*, pWeapon, EDI);
+
+	if (pThis->WhatAmI() == AbstractType::Unit && WeaponTypeExt::GetRangeWithModifiers(pWeapon, pThis) < 384.0)
+		return CannotFire;
+
+	return ContinueChecks;
+}
+
+DEFINE_HOOK(0x70CF6F, TechnoClass_ThreatCoefficients_WeaponRange, 0x6)
+{
+	enum { SkipGameCode = 0x70CF75 };
+
+	GET(TechnoClass*, pThis, EDI);
+	GET(WeaponTypeClass*, pWeapon, EBX);
+
+	R->EAX(WeaponTypeExt::GetRangeWithModifiers(pWeapon, pThis));
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x41810F, AircraftClass_MissionAttack_WeaponRangeCheck1, 0x6)
+{
+	enum { WithinDistance = 0x418117, NotWithinDistance = 0x418131 };
+
+	GET(AircraftClass*, pThis, ESI);
+	GET(WeaponTypeClass*, pWeapon, EDI);
+	GET(int, distance, EAX);
+
+	int range = WeaponTypeExt::GetRangeWithModifiers(pWeapon, pThis);
+
+	if (distance < range)
+		return WithinDistance;
+
+	return NotWithinDistance;
+}
+
+DEFINE_HOOK(0x418BA8, AircraftClass_MissionAttack_WeaponRangeCheck2, 0x6)
+{
+	enum { SkipGameCode = 0x418BAE };
+
+	GET(AircraftClass*, pThis, ESI);
+	GET(WeaponTypeClass*, pWeapon, EAX);
+
+	R->EAX(WeaponTypeExt::GetRangeWithModifiers(pWeapon, pThis));
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK_AGAIN(0x6DC18E, TacticalClass_DrawRadialIndicators_WeaponRange, 0x6)
+DEFINE_HOOK(0x6DBE63, TacticalClass_DrawRadialIndicators_WeaponRange, 0x6)
+{
+	enum { SkipGameCode1 = 0x6DBE6F, SkipGameCode2 = 0x6DC19A };
+
+	GET(ObjectClass*, pObject, ESI);
+
+	int* range = nullptr;
+	int originalRange = 0;
+
+	if (auto const pTechno = abstract_cast<TechnoClass*>(pObject))
+	{
+		auto const pWeapon = pTechno->GetPrimaryWeapon()->WeaponType;
+
+		if (pWeapon)
+		{
+			range = &pWeapon->Range;
+			originalRange = *range;
+			pWeapon->Range = WeaponTypeExt::GetRangeWithModifiers(pWeapon, pTechno);
+		}
+	}
+
+	pObject->DrawRadialIndicator(1);
+
+	if (range)
+		*range = originalRange;
+
+	return R->Origin() == 0x6DBE63 ? SkipGameCode1 : SkipGameCode2;
+}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1,6 +1,8 @@
 #include <AircraftClass.h>
-#include <ScenarioClass.h>
 #include "Body.h"
+
+#include <ScenarioClass.h>
+#include <TunnelLocomotionClass.h>
 
 #include <Ext/BuildingType/Body.h>
 #include <Ext/House/Body.h>
@@ -15,10 +17,27 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	// Do not search this up again in any functions called here because it is costly for performance - Starkku
 	auto pExt = TechnoExt::ExtMap.Find(pThis);
 	pExt->OnEarlyUpdate();
-
+	pExt->UpdateAttachEffects();
 	TechnoExt::ApplyMindControlRangeLimit(pThis);
 
 	return 0;
+}
+
+// Ares-hook jmp to this offset
+DEFINE_HOOK(0x71A88D, TemporalClass_AI, 0x0)
+{
+	GET(TemporalClass*, pThis, ESI);
+
+	if (auto const pTarget = pThis->Target)
+	{
+		pTarget->IsMouseHovering = false;
+
+		const auto pExt = TechnoExt::ExtMap.Find(pTarget);
+		pExt->UpdateTemporal();
+	}
+
+	// Recovering vanilla instructions that were broken by a hook call
+	return R->EAX<int>() <= 0 ? 0x71A895 : 0x71AB08;
 }
 
 DEFINE_HOOK_AGAIN(0x51BAC7, FootClass_AI_Tunnel, 0x6)//InfantryClass_AI_Tunnel
@@ -57,6 +76,7 @@ DEFINE_HOOK(0x6F42F7, TechnoClass_Init, 0x2)
 
 	pExt->CurrentShieldType = pExt->TypeExtData->ShieldType;
 	pExt->InitializeLaserTrails();
+	pExt->InitializeAttachEffects();
 
 	return 0;
 }
@@ -415,6 +435,49 @@ DEFINE_HOOK(0x70EFE0, TechnoClass_GetMaxSpeed, 0x6)
 
 	R->EAX(maxSpeed);
 	return SkipGameCode;
+}
+
+
+DEFINE_HOOK(0x728F74, TunnelLocomotionClass_Process_KillAnims, 0x5)
+{
+	GET(ILocomotion*, pThis, ESI);
+
+	const auto pLoco = static_cast<TunnelLocomotionClass*>(pThis);
+	const auto pExt = TechnoExt::ExtMap.Find(pLoco->LinkedTo);
+	pExt->IsBurrowed = true;
+
+	if (const auto pShieldData = pExt->Shield.get())
+		pShieldData->SetAnimationVisibility(false);
+
+	for (auto const& attachEffect : pExt->AttachedEffects)
+	{
+		attachEffect->SetAnimationVisibility(false);
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x728E5F, TunnelLocomotionClass_Process_RestoreAnims, 0x7)
+{
+	GET(ILocomotion*, pThis, ESI);
+
+	const auto pLoco = static_cast<TunnelLocomotionClass*>(pThis);
+
+	if (pLoco->State == TunnelLocomotionClass::State::PreDigOut)
+	{
+		const auto pExt = TechnoExt::ExtMap.Find(pLoco->LinkedTo);
+		pExt->IsBurrowed = false;
+
+		if (const auto pShieldData = pExt->Shield.get())
+			pShieldData->SetAnimationVisibility(true);
+
+		for (auto const& attachEffect : pExt->AttachedEffects)
+		{
+			attachEffect->SetAnimationVisibility(true);
+		}
+	}
+
+	return 0;
 }
 
 #pragma region Fly Layer Update

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -548,3 +548,15 @@ DEFINE_HOOK(0x708FC0, TechnoClass_ResponseMove_Pickup, 0x5)
 
 	return 0;
 }
+
+FireError __fastcall TechnoClass_TargetSomethingNearby_CanFire_Wrapper(TechnoClass* pThis, void* _, AbstractClass* pTarget, int weaponIndex, bool ignoreRange)
+{
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	bool disableWeapons = pExt->AE_DisableWeapons;
+	pExt->AE_DisableWeapons = false;
+	auto const fireError = pThis->GetFireError(pTarget, weaponIndex, ignoreRange);
+	pExt->AE_DisableWeapons = disableWeapons;
+	return fireError;
+}
+
+DEFINE_JUMP(CALL6, 0x7098E6, GET_OFFSET(TechnoClass_TargetSomethingNearby_CanFire_Wrapper));

--- a/src/Ext/Techno/WeaponHelpers.cpp
+++ b/src/Ext/Techno/WeaponHelpers.cpp
@@ -34,7 +34,8 @@ int TechnoExt::PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, A
 	{
 		if ((pTargetCell && !EnumFunctions::IsCellEligible(pTargetCell, pSecondExt->CanTarget, true, true)) ||
 			(pTargetTechno && (!EnumFunctions::IsTechnoEligible(pTargetTechno, pSecondExt->CanTarget) ||
-				!EnumFunctions::CanTargetHouse(pSecondExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner))))
+				!EnumFunctions::CanTargetHouse(pSecondExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner) ||
+				!pSecondExt->HasRequiredAttachedEffects(pTargetTechno))))
 		{
 			return weaponIndexOne;
 		}
@@ -47,7 +48,8 @@ int TechnoExt::PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, A
 
 			if ((pTargetCell && !EnumFunctions::IsCellEligible(pTargetCell, pFirstExt->CanTarget, true, true)) ||
 				(pTargetTechno && (!EnumFunctions::IsTechnoEligible(pTargetTechno, pFirstExt->CanTarget) ||
-					!EnumFunctions::CanTargetHouse(pFirstExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner))))
+					!EnumFunctions::CanTargetHouse(pFirstExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner) ||
+					!pFirstExt->HasRequiredAttachedEffects(pTargetTechno))))
 			{
 				return weaponIndexTwo;
 			}

--- a/src/Ext/Techno/WeaponHelpers.cpp
+++ b/src/Ext/Techno/WeaponHelpers.cpp
@@ -35,7 +35,7 @@ int TechnoExt::PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, A
 		if ((pTargetCell && !EnumFunctions::IsCellEligible(pTargetCell, pSecondExt->CanTarget, true, true)) ||
 			(pTargetTechno && (!EnumFunctions::IsTechnoEligible(pTargetTechno, pSecondExt->CanTarget) ||
 				!EnumFunctions::CanTargetHouse(pSecondExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner) ||
-				!pSecondExt->HasRequiredAttachedEffects(pTargetTechno))))
+				!pSecondExt->HasRequiredAttachedEffects(pTargetTechno, pThis))))
 		{
 			return weaponIndexOne;
 		}
@@ -49,7 +49,7 @@ int TechnoExt::PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, A
 			if ((pTargetCell && !EnumFunctions::IsCellEligible(pTargetCell, pFirstExt->CanTarget, true, true)) ||
 				(pTargetTechno && (!EnumFunctions::IsTechnoEligible(pTargetTechno, pFirstExt->CanTarget) ||
 					!EnumFunctions::CanTargetHouse(pFirstExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner) ||
-					!pFirstExt->HasRequiredAttachedEffects(pTargetTechno))))
+					!pFirstExt->HasRequiredAttachedEffects(pTargetTechno, pThis))))
 			{
 				return weaponIndexTwo;
 			}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -212,6 +212,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->OpenTopped_IgnoreRangefinding.Read(exINI, pSection, "OpenTopped.IgnoreRangefinding");
 	this->OpenTopped_AllowFiringIfDeactivated.Read(exINI, pSection, "OpenTopped.AllowFiringIfDeactivated");
 	this->OpenTopped_ShareTransportTarget.Read(exINI, pSection, "OpenTopped.ShareTransportTarget");
+	this->OpenTopped_UseTransportRangeModifiers.Read(exINI, pSection, "OpenTopped.UseTransportRangeModifiers");
 
 	this->AutoFire.Read(exINI, pSection, "AutoFire");
 	this->AutoFire_TargetSelf.Read(exINI, pSection, "AutoFire.TargetSelf");
@@ -280,6 +281,19 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Convert_ComputerToHuman.Read(exINI, pSection, "Convert.ComputerToHuman");
 
 	this->CrateGoodie_RerollChance.Read(exINI, pSection, "CrateGoodie.RerollChance");
+
+	this->Tint_Color.Read(exINI, pSection, "Tint.Color");
+	this->Tint_Intensity.Read(exINI, pSection, "Tint.Intensity");
+	this->Tint_VisibleToHouses.Read(exINI, pSection, "Tint.VisibleToHouses");
+
+	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon", true);
+	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
+
+	this->AttachEffect_AttachTypes.Read(exINI, pSection, "AttachEffect.AttachTypes");
+	this->AttachEffect_DurationOverrides.Read(exINI, pSection, "AttachEffect.DurationOverrides");
+	this->AttachEffect_Delays.Read(exINI, pSection, "AttachEffect.Delays");
+	this->AttachEffect_InitialDelays.Read(exINI, pSection, "AttachEffect.InitialDelays");
+	this->AttachEffect_RecreationDelays.Read(exINI, pSection, "AttachEffect.RecreationDelays");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -530,6 +544,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->OpenTopped_IgnoreRangefinding)
 		.Process(this->OpenTopped_AllowFiringIfDeactivated)
 		.Process(this->OpenTopped_ShareTransportTarget)
+		.Process(this->OpenTopped_UseTransportRangeModifiers)
 
 		.Process(this->AutoFire)
 		.Process(this->AutoFire_TargetSelf)
@@ -609,6 +624,19 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Convert_ComputerToHuman)
 
 		.Process(this->CrateGoodie_RerollChance)
+
+		.Process(this->Tint_Color)
+		.Process(this->Tint_Intensity)
+		.Process(this->Tint_VisibleToHouses)
+
+		.Process(this->RevengeWeapon)
+		.Process(this->RevengeWeapon_AffectsHouses)
+
+		.Process(this->AttachEffect_AttachTypes)
+		.Process(this->AttachEffect_DurationOverrides)
+		.Process(this->AttachEffect_Delays)
+		.Process(this->AttachEffect_InitialDelays)
+		.Process(this->AttachEffect_RecreationDelays)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -286,7 +286,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Tint_Intensity.Read(exINI, pSection, "Tint.Intensity");
 	this->Tint_VisibleToHouses.Read(exINI, pSection, "Tint.VisibleToHouses");
 
-	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon", true);
+	this->RevengeWeapon.Read<true>(exINI, pSection, "RevengeWeapon");
 	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
 
 	this->AttachEffect_AttachTypes.Read(exINI, pSection, "AttachEffect.AttachTypes");

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -7,6 +7,7 @@
 
 #include <New/Type/ShieldTypeClass.h>
 #include <New/Type/LaserTrailTypeClass.h>
+#include <New/Type/AttachEffectTypeClass.h>
 #include <New/Type/Affiliated/InterceptorTypeClass.h>
 #include <New/Type/Affiliated/PassengerDeletionTypeClass.h>
 #include <New/Type/DigitalDisplayTypeClass.h>
@@ -117,6 +118,7 @@ public:
 		Valueable<bool> OpenTopped_IgnoreRangefinding;
 		Valueable<bool> OpenTopped_AllowFiringIfDeactivated;
 		Valueable<bool> OpenTopped_ShareTransportTarget;
+		Valueable<bool> OpenTopped_UseTransportRangeModifiers;
 
 		Valueable<bool> AutoFire;
 		Valueable<bool> AutoFire_TargetSelf;
@@ -192,6 +194,19 @@ public:
 		Valueable<TechnoTypeClass*> Convert_ComputerToHuman;
 
 		Valueable<double> CrateGoodie_RerollChance;
+
+		Nullable<ColorStruct> Tint_Color;
+		Valueable<double> Tint_Intensity;
+		Valueable<AffectedHouse> Tint_VisibleToHouses;
+
+		Nullable<WeaponTypeClass*> RevengeWeapon;
+		Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
+
+		ValueableVector<AttachEffectTypeClass*> AttachEffect_AttachTypes;
+		ValueableVector<int> AttachEffect_DurationOverrides;
+		ValueableVector<int> AttachEffect_Delays;
+		ValueableVector<int> AttachEffect_InitialDelays;
+		NullableVector<int> AttachEffect_RecreationDelays;
 
 		struct LaserTrailDataEntry
 		{
@@ -277,6 +292,7 @@ public:
 			, OpenTopped_IgnoreRangefinding { false }
 			, OpenTopped_AllowFiringIfDeactivated { true }
 			, OpenTopped_ShareTransportTarget { true }
+			, OpenTopped_UseTransportRangeModifiers { false }
 
 			, AutoFire { false }
 			, AutoFire_TargetSelf { false }
@@ -381,6 +397,19 @@ public:
 			, Convert_ComputerToHuman { }
 
 			, CrateGoodie_RerollChance { 0.0 }
+
+			, Tint_Color {}
+			, Tint_Intensity { 0.0 }
+			, Tint_VisibleToHouses { AffectedHouse::All }
+
+			, RevengeWeapon {}
+			, RevengeWeapon_AffectsHouses { AffectedHouse::All }
+
+			, AttachEffect_AttachTypes {}
+			, AttachEffect_DurationOverrides {}
+			, AttachEffect_Delays {}
+			, AttachEffect_InitialDelays {}
+			, AttachEffect_RecreationDelays {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -12,7 +12,8 @@
 #include <Ext/AnimType/Body.h>
 #include <Ext/BulletType/Body.h>
 #include <Ext/Techno/Body.h>
-
+#include <Ext/WeaponType/Body.h>
+#include <Utilities/EnumFunctions.h>
 #include <Utilities/Macro.h>
 #include <Utilities/AresHelper.h>
 #include <JumpjetLocomotionClass.h>
@@ -283,7 +284,7 @@ DEFINE_HOOK(0x4AE670, DisplayClass_GetToolTip_EnemyUIName, 0x8)
 {
 	enum { SetUIName = 0x4AE678 };
 
-	GET(ObjectClass* , pObject, ECX);
+	GET(ObjectClass*, pObject, ECX);
 
 	auto pDecidedUIName = pObject->GetUIName();
 	auto pFoot = generic_cast<FootClass*>(pObject);
@@ -334,6 +335,40 @@ DEFINE_HOOK(0x6B0C2C, SlaveManagerClass_FreeSlaves_SlavesFreeSound, 0x5)
 		VocClass::PlayAt(sound, pSlave->Location);
 
 	return 0x6B0C65;
+}
+
+DEFINE_HOOK(0x702672, TechnoClass_ReceiveDamage_RevengeWeapon, 0x5)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET_STACK(TechnoClass*, pSource, STACK_OFFSET(0xC4, 0x10));
+
+	if (pSource)
+	{
+		auto const pExt = TechnoExt::ExtMap.Find(pThis);
+		auto const pTypeExt = pExt->TypeExtData;
+
+		if (pTypeExt && pTypeExt->RevengeWeapon.isset() &&
+			EnumFunctions::CanTargetHouse(pTypeExt->RevengeWeapon_AffectsHouses, pThis->Owner, pSource->Owner))
+		{
+			WeaponTypeExt::DetonateAt(pTypeExt->RevengeWeapon.Get(), pSource, pThis);
+		}
+
+		for (auto& attachEffect : pExt->AttachedEffects)
+		{
+			if (!attachEffect->IsActive())
+				continue;
+
+			auto const pType = attachEffect->GetType();
+
+			if (!pType->RevengeWeapon.isset())
+				continue;
+
+			if (EnumFunctions::CanTargetHouse(pType->RevengeWeapon_AffectsHouses, pThis->Owner, pSource->Owner))
+				WeaponTypeExt::DetonateAt(pType->RevengeWeapon, pSource, pThis);
+		}
+	}
+
+	return 0;
 }
 
 // 2nd order Pade approximant just in case someone complains about performance

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -228,6 +228,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttachEffect_AttachTypes.Read(exINI, pSection, "AttachEffect.AttachTypes");
 	this->AttachEffect_RemoveTypes.Read(exINI, pSection, "AttachEffect.RemoveTypes");
 	exINI.ParseStringList(this->AttachEffect_RemoveGroups, pSection, "AttachEffect.RemoveGroups");
+	this->AttachEffect_CumulativeRemoveMinCounts.Read(exINI, pSection, "AttachEffect.CumulativeRemoveMinCounts");
+	this->AttachEffect_CumulativeRemoveMaxCounts.Read(exINI, pSection, "AttachEffect.CumulativeRemoveMaxCounts");
 	this->AttachEffect_DurationOverrides.Read(exINI, pSection, "AttachEffect.DurationOverrides");
 
 	// Convert.From & Convert.To
@@ -419,6 +421,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttachEffect_AttachTypes)
 		.Process(this->AttachEffect_RemoveTypes)
 		.Process(this->AttachEffect_RemoveGroups)
+		.Process(this->AttachEffect_CumulativeRemoveMinCounts)
+		.Process(this->AttachEffect_CumulativeRemoveMaxCounts)
 		.Process(this->AttachEffect_DurationOverrides)
 
 		.Process(this->InflictLocomotor)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -269,7 +269,6 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->PossibleCellSpreadDetonate = (
 		this->RemoveDisguise
 		|| this->RemoveMindControl
-		|| this->Crit_Chance
 		|| this->Shield_Break
 		|| this->Shield_Respawn_Duration > 0
 		|| this->Shield_SelfHealing_Duration > 0

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -49,10 +49,8 @@ bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget, TechnoExt::E
 		{
 			if (pShieldData->IsActive())
 			{
-				if (pShieldData->CanBePenetrated(this->OwnerObject()))
-					return true;
-
-				armorType = pShieldData->GetArmorType();
+				if (!pShieldData->CanBePenetrated(this->OwnerObject()))
+					armorType = pShieldData->GetArmorType();
 			}
 		}
 	}

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -227,6 +227,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->AttachEffect_AttachTypes.Read(exINI, pSection, "AttachEffect.AttachTypes");
 	this->AttachEffect_RemoveTypes.Read(exINI, pSection, "AttachEffect.RemoveTypes");
+	exINI.ParseStringList(this->AttachEffect_RemoveGroups, pSection, "AttachEffect.RemoveGroups");
 	this->AttachEffect_DurationOverrides.Read(exINI, pSection, "AttachEffect.DurationOverrides");
 
 	// Convert.From & Convert.To
@@ -277,6 +278,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		|| this->RemoveInflictedLocomotor
 		|| this->AttachEffect_AttachTypes.size() > 0
 		|| this->AttachEffect_RemoveTypes.size() > 0
+		|| this->AttachEffect_RemoveGroups.size() > 0
 	);
 
 	char tempBuffer[32];
@@ -416,6 +418,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->AttachEffect_AttachTypes)
 		.Process(this->AttachEffect_RemoveTypes)
+		.Process(this->AttachEffect_RemoveGroups)
 		.Process(this->AttachEffect_DurationOverrides)
 
 		.Process(this->InflictLocomotor)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -30,7 +30,7 @@ bool WarheadTypeExt::ExtData::CanTargetHouse(HouseClass* pHouse, TechnoClass* pT
 	return true;
 }
 
-bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget)
+bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt = nullptr)
 {
 	if (!pTarget)
 		return false;
@@ -40,9 +40,12 @@ bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget)
 
 	auto armorType = pTarget->GetTechnoType()->Armor;
 
-	if (const auto pExt = TechnoExt::ExtMap.Find(pTarget))
+	if (!pTargetExt)
+		pTargetExt = TechnoExt::ExtMap.Find(pTarget);
+
+	if (pTargetExt)
 	{
-		if (const auto pShieldData = pExt->Shield.get())
+		if (const auto pShieldData = pTargetExt->Shield.get())
 		{
 			if (pShieldData->IsActive())
 			{
@@ -224,6 +227,10 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DetonateOnAllMapObjects_AffectTypes.Read(exINI, pSection, "DetonateOnAllMapObjects.AffectTypes");
 	this->DetonateOnAllMapObjects_IgnoreTypes.Read(exINI, pSection, "DetonateOnAllMapObjects.IgnoreTypes");
 
+	this->AttachEffect_AttachTypes.Read(exINI, pSection, "AttachEffect.AttachTypes");
+	this->AttachEffect_RemoveTypes.Read(exINI, pSection, "AttachEffect.RemoveTypes");
+	this->AttachEffect_DurationOverrides.Read(exINI, pSection, "AttachEffect.DurationOverrides");
+
 	// Convert.From & Convert.To
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::All);
 
@@ -270,6 +277,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		|| this->Convert_Pairs.size() > 0
 		|| this->InflictLocomotor
 		|| this->RemoveInflictedLocomotor
+		|| this->AttachEffect_AttachTypes.size() > 0
+		|| this->AttachEffect_RemoveTypes.size() > 0
 	);
 
 	char tempBuffer[32];
@@ -406,6 +415,10 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DetonateOnAllMapObjects_IgnoreTypes)
 
 		.Process(this->Convert_Pairs)
+
+		.Process(this->AttachEffect_AttachTypes)
+		.Process(this->AttachEffect_RemoveTypes)
+		.Process(this->AttachEffect_DurationOverrides)
 
 		.Process(this->InflictLocomotor)
 		.Process(this->RemoveInflictedLocomotor)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -122,6 +122,8 @@ public:
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_AttachTypes;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_RemoveTypes;
 		std::vector<const char*> AttachEffect_RemoveGroups;
+		ValueableVector<int> AttachEffect_CumulativeRemoveMinCounts;
+		ValueableVector<int> AttachEffect_CumulativeRemoveMaxCounts;
 		ValueableVector<int> AttachEffect_DurationOverrides;
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
@@ -243,6 +245,8 @@ public:
 			, AttachEffect_AttachTypes {}
 			, AttachEffect_RemoveTypes {}
 			, AttachEffect_RemoveGroups {}
+			, AttachEffect_CumulativeRemoveMinCounts {}
+			, AttachEffect_CumulativeRemoveMaxCounts {}
 			, AttachEffect_DurationOverrides {}
 
 			, AffectsEnemies { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -6,6 +6,7 @@
 #include <Utilities/TemplateDef.h>
 #include <New/Type/ShieldTypeClass.h>
 #include <Ext/Bullet/Body.h>
+#include <Ext/Techno/Body.h>
 #include <New/Type/Affiliated/TypeConvertGroup.h>
 
 class WarheadTypeExt
@@ -118,6 +119,9 @@ public:
 		Valueable<bool> InflictLocomotor;
 		Valueable<bool> RemoveInflictedLocomotor;
 
+		ValueableVector<AttachEffectTypeClass*> AttachEffect_AttachTypes;
+		ValueableVector<AttachEffectTypeClass*> AttachEffect_RemoveTypes;
+		ValueableVector<int> AttachEffect_DurationOverrides;
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 		Valueable<bool> AffectsEnemies;
@@ -235,6 +239,10 @@ public:
 			, InflictLocomotor { false }
 			, RemoveInflictedLocomotor { false }
 
+			, AttachEffect_AttachTypes {}
+			, AttachEffect_RemoveTypes {}
+			, AttachEffect_DurationOverrides {}
+
 			, AffectsEnemies { true }
 			, AffectsOwner {}
 			, EffectsRequireVerses { true }
@@ -252,7 +260,7 @@ public:
 		void ApplyLocomotorInflictionReset(TechnoClass* pTarget);
 	public:
 		bool CanTargetHouse(HouseClass* pHouse, TechnoClass* pTechno);
-		bool CanAffectTarget(TechnoClass* pTarget);
+		bool CanAffectTarget(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt);
 		bool EligibleForFullMapDetonation(TechnoClass* pTechno, HouseClass* pOwner);
 
 		virtual ~ExtData() = default;
@@ -273,9 +281,9 @@ public:
 		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr, bool bulletWasIntercepted = false);
 		void ApplyRemoveDisguiseToInf(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);
-		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner);
-		void ApplyShieldModifiers(TechnoClass* pTarget);
-
+		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner, TechnoExt::ExtData* pTargetExt);
+		void ApplyShieldModifiers(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt);
+		void ApplyAttachEffects(TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker);
 	};
 
 	class ExtContainer final : public Container<WarheadTypeExt>

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -284,6 +284,7 @@ public:
 		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner, TechnoExt::ExtData* pTargetExt);
 		void ApplyShieldModifiers(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt);
 		void ApplyAttachEffects(TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker);
+		double GetCritChance(TechnoClass* pFirer);
 	};
 
 	class ExtContainer final : public Container<WarheadTypeExt>

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -122,6 +122,7 @@ public:
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 		Valueable<bool> AffectsEnemies;
 		Nullable<bool> AffectsOwner;
+		Valueable<bool> EffectsRequireVerses;
 
 		double Crit_RandomBuffer;
 		bool HasCrit;
@@ -236,6 +237,7 @@ public:
 
 			, AffectsEnemies { true }
 			, AffectsOwner {}
+			, EffectsRequireVerses { true }
 
 			, Crit_RandomBuffer { 0.0 }
 			, HasCrit { false }
@@ -245,21 +247,12 @@ public:
 			, PossibleCellSpreadDetonate {false}
 		{ }
 
-	private:
-		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr, bool bulletWasIntercepted = false);
-
-		void ApplyRemoveDisguiseToInf(HouseClass* pHouse, TechnoClass* pTarget);
-		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);
-		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner);
-		void ApplyShieldModifiers(TechnoClass* pTarget);
 		void ApplyConvert(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyLocomotorInfliction(TechnoClass* pTarget);
 		void ApplyLocomotorInflictionReset(TechnoClass* pTarget);
-
 	public:
-		void Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletExt::ExtData* pBullet, CoordStruct coords);
 		bool CanTargetHouse(HouseClass* pHouse, TechnoClass* pTechno);
-		void InterceptBullets(TechnoClass* pOwner, WeaponTypeClass* pWeapon, CoordStruct coords);
+		bool CanAffectTarget(TechnoClass* pTarget);
 		bool EligibleForFullMapDetonation(TechnoClass* pTechno, HouseClass* pOwner);
 
 		virtual ~ExtData() = default;
@@ -271,6 +264,18 @@ public:
 	private:
 		template <typename T>
 		void Serialize(T& Stm);
+
+	public:
+		// Detonate.cpp
+		void Detonate(TechnoClass* pOwner, HouseClass* pHouse, BulletExt::ExtData* pBullet, CoordStruct coords);
+		void InterceptBullets(TechnoClass* pOwner, WeaponTypeClass* pWeapon, CoordStruct coords);
+	private:
+		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr, bool bulletWasIntercepted = false);
+		void ApplyRemoveDisguiseToInf(HouseClass* pHouse, TechnoClass* pTarget);
+		void ApplyRemoveMindControl(HouseClass* pHouse, TechnoClass* pTarget);
+		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner);
+		void ApplyShieldModifiers(TechnoClass* pTarget);
+
 	};
 
 	class ExtContainer final : public Container<WarheadTypeExt>

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -121,6 +121,7 @@ public:
 
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_AttachTypes;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_RemoveTypes;
+		std::vector<const char*> AttachEffect_RemoveGroups;
 		ValueableVector<int> AttachEffect_DurationOverrides;
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
@@ -241,6 +242,7 @@ public:
 
 			, AttachEffect_AttachTypes {}
 			, AttachEffect_RemoveTypes {}
+			, AttachEffect_RemoveGroups {}
 			, AttachEffect_DurationOverrides {}
 
 			, AffectsEnemies { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -132,7 +132,8 @@ public:
 		Valueable<bool> EffectsRequireVerses;
 
 		double Crit_RandomBuffer;
-		bool HasCrit;
+		double Crit_CurrentChance;
+		bool Crit_Active;
 		bool WasDetonatedOnAllMapObjects;
 		bool Splashed;
 		int RemainingAnimCreationInterval;
@@ -254,7 +255,8 @@ public:
 			, EffectsRequireVerses { true }
 
 			, Crit_RandomBuffer { 0.0 }
-			, HasCrit { false }
+			, Crit_CurrentChance { 0.0 }
+			, Crit_Active { false }
 			, WasDetonatedOnAllMapObjects { false }
 			, Splashed { false }
 			, RemainingAnimCreationInterval { 0 }
@@ -290,7 +292,7 @@ public:
 		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner, TechnoExt::ExtData* pTargetExt);
 		void ApplyShieldModifiers(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt);
 		void ApplyAttachEffects(TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker);
-		double GetCritChance(TechnoClass* pFirer);
+		double GetCritChance(TechnoClass* pFirer) const;
 	};
 
 	class ExtContainer final : public Container<WarheadTypeExt>

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -105,6 +105,7 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 	if (this->PossibleCellSpreadDetonate)
 	{
 		this->HasCrit = false;
+
 		if (!this->Crit_ApplyChancePerTarget)
 			this->Crit_RandomBuffer = ScenarioClass::Instance->Random.RandomDouble();
 

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -8,7 +8,6 @@
 #include <AnimClass.h>
 #include <BitFont.h>
 #include <SuperClass.h>
-#include <AircraftClass.h>
 
 #include <Utilities/Helpers.Alex.h>
 #include <Ext/Bullet/Body.h>
@@ -132,7 +131,7 @@ void WarheadTypeExt::ExtData::DetonateOnOneUnit(HouseClass* pHouse, TechnoClass*
 	if (!pTarget || pTarget->InLimbo || !pTarget->IsAlive || !pTarget->Health || pTarget->IsSinking)
 		return;
 
-	if (!this->CanTargetHouse(pHouse, pTarget))
+	if (!this->CanTargetHouse(pHouse, pTarget) || !this->CanAffectTarget(pTarget))
 		return;
 
 	this->ApplyShieldModifiers(pTarget);
@@ -162,13 +161,11 @@ void WarheadTypeExt::ExtData::ApplyShieldModifiers(TechnoClass* pTarget)
 {
 	if (auto pExt = TechnoExt::ExtMap.Find(pTarget))
 	{
-		bool canAffectTarget = GeneralUtils::GetWarheadVersusArmor(this->OwnerObject(), pTarget->GetTechnoType()->Armor) != 0.0;
-
 		int shieldIndex = -1;
 		double ratio = 1.0;
 
 		// Remove shield.
-		if (pExt->Shield && canAffectTarget)
+		if (pExt->Shield)
 		{
 			const auto shieldType = pExt->Shield->GetType();
 			shieldIndex = this->Shield_RemoveTypes.IndexOf(shieldType);
@@ -183,7 +180,7 @@ void WarheadTypeExt::ExtData::ApplyShieldModifiers(TechnoClass* pTarget)
 		}
 
 		// Attach shield.
-		if (canAffectTarget && Shield_AttachTypes.size() > 0)
+		if (Shield_AttachTypes.size() > 0)
 		{
 			ShieldTypeClass* shieldType = nullptr;
 

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -435,6 +435,7 @@ double WarheadTypeExt::ExtData::GetCritChance(TechnoClass* pFirer)
 		return critChance;
 
 	auto const pExt = TechnoExt::ExtMap.Find(pFirer);
+	double extraChance = 0.0;
 
 	for (auto& attachEffect : pExt->AttachedEffects)
 	{
@@ -443,18 +444,19 @@ double WarheadTypeExt::ExtData::GetCritChance(TechnoClass* pFirer)
 
 		auto const pType = attachEffect->GetType();
 
-		if (pType->CritMultiplier == 1.0)
+		if (pType->Crit_Multiplier == 1.0 && pType->Crit_ExtraChance == 0.0)
 			continue;
 
-		if (pType->CritMultiplier_AllowWarheads.size() > 0 && !pType->CritMultiplier_AllowWarheads.Contains(this->OwnerObject()))
+		if (pType->Crit_AllowWarheads.size() > 0 && !pType->Crit_AllowWarheads.Contains(this->OwnerObject()))
 			continue;
 
-		if (pType->CritMultiplier_DisallowWarheads.size() > 0 && pType->CritMultiplier_DisallowWarheads.Contains(this->OwnerObject()))
+		if (pType->Crit_DisallowWarheads.size() > 0 && pType->Crit_DisallowWarheads.Contains(this->OwnerObject()))
 			continue;
 
-		critChance = critChance * Math::max(pType->CritMultiplier, 0);
+		critChance = critChance * Math::max(pType->Crit_Multiplier, 0);
+		extraChance += pType->Crit_ExtraChance;
 	}
 
-	return critChance;
+	return critChance + extraChance;
 }
 

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -424,8 +424,8 @@ void WarheadTypeExt::ExtData::ApplyAttachEffects(TechnoClass* pTarget, HouseClas
 	std::vector<int> dummy = std::vector<int>();
 
 	AttachEffectClass::Attach(this->AttachEffect_AttachTypes, pTarget, pInvokerHouse, pInvoker, this->OwnerObject(), this->AttachEffect_DurationOverrides, dummy, dummy, dummy);
-	AttachEffectClass::Detach(this->AttachEffect_RemoveTypes, pTarget);
-	AttachEffectClass::DetachByGroups(this->AttachEffect_RemoveGroups, pTarget);
+	AttachEffectClass::Detach(this->AttachEffect_RemoveTypes, pTarget, this->AttachEffect_CumulativeRemoveMinCounts, this->AttachEffect_CumulativeRemoveMaxCounts);
+	AttachEffectClass::DetachByGroups(this->AttachEffect_RemoveGroups, pTarget, this->AttachEffect_CumulativeRemoveMinCounts, this->AttachEffect_CumulativeRemoveMaxCounts);
 }
 
 double WarheadTypeExt::ExtData::GetCritChance(TechnoClass* pFirer)

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -274,7 +274,7 @@ void WarheadTypeExt::ExtData::ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget
 	else
 		dice = this->Crit_RandomBuffer;
 
-	if (GetCritChance(pOwner) < dice)
+	if (this->GetCritChance(pOwner) < dice)
 		return;
 
 	if (!pTargetExt)

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -149,7 +149,7 @@ void WarheadTypeExt::ExtData::DetonateOnOneUnit(HouseClass* pHouse, TechnoClass*
 	if (this->Convert_Pairs.size() > 0)
 		this->ApplyConvert(pHouse, pTarget);
 
-	if (this->AttachEffect_AttachTypes.size() > 0 || this->AttachEffect_RemoveTypes.size() > 0)
+	if (this->AttachEffect_AttachTypes.size() > 0 || this->AttachEffect_RemoveTypes.size() > 0 || this->AttachEffect_RemoveGroups.size() > 0)
 		this->ApplyAttachEffects(pTarget, pHouse, pOwner);
 
 #ifdef LOCO_TEST_WARHEADS
@@ -425,6 +425,7 @@ void WarheadTypeExt::ExtData::ApplyAttachEffects(TechnoClass* pTarget, HouseClas
 
 	AttachEffectClass::Attach(this->AttachEffect_AttachTypes, pTarget, pInvokerHouse, pInvoker, this->OwnerObject(), this->AttachEffect_DurationOverrides, dummy, dummy, dummy);
 	AttachEffectClass::Detach(this->AttachEffect_RemoveTypes, pTarget);
+	AttachEffectClass::DetachByGroups(this->AttachEffect_RemoveGroups, pTarget);
 }
 
 double WarheadTypeExt::ExtData::GetCritChance(TechnoClass* pFirer)

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -99,7 +99,7 @@ DEFINE_HOOK(0x48A5B3, SelectDamageAnimation_CritAnim, 0x6)
 	GET(WarheadTypeClass* const, pThis, ESI);
 	auto pWHExt = WarheadTypeExt::ExtMap.Find(pThis);
 
-	if (pWHExt && pWHExt->HasCrit && pWHExt->Crit_AnimList.size() && !pWHExt->Crit_AnimOnAffectedTargets)
+	if (pWHExt && pWHExt->Crit_Active && pWHExt->Crit_AnimList.size() && !pWHExt->Crit_AnimOnAffectedTargets)
 	{
 		GET(int, nDamage, ECX);
 		int idx = pThis->EMEffect || pWHExt->Crit_AnimList_PickRandom.Get(pWHExt->AnimList_PickRandom) ?

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -5,19 +5,19 @@
 
 WeaponTypeExt::ExtContainer WeaponTypeExt::ExtMap;
 
-bool WeaponTypeExt::ExtData::HasRequiredAttachedEffects(TechnoClass* pTechno)
+bool WeaponTypeExt::ExtData::HasRequiredAttachedEffects(TechnoClass* pTechno, TechnoClass* pFirer)
 {
-	bool required = this->AttachEffect_RequiredTypes.size() > 0;
-	bool disallowed = this->AttachEffect_DisallowedTypes.size() > 0;
+	bool hasRequiredTypes = this->AttachEffect_RequiredTypes.size() > 0;
+	bool hasDisallowedTypes = this->AttachEffect_DisallowedTypes.size() > 0;
 
-	if (required || disallowed)
+	if (hasRequiredTypes || hasDisallowedTypes)
 	{
 		auto const pTechnoExt = TechnoExt::ExtMap.Find(pTechno);
 
-		if (disallowed && pTechnoExt->HasAttachedEffects(this->AttachEffect_DisallowedTypes, false))
+		if (hasDisallowedTypes && pTechnoExt->HasAttachedEffects(this->AttachEffect_DisallowedTypes, false, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
 			return false;
 
-		if (required && !pTechnoExt->HasAttachedEffects(this->AttachEffect_RequiredTypes, true))
+		if (hasRequiredTypes && !pTechnoExt->HasAttachedEffects(this->AttachEffect_RequiredTypes, true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
 			return false;
 	}
 
@@ -84,6 +84,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AmbientDamage_IgnoreTarget.Read(exINI, pSection, "AmbientDamage.IgnoreTarget");
 	this->AttachEffect_RequiredTypes.Read(exINI, pSection, "AttachEffect.RequiredTypes");
 	this->AttachEffect_DisallowedTypes.Read(exINI, pSection, "AttachEffect.DisallowedTypes");
+	this->AttachEffect_IgnoreFromSameSource.Read(exINI, pSection, "AttachEffect.IgnoreFromSameSource");
 }
 
 template <typename T>
@@ -114,6 +115,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AmbientDamage_IgnoreTarget)
 		.Process(this->AttachEffect_RequiredTypes)
 		.Process(this->AttachEffect_DisallowedTypes)
+		.Process(this->AttachEffect_IgnoreFromSameSource)
 		;
 };
 

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -16,17 +16,17 @@ bool WeaponTypeExt::ExtData::HasRequiredAttachedEffects(TechnoClass* pTechno, Te
 	{
 		auto const pTechnoExt = TechnoExt::ExtMap.Find(pTechno);
 
-		if (hasDisallowedTypes && pTechnoExt->HasAttachedEffects(this->AttachEffect_DisallowedTypes, false, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
+		if (hasDisallowedTypes && pTechnoExt->HasAttachedEffects(this->AttachEffect_DisallowedTypes, false, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead, this->AttachEffect_DisallowedMinCounts, this->AttachEffect_DisallowedMaxCounts))
 			return false;
 
-		if (hasDisallowedGroups && pTechnoExt->HasAttachedEffects(AttachEffectTypeClass::GetTypesFromGroups(this->AttachEffect_DisallowedGroups), false, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
+		if (hasDisallowedGroups && pTechnoExt->HasAttachedEffects(AttachEffectTypeClass::GetTypesFromGroups(this->AttachEffect_DisallowedGroups), false, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead, this->AttachEffect_DisallowedMinCounts, this->AttachEffect_DisallowedMaxCounts))
 			return false;
 
-		if (hasRequiredTypes &&!pTechnoExt->HasAttachedEffects(this->AttachEffect_RequiredTypes, true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
+		if (hasRequiredTypes &&!pTechnoExt->HasAttachedEffects(this->AttachEffect_RequiredTypes, true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead, this->AttachEffect_RequiredMinCounts, this->AttachEffect_RequiredMaxCounts))
 			return false;
 
 		if (hasRequiredGroups &&
-			!pTechnoExt->HasAttachedEffects(AttachEffectTypeClass::GetTypesFromGroups(this->AttachEffect_RequiredGroups), true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
+			!pTechnoExt->HasAttachedEffects(AttachEffectTypeClass::GetTypesFromGroups(this->AttachEffect_RequiredGroups), true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead, this->AttachEffect_RequiredMinCounts, this->AttachEffect_RequiredMaxCounts))
 			return false;
 	}
 
@@ -95,6 +95,10 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttachEffect_DisallowedTypes.Read(exINI, pSection, "AttachEffect.DisallowedTypes");
 	exINI.ParseStringList(this->AttachEffect_RequiredGroups, pSection, "AttachEffect.RequiredGroups");
 	exINI.ParseStringList(this->AttachEffect_DisallowedGroups, pSection, "AttachEffect.DisallowedGroups");
+	this->AttachEffect_RequiredMinCounts.Read(exINI, pSection, "AttachEffect.RequiredMinCounts");
+	this->AttachEffect_RequiredMaxCounts.Read(exINI, pSection, "AttachEffect.RequiredMaxCounts");
+	this->AttachEffect_DisallowedMinCounts.Read(exINI, pSection, "AttachEffect.DisallowedMinCounts");
+	this->AttachEffect_DisallowedMaxCounts.Read(exINI, pSection, "AttachEffect.DisallowedMaxCounts");
 	this->AttachEffect_IgnoreFromSameSource.Read(exINI, pSection, "AttachEffect.IgnoreFromSameSource");
 }
 
@@ -128,6 +132,10 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttachEffect_DisallowedTypes)
 		.Process(this->AttachEffect_RequiredGroups)
 		.Process(this->AttachEffect_DisallowedGroups)
+		.Process(this->AttachEffect_RequiredMinCounts)
+		.Process(this->AttachEffect_RequiredMaxCounts)
+		.Process(this->AttachEffect_DisallowedMinCounts)
+		.Process(this->AttachEffect_DisallowedMaxCounts)
 		.Process(this->AttachEffect_IgnoreFromSameSource)
 		;
 };

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -222,6 +222,8 @@ int WeaponTypeExt::GetRangeWithModifiers(WeaponTypeClass* pThis, TechnoClass* pF
 
 	if (auto const pTechnoExt = TechnoExt::ExtMap.Find(pTechno))
 	{
+		int extraRange = 0;
+
 		for (auto const& attachEffect : pTechnoExt->AttachedEffects)
 		{
 			if (!attachEffect->IsActive())
@@ -229,17 +231,20 @@ int WeaponTypeExt::GetRangeWithModifiers(WeaponTypeClass* pThis, TechnoClass* pF
 
 			auto const type = attachEffect->GetType();
 
-			if (type->WeaponRangeBonus == 0.0)
+			if (type->WeaponRange_Multiplier == 1.0 && type->WeaponRange_ExtraRange == 0.0)
 				continue;
 
-			if (type->WeaponRangeBonus_AllowWeapons.size() > 0 && !type->WeaponRangeBonus_AllowWeapons.Contains(pThis))
+			if (type->WeaponRange_AllowWeapons.size() > 0 && !type->WeaponRange_AllowWeapons.Contains(pThis))
 				continue;
 
-			if (type->WeaponRangeBonus_DisallowWeapons.size() > 0 && type->WeaponRangeBonus_DisallowWeapons.Contains(pThis))
+			if (type->WeaponRange_DisallowWeapons.size() > 0 && type->WeaponRange_DisallowWeapons.Contains(pThis))
 				continue;
 
-			range += static_cast<int>(type->WeaponRangeBonus * Unsorted::LeptonsPerCell);
+			range = static_cast<int>(range * Math::max(type->WeaponRange_Multiplier, 0.0));
+			extraRange += static_cast<int>(type->WeaponRange_ExtraRange * Unsorted::LeptonsPerCell);
 		}
+
+		range += extraRange;
 	}
 
 	return Math::max(range, 0);

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -9,15 +9,24 @@ bool WeaponTypeExt::ExtData::HasRequiredAttachedEffects(TechnoClass* pTechno, Te
 {
 	bool hasRequiredTypes = this->AttachEffect_RequiredTypes.size() > 0;
 	bool hasDisallowedTypes = this->AttachEffect_DisallowedTypes.size() > 0;
+	bool hasRequiredGroups = this->AttachEffect_RequiredGroups.size() > 0;
+	bool hasDisallowedGroups = this->AttachEffect_DisallowedGroups.size() > 0;
 
-	if (hasRequiredTypes || hasDisallowedTypes)
+	if (hasRequiredTypes || hasDisallowedTypes || hasRequiredGroups || hasDisallowedGroups)
 	{
 		auto const pTechnoExt = TechnoExt::ExtMap.Find(pTechno);
 
 		if (hasDisallowedTypes && pTechnoExt->HasAttachedEffects(this->AttachEffect_DisallowedTypes, false, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
 			return false;
 
-		if (hasRequiredTypes && !pTechnoExt->HasAttachedEffects(this->AttachEffect_RequiredTypes, true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
+		if (hasDisallowedGroups && pTechnoExt->HasAttachedEffects(AttachEffectTypeClass::GetTypesFromGroups(this->AttachEffect_DisallowedGroups), false, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
+			return false;
+
+		if (hasRequiredTypes &&!pTechnoExt->HasAttachedEffects(this->AttachEffect_RequiredTypes, true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
+			return false;
+
+		if (hasRequiredGroups &&
+			!pTechnoExt->HasAttachedEffects(AttachEffectTypeClass::GetTypesFromGroups(this->AttachEffect_RequiredGroups), true, this->AttachEffect_IgnoreFromSameSource, pFirer, this->OwnerObject()->Warhead))
 			return false;
 	}
 
@@ -84,6 +93,8 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AmbientDamage_IgnoreTarget.Read(exINI, pSection, "AmbientDamage.IgnoreTarget");
 	this->AttachEffect_RequiredTypes.Read(exINI, pSection, "AttachEffect.RequiredTypes");
 	this->AttachEffect_DisallowedTypes.Read(exINI, pSection, "AttachEffect.DisallowedTypes");
+	exINI.ParseStringList(this->AttachEffect_RequiredGroups, pSection, "AttachEffect.RequiredGroups");
+	exINI.ParseStringList(this->AttachEffect_DisallowedGroups, pSection, "AttachEffect.DisallowedGroups");
 	this->AttachEffect_IgnoreFromSameSource.Read(exINI, pSection, "AttachEffect.IgnoreFromSameSource");
 }
 
@@ -115,6 +126,8 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AmbientDamage_IgnoreTarget)
 		.Process(this->AttachEffect_RequiredTypes)
 		.Process(this->AttachEffect_DisallowedTypes)
+		.Process(this->AttachEffect_RequiredGroups)
+		.Process(this->AttachEffect_DisallowedGroups)
 		.Process(this->AttachEffect_IgnoreFromSameSource)
 		;
 };

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -45,6 +45,7 @@ public:
 		Valueable<bool> AmbientDamage_IgnoreTarget;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_RequiredTypes;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_DisallowedTypes;
+		Valueable<bool> AttachEffect_IgnoreFromSameSource;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius { DiskLaserClass::Radius }
@@ -71,11 +72,12 @@ public:
 			, AmbientDamage_IgnoreTarget { false }
 			, AttachEffect_RequiredTypes {}
 			, AttachEffect_DisallowedTypes {}
+			, AttachEffect_IgnoreFromSameSource { false }
 		{ }
 
 		int GetBurstDelay(int burstIndex);
 
-		bool HasRequiredAttachedEffects(TechnoClass* pTechno);
+		bool HasRequiredAttachedEffects(TechnoClass* pTechno, TechnoClass* pFirer);
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -45,6 +45,8 @@ public:
 		Valueable<bool> AmbientDamage_IgnoreTarget;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_RequiredTypes;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_DisallowedTypes;
+		std::vector<const char*> AttachEffect_RequiredGroups;
+		std::vector<const char*> AttachEffect_DisallowedGroups;
 		Valueable<bool> AttachEffect_IgnoreFromSameSource;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
@@ -72,6 +74,8 @@ public:
 			, AmbientDamage_IgnoreTarget { false }
 			, AttachEffect_RequiredTypes {}
 			, AttachEffect_DisallowedTypes {}
+			, AttachEffect_RequiredGroups {}
+			, AttachEffect_DisallowedGroups {}
 			, AttachEffect_IgnoreFromSameSource { false }
 		{ }
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -7,6 +7,7 @@
 #include <Utilities/TemplateDef.h>
 
 #include <New/Type/RadTypeClass.h>
+#include <New/Type/AttachEffectTypeClass.h>
 
 class WeaponTypeExt
 {
@@ -42,6 +43,8 @@ public:
 		ValueableVector<double> ExtraWarheads_DetonationChances;
 		Nullable<WarheadTypeClass*> AmbientDamage_Warhead;
 		Valueable<bool> AmbientDamage_IgnoreTarget;
+		ValueableVector<AttachEffectTypeClass*> AttachEffect_RequiredTypes;
+		ValueableVector<AttachEffectTypeClass*> AttachEffect_DisallowedTypes;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius { DiskLaserClass::Radius }
@@ -66,9 +69,13 @@ public:
 			, ExtraWarheads_DetonationChances {}
 			, AmbientDamage_Warhead {}
 			, AmbientDamage_IgnoreTarget { false }
+			, AttachEffect_RequiredTypes {}
+			, AttachEffect_DisallowedTypes {}
 		{ }
 
 		int GetBurstDelay(int burstIndex);
+
+		bool HasRequiredAttachedEffects(TechnoClass* pTechno);
 
 		virtual ~ExtData() = default;
 
@@ -104,4 +111,5 @@ public:
 	static void DetonateAt(WeaponTypeClass* pThis, AbstractClass* pTarget, TechnoClass* pOwner, int damage, HouseClass* pFiringHouse = nullptr);
 	static void DetonateAt(WeaponTypeClass* pThis, const CoordStruct& coords, TechnoClass* pOwner, HouseClass* pFiringHouse = nullptr);
 	static void DetonateAt(WeaponTypeClass* pThis, const CoordStruct& coords, TechnoClass* pOwner, int damage, HouseClass* pFiringHouse = nullptr);
+	static int GetRangeWithModifiers(WeaponTypeClass* pThis, TechnoClass* pFirer);
 };

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -47,6 +47,10 @@ public:
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_DisallowedTypes;
 		std::vector<const char*> AttachEffect_RequiredGroups;
 		std::vector<const char*> AttachEffect_DisallowedGroups;
+		ValueableVector<int> AttachEffect_RequiredMinCounts;
+		ValueableVector<int> AttachEffect_RequiredMaxCounts;
+		ValueableVector<int> AttachEffect_DisallowedMinCounts;
+		ValueableVector<int> AttachEffect_DisallowedMaxCounts;
 		Valueable<bool> AttachEffect_IgnoreFromSameSource;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
@@ -76,6 +80,10 @@ public:
 			, AttachEffect_DisallowedTypes {}
 			, AttachEffect_RequiredGroups {}
 			, AttachEffect_DisallowedGroups {}
+			, AttachEffect_RequiredMinCounts {}
+			, AttachEffect_RequiredMaxCounts {}
+			, AttachEffect_DisallowedMinCounts {}
+			, AttachEffect_DisallowedMaxCounts {}
 			, AttachEffect_IgnoreFromSameSource { false }
 		{ }
 

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -310,6 +310,11 @@ bool AttachEffectClass::IsActive() const
 		return this->Duration && this->IsOnline;
 }
 
+bool AttachEffectClass::IsFromSource(TechnoClass* pInvoker, AbstractClass* pSource) const
+{
+	return pInvoker == this->Invoker && pSource == this->Source;
+}
+
 AttachEffectTypeClass* AttachEffectClass::GetType() const
 {
 	return Type;

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -1,0 +1,542 @@
+#include "AttachEffectClass.h"
+
+#include <AnimClass.h>
+#include <BuildingClass.h>
+
+#include <Ext/Anim/Body.h>
+#include <Ext/Techno/Body.h>
+
+std::vector<AttachEffectClass*> AttachEffectClass::Array;
+
+AttachEffectClass::AttachEffectClass() : Type { nullptr }, Techno { nullptr }, InvokerHouse { nullptr }, Invoker { nullptr }, Source { nullptr }, DurationOverride { 0 }, Delay { 0 }, InitialDelay { 0 }, RecreationDelay { -1 }
+, Duration { 0 }
+, CurrentDelay { 0 }
+{
+	this->HasInitialized = false;
+	AttachEffectClass::Array.emplace_back(this);
+}
+
+AttachEffectClass::AttachEffectClass(AttachEffectTypeClass* pType, TechnoClass* pTechno,
+	HouseClass* pInvokerHouse, TechnoClass* pInvoker, AbstractClass* pSource, int durationOverride, int delay, int initialDelay, int recreationDelay) :
+	Type { pType }, Techno { pTechno }, InvokerHouse { pInvokerHouse }, Invoker { pInvoker }, Source { pSource },
+	DurationOverride { durationOverride }, Delay { delay }, InitialDelay { initialDelay }, RecreationDelay { recreationDelay }
+	, Duration { 0 }
+	, CurrentDelay { 0 }
+	, Animation { nullptr }
+	, IsAnimHidden { false }
+	, IsUnderTemporal { false }
+	, IsOnline { true }
+	, IsCloaked { false }
+{
+	this->HasInitialized = false;
+
+	if (this->InitialDelay <= 0)
+		this->HasInitialized = true;
+
+	Duration = this->DurationOverride != 0 ? this->DurationOverride : this->Type->Duration;
+
+	AttachEffectClass::Array.emplace_back(this);
+}
+
+AttachEffectClass::~AttachEffectClass()
+{
+	auto it = std::find(AttachEffectClass::Array.begin(), AttachEffectClass::Array.end(), this);
+
+	if (it != AttachEffectClass::Array.end())
+		AttachEffectClass::Array.erase(it);
+
+	this->KillAnim();
+}
+
+void AttachEffectClass::PointerGotInvalid(void* ptr, bool removed)
+{
+	auto const abs = static_cast<AbstractClass*>(ptr);
+	auto const absType = abs->WhatAmI();
+
+	if (absType == AbstractType::Anim)
+	{
+		for (auto pEffect : AttachEffectClass::Array)
+		{
+			if (ptr == pEffect->Animation)
+				pEffect->Animation = nullptr;
+		}
+	}
+	else if ((abs->AbstractFlags & AbstractFlags::Techno) != AbstractFlags::None)
+	{
+		for (auto pEffect : AttachEffectClass::Array)
+			AnnounceInvalidPointer(pEffect->Invoker, ptr);
+	}
+	else if (absType == AbstractType::House)
+	{
+		for (auto pEffect : AttachEffectClass::Array)
+			AnnounceInvalidPointer(pEffect->InvokerHouse, ptr);
+	}
+}
+
+// =============================
+// actual logic
+
+void AttachEffectClass::AI()
+{
+	if (!this->Techno || this->Techno->InLimbo || this->Techno->IsImmobilized || this->Techno->Transporter)
+		return;
+
+	if (this->InitialDelay > 0)
+	{
+		this->InitialDelay--;
+		return;
+	}
+
+	if (!this->HasInitialized && this->InitialDelay == 0)
+	{
+		this->HasInitialized = true;
+
+		if (this->Type->ROFMultiplier > 0.0 && this->Type->ROFMultiplier_ApplyOnCurrentTimer)
+		{
+			double ROFModifier = this->Type->ROFMultiplier;
+			auto const pTechno = this->Techno;
+			pTechno->DiskLaserTimer.Start(static_cast<int>(pTechno->DiskLaserTimer.GetTimeLeft() * ROFModifier));
+			pTechno->ROF = static_cast<int>(pTechno->ROF * ROFModifier);
+		}
+
+		if (this->Type->HasTint())
+			this->Techno->MarkForRedraw();
+	}
+
+	if (this->CurrentDelay > 0)
+	{
+		this->CurrentDelay--;
+
+		if (this->CurrentDelay == 0)
+			this->RefreshDuration();
+
+		return;
+	}
+
+	if (this->Duration > 0)
+		this->Duration--;
+
+	if (this->Duration == 0)
+	{
+		if (!this->IsSelfOwned() || this->Delay < 0)
+			return;
+
+		this->CurrentDelay = this->Delay;
+
+		if (this->Delay > 0)
+			KillAnim();
+		else
+			this->RefreshDuration();
+
+		return;
+	}
+
+	if (this->IsUnderTemporal)
+		this->IsUnderTemporal = false;
+
+	this->CloakCheck();
+	this->OnlineCheck();
+
+	if (!this->Animation && !this->IsUnderTemporal && this->IsOnline && !this->IsCloaked && !this->IsAnimHidden)
+		CreateAnim();
+}
+
+void AttachEffectClass::AI_Temporal()
+{
+	if (!this->IsUnderTemporal)
+	{
+		this->IsUnderTemporal = true;
+
+		this->CloakCheck();
+
+		if (!this->Animation && this->Type->Animation_TemporalAction != AttachedAnimFlag::Hides && this->IsOnline && !this->IsCloaked && !this->IsAnimHidden)
+			CreateAnim();
+
+		if (this->Animation)
+		{
+			switch (this->Type->Animation_TemporalAction)
+			{
+			case AttachedAnimFlag::Hides:
+				this->KillAnim();
+				break;
+			case AttachedAnimFlag::Temporal:
+				this->Animation->UnderTemporal = true;
+				break;
+
+			case AttachedAnimFlag::Paused:
+				this->Animation->Pause();
+				break;
+
+			case AttachedAnimFlag::PausedTemporal:
+				this->Animation->Pause();
+				this->Animation->UnderTemporal = true;
+				break;
+			}
+		}
+	}
+}
+
+void AttachEffectClass::OnlineCheck()
+{
+	if (!this->Type->Powered)
+		return;
+
+	auto pTechno = this->Techno;
+	bool isActive = !(pTechno->Deactivated || pTechno->IsUnderEMP());
+
+	if (isActive && this->Techno->WhatAmI() == AbstractType::Building)
+	{
+		auto const pBuilding = static_cast<BuildingClass const*>(this->Techno);
+		isActive = pBuilding->IsPowerOnline();
+	}
+
+	this->IsOnline = isActive;
+
+	if (!this->Animation)
+		return;
+
+	if (!isActive)
+	{
+		switch (this->Type->Animation_OfflineAction)
+		{
+		case AttachedAnimFlag::Hides:
+			this->KillAnim();
+			break;
+
+		case AttachedAnimFlag::Temporal:
+			this->Animation->UnderTemporal = true;
+			break;
+
+		case AttachedAnimFlag::Paused:
+			this->Animation->Pause();
+			break;
+
+		case AttachedAnimFlag::PausedTemporal:
+			this->Animation->Pause();
+			this->Animation->UnderTemporal = true;
+			break;
+		}
+	}
+	else
+	{
+		this->Animation->UnderTemporal = false;
+		this->Animation->Unpause();
+	}
+}
+
+void AttachEffectClass::CloakCheck()
+{
+	const auto cloakState = this->Techno->CloakState;
+
+	if (cloakState == CloakState::Cloaked || cloakState == CloakState::Cloaking)
+	{
+		this->IsCloaked = true;
+		KillAnim();
+	}
+	else
+	{
+		this->IsCloaked = false;
+	}
+}
+
+void AttachEffectClass::CreateAnim()
+{
+	if (!this->Type)
+		return;
+
+	auto pAnimType = this->Type->Animation.Get(nullptr);
+
+	if (!this->Animation && pAnimType)
+	{
+		if (auto const pAnim = GameCreate<AnimClass>(pAnimType, this->Techno->Location))
+		{
+			pAnim->SetOwnerObject(this->Techno);
+			pAnim->Owner = this->Type->Animation_UseInvokerAsOwner ? InvokerHouse : this->Techno->Owner;
+			pAnim->RemainingIterations = 0xFFu;
+			this->Animation = pAnim;
+
+			if (this->Type->Animation_UseInvokerAsOwner)
+			{
+				auto const pAnimExt = AnimExt::ExtMap.Find(pAnim);
+				pAnimExt->SetInvoker(Invoker);
+			}
+		}
+	}
+}
+
+void AttachEffectClass::KillAnim()
+{
+	if (this->Animation)
+	{
+		this->Animation->UnInit();
+		this->Animation = nullptr;
+	}
+}
+
+void AttachEffectClass::SetAnimationVisibility(bool visible)
+{
+	if (!this->IsAnimHidden && !visible)
+		this->KillAnim();
+
+	this->IsAnimHidden = !visible;
+}
+
+void AttachEffectClass::RefreshDuration()
+{
+	this->Duration = this->DurationOverride ? this->DurationOverride : this->Type->Duration;
+
+	if (this->Type->Animation_ResetOnReapply)
+	{
+		this->KillAnim();
+		this->CreateAnim();
+	}
+}
+
+bool AttachEffectClass::IsSelfOwned() const
+{
+	return this->Source == this->Techno;
+}
+
+bool AttachEffectClass::HasExpired() const
+{
+	return IsSelfOwned() && this->Delay >= 0 ? false : !this->Duration;
+}
+
+bool AttachEffectClass::IsActive() const
+{
+	if (this->IsSelfOwned())
+		return this->InitialDelay <= 0 && this->CurrentDelay == 0 && this->HasInitialized && this->IsOnline;
+	else
+		return this->Duration && this->IsOnline;
+}
+
+AttachEffectTypeClass* AttachEffectClass::GetType() const
+{
+	return Type;
+}
+
+void AttachEffectClass::Attach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
+	AbstractClass* pSource, std::vector<int>& durationOverrides, std::vector<int> const& delays, std::vector<int> const& initialDelays, std::vector<int> const& recreationDelays)
+{
+	if (types.size() < 1 || !pTarget)
+		return;
+
+	auto const pTargetExt = TechnoExt::ExtMap.Find(pTarget);
+
+	int modifiedCount = 0;
+	bool markForRedraw = false;
+	double ROFModifier = 1.0;
+
+	for (size_t i = 0; i < types.size(); i++)
+	{
+		auto const type = types[i];
+
+		if (!type->PenetratesIronCurtain && pTarget->IsIronCurtained())
+			continue;
+
+		int currentTypeCount = 0;
+		AttachEffectClass* match = nullptr;
+		AttachEffectClass* sourceMatch = nullptr;
+
+		for (auto const& aePtr : pTargetExt->AttachedEffects)
+		{
+			auto const attachEffect = aePtr.get();
+
+			if (attachEffect->GetType() == type)
+			{
+				currentTypeCount++;
+				match = attachEffect;
+
+				if (attachEffect->Source == pSource && attachEffect->Invoker == pInvoker)
+					sourceMatch = attachEffect;
+			}
+		}
+
+		if (type->Cumulative && type->Cumulative_MaxCount >= 0 && currentTypeCount >= type->Cumulative_MaxCount)
+		{
+			if (sourceMatch)
+				sourceMatch->RefreshDuration();
+			else
+				continue;
+		}
+
+		if (!type->Cumulative && currentTypeCount > 0 && match)
+		{
+			match->RefreshDuration();
+		}
+		else
+		{
+			int durationOverride = 0;
+			int delay = 0;
+			int initialDelay = 0;
+			int recreationDelay = -1;
+
+			if (durationOverrides.size() > 0)
+				durationOverride = durationOverrides[durationOverrides.size() > i ? i : durationOverrides.size() - 1];
+
+			if (delays.size() > 0)
+				delay = delays[delays.size() > i ? i : delays.size() - 1];
+
+			if (initialDelays.size() > 0)
+				initialDelay = initialDelays[initialDelays.size() > i ? i : initialDelays.size() - 1];
+
+			if (recreationDelays.size() > 0)
+				recreationDelay = recreationDelays[recreationDelays.size() > i ? i : recreationDelays.size() - 1];
+
+			pTargetExt->AttachedEffects.push_back(std::make_unique<AttachEffectClass>(type, pTarget, pInvokerHouse, pInvoker, pSource, durationOverride, delay, initialDelay, recreationDelay));
+			modifiedCount++;
+
+			if (initialDelay <= 0)
+			{
+				if (type->ROFMultiplier > 0.0 && type->ROFMultiplier_ApplyOnCurrentTimer)
+					ROFModifier *= type->ROFMultiplier;
+
+				if (type->HasTint())
+					markForRedraw = true;
+			}
+		}
+	}
+
+	if (ROFModifier != 1.0)
+	{
+		pTarget->DiskLaserTimer.Start(static_cast<int>(pTarget->DiskLaserTimer.GetTimeLeft() * ROFModifier));
+		pTarget->ROF = static_cast<int>(pTarget->ROF * ROFModifier);
+	}
+
+	if (modifiedCount > 0)
+		pTargetExt->RecalculateStatMultipliers();
+
+	if (markForRedraw)
+		pTarget->MarkForRedraw();
+}
+
+void AttachEffectClass::Detach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget)
+{
+	if (types.size() < 1 || !pTarget)
+		return;
+
+	auto const pTargetExt = TechnoExt::ExtMap.Find(pTarget);
+	int modifiedCount = 0;
+	bool markForRedraw = false;
+	std::vector<std::unique_ptr<AttachEffectClass>>::iterator it;
+
+	for (it = pTargetExt->AttachedEffects.begin(); it != pTargetExt->AttachedEffects.end(); )
+	{
+		auto const attachEffect = it->get();
+		bool contains = std::find(types.begin(), types.end(), attachEffect->GetType()) != types.end();
+
+		if (contains)
+		{
+			if (attachEffect->IsSelfOwned() && attachEffect->RecreationDelay >= 0)
+			{
+				attachEffect->KillAnim();
+				attachEffect->CurrentDelay = attachEffect->RecreationDelay;
+				continue;
+			}
+
+			if (attachEffect->GetType()->HasTint())
+				markForRedraw = true;
+
+			modifiedCount++;
+			it = pTargetExt->AttachedEffects.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	if (modifiedCount > 0)
+		pTargetExt->RecalculateStatMultipliers();
+
+	if (markForRedraw)
+		pTarget->MarkForRedraw();
+}
+
+void AttachEffectClass::TransferAttachedEffects(TechnoClass* pSource, TechnoClass* pTarget)
+{
+	const auto pSourceExt = TechnoExt::ExtMap.Find(pSource);
+	const auto pTargetExt = TechnoExt::ExtMap.Find(pTarget);
+	std::vector<std::unique_ptr<AttachEffectClass>>::iterator it;
+
+	for (it = pSourceExt->AttachedEffects.begin(); it != pSourceExt->AttachedEffects.end(); )
+	{
+		auto const attachEffect = it->get();
+
+		if (attachEffect->IsSelfOwned())
+			continue;
+
+		auto const type = attachEffect->GetType();
+		int currentTypeCount = 0;
+		AttachEffectClass* match = nullptr;
+		AttachEffectClass* sourceMatch = nullptr;
+
+		for (auto const& aePtr : pTargetExt->AttachedEffects)
+		{
+			auto const targetAttachEffect = aePtr.get();
+
+			if (targetAttachEffect->GetType() == type)
+			{
+				currentTypeCount++;
+				match = targetAttachEffect;
+
+				if (targetAttachEffect->Source == attachEffect->Source && targetAttachEffect->Invoker == attachEffect->Invoker)
+					sourceMatch = targetAttachEffect;
+			}
+		}
+
+		if (type->Cumulative && type->Cumulative_MaxCount >= 0 && currentTypeCount >= type->Cumulative_MaxCount && sourceMatch)
+		{
+			sourceMatch->Duration = Math::max(sourceMatch->Duration, attachEffect->Duration);
+		}
+		else if (!type->Cumulative && currentTypeCount > 0 && match)
+		{
+			match->Duration = Math::max(sourceMatch->Duration, attachEffect->Duration);
+		}
+		else
+		{
+			attachEffect->Techno = pTarget;
+			pTargetExt->AttachedEffects.push_back(std::unique_ptr<AttachEffectClass>(attachEffect));
+		}
+
+		it = pSourceExt->AttachedEffects.erase(it);
+	}
+}
+
+// =============================
+// load / save
+
+template <typename T>
+bool AttachEffectClass::Serialize(T& Stm)
+{
+	return Stm
+		.Process(this->Duration)
+		.Process(this->DurationOverride)
+		.Process(this->Delay)
+		.Process(this->CurrentDelay)
+		.Process(this->InitialDelay)
+		.Process(this->RecreationDelay)
+		.Process(this->Type)
+		.Process(this->Techno)
+		.Process(this->InvokerHouse)
+		.Process(this->Invoker)
+		.Process(this->Source)
+		.Process(this->Animation)
+		.Process(this->IsAnimHidden)
+		.Process(this->IsUnderTemporal)
+		.Process(this->IsOnline)
+		.Process(this->IsCloaked)
+		.Process(this->HasInitialized)
+		.Success();
+}
+
+bool AttachEffectClass::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
+	return Serialize(Stm);
+}
+
+bool AttachEffectClass::Save(PhobosStreamWriter& Stm) const
+{
+	return const_cast<AttachEffectClass*>(this)->Serialize(Stm);
+}
+

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -559,6 +559,25 @@ int AttachEffectClass::Detach(std::vector<AttachEffectTypeClass*> const& types, 
 	return detachedCount;
 }
 
+int AttachEffectClass::DetachByGroups(std::vector<const char*> const& groups, TechnoClass* pTarget)
+{
+	if (groups.size() < 1 || !pTarget)
+		return 0;
+
+	auto const pTargetExt = TechnoExt::ExtMap.Find(pTarget);
+	std::vector<AttachEffectTypeClass*> types;
+
+	for (auto const& attachEffect : pTargetExt->AttachedEffects)
+	{
+		auto const pType = attachEffect->Type;
+
+		if (pType->HasGroups(groups, false))
+			types.push_back(pType);
+	}
+
+	return Detach(types, pTarget);
+}
+
 int AttachEffectClass::RemoveAllOfType(AttachEffectTypeClass* pType, std::vector<std::unique_ptr<AttachEffectClass>>& targetAEs)
 {
 	if (!pType || targetAEs.size() <= 0)

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -346,6 +346,9 @@ bool AttachEffectClass::AllowedToBeActive() const
 			return false;
 	}
 
+	if (this->Techno->DrainingMe && (Type->DiscardOn & DiscardCondition::Drain) != DiscardCondition::None)
+		return false;
+
 	return true;
 }
 

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -440,6 +440,7 @@ void AttachEffectClass::Detach(std::vector<AttachEffectTypeClass*> const& types,
 			{
 				attachEffect->KillAnim();
 				attachEffect->CurrentDelay = attachEffect->RecreationDelay;
+				++it;
 				continue;
 			}
 
@@ -473,7 +474,10 @@ void AttachEffectClass::TransferAttachedEffects(TechnoClass* pSource, TechnoClas
 		auto const attachEffect = it->get();
 
 		if (attachEffect->IsSelfOwned())
+		{
+			++it;
 			continue;
+		}
 
 		auto const type = attachEffect->GetType();
 		int currentTypeCount = 0;

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -281,9 +281,12 @@ void AttachEffectClass::SetAnimationVisibility(bool visible)
 	this->IsAnimHidden = !visible;
 }
 
-void AttachEffectClass::RefreshDuration()
+void AttachEffectClass::RefreshDuration(int durationOverride)
 {
-	this->Duration = this->DurationOverride ? this->DurationOverride : this->Type->Duration;
+	if (durationOverride)
+		this->Duration = durationOverride;
+	else
+		this->Duration = this->DurationOverride ? this->DurationOverride : this->Type->Duration;
 
 	if (this->Type->Animation_ResetOnReapply)
 	{
@@ -357,27 +360,28 @@ void AttachEffectClass::Attach(std::vector<AttachEffectTypeClass*> const& types,
 			}
 		}
 
+		int durationOverride = 0;
+
+		if (durationOverrides.size() > 0)
+			durationOverride = durationOverrides[durationOverrides.size() > i ? i : durationOverrides.size() - 1];
+
 		if (type->Cumulative && type->Cumulative_MaxCount >= 0 && currentTypeCount >= type->Cumulative_MaxCount)
 		{
 			if (sourceMatch)
-				sourceMatch->RefreshDuration();
+				sourceMatch->RefreshDuration(durationOverride);
 			else
 				continue;
 		}
 
 		if (!type->Cumulative && currentTypeCount > 0 && match)
 		{
-			match->RefreshDuration();
+			match->RefreshDuration(durationOverride);
 		}
 		else
 		{
-			int durationOverride = 0;
 			int delay = 0;
 			int initialDelay = 0;
 			int recreationDelay = -1;
-
-			if (durationOverrides.size() > 0)
-				durationOverride = durationOverrides[durationOverrides.size() > i ? i : durationOverrides.size() - 1];
 
 			if (delays.size() > 0)
 				delay = delays[delays.size() > i ? i : delays.size() - 1];

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -315,7 +315,7 @@ void AttachEffectClass::RefreshDuration(int durationOverride)
 
 bool AttachEffectClass::ResetIfRecreatable()
 {
-	if (!this->IsSelfOwned() && this->RecreationDelay < 0)
+	if (!this->IsSelfOwned() || this->RecreationDelay < 0)
 		return false;
 
 	this->KillAnim();

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -493,8 +493,8 @@ AttachEffectClass* AttachEffectClass::CreateAndAttach(AttachEffectTypeClass* pTy
 	{
 		if (sourceMatch)
 			sourceMatch->RefreshDuration(durationOverride);
-		else
-			return nullptr;
+
+		return nullptr;
 	}
 
 	if (!pType->Cumulative && currentTypeCount > 0 && match)

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -71,5 +71,6 @@ private:
 	bool IsOnline;
 	bool IsCloaked;
 	bool HasInitialized;
+	bool NeedsDurationRefresh;
 };
 

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -27,6 +27,8 @@ public:
 	bool IsActive() const;
 	bool IsFromSource(TechnoClass* pInvoker, AbstractClass* pSource) const;
 
+	void ExpireWeapon() const;
+
 	static void PointerGotInvalid(void* ptr, bool removed);
 	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	bool Save(PhobosStreamWriter& Stm) const;

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <New/Type/AttachEffectTypeClass.h>
+
+
+class AttachEffectClass
+{
+public:
+	static std::vector<AttachEffectClass*> Array;
+
+	AttachEffectClass();
+
+	AttachEffectClass(AttachEffectTypeClass* pType, TechnoClass* pTechno, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
+		AbstractClass* pSource, int durationOverride, int delay, int initialDelay, int recreationDelay);
+
+	~AttachEffectClass();
+
+	void AI();
+	void AI_Temporal();
+	void KillAnim();
+	void SetAnimationVisibility(bool visible);
+	AttachEffectTypeClass* GetType() const;
+	void RefreshDuration();
+	bool IsSelfOwned() const;
+	bool HasExpired() const;
+	bool IsActive() const;
+
+	static void PointerGotInvalid(void* ptr, bool removed);
+	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
+	bool Save(PhobosStreamWriter& Stm) const;
+
+	static void Attach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
+		AbstractClass* pSource, std::vector<int>& durationOverrides, std::vector<int> const& delays, std::vector<int> const& initialDelays, std::vector<int> const& recreationDelays);
+
+	static void Detach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget);
+	static void TransferAttachedEffects(TechnoClass* pSource, TechnoClass* pTarget);
+
+private:
+	void OnlineCheck();
+	void CloakCheck();
+	void CreateAnim();
+
+	template <typename T>
+	bool Serialize(T& Stm);
+
+	int Duration;
+	int DurationOverride;
+	int Delay;
+	int CurrentDelay;
+	int InitialDelay;
+	int RecreationDelay;
+	AttachEffectTypeClass* Type;
+	TechnoClass* Techno;
+	HouseClass* InvokerHouse;
+	TechnoClass* Invoker;
+	AbstractClass* Source;
+	AnimClass* Animation;
+	bool IsAnimHidden;
+	bool IsUnderTemporal;
+	bool IsOnline;
+	bool IsCloaked;
+	bool HasInitialized;
+};
+

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -20,8 +20,10 @@ public:
 	void SetAnimationVisibility(bool visible);
 	AttachEffectTypeClass* GetType() const;
 	void RefreshDuration(int durationOverride = 0);
+	bool ResetIfRecreatable();
 	bool IsSelfOwned() const;
 	bool HasExpired() const;
+	bool AllowedToBeActive() const;
 	bool IsActive() const;
 	bool IsFromSource(TechnoClass* pInvoker, AbstractClass* pSource) const;
 

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -39,6 +39,7 @@ public:
 
 	static int Detach(AttachEffectTypeClass* pType, TechnoClass* pTarget);
 	static int Detach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget);
+	static int DetachByGroups(std::vector<const char*> const& groups, TechnoClass* pTarget);
 	static void TransferAttachedEffects(TechnoClass* pSource, TechnoClass* pTarget);
 
 private:

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -24,6 +24,7 @@ public:
 	bool IsSelfOwned() const;
 	bool HasExpired() const;
 	bool IsActive() const;
+	bool IsFromSource(TechnoClass* pInvoker, AbstractClass* pSource) const;
 
 	static void PointerGotInvalid(void* ptr, bool removed);
 	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -20,7 +20,7 @@ public:
 	void KillAnim();
 	void SetAnimationVisibility(bool visible);
 	AttachEffectTypeClass* GetType() const;
-	void RefreshDuration();
+	void RefreshDuration(int durationOverride = 0);
 	bool IsSelfOwned() const;
 	bool HasExpired() const;
 	bool IsActive() const;

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -2,7 +2,6 @@
 
 #include <New/Type/AttachEffectTypeClass.h>
 
-
 class AttachEffectClass
 {
 public:
@@ -30,16 +29,25 @@ public:
 	bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 	bool Save(PhobosStreamWriter& Stm) const;
 
-	static void Attach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
+	static bool Attach(AttachEffectTypeClass* pType, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
+		AbstractClass* pSource, int durationOverride = 0, int delay = 0, int initialDelay = 0, int recreationDelay = -1);
+
+	static bool Attach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
 		AbstractClass* pSource, std::vector<int>& durationOverrides, std::vector<int> const& delays, std::vector<int> const& initialDelays, std::vector<int> const& recreationDelays);
 
-	static void Detach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget);
+	static int Detach(AttachEffectTypeClass* pType, TechnoClass* pTarget);
+	static int Detach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget);
 	static void TransferAttachedEffects(TechnoClass* pSource, TechnoClass* pTarget);
 
 private:
 	void OnlineCheck();
 	void CloakCheck();
 	void CreateAnim();
+
+	static AttachEffectClass* CreateAndAttach(AttachEffectTypeClass* pType, TechnoClass* pTarget, std::vector<std::unique_ptr<AttachEffectClass>>& targetAEs,
+		HouseClass* pInvokerHouse, TechnoClass* pInvoker, AbstractClass* pSource, int durationOverride = 0, int delay = 0, int initialDelay = 0, int recreationDelay = -1);
+
+	static int RemoveAllOfType(AttachEffectTypeClass* pType, std::vector<std::unique_ptr<AttachEffectClass>>& targetAEs);
 
 	template <typename T>
 	bool Serialize(T& Stm);

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -34,12 +34,12 @@ public:
 	static bool Attach(AttachEffectTypeClass* pType, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
 		AbstractClass* pSource, int durationOverride = 0, int delay = 0, int initialDelay = 0, int recreationDelay = -1);
 
-	static bool Attach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
+	static int Attach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker,
 		AbstractClass* pSource, std::vector<int>& durationOverrides, std::vector<int> const& delays, std::vector<int> const& initialDelays, std::vector<int> const& recreationDelays);
 
-	static int Detach(AttachEffectTypeClass* pType, TechnoClass* pTarget);
-	static int Detach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget);
-	static int DetachByGroups(std::vector<const char*> const& groups, TechnoClass* pTarget);
+	static int Detach(AttachEffectTypeClass* pType, TechnoClass* pTarget,int minCount = -1, int maxCount = -1);
+	static int Detach(std::vector<AttachEffectTypeClass*> const& types, TechnoClass* pTarget, std::vector<int> const& minCounts, std::vector<int> const& maxCounts);
+	static int DetachByGroups(std::vector<const char*> const& groups, TechnoClass* pTarget, std::vector<int> const& minCounts, std::vector<int> const& maxCounts);
 	static void TransferAttachedEffects(TechnoClass* pSource, TechnoClass* pTarget);
 
 private:
@@ -50,7 +50,7 @@ private:
 	static AttachEffectClass* CreateAndAttach(AttachEffectTypeClass* pType, TechnoClass* pTarget, std::vector<std::unique_ptr<AttachEffectClass>>& targetAEs,
 		HouseClass* pInvokerHouse, TechnoClass* pInvoker, AbstractClass* pSource, int durationOverride = 0, int delay = 0, int initialDelay = 0, int recreationDelay = -1);
 
-	static int RemoveAllOfType(AttachEffectTypeClass* pType, std::vector<std::unique_ptr<AttachEffectClass>>& targetAEs);
+	static int RemoveAllOfType(AttachEffectTypeClass* pType, TechnoClass* pTarget, int minCount, int maxCount);
 
 	template <typename T>
 	bool Serialize(T& Stm);
@@ -73,5 +73,8 @@ private:
 	bool IsCloaked;
 	bool HasInitialized;
 	bool NeedsDurationRefresh;
+
+public:
+	bool IsFirstCumulativeInstance;
 };
 

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -449,6 +449,9 @@ void ShieldClass::OnlineCheck()
 
 	if (!isActive)
 	{
+		if (this->Online)
+			UpdateTint();
+
 		this->Online = false;
 		timer->Pause();
 
@@ -477,6 +480,9 @@ void ShieldClass::OnlineCheck()
 	}
 	else
 	{
+		if (!this->Online)
+			UpdateTint();
+
 		this->Online = true;
 		timer->Resume();
 
@@ -524,6 +530,7 @@ bool ShieldClass::ConvertCheck()
 		this->KillAnim();
 		pTechnoExt->CurrentShieldType = ShieldTypeClass::FindOrAllocate(NONE_STR);
 		pTechnoExt->Shield = nullptr;
+		UpdateTint();
 
 		return true;
 	}
@@ -566,6 +573,7 @@ bool ShieldClass::ConvertCheck()
 	}
 
 	this->TechnoID = newID;
+	UpdateTint();
 
 	return false;
 }
@@ -662,6 +670,8 @@ void ShieldClass::BreakShield(AnimTypeClass* pBreakAnim, WeaponTypeClass* pBreak
 
 	this->LastBreakFrame = Unsorted::CurrentFrame;
 
+	UpdateTint();
+
 	if (pWeaponType)
 		TechnoExt::FireWeaponAtSelf(this->Techno, pWeaponType);
 }
@@ -676,6 +686,7 @@ void ShieldClass::RespawnShield()
 		timer->Stop();
 		double amount = timerWHModifier->InProgress() ? Respawn_Warhead : this->Type->Respawn;
 		this->HP = this->GetPercentageAmount(amount);
+		UpdateTint();
 	}
 	else if (timerWHModifier->Completed() && timer->InProgress())
 	{
@@ -762,6 +773,12 @@ void ShieldClass::UpdateIdleAnim()
 		this->KillAnim();
 		this->CreateAnim();
 	}
+}
+
+void ShieldClass::UpdateTint()
+{
+	if (this->Type->Tint_Color.isset() || this->Type->Tint_Intensity != 0.0)
+		this->Techno->MarkForRedraw();
 }
 
 AnimTypeClass* ShieldClass::GetIdleAnimType()

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -393,6 +393,7 @@ void ShieldClass::AI()
 		return;
 
 	this->TemporalCheck();
+
 	if (this->Temporal)
 		return;
 
@@ -450,7 +451,7 @@ void ShieldClass::OnlineCheck()
 	if (!isActive)
 	{
 		if (this->Online)
-			UpdateTint();
+			this->UpdateTint();
 
 		this->Online = false;
 		timer->Pause();
@@ -481,7 +482,7 @@ void ShieldClass::OnlineCheck()
 	else
 	{
 		if (!this->Online)
-			UpdateTint();
+			this->UpdateTint();
 
 		this->Online = true;
 		timer->Resume();
@@ -530,7 +531,7 @@ bool ShieldClass::ConvertCheck()
 		this->KillAnim();
 		pTechnoExt->CurrentShieldType = ShieldTypeClass::FindOrAllocate(NONE_STR);
 		pTechnoExt->Shield = nullptr;
-		UpdateTint();
+		this->UpdateTint();
 
 		return true;
 	}
@@ -573,7 +574,7 @@ bool ShieldClass::ConvertCheck()
 	}
 
 	this->TechnoID = newID;
-	UpdateTint();
+	this->UpdateTint();
 
 	return false;
 }
@@ -670,7 +671,7 @@ void ShieldClass::BreakShield(AnimTypeClass* pBreakAnim, WeaponTypeClass* pBreak
 
 	this->LastBreakFrame = Unsorted::CurrentFrame;
 
-	UpdateTint();
+	this->UpdateTint();
 
 	if (pWeaponType)
 		TechnoExt::FireWeaponAtSelf(this->Techno, pWeaponType);
@@ -686,7 +687,7 @@ void ShieldClass::RespawnShield()
 		timer->Stop();
 		double amount = timerWHModifier->InProgress() ? Respawn_Warhead : this->Type->Respawn;
 		this->HP = this->GetPercentageAmount(amount);
-		UpdateTint();
+		this->UpdateTint();
 	}
 	else if (timerWHModifier->Completed() && timer->InProgress())
 	{

--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -80,6 +80,8 @@ private:
 	int DrawShieldBar_Pip(const bool isBuilding) const;
 	int DrawShieldBar_PipAmount(const int length) const;
 
+	void UpdateTint();
+
 	/// Properties ///
 	TechnoClass* Techno;
 	TechnoTypeClass* TechnoID;

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -1,6 +1,5 @@
 #include "AttachEffectTypeClass.h"
 
-Enumerable<AttachEffectTypeClass>::container_t Enumerable<AttachEffectTypeClass>::Array;
 std::unordered_map<const char*, std::set<AttachEffectTypeClass*>> AttachEffectTypeClass::GroupsMap;
 
 bool AttachEffectTypeClass::HasTint()
@@ -67,6 +66,7 @@ AnimTypeClass* AttachEffectTypeClass::GetCumulativeAnimation(int cumulativeCount
 	return this->CumulativeAnimations.at(index);
 }
 
+template<>
 const char* Enumerable<AttachEffectTypeClass>::GetMainSection()
 {
 	return "AttachEffectTypes";

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -50,9 +50,10 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon");
 	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
 
-	this->WeaponRangeBonus.Read(exINI, pSection, "WeaponRangeBonus");
-	this->WeaponRangeBonus_AllowWeapons.Read(exINI, pSection, "WeaponRangeBonus.AllowWeapons");
-	this->WeaponRangeBonus_DisallowWeapons.Read(exINI, pSection, "WeaponRangeBonus.DisallowWeapons");
+	this->WeaponRange_Multiplier.Read(exINI, pSection, "WeaponRange.Multiplier");
+	this->WeaponRange_ExtraRange.Read(exINI, pSection, "WeaponRange.ExtraRange");
+	this->WeaponRange_AllowWeapons.Read(exINI, pSection, "WeaponRange.AllowWeapons");
+	this->WeaponRange_DisallowWeapons.Read(exINI, pSection, "WeaponRange.DisallowWeapons");
 }
 
 template <typename T>
@@ -82,9 +83,10 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->ForceDecloak)
 		.Process(this->RevengeWeapon)
 		.Process(this->RevengeWeapon_AffectsHouses)
-		.Process(this->WeaponRangeBonus)
-		.Process(this->WeaponRangeBonus_AllowWeapons)
-		.Process(this->WeaponRangeBonus_DisallowWeapons)
+		.Process(this->WeaponRange_Multiplier)
+		.Process(this->WeaponRange_ExtraRange)
+		.Process(this->WeaponRange_AllowWeapons)
+		.Process(this->WeaponRange_DisallowWeapons)
 		;
 }
 

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -47,13 +47,17 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->Cloakable.Read(exINI, pSection, "Cloakable");
 	this->ForceDecloak.Read(exINI, pSection, "ForceDecloak");
 
-	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon");
-	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
-
 	this->WeaponRange_Multiplier.Read(exINI, pSection, "WeaponRange.Multiplier");
 	this->WeaponRange_ExtraRange.Read(exINI, pSection, "WeaponRange.ExtraRange");
 	this->WeaponRange_AllowWeapons.Read(exINI, pSection, "WeaponRange.AllowWeapons");
 	this->WeaponRange_DisallowWeapons.Read(exINI, pSection, "WeaponRange.DisallowWeapons");
+
+	this->CritMultiplier.Read(exINI, pSection, "CritMultiplier");
+	this->CritMultiplier_AllowWarheads.Read(exINI, pSection, "CritMultiplier.AllowWarheads");
+	this->CritMultiplier_DisallowWarheads.Read(exINI, pSection, "CritMultiplier.DisallowWarheads");
+
+	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon");
+	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
 }
 
 template <typename T>
@@ -81,12 +85,15 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->ROFMultiplier_ApplyOnCurrentTimer)
 		.Process(this->Cloakable)
 		.Process(this->ForceDecloak)
-		.Process(this->RevengeWeapon)
-		.Process(this->RevengeWeapon_AffectsHouses)
 		.Process(this->WeaponRange_Multiplier)
 		.Process(this->WeaponRange_ExtraRange)
 		.Process(this->WeaponRange_AllowWeapons)
 		.Process(this->WeaponRange_DisallowWeapons)
+		.Process(this->CritMultiplier)
+		.Process(this->CritMultiplier_AllowWarheads)
+		.Process(this->CritMultiplier_DisallowWarheads)
+		.Process(this->RevengeWeapon)
+		.Process(this->RevengeWeapon_AffectsHouses)
 		;
 }
 

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -95,6 +95,10 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->Animation_TemporalAction.Read(exINI, pSection, "Animation.TemporalAction");
 	this->Animation_UseInvokerAsOwner.Read(exINI, pSection, "Animation.UseInvokerAsOwner");
 
+	this->ExpireWeapon.Read<true>(exINI, pSection, "ExpireWeapon");
+	this->ExpireWeapon_TriggerOn.Read(exINI, pSection, "ExpireWeapon.TriggerOn");
+	this->ExpireWeapon_CumulativeOnlyOnce.Read(exINI, pSection, "ExpireWeapon.CumulativeOnlyOnce");
+
 	this->Tint_Color.Read(exINI, pSection, "Tint.Color");
 	this->Tint_Intensity.Read(exINI, pSection, "Tint.Intensity");
 	this->Tint_VisibleToHouses.Read(exINI, pSection, "Tint.VisibleToHouses");
@@ -157,6 +161,9 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->Animation_OfflineAction)
 		.Process(this->Animation_TemporalAction)
 		.Process(this->Animation_UseInvokerAsOwner)
+		.Process(this->ExpireWeapon)
+		.Process(this->ExpireWeapon_TriggerOn)
+		.Process(this->ExpireWeapon_CumulativeOnlyOnce)
 		.Process(this->Tint_Color)
 		.Process(this->Tint_Intensity)
 		.Process(this->Tint_VisibleToHouses)

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -1,0 +1,99 @@
+#include "AttachEffectTypeClass.h"
+
+Enumerable<AttachEffectTypeClass>::container_t Enumerable<AttachEffectTypeClass>::Array;
+
+bool AttachEffectTypeClass::HasTint()
+{
+	return this->Tint_Color.isset() || this->Tint_Intensity != 0.0;
+}
+
+const char* Enumerable<AttachEffectTypeClass>::GetMainSection()
+{
+	return "AttachEffectTypes";
+}
+
+void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
+{
+	const char* pSection = this->Name;
+
+	if (strcmp(pSection, NONE_STR) == 0)
+		return;
+
+	INI_EX exINI(pINI);
+
+	this->Duration.Read(exINI, pSection, "Duration");
+	this->Cumulative.Read(exINI, pSection, "Cumulative");
+	this->Cumulative_MaxCount.Read(exINI, pSection, "Cumulative.MaxCount");
+	this->Powered.Read(exINI, pSection, "Powered");
+	this->DiscardOnEntry.Read(exINI, pSection, "DiscardOnEntry");
+	this->PenetratesIronCurtain.Read(exINI, pSection, "PenetratesIronCurtain");
+
+	this->Animation.Read(exINI, pSection, "Animation");
+	this->Animation_ResetOnReapply.Read(exINI, pSection, "Animation.ResetOnReapply");
+	this->Animation_OfflineAction.Read(exINI, pSection, "Animation.OfflineAction");
+	this->Animation_TemporalAction.Read(exINI, pSection, "Animation.TemporalAction");
+	this->Animation_UseInvokerAsOwner.Read(exINI, pSection, "Animation.UseInvokerAsOwner");
+
+	this->Tint_Color.Read(exINI, pSection, "Tint.Color");
+	this->Tint_Intensity.Read(exINI, pSection, "Tint.Intensity");
+	this->Tint_VisibleToHouses.Read(exINI, pSection, "Tint.VisibleToHouses");
+
+	this->FirepowerMultiplier.Read(exINI, pSection, "FirepowerMultiplier");
+	this->ArmorMultiplier.Read(exINI, pSection, "ArmorMultiplier");
+	this->SpeedMultiplier.Read(exINI, pSection, "SpeedMultiplier");
+	this->ROFMultiplier.Read(exINI, pSection, "ROFMultiplier");
+	this->ROFMultiplier_ApplyOnCurrentTimer.Read(exINI, pSection, "ROFMultiplier.ApplyOnCurrentTimer");
+
+	this->Cloakable.Read(exINI, pSection, "Cloakable");
+	this->ForceDecloak.Read(exINI, pSection, "ForceDecloak");
+
+	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon");
+	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
+
+	this->WeaponRangeBonus.Read(exINI, pSection, "WeaponRangeBonus");
+	this->WeaponRangeBonus_AllowWeapons.Read(exINI, pSection, "WeaponRangeBonus.AllowWeapons");
+	this->WeaponRangeBonus_DisallowWeapons.Read(exINI, pSection, "WeaponRangeBonus.DisallowWeapons");
+}
+
+template <typename T>
+void AttachEffectTypeClass::Serialize(T& Stm)
+{
+	Stm
+		.Process(this->Duration)
+		.Process(this->Cumulative)
+		.Process(this->Cumulative_MaxCount)
+		.Process(this->Powered)
+		.Process(this->DiscardOnEntry)
+		.Process(this->PenetratesIronCurtain)
+		.Process(this->Animation)
+		.Process(this->Animation_ResetOnReapply)
+		.Process(this->Animation_OfflineAction)
+		.Process(this->Animation_TemporalAction)
+		.Process(this->Animation_UseInvokerAsOwner)
+		.Process(this->Tint_Color)
+		.Process(this->Tint_Intensity)
+		.Process(this->Tint_VisibleToHouses)
+		.Process(this->FirepowerMultiplier)
+		.Process(this->ArmorMultiplier)
+		.Process(this->SpeedMultiplier)
+		.Process(this->ROFMultiplier)
+		.Process(this->ROFMultiplier_ApplyOnCurrentTimer)
+		.Process(this->Cloakable)
+		.Process(this->ForceDecloak)
+		.Process(this->RevengeWeapon)
+		.Process(this->RevengeWeapon_AffectsHouses)
+		.Process(this->WeaponRangeBonus)
+		.Process(this->WeaponRangeBonus_AllowWeapons)
+		.Process(this->WeaponRangeBonus_DisallowWeapons)
+		;
+}
+
+void AttachEffectTypeClass::LoadFromStream(PhobosStreamReader& Stm)
+{
+	this->Serialize(Stm);
+}
+
+void AttachEffectTypeClass::SaveToStream(PhobosStreamWriter& Stm)
+{
+	this->Serialize(Stm);
+}

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -57,6 +57,16 @@ std::vector<AttachEffectTypeClass*> AttachEffectTypeClass::GetTypesFromGroups(st
 	return std::vector<AttachEffectTypeClass*> (types.begin(), types.end());;
 }
 
+AnimTypeClass* AttachEffectTypeClass::GetCumulativeAnimation(int cumulativeCount)
+{
+	if (cumulativeCount < 0 || !this->CumulativeAnimations.HasValue())
+		return nullptr;
+
+	int index = static_cast<size_t>(cumulativeCount) >= this->CumulativeAnimations.size() ? this->CumulativeAnimations.size() - 1 : cumulativeCount - 1;
+
+	return this->CumulativeAnimations.at(index);
+}
+
 const char* Enumerable<AttachEffectTypeClass>::GetMainSection()
 {
 	return "AttachEffectTypes";
@@ -79,6 +89,7 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->PenetratesIronCurtain.Read(exINI, pSection, "PenetratesIronCurtain");
 
 	this->Animation.Read(exINI, pSection, "Animation");
+	this->CumulativeAnimations.Read(exINI, pSection, "CumulativeAnimations");
 	this->Animation_ResetOnReapply.Read(exINI, pSection, "Animation.ResetOnReapply");
 	this->Animation_OfflineAction.Read(exINI, pSection, "Animation.OfflineAction");
 	this->Animation_TemporalAction.Read(exINI, pSection, "Animation.TemporalAction");
@@ -107,7 +118,7 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->Crit_AllowWarheads.Read(exINI, pSection, "Crit.AllowWarheads");
 	this->Crit_DisallowWarheads.Read(exINI, pSection, "Crit.DisallowWarheads");
 
-	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon");
+	this->RevengeWeapon.Read<true>(exINI, pSection, "RevengeWeapon");
 	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
 
 	this->DisableWeapons.Read(exINI, pSection, "DisableWeapons");
@@ -141,6 +152,7 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->DiscardOn)
 		.Process(this->PenetratesIronCurtain)
 		.Process(this->Animation)
+		.Process(this->CumulativeAnimations)
 		.Process(this->Animation_ResetOnReapply)
 		.Process(this->Animation_OfflineAction)
 		.Process(this->Animation_TemporalAction)

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -59,6 +59,8 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 
 	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon");
 	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
+
+	this->DisableWeapons.Read(exINI, pSection, "DisableWeapons");
 }
 
 template <typename T>
@@ -96,6 +98,7 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->Crit_DisallowWarheads)
 		.Process(this->RevengeWeapon)
 		.Process(this->RevengeWeapon_AffectsHouses)
+		.Process(this->DisableWeapons)
 		;
 }
 

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -25,7 +25,7 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->Cumulative.Read(exINI, pSection, "Cumulative");
 	this->Cumulative_MaxCount.Read(exINI, pSection, "Cumulative.MaxCount");
 	this->Powered.Read(exINI, pSection, "Powered");
-	this->DiscardOnEntry.Read(exINI, pSection, "DiscardOnEntry");
+	this->DiscardOn.Read(exINI, pSection, "DiscardOn");
 	this->PenetratesIronCurtain.Read(exINI, pSection, "PenetratesIronCurtain");
 
 	this->Animation.Read(exINI, pSection, "Animation");
@@ -69,7 +69,7 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->Cumulative)
 		.Process(this->Cumulative_MaxCount)
 		.Process(this->Powered)
-		.Process(this->DiscardOnEntry)
+		.Process(this->DiscardOn)
 		.Process(this->PenetratesIronCurtain)
 		.Process(this->Animation)
 		.Process(this->Animation_ResetOnReapply)

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -52,9 +52,10 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->WeaponRange_AllowWeapons.Read(exINI, pSection, "WeaponRange.AllowWeapons");
 	this->WeaponRange_DisallowWeapons.Read(exINI, pSection, "WeaponRange.DisallowWeapons");
 
-	this->CritMultiplier.Read(exINI, pSection, "CritMultiplier");
-	this->CritMultiplier_AllowWarheads.Read(exINI, pSection, "CritMultiplier.AllowWarheads");
-	this->CritMultiplier_DisallowWarheads.Read(exINI, pSection, "CritMultiplier.DisallowWarheads");
+	this->Crit_Multiplier.Read(exINI, pSection, "Crit.Multiplier");
+	this->Crit_ExtraChance.Read(exINI, pSection, "Crit.ExtraChance");
+	this->Crit_AllowWarheads.Read(exINI, pSection, "Crit.AllowWarheads");
+	this->Crit_DisallowWarheads.Read(exINI, pSection, "Crit.DisallowWarheads");
 
 	this->RevengeWeapon.Read(exINI, pSection, "RevengeWeapon");
 	this->RevengeWeapon_AffectsHouses.Read(exINI, pSection, "RevengeWeapon.AffectsHouses");
@@ -89,9 +90,10 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->WeaponRange_ExtraRange)
 		.Process(this->WeaponRange_AllowWeapons)
 		.Process(this->WeaponRange_DisallowWeapons)
-		.Process(this->CritMultiplier)
-		.Process(this->CritMultiplier_AllowWarheads)
-		.Process(this->CritMultiplier_DisallowWarheads)
+		.Process(this->Crit_Multiplier)
+		.Process(this->Crit_ExtraChance)
+		.Process(this->Crit_AllowWarheads)
+		.Process(this->Crit_DisallowWarheads)
 		.Process(this->RevengeWeapon)
 		.Process(this->RevengeWeapon_AffectsHouses)
 		;

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -11,7 +11,7 @@ public:
 	Valueable<bool> Cumulative;
 	Valueable<int> Cumulative_MaxCount;
 	Valueable<bool> Powered;
-	Valueable<bool> DiscardOnEntry;
+	Valueable<DiscardCondition> DiscardOn;
 	Valueable<bool> PenetratesIronCurtain;
 	Nullable<AnimTypeClass*> Animation;
 	Valueable<bool> Animation_ResetOnReapply;
@@ -44,7 +44,7 @@ public:
 		, Cumulative { false }
 		, Cumulative_MaxCount { -1 }
 		, Powered { false }
-		, DiscardOnEntry { false }
+		, DiscardOn { DiscardCondition::None }
 		, PenetratesIronCurtain { false }
 		, Animation {}
 		, Animation_ResetOnReapply { false }

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -24,6 +24,9 @@ public:
 	Valueable<AttachedAnimFlag> Animation_OfflineAction;
 	Valueable<AttachedAnimFlag> Animation_TemporalAction;
 	Valueable<bool> Animation_UseInvokerAsOwner;
+	Nullable<WeaponTypeClass*> ExpireWeapon;
+	Valueable<ExpireWeaponCondition> ExpireWeapon_TriggerOn;
+	Valueable<bool> ExpireWeapon_CumulativeOnlyOnce;
 	Nullable<ColorStruct> Tint_Color;
 	Valueable<double> Tint_Intensity;
 	Valueable<AffectedHouse> Tint_VisibleToHouses;
@@ -61,6 +64,9 @@ public:
 		, Animation_OfflineAction { AttachedAnimFlag::Hides }
 		, Animation_TemporalAction { AttachedAnimFlag::None }
 		, Animation_UseInvokerAsOwner { false }
+		, ExpireWeapon {}
+		, ExpireWeapon_TriggerOn { ExpireWeaponCondition::Expire }
+		, ExpireWeapon_CumulativeOnlyOnce { false }
 		, Tint_Color {}
 		, Tint_Intensity { 0.0 }
 		, Tint_VisibleToHouses { AffectedHouse::All }

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <Utilities/Enumerable.h>
+#include <Utilities/Template.h>
+#include <Utilities/TemplateDef.h>
+
+class AttachEffectTypeClass final : public Enumerable<AttachEffectTypeClass>
+{
+public:
+	Valueable<int> Duration;
+	Valueable<bool> Cumulative;
+	Valueable<int> Cumulative_MaxCount;
+	Valueable<bool> Powered;
+	Valueable<bool> DiscardOnEntry;
+	Valueable<bool> PenetratesIronCurtain;
+	Nullable<AnimTypeClass*> Animation;
+	Valueable<bool> Animation_ResetOnReapply;
+	Valueable<AttachedAnimFlag> Animation_OfflineAction;
+	Valueable<AttachedAnimFlag> Animation_TemporalAction;
+	Valueable<bool> Animation_UseInvokerAsOwner;
+	Nullable<ColorStruct> Tint_Color;
+	Valueable<double> Tint_Intensity;
+	Valueable<AffectedHouse> Tint_VisibleToHouses;
+	Valueable<double> FirepowerMultiplier;
+	Valueable<double> ArmorMultiplier;
+	Valueable<double> SpeedMultiplier;
+	Valueable<double> ROFMultiplier;
+	Valueable<bool> ROFMultiplier_ApplyOnCurrentTimer;
+	Valueable<bool> Cloakable;
+	Valueable<bool> ForceDecloak;
+	Nullable<WeaponTypeClass*> RevengeWeapon;
+	Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
+	Valueable<double> WeaponRangeBonus;
+	ValueableVector<WeaponTypeClass*> WeaponRangeBonus_AllowWeapons;
+	ValueableVector<WeaponTypeClass*> WeaponRangeBonus_DisallowWeapons;
+
+	AttachEffectTypeClass(const char* const pTitle) : Enumerable<AttachEffectTypeClass>(pTitle)
+		, Duration { 0 }
+		, Cumulative { false }
+		, Cumulative_MaxCount { -1 }
+		, Powered { false }
+		, DiscardOnEntry { false }
+		, PenetratesIronCurtain { false }
+		, Animation {}
+		, Animation_ResetOnReapply { false }
+		, Animation_OfflineAction { AttachedAnimFlag::Hides }
+		, Animation_TemporalAction { AttachedAnimFlag::None }
+		, Animation_UseInvokerAsOwner { false }
+		, Tint_Color {}
+		, Tint_Intensity { 0.0 }
+		, Tint_VisibleToHouses { AffectedHouse::All }
+		, FirepowerMultiplier { 1.0 }
+		, ArmorMultiplier { 1.0 }
+		, SpeedMultiplier { 1.0 }
+		, ROFMultiplier { 1.0 }
+		, ROFMultiplier_ApplyOnCurrentTimer { true }
+		, Cloakable { false }
+		, ForceDecloak { false }
+		, RevengeWeapon {}
+		, RevengeWeapon_AffectsHouses { AffectedHouse::All }
+		, WeaponRangeBonus { 0.0 }
+		, WeaponRangeBonus_AllowWeapons {}
+		, WeaponRangeBonus_DisallowWeapons {}
+	{};
+
+	bool HasTint();
+
+	virtual ~AttachEffectTypeClass() override = default;
+
+	virtual void LoadFromINI(CCINIClass* pINI) override;
+	virtual void LoadFromStream(PhobosStreamReader& Stm);
+	virtual void SaveToStream(PhobosStreamWriter& Stm);
+
+private:
+	template <typename T>
+	void Serialize(T& Stm);
+};
+

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -1,11 +1,16 @@
 #pragma once
 
+#include <set>
+#include <unordered_map>
+
 #include <Utilities/Enumerable.h>
 #include <Utilities/Template.h>
 #include <Utilities/TemplateDef.h>
 
 class AttachEffectTypeClass final : public Enumerable<AttachEffectTypeClass>
 {
+	static std::unordered_map<const char*, std::set<AttachEffectTypeClass*>> GroupsMap;
+
 public:
 	Valueable<int> Duration;
 	Valueable<bool> Cumulative;
@@ -40,6 +45,8 @@ public:
 	Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
 	Valueable<bool> DisableWeapons;
 
+	std::vector<const char*> Groups;
+
 	AttachEffectTypeClass(const char* const pTitle) : Enumerable<AttachEffectTypeClass>(pTitle)
 		, Duration { 0 }
 		, Cumulative { false }
@@ -73,15 +80,20 @@ public:
 		, RevengeWeapon {}
 		, RevengeWeapon_AffectsHouses{ AffectedHouse::All }
 		, DisableWeapons { false }
+		, Groups {}
 	{};
 
 	bool HasTint();
+	bool HasGroup(const char* pGroupID);
+	bool HasGroups(std::vector<const char*> groupIDs, bool requireAll);
 
 	virtual ~AttachEffectTypeClass() override = default;
 
 	virtual void LoadFromINI(CCINIClass* pINI) override;
 	virtual void LoadFromStream(PhobosStreamReader& Stm);
 	virtual void SaveToStream(PhobosStreamWriter& Stm);
+
+	static std::vector<AttachEffectTypeClass*> GetTypesFromGroups(std::vector<const char*> groupIDs);
 
 private:
 	template <typename T>

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -30,9 +30,10 @@ public:
 	Valueable<bool> ForceDecloak;
 	Nullable<WeaponTypeClass*> RevengeWeapon;
 	Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
-	Valueable<double> WeaponRangeBonus;
-	ValueableVector<WeaponTypeClass*> WeaponRangeBonus_AllowWeapons;
-	ValueableVector<WeaponTypeClass*> WeaponRangeBonus_DisallowWeapons;
+	Valueable<double> WeaponRange_Multiplier;
+	Valueable<double> WeaponRange_ExtraRange;
+	ValueableVector<WeaponTypeClass*> WeaponRange_AllowWeapons;
+	ValueableVector<WeaponTypeClass*> WeaponRange_DisallowWeapons;
 
 	AttachEffectTypeClass(const char* const pTitle) : Enumerable<AttachEffectTypeClass>(pTitle)
 		, Duration { 0 }
@@ -58,9 +59,10 @@ public:
 		, ForceDecloak { false }
 		, RevengeWeapon {}
 		, RevengeWeapon_AffectsHouses { AffectedHouse::All }
-		, WeaponRangeBonus { 0.0 }
-		, WeaponRangeBonus_AllowWeapons {}
-		, WeaponRangeBonus_DisallowWeapons {}
+		, WeaponRange_Multiplier { 1.0 }
+		, WeaponRange_ExtraRange { 0.0 }
+		, WeaponRange_AllowWeapons {}
+		, WeaponRange_DisallowWeapons {}
 	{};
 
 	bool HasTint();

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -102,10 +102,16 @@ public:
 	virtual void LoadFromStream(PhobosStreamReader& Stm);
 	virtual void SaveToStream(PhobosStreamWriter& Stm);
 
+	static void Clear()
+	{
+		AttachEffectTypeClass::GroupsMap.clear();
+	}
+
 	static std::vector<AttachEffectTypeClass*> GetTypesFromGroups(std::vector<const char*> groupIDs);
 
 private:
 	template <typename T>
 	void Serialize(T& Stm);
+	void AddToGroupsMap();
 };
 

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -32,9 +32,10 @@ public:
 	Valueable<double> WeaponRange_ExtraRange;
 	ValueableVector<WeaponTypeClass*> WeaponRange_AllowWeapons;
 	ValueableVector<WeaponTypeClass*> WeaponRange_DisallowWeapons;
-	Valueable<double> CritMultiplier;
-	ValueableVector<WarheadTypeClass*> CritMultiplier_AllowWarheads;
-	ValueableVector<WarheadTypeClass*> CritMultiplier_DisallowWarheads;
+	Valueable<double> Crit_Multiplier;
+	Valueable<double> Crit_ExtraChance;
+	ValueableVector<WarheadTypeClass*> Crit_AllowWarheads;
+	ValueableVector<WarheadTypeClass*> Crit_DisallowWarheads;
 	Nullable<WeaponTypeClass*> RevengeWeapon;
 	Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
 
@@ -64,9 +65,10 @@ public:
 		, WeaponRange_ExtraRange { 0.0 }
 		, WeaponRange_AllowWeapons {}
 		, WeaponRange_DisallowWeapons {}
-		, CritMultiplier { 1.0 }
-		, CritMultiplier_AllowWarheads {}
-		, CritMultiplier_DisallowWarheads {}
+		, Crit_Multiplier { 1.0 }
+		, Crit_ExtraChance { 0.0 }
+		, Crit_AllowWarheads {}
+		, Crit_DisallowWarheads {}
 		, RevengeWeapon {}
 		, RevengeWeapon_AffectsHouses{ AffectedHouse::All }
 	{};

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -28,12 +28,15 @@ public:
 	Valueable<bool> ROFMultiplier_ApplyOnCurrentTimer;
 	Valueable<bool> Cloakable;
 	Valueable<bool> ForceDecloak;
-	Nullable<WeaponTypeClass*> RevengeWeapon;
-	Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
 	Valueable<double> WeaponRange_Multiplier;
 	Valueable<double> WeaponRange_ExtraRange;
 	ValueableVector<WeaponTypeClass*> WeaponRange_AllowWeapons;
 	ValueableVector<WeaponTypeClass*> WeaponRange_DisallowWeapons;
+	Valueable<double> CritMultiplier;
+	ValueableVector<WarheadTypeClass*> CritMultiplier_AllowWarheads;
+	ValueableVector<WarheadTypeClass*> CritMultiplier_DisallowWarheads;
+	Nullable<WeaponTypeClass*> RevengeWeapon;
+	Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
 
 	AttachEffectTypeClass(const char* const pTitle) : Enumerable<AttachEffectTypeClass>(pTitle)
 		, Duration { 0 }
@@ -57,12 +60,15 @@ public:
 		, ROFMultiplier_ApplyOnCurrentTimer { true }
 		, Cloakable { false }
 		, ForceDecloak { false }
-		, RevengeWeapon {}
-		, RevengeWeapon_AffectsHouses { AffectedHouse::All }
 		, WeaponRange_Multiplier { 1.0 }
 		, WeaponRange_ExtraRange { 0.0 }
 		, WeaponRange_AllowWeapons {}
 		, WeaponRange_DisallowWeapons {}
+		, CritMultiplier { 1.0 }
+		, CritMultiplier_AllowWarheads {}
+		, CritMultiplier_DisallowWarheads {}
+		, RevengeWeapon {}
+		, RevengeWeapon_AffectsHouses{ AffectedHouse::All }
 	{};
 
 	bool HasTint();

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -19,6 +19,7 @@ public:
 	Valueable<DiscardCondition> DiscardOn;
 	Valueable<bool> PenetratesIronCurtain;
 	Nullable<AnimTypeClass*> Animation;
+	NullableVector<AnimTypeClass*> CumulativeAnimations;
 	Valueable<bool> Animation_ResetOnReapply;
 	Valueable<AttachedAnimFlag> Animation_OfflineAction;
 	Valueable<AttachedAnimFlag> Animation_TemporalAction;
@@ -55,6 +56,7 @@ public:
 		, DiscardOn { DiscardCondition::None }
 		, PenetratesIronCurtain { false }
 		, Animation {}
+		, CumulativeAnimations {}
 		, Animation_ResetOnReapply { false }
 		, Animation_OfflineAction { AttachedAnimFlag::Hides }
 		, Animation_TemporalAction { AttachedAnimFlag::None }
@@ -86,6 +88,7 @@ public:
 	bool HasTint();
 	bool HasGroup(const char* pGroupID);
 	bool HasGroups(std::vector<const char*> groupIDs, bool requireAll);
+	AnimTypeClass* GetCumulativeAnimation(int cumulativeCount);
 
 	virtual ~AttachEffectTypeClass() override = default;
 

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -38,6 +38,7 @@ public:
 	ValueableVector<WarheadTypeClass*> Crit_DisallowWarheads;
 	Nullable<WeaponTypeClass*> RevengeWeapon;
 	Valueable<AffectedHouse> RevengeWeapon_AffectsHouses;
+	Valueable<bool> DisableWeapons;
 
 	AttachEffectTypeClass(const char* const pTitle) : Enumerable<AttachEffectTypeClass>(pTitle)
 		, Duration { 0 }
@@ -71,6 +72,7 @@ public:
 		, Crit_DisallowWarheads {}
 		, RevengeWeapon {}
 		, RevengeWeapon_AffectsHouses{ AffectedHouse::All }
+		, DisableWeapons { false }
 	{};
 
 	bool HasTint();

--- a/src/New/Type/ShieldTypeClass.cpp
+++ b/src/New/Type/ShieldTypeClass.cpp
@@ -84,6 +84,10 @@ void ShieldTypeClass::LoadFromINI(CCINIClass* pINI)
 
 	this->ImmuneToBerserk.Read(exINI, pSection, "ImmuneToBerserk");
 	this->ImmuneToCrit.Read(exINI, pSection, "ImmuneToCrit");
+
+	this->Tint_Color.Read(exINI, pSection, "Tint.Color");
+	this->Tint_Intensity.Read(exINI, pSection, "Tint.Intensity");
+	this->Tint_VisibleToHouses.Read(exINI, pSection, "Tint.VisibleToHouses");
 }
 
 template <typename T>
@@ -122,6 +126,9 @@ void ShieldTypeClass::Serialize(T& Stm)
 		.Process(this->Pips_Building_Empty)
 		.Process(this->ImmuneToBerserk)
 		.Process(this->ImmuneToCrit)
+		.Process(this->Tint_Color)
+		.Process(this->Tint_Intensity)
+		.Process(this->Tint_VisibleToHouses)
 		;
 }
 

--- a/src/New/Type/ShieldTypeClass.h
+++ b/src/New/Type/ShieldTypeClass.h
@@ -46,6 +46,10 @@ public:
 	Valueable<bool> ImmuneToCrit;
 	Valueable<bool> ImmuneToBerserk;
 
+	Nullable<ColorStruct> Tint_Color;
+	Valueable<double> Tint_Intensity;
+	Valueable<AffectedHouse> Tint_VisibleToHouses;
+
 public:
 	ShieldTypeClass(const char* const pTitle) : Enumerable<ShieldTypeClass>(pTitle)
 		, Strength { 0 }
@@ -81,6 +85,9 @@ public:
 		, Pips_Building_Empty { }
 		, ImmuneToBerserk { false }
 		, ImmuneToCrit { false }
+		, Tint_Color {}
+		, Tint_Intensity { 0.0 }
+		, Tint_VisibleToHouses { AffectedHouse::All }
 	{ };
 
 	virtual ~ShieldTypeClass() override = default;

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -222,7 +222,9 @@ using PhobosTypeRegistry = TypeRegistry<
 	LaserTrailTypeClass,
 	RadTypeClass,
 	ShieldClass,
-	DigitalDisplayTypeClass
+	DigitalDisplayTypeClass,
+	AttachEffectTypeClass,
+	AttachEffectClass
 	// other classes
 >;
 

--- a/src/Utilities/Constructs.cpp
+++ b/src/Utilities/Constructs.cpp
@@ -43,12 +43,14 @@ bool CustomPalette::LoadFromINI(
 	CCINIClass* pINI, const char* pSection, const char* pKey,
 	const char* pDefault)
 {
-	if (pINI->ReadString(pSection, pKey, pDefault, Phobos::readBuffer)) {
+	if (pINI->ReadString(pSection, pKey, pDefault, Phobos::readBuffer))
+	{
 		GeneralUtils::ApplyTheaterSuffixToString(Phobos::readBuffer);
 
 		this->Clear();
 
-		if (auto pPal = FileSystem::AllocatePalette(Phobos::readBuffer)) {
+		if (auto pPal = FileSystem::AllocatePalette(Phobos::readBuffer))
+		{
 			this->Palette.reset(pPal);
 			this->CreateConvert();
 		}
@@ -65,11 +67,13 @@ bool CustomPalette::Load(PhobosStreamReader& Stm, bool RegisterForChange)
 	bool hasPalette = false;
 	auto ret = Stm.Load(this->Mode) && Stm.Load(hasPalette);
 
-	if (ret && hasPalette) {
+	if (ret && hasPalette)
+	{
 		this->Palette.reset(GameCreate<BytePalette>());
 		ret = Stm.Load(*this->Palette);
 
-		if (ret) {
+		if (ret)
+		{
 			this->CreateConvert();
 		}
 	}
@@ -81,7 +85,8 @@ bool CustomPalette::Save(PhobosStreamWriter& Stm) const
 {
 	Stm.Save(this->Mode);
 	Stm.Save(this->Palette != nullptr);
-	if (this->Palette) {
+	if (this->Palette)
+	{
 		Stm.Save(*this->Palette);
 	}
 	return true;
@@ -96,12 +101,14 @@ void CustomPalette::Clear()
 void CustomPalette::CreateConvert()
 {
 	ConvertClass* buffer = nullptr;
-	if (this->Mode == PaletteMode::Temperate) {
+	if (this->Mode == PaletteMode::Temperate)
+	{
 		buffer = GameCreate<ConvertClass>(
 			*this->Palette.get(), FileSystem::TEMPERAT_PAL, DSurface::Primary,
 			53, false);
 	}
-	else {
+	else
+	{
 		buffer = GameCreate<ConvertClass>(
 			*this->Palette.get(), *this->Palette.get(), DSurface::Alternate,
 			1, false);
@@ -279,3 +286,4 @@ bool TheaterSpecificSHP::Save(PhobosStreamWriter& Stm) const
 {
 	return Savegame::WritePhobosStream(Stm, this->value);
 }
+

--- a/src/Utilities/Constructs.h
+++ b/src/Utilities/Constructs.h
@@ -51,12 +51,12 @@
 
 class PhobosStreamReader;
 class PhobosStreamWriter;
+#include "Enum.h"
 
 class ConvertClass;
 
 template <typename T>
 using UniqueGamePtr = std::unique_ptr<T, GameDeleter>;
-
 
 class ArmorType
 {

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -214,6 +214,16 @@ enum class ChronoSparkleDisplayPosition : unsigned char
 
 MAKE_ENUM_FLAGS(ChronoSparkleDisplayPosition);
 
+enum class DiscardCondition : unsigned char
+{
+	None = 0x0,
+	Entry = 0x1,
+	Move = 0x2,
+	Stationary = 0x4,
+};
+
+MAKE_ENUM_FLAGS(DiscardCondition);
+
 enum class HorizontalPosition : BYTE
 {
 	Left = 0,

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -225,6 +225,18 @@ enum class DiscardCondition : unsigned char
 
 MAKE_ENUM_FLAGS(DiscardCondition);
 
+enum class ExpireWeaponCondition : unsigned char
+{
+	None = 0x0,
+	Expire = 0x1,
+	Remove = 0x2,
+	Death = 0x4,
+
+	All = 0xFF,
+};
+
+MAKE_ENUM_FLAGS(ExpireWeaponCondition);
+
 enum class HorizontalPosition : BYTE
 {
 	Left = 0,

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -220,6 +220,7 @@ enum class DiscardCondition : unsigned char
 	Entry = 0x1,
 	Move = 0x2,
 	Stationary = 0x4,
+	Drain = 0x8,
 };
 
 MAKE_ENUM_FLAGS(DiscardCondition);

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -215,3 +215,29 @@ void GeneralUtils::DisplayDamageNumberString(int damage, DamageDisplayType type,
 
 	offset = offset + width;
 }
+
+// Gets integer representation of color from ColorAdd corresponding to given index, or 0 if there's no color found.
+// Code is pulled straight from game's draw functions that deal with the tint colors.
+int GeneralUtils::GetColorFromColorAdd(int colorIndex)
+{
+	auto const& colorAdd = RulesClass::Instance->ColorAdd;
+	int colorValue = 0;
+
+	if (colorIndex < 0 || colorIndex >= (sizeof(colorAdd) / sizeof(ColorStruct)))
+		return colorValue;
+
+	auto const& color = colorAdd[colorIndex];
+	int red = color.R;
+	int green = color.G;
+	int blue = color.B;
+
+	if (Drawing::ColorMode() == RGBMode::RGB565)
+		colorValue |= blue | (32 * (green | (red << 6)));
+
+	if (Drawing::ColorMode() != RGBMode::RGB655)
+		colorValue |= blue | (((32 * red) | (green >> 1)) << 6);
+
+	colorValue |= blue | (32 * ((32 * red) | (green >> 1)));
+
+	return colorValue;
+}

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -36,6 +36,7 @@ public:
 	static int CountDigitsInNumber(int number);
 	static CoordStruct CalculateCoordsFromDistance(CoordStruct currentCoords, CoordStruct targetCoords, int distance);
 	static void DisplayDamageNumberString(int damage, DamageDisplayType type, CoordStruct coords, int& offset);
+	static int GetColorFromColorAdd(int colorIndex);
 
 	template<typename T>
 	static constexpr T FastPow(T x, size_t n)

--- a/src/Utilities/INIParser.h
+++ b/src/Utilities/INIParser.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "Parser.h"
 
 #include <Phobos.h>
@@ -130,5 +132,21 @@ public:
 	bool ReadArmor(const char* pSection, const char* pKey, int *nBuffer) {
 		*nBuffer = IniFile->ReadArmorType(pSection, pKey, *nBuffer);
 		return (*nBuffer != -1);
+	}
+
+	bool ParseStringList(std::vector<const char*>& values, const char* pSection, const char* pKey)
+	{
+		if (this->ReadString(pSection, pKey))
+		{
+			values.clear();
+			char* context = nullptr;
+
+			for (auto pCur = strtok_s(this->value(), Phobos::readDelims, &context); pCur; pCur = strtok_s(nullptr, Phobos::readDelims, &context))
+				values.push_back(pCur);
+
+			return true;
+		}
+
+		return false;
 	}
 };

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1085,6 +1085,10 @@ namespace detail
 				{
 					parsed |= DiscardCondition::Stationary;
 				}
+				else if (!_strcmpi(cur, "drain"))
+				{
+					parsed |= DiscardCondition::Drain;
+				}
 				else
 				{
 					Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a discard condition type");

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1059,6 +1059,47 @@ namespace detail
 	}
 
 	template <>
+	inline bool read<DiscardCondition>(DiscardCondition& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			auto parsed = DiscardCondition::None;
+
+			auto str = parser.value();
+			char* context = nullptr;
+			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
+				if (!_strcmpi(cur, "none"))
+				{
+					parsed |= DiscardCondition::None;
+				}
+				else if (!_strcmpi(cur, "entry"))
+				{
+					parsed |= DiscardCondition::Entry;
+				}
+				else if (!_strcmpi(cur, "move"))
+				{
+					parsed |= DiscardCondition::Move;
+				}
+				else if (!_strcmpi(cur, "stationary"))
+				{
+					parsed |= DiscardCondition::Stationary;
+				}
+				else
+				{
+					Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a discard condition type");
+					return false;
+				}
+			}
+
+			value = parsed;
+			return true;
+		}
+
+		return false;
+	}
+
+	template <>
 	inline bool read<CLSID>(CLSID &value, INI_EX &parser, const char *pSection, const char *pKey)
 	{
 		if (!parser.ReadString(pSection, pKey))

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1059,7 +1059,7 @@ namespace detail
 	}
 
 	template <>
-	inline bool read<DiscardCondition>(DiscardCondition& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	inline bool read<DiscardCondition>(DiscardCondition& value, INI_EX& parser, const char* pSection, const char* pKey)
 	{
 		if (parser.ReadString(pSection, pKey))
 		{

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1104,6 +1104,51 @@ namespace detail
 	}
 
 	template <>
+	inline bool read<ExpireWeaponCondition>(ExpireWeaponCondition& value, INI_EX& parser, const char* pSection, const char* pKey)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			auto parsed = ExpireWeaponCondition::None;
+
+			auto str = parser.value();
+			char* context = nullptr;
+			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
+				if (!_strcmpi(cur, "none"))
+				{
+					parsed |= ExpireWeaponCondition::None;
+				}
+				else if (!_strcmpi(cur, "expire"))
+				{
+					parsed |= ExpireWeaponCondition::Expire;
+				}
+				else if (!_strcmpi(cur, "remove"))
+				{
+					parsed |= ExpireWeaponCondition::Remove;
+				}
+				else if (!_strcmpi(cur, "death"))
+				{
+					parsed |= ExpireWeaponCondition::Death;
+				}
+				else if (!_strcmpi(cur, "all"))
+				{
+					parsed |= ExpireWeaponCondition::All;
+				}
+				else
+				{
+					Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a expire weapon trigger condition type");
+					return false;
+				}
+			}
+
+			value = parsed;
+			return true;
+		}
+
+		return false;
+	}
+
+	template <>
 	inline bool read<CLSID>(CLSID &value, INI_EX &parser, const char *pSection, const char *pKey)
 	{
 		if (!parser.ReadString(pSection, pKey))


### PR DESCRIPTION
# [Link to the bot comment with download link](https://github.com/Phobos-developers/Phobos/pull/826#issuecomment-1636739508)

Phobos-introduced Warhead effects like shield modifiers, critical hits, disguise & mind control removal now require Warhead `Verses` to affect target to apply unless `EffectsRequireVerses` is set to false. Shield armor type is used if target has an active shield that cannot be penetrated by the Warhead.

----------------------------

### Attached effects

- Similar (but not identical) to Ares' AttachEffect, but with some differences and new features. The largest difference is that here attached effects are explicitly defined types.
  - `Duration` determines how long the effect lasts for. It can be overriden by `DurationOverrides` on TechnoTypes and Warheads.
  - `Cumulative`, if set to true, allows the same type of effect to be applied on same object multiple times, up to `Cumulative.MaxCount` number or with no limit if `Cumulative.MaxCount` is a negative number.
  - `Powered` controls whether or not the effect is rendered inactive if the object it is attached to is deactivated (`PoweredUnit` or affected by EMP) or on low power. What happens to animation is controlled by `Animation.OfflineAction`.
  - `DiscardOn` accepts a list of values corresponding to conditions where the attached effect should be discarded. Defaults to `none`, meaning it is never discarded.
    - `entry`: Discard on exiting the map when entering transports or buildings etc.
    - `move`: Discard when the object the effect is attached on moves. Ignored if the object is a building.
    - `stationary`: Discard when the object the effect is attached on stops moving. Ignored if the object is a building.
    - `drain`: Discard when the object is being affected by a weapon with `DrainWeapon=true`.
  - If `PenetratesIronCurtain` is not set to true, the effect is not applied on currently invulnerable objects (Iron Curtain / Force Shield).
  - `Animation` defines animation to play in an indefinite loop for as long as the effect is active on the object it is attached to.
    - If `Animation.ResetOnReapply` is set to true, the animation playback is reset every time the effect is applied if `Cumulative=false`.
    - `Animation.OfflineAction` determines what happens to the animation when the attached object is deactivated or not powered. Only applies if `Powered=true`.
    - `Animation.TemporalAction` determines what happens to the animation when the attached object is under effect of `Temporal=true` Warhead.
    - `Animation.UseInvokerAsOwner` can be used to set the house and TechnoType that created the effect (e.g firer of the weapon that applied it) as the animation's owner & invoker instead of the object the effect is attached to.
  - `CumulativeAnimations` can be used to declare a list of animations used for `Cumulative=true` types instead of `Animation`. An animation is picked from the list in order matching the number of active instances of the type on the object, with last listed animation used if number is higher than the number of listed animations. This animation is only displayed once, on the first active instance of the effect found attached and is updated and restarted if the number of active instances changed.
  - Attached effect can fire off a weapon when expired / removed / object dies by setting `ExpireWeapon`.
    - `ExpireWeapon.TriggerOn` determines the exact conditions upon which the weapon is fired, defaults to `expire` which means only if the effect naturally expires.
    - `ExpireWeapon.CumulativeOnlyOnce`, if set to true, makes it so that `Cumulative=true` attached effects only detonate the weapon once period, instead of once per active instance. On `remove` and `expire` condition this means it will only detonate after last instance has expired or been removed.
  - `Tint.Color` & `Tint.Intensity` can be used to set a color tint effect and additive lighting increase/decrease on the object the effect is attached to, respectively.
    - `Tint.VisibleToHouses` can be used to control which houses can see the tint effect.
  - `FirepowerMultiplier`, `ArmorMultiplier`, `SpeedMultiplier` and `ROFMultiplier` can be used to modify the object's firepower, armor strength, movement speed and weapon reload rate, respectively.
    - If `ROFMultiplier.ApplyOnCurrentTimer` is set to true, `ROFMultiplier` is applied on currently running reload timer (if any) when the effect is first applied.
  - If `Cloakable` is set to true, the object the effect is attached to is granted ability to cloak itself for duration of the effect.
  - `ForceDecloak`, if set to true, will uncloak and make the object the effect is attached to unable to cloak itself for duration of the effect.
  - `WeaponRange.Multiplier` and `WeaponRange.ExtraRange` can be used to multiply the weapon firing range of the object the effect is attached to, or give it an increase / decrease (measured in cells), respectively. `ExtraRange` is cumulatively applied from all attached effects after all `Multiplier` values have been applied.
    - `WeaponRange.AllowWeapons` can be used to list only weapons that can benefit from this range bonus and `WeaponRange.DisallowWeapons` weapons that are not allowed to, respectively.
    - On TechnoTypes with `OpenTopped=true`, `OpenTopped.UseTransportRangeModifiers` can be set to true to make passengers firing out use the transport's active range bonuses instead.
  - `Crit.Multiplier` and `Crit.ExtraChance` can be used to multiply the [critical hit](#chance-based-extra-damage-or-warhead-detonation--critical-hits) chance or grant a fixed bonus to it for the object the effect is attached to, respectively.
    - `Crit.AllowWarheads` can be used to list only Warheads that can benefit from this critical hit chance multiplier and `Crit.DisallowWarheads` weapons that are not allowed to, respectively.
  - `RevengeWeapon` can be used to temporarily grant the specified weapon as a [revenge weapon](#revenge-weapon) for the attached object.
    - `RevengeWeapon.AffectsHouses` customizes which houses can trigger the revenge weapon.
  - `DisableWeapons` can be used to disable ability to fire any and all weapons.
  - It is possible to set groups for attach effect types by defining strings in `Groups`.
    - Groups can be used instead of types for removing effects and weapon filters.

- AttachEffectTypes can be attached to TechnoTypes using `AttachEffect.AttachTypes`.
  - `AttachEffect.DurationOverrides` can be used to override the default durations. Duration matching the position in `AttachTypes` is used for that type, or the last listed duration if not available.
  - `AttachEffect.Delays` can be used to set the delays for recreating the effects on the TechnoType after they expire. Defaults to 0 (immediately), negative values mean the effects are not recreated. Delay matching the position in `AttachTypes` is used for that type, or the last listed delay if not available.
  - `AttachEffect.InitialDelays` can be used to set the delays before first creating the effects on TechnoType. Defaults to 0 (immediately). Delay matching the position in `AttachTypes` is used for that type, or the last listed delay if not available.
  - `AttachEffect.RecreationDelays` is used to determine if the effect can be recreated if it is removed completely (e.g `AttachEffect.RemoveTypes`), and if yes, how long this takes. Defaults to -1, meaning no recreation. Delay matching the position in `AttachTypes` is used for that type, or the last listed delay if not available.

- AttachEffectTypes can be attached to objects via Warheads using `AttachEffect.AttachTypes`.
  - `AttachEffect.DurationOverrides` can be used to override the default durations. Duration matching the position in `AttachTypes` is used for that type, or the last listed duration if not available.
  - Attached effects can be removed from objects by Warheads using `AttachEffect.RemoveTypes` or `AttachEffect.RemoveGroups`.
    - `AttachEffect.CumulativeRemoveMinCounts` sets minimum number of active instaces per `RemoveTypes`/`RemoveGroups` required for `Cumulative=true` types to be removed.
    - `AttachEffect.CumulativeRemoveMaxCounts` sets maximum number of active instaces per `RemoveTypes`/`RemoveGroups` for `Cumulative=true` that are removed at once by this Warhead.

- Weapons can require attached effects on target to fire, or be prevented by firing if specific attached effects are applied.
  - `AttachEffect.RequiredTypes` can be used to list attached effects required to be on target to fire, all listed effect types must be present to allow firing.
  - `AttachEffect.DisallowedTypes` can be used to list attached effects that when present prevent the weapon from firing, any of the listed effect types will prevent firing if present.
  - `AttachEffect.Required/DisallowedGroups` have the same effect except applied with/to all types that have one of the listed groups in their `Groups` listing.
  - `AttachEffect.(Required|Disallowed)MinCounts & (Required|Disallowed)MaxCounts` can be used to set the minimum and maximum number of instances required / disallowed to be on the Techno for `Cumulative=true` types (ignored for other types) respectively.
  - `AttachEffect.IgnoreFromSameSource` can be set to true to ignore effects that have been attached by the firer of the weapon and its Warhead.

In `rulesmd.ini`:
```ini
[AttachEffectTypes]
0=SOMEATTACHEFFECT

[SOMEATTACHEFFECT]                           ; AttachEffectType
Duration=0                                   ; integer - game frames or negative value for indefinite duration
Cumulative=false                             ; boolean
Cumulative.MaxCount=-1                       ; integer
Powered=false                                ; boolean
DiscardOn=none                               ; list of discard condition enumeration (none|entry|move|stationary|drain)
PenetratesIronCurtain=false                  ; boolean
Animation=                                   ; Animation
Animation.ResetOnReapply=false               ; boolean
Animation.OfflineAction=Hides                ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
Animation.TemporalAction=None                ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
Animation.UseInvokerAsOwner=false            ; boolean
CumulativeAnimations=                        ; list of animations
ExpireWeapon=
ExpireWeapon.TriggerOn=expire                ; List of expire weapon trigger condition enumeration (none|expire|remove|death|all)
ExpireWeapon.CumulativeOnlyOnce=false        ; boolean
Tint.Color=                                  ; integer - R,G,B
Tint.Intensity=                              ; floating point value
Tint.VisibleToHouses=all                     ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
FirepowerMultiplier=1.0                      ; floating point value
ArmorMultiplier=1.0                          ; floating point value
SpeedMultiplier=1.0                          ; floating point value
ROFMultiplier=1.0                            ; floating point value
ROFMultiplier.ApplyOnCurrentTimer=true       ; boolean
Cloakable=false                              ; boolean
ForceDecloak=false                           ; boolean
WeaponRange.Multiplier=1.0                   ; floating point value
WeaponRange.ExtraRange=0.0                   ; floating point value
WeaponRange.AllowWeapons=                    ; list of WeaponTypes
WeaponRange.DisallowWeapons=                 ; list of WeaponTypes
Crit.Multiplier=1.0                          ; floating point value
Crit.ExtraChance=0.0                         ; floating point value
Crit.AllowWarheads=                          ; list of WarheadTypes
Crit.DisallowWarheads=                       ; list of WarheadTypes
RevengeWeapon=                               ; WeaponType
RevengeWeapon.AffectsHouses=all              ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
DisableWeapons=false                         ; boolean
Groups=                                      ; comma-separated list of strings (group IDs)

[SOMETECHNO]                                 ; TechnoType
AttachEffect.AttachTypes=                    ; List of AttachEffectTypes
AttachEffect.DurationOverrides=              ; integer - duration overrides (comma-separated) for AttachTypes in order from first to last.
AttachEffect.Delays=                         ; integer - delays (comma-separated) for AttachTypes in order from first to last.
AttachEffect.InitialDelays=                  ; integer - initial delays (comma-separated) for AttachTypes in order from first to last.
AttachEffect.RecreationDelays=               ; integer - recreation delays (comma-separated) for AttachTypes in order from first to last.
OpenTopped.UseTransportRangeModifiers=false  ; boolean

[SOMEWEAPON]                                 ; WeaponType
AttachEffect.RequiredTypes=                  ; List of AttachEffectTypes
AttachEffect.DisallowedTypes=                ; List of AttachEffectTypes
AttachEffect.RequiredGroups=                 ; comma-separated list of strings (group IDs)
AttachEffect.DisallowedGroups=               ; comma-separated list of strings (group IDs)
AttachEffect.RequiredMinCounts=              ; integer - minimum required instance count (comma-separated) for cumulative types in order from first to last.
AttachEffect.RequiredMaxCounts=              ; integer - maximum required instance count (comma-separated) for cumulative types in order from first to last.
AttachEffect.DisallowedMinCounts=            ; integer - minimum disallowed instance count (comma-separated) for cumulative types in order from first to last.
AttachEffect.DisallowedMaxCounts=            ; integer - maximum disallowed instance count (comma-separated) for cumulative types in order from first to last.
AttachEffect.IgnoreFromSameSource=false      ; boolean

[SOMEWARHEAD]
AttachEffect.AttachTypes=                    ; List of AttachEffectTypes
AttachEffect.RemoveTypes=                    ; List of AttachEffectTypes
AttachEffect.RemoveGroups=                   ; comma-separated list of strings (group IDs)
AttachEffect.CumulativeRemoveMinCounts=      ; integer - minimum required instance count (comma-separated) for cumulative types in order from first to last.
AttachEffect.CumulativeRemoveMaxCounts=      ; integer - maximum removed instance count (comma-separated) for cumulative types in order from first to last.
AttachEffect.DurationOverrides=              ; integer - duration overrides (comma-separated) for AttachTypes in order from first to last.
```

### Custom tint on TechnoTypes

- A tint effect similar to that used by Iron Curtain / Force Shield or `Psychedelic=true` Warheads can be applied to TechnoTypes naturally by setting `Tint.Color` and/or `Tint Intensity`.
  - `Tint.Intensity` is additive lighting increase/decrease - 1.0 is the default object lighting.
  - `Tint.VisibleToHouses` can be used to customize which houses can see the tint effect.

In `rulesmd.ini`:
```ini
[SOMETECHNO]              ; TechnoType
Tint.Color=               ; integer - R,G,B
Tint.Intensity=0.0        ; floating point value
Tint.VisibleToHouses=all  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
```
Theres also a couple of tinting-related bugfixes:

- Tint effects are now correctly applied to SHP vehicles and all types of aircraft as well as building animations regardless of their position.
- Iron Curtained / Force Shielded objects now always use the correct tint color.

-----------------

### Revenge weapon

- Similar to `DeathWeapon` in that it is fired after a TechnoType is killed, but with the difference that it will be fired on whoever dealt the damage that killed the TechnoType. If TechnoType died of sources other than direct damage dealt by another TechnoType, `RevengeWeapon` will not be fired.
  - `RevengeWeapon.AffectsHouses` can be used to filter which houses the damage that killed the TechnoType is allowed to come from to fire the weapon.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                    ; TechnoType
RevengeWeapon=                  ; WeaponType
RevengeWeapon.AffectsHouses=all ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
```
