### PR TITLE
`AutoDeath` logic support for limboed objects

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -731,10 +731,9 @@ Both `InitialStrength` and `InitialStrength.Cloning` never surpass the type's `S
 If this option is not set, the self-destruction logic will not be enabled.
 ```{note}
 Please notice that if the object is a unit which carries passengers, they will not be released even with the `kill` option. This might change in the future if necessary.
-
-If the object enters transport, the countdown will continue, but it will not self-destruct inside the transport.
 ```
 
+This logic also supports buildings delivered by [LimboDelivery](#LimboDelivery)
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -300,6 +300,7 @@ Vanilla fixes:
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)
 - Add `ImmuneToCrit` for shields (by Trsdy)
+- `AutoDeath` support for objects in limbo (by Trsdy)
 - Fixed shield animation being hidden while underground or in tunnels fix not working correctly (by Starkku)
 - Restore the `MindClearedSound` when deploying a mind-controlled unit into a building loses the mind-control (by Trsdy)
 - Reimplemented the bugfix for jumpjet units' facing when firing, discard the inappropriate `JumpjetTurnToTarget` tag (by Trsdy)

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -74,6 +74,22 @@ HouseClass* HouseExt::GetHouseKind(OwnerHouseKind const kind, bool const allowRa
 	}
 }
 
+void HouseExt::ExtData::UpdateAutoDeathObjectsInLimbo()
+{
+	for (auto pExt : this->OwnedTimedAutoDeathObjects)
+	{
+		auto pItem = pExt->OwnerObject();
+		if (!pItem->IsInLogic && pItem->IsAlive && pExt->TypeExtData->AutoDeath_Behavior.isset() && pExt->AutoDeathTimer.Completed())
+		{
+			if (this->OwnedLimboDeliveredBuildings.contains(pItem->UniqueID))
+				this->OwnedLimboDeliveredBuildings.erase(pItem->UniqueID);
+			pItem->RegisterDestruction(nullptr);
+			// I doubt those in LimboDelete being really necessary, they're gonna be updated either next frame or after uninit anyway
+			pItem->UnInit();
+		}
+	}
+}
+
 void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 {
 	const char* pSection = this->OwnerObject()->PlainName;
@@ -101,6 +117,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 	Stm
 		.Process(this->BuildingCounter)
 		.Process(this->OwnedLimboDeliveredBuildings)
+		.Process(this->OwnedTimedAutoDeathObjects)
 		.Process(this->Factory_BuildingType)
 		.Process(this->Factory_InfantryType)
 		.Process(this->Factory_VehicleType)

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -18,6 +18,7 @@ public:
 	public:
 		std::map<BuildingTypeExt::ExtData*, int> BuildingCounter;
 		std::map<DWORD, BuildingExt::ExtData*> OwnedLimboDeliveredBuildings;
+		std::vector<TechnoExt::ExtData*> OwnedTimedAutoDeathObjects;
 
 		BuildingClass* Factory_BuildingType;
 		BuildingClass* Factory_InfantryType;
@@ -31,6 +32,7 @@ public:
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, BuildingCounter {}
 			, OwnedLimboDeliveredBuildings {}
+			, OwnedTimedAutoDeathObjects {}
 			, Factory_BuildingType { nullptr }
 			, Factory_InfantryType { nullptr }
 			, Factory_VehicleType { nullptr }
@@ -40,6 +42,7 @@ public:
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass const* pBuilding);
+		void UpdateAutoDeathObjectsInLimbo();
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -3,6 +3,17 @@
 #include "../Building/Body.h"
 #include <unordered_map>
 
+DEFINE_HOOK(0x4F8440, HouseClass_Update_Beginning, 0x5)
+{
+	GET(HouseClass* const, pThis, ECX);
+
+	auto pExt = HouseExt::ExtMap.Find(pThis);
+
+	pExt->UpdateAutoDeathObjectsInLimbo();
+
+	return 0;
+}
+
 DEFINE_HOOK(0x508C30, HouseClass_UpdatePower_UpdateCounter, 0x5)
 {
 	GET(HouseClass*, pThis, ECX);

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -37,8 +37,6 @@ void SWTypeExt::FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell)
 #pragma region LimboDelivery
 inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 {
-	auto pOwnerExt = HouseExt::ExtMap.Find(pOwner);
-
 	// BuildLimit check goes before creation
 	if (pType->BuildLimit > 0)
 	{
@@ -93,9 +91,17 @@ inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 			// LimboKill ID
 			pBuildingExt->LimboID = ID;
 
-			// Add building to list of owned limbo buildings
-			if (pOwnerExt)
+			if (auto pOwnerExt = HouseExt::ExtMap.Find(pOwner))
+			{	// Add building to list of owned limbo buildings
 				pOwnerExt->OwnedLimboDeliveredBuildings.insert({ pBuilding->UniqueID, pBuildingExt });
+
+				auto pTechExt = TechnoExt::ExtMap.Find(pBuilding);
+				if (pTechExt->TypeExtData->AutoDeath_Behavior.isset() && pTechExt->TypeExtData->AutoDeath_AfterDelay > 0)
+				{
+					pTechExt->AutoDeathTimer.Start(pTechExt->TypeExtData->AutoDeath_AfterDelay);
+					pOwnerExt->OwnedTimedAutoDeathObjects.push_back(pTechExt);
+				}
+			}
 		}
 	}
 }

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -70,7 +70,7 @@ public:
 		void UpdateLaserTrails();
 		void InitializeLaserTrails();
 
-		virtual ~ExtData() = default;
+		virtual ~ExtData() override;
 
 		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
 


### PR DESCRIPTION
This allows LimboDeliver-ed buildings to use AutoDeath logic