### PR TITLE
Real time timers

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -178,13 +178,14 @@ This page lists all the individual contributions to the project by their author.
   - Removal of hardcoded AA & Gattling weapon selection restrictions
   - Projectile obstacle logic additions
 - **Morton (MortonPL)**:
-  - `XDrawOffset`
+  - `XDrawOffset` for animations
   - Shield passthrough & absorption
   - Building `LimboDelivery` logic
   - Fix for `Image` in art rules
   - Power delta counter
   - Super Weapons launching other Super Weapons
   - SpyEffects expansion, launching Super Weapons on building infiltration
+  - Real time timers
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -121,6 +121,7 @@
     <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
     <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
+	<ClCompile Include="src\Misc\Hooks.Timers.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
     <ClCompile Include="src\Phobos.CRT.cpp" />
     <ClCompile Include="src\Phobos.Ext.cpp" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -121,7 +121,7 @@
     <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
     <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
-	<ClCompile Include="src\Misc\Hooks.Timers.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
     <ClCompile Include="src\Phobos.CRT.cpp" />
     <ClCompile Include="src\Phobos.Ext.cpp" />

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -100,6 +100,20 @@ In `ra2md.ini`:
 ShowPlacementPreview=yes   ; boolean
 ```
 
+### Real time timers
+
+- Timers can now display values in real time, taking game speed into account. This can be enabled with `RealTimeTimers=yes`.
+- This option respects custom game speeds.
+- When playing on the highest single player game speed (or custom speed above 60 FPS), the timers might constantly change value because of the unstable nature of unlimited FPS.
+
+- This behavior is designed to be toggleable by users. For now you can only do that externally via client or manually.
+
+In `ra2md.ini`:
+```ini
+[Phobos]
+RealTimeTimers=no   ; boolean
+```
+
 ### SuperWeapon ShowTimer sorting
 
 - You can now sort the timers of superweapons in ascending order from top to bottom according to a given priority value.

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -103,15 +103,17 @@ ShowPlacementPreview=yes   ; boolean
 ### Real time timers
 
 - Timers can now display values in real time, taking game speed into account. This can be enabled with `RealTimeTimers=yes`.
+- By default, time is calculated relative to desired framerate. Enabling `RealTimeTimers.Adaptive=yes` (always on for unlimited FPS) will calculate time relative to *current* FPS, accounting for lag.
+  - When playing with unlimited FPS (or custom speed above 60 FPS), the timers might constantly change value because of the unstable nature.
 - This option respects custom game speeds.
-- When playing on the highest single player game speed (or custom speed above 60 FPS), the timers might constantly change value because of the unstable nature of unlimited FPS.
 
 - This behavior is designed to be toggleable by users. For now you can only do that externally via client or manually.
 
 In `ra2md.ini`:
 ```ini
 [Phobos]
-RealTimeTimers=no   ; boolean
+RealTimeTimers=no           ; boolean
+RealTimeTimers.Adaptive=no  ; boolean
 ```
 
 ### SuperWeapon ShowTimer sorting

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -277,6 +277,7 @@ New:
 - Attached particle system for animations (by Starkku)
 - Removal of hardcoded AA & Gattling weapon selection restrictions (by Starkku)
 - Projectile `SubjectToLand/Water` (by Starkku)
+- Real time timers (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Misc/Hooks.Timers.cpp
+++ b/src/Misc/Hooks.Timers.cpp
@@ -2,16 +2,20 @@
 #include <GameOptionsClass.h>
 #include <FPSCounter.h>
 #include <SessionClass.h>
+#include <Phobos.h>
 
 int oldValue;
 DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical_Start, 0x6)
 {
+	if (!Phobos::Config::RealTimeTimers)
+		return 0;
+
 	REF_STACK(int, value, STACK_OFFSET(0, 0x4));
 	oldValue = value;
 
 	if (false && !SessionClass::IsMultiplayer()) // TODO change when custom game speed gets merged
 	{
-		value = std::max(value / (int)(std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0), 1);
+		value = (int)((double)value / (std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0));
 		return 0;
 	}
 
@@ -46,6 +50,9 @@ DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical_Start, 0x6)
 
 DEFINE_HOOK(0x6D4C68, Print_Timer_On_Tactical_End, 0x8)
 {
+	if (!Phobos::Config::RealTimeTimers)
+		return 0;
+
 	REF_STACK(int, value, STACK_OFFSET(0x654, 0x4));
 	value = oldValue;
 	return 0;

--- a/src/Misc/Hooks.Timers.cpp
+++ b/src/Misc/Hooks.Timers.cpp
@@ -1,0 +1,30 @@
+#include <Utilities/Macro.h>
+#include <GameOptionsClass.h>
+
+DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical, 0x6)
+{
+	REF_STACK(int, value, STACK_OFFS(0, 0x8));
+	switch (GameOptionsClass::Instance->GameSpeed)
+	{
+	case 0: // no cap
+	case 1:	// 60 FPS
+		value = value / 4;
+		break;
+	case 2:	// 30 FPS
+		value = value / 2;
+		break;
+	case 3:	// 20 FPS
+		value = (value * 3) / 4;
+		break;
+	case 4:	// 15 FPS
+		break;
+	case 5:	// 12 FPS
+		value = (value * 5) / 4;
+		break;
+	case 6:	// 10 FPS
+		value = (value * 3) / 2;
+		break;
+	default:
+		break;
+	}
+}

--- a/src/Misc/Hooks.Timers.cpp
+++ b/src/Misc/Hooks.Timers.cpp
@@ -4,14 +4,18 @@
 #include <SessionClass.h>
 #include <Phobos.h>
 
-int oldValue;
+namespace TimerValueTemp
+{
+	static int oldValue;
+};
+
 DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical_Start, 0x6)
 {
 	if (!Phobos::Config::RealTimeTimers)
 		return 0;
 
 	REF_STACK(int, value, STACK_OFFSET(0, 0x4));
-	oldValue = value;
+	TimerValueTemp::oldValue = value;
 
 	if (Phobos::Config::RealTimeTimers_Adaptive
 		|| GameOptionsClass::Instance->GameSpeed == 0
@@ -53,6 +57,6 @@ DEFINE_HOOK(0x6D4C68, Print_Timer_On_Tactical_End, 0x8)
 		return 0;
 
 	REF_STACK(int, value, STACK_OFFSET(0x654, 0x4));
-	value = oldValue;
+	value = TimerValueTemp::oldValue;
 	return 0;
 }

--- a/src/Misc/Hooks.Timers.cpp
+++ b/src/Misc/Hooks.Timers.cpp
@@ -13,7 +13,9 @@ DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical_Start, 0x6)
 	REF_STACK(int, value, STACK_OFFSET(0, 0x4));
 	oldValue = value;
 
-	if (false && !SessionClass::IsMultiplayer()) // TODO change when custom game speed gets merged
+	if (Phobos::Config::RealTimeTimers_Adaptive
+		|| GameOptionsClass::Instance->GameSpeed == 0
+		|| (false && !SessionClass::IsMultiplayer())) // TODO change when custom game speed gets merged
 	{
 		value = (int)((double)value / (std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0));
 		return 0;
@@ -21,9 +23,6 @@ DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical_Start, 0x6)
 
 	switch (GameOptionsClass::Instance->GameSpeed)
 	{
-	case 0: // no cap
-		value = (int)((double)value / (std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0));
-		break;
 	case 1:	// 60 FPS
 		value = value / 4;
 		break;

--- a/src/Misc/Hooks.Timers.cpp
+++ b/src/Misc/Hooks.Timers.cpp
@@ -1,12 +1,25 @@
 #include <Utilities/Macro.h>
 #include <GameOptionsClass.h>
+#include <FPSCounter.h>
+#include <SessionClass.h>
 
-DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical, 0x6)
+int oldValue;
+DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical_Start, 0x6)
 {
-	REF_STACK(int, value, STACK_OFFS(0, 0x8));
+	REF_STACK(int, value, STACK_OFFSET(0, 0x4));
+	oldValue = value;
+
+	if (false && !SessionClass::IsMultiplayer()) // TODO change when custom game speed gets merged
+	{
+		value = std::max(value / (int)(std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0), 1);
+		return 0;
+	}
+
 	switch (GameOptionsClass::Instance->GameSpeed)
 	{
 	case 0: // no cap
+		value = (int)((double)value / (std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0));
+		break;
 	case 1:	// 60 FPS
 		value = value / 4;
 		break;
@@ -27,4 +40,13 @@ DEFINE_HOOK(0x6D4B50, Print_Timer_On_Tactical, 0x6)
 	default:
 		break;
 	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6D4C68, Print_Timer_On_Tactical_End, 0x8)
+{
+	REF_STACK(int, value, STACK_OFFSET(0x654, 0x4));
+	value = oldValue;
+	return 0;
 }

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -99,12 +99,12 @@ inline int tickTimeToSeconds(int tickTime)
 	if (!Phobos::Config::RealTimeTimers)
 		return tickTime / 15;
 
-	if (false && !SessionClass::IsMultiplayer()) // TODO change when custom game speed gets merged
+	if (Phobos::Config::RealTimeTimers_Adaptive
+		|| GameOptionsClass::Instance->GameSpeed == 0
+		|| (false && !SessionClass::IsMultiplayer())) // TODO change when custom game speed gets merged
 		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
-	else if (GameOptionsClass::Instance->GameSpeed != 0)
-		return tickTime / (60 / GameOptionsClass::Instance->GameSpeed);
-	else
-		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
+
+	return tickTime / (60 / GameOptionsClass::Instance->GameSpeed);
 }
 
 void PhobosToolTip::HelpText(TechnoTypeClass* pType)

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -12,6 +12,7 @@
 #include <CCToolTip.h>
 #include <BitFont.h>
 #include <BitText.h>
+#include <FPSCounter.h>
 
 #include <Ext/Side/Body.h>
 #include <Ext/Surface/Body.h>
@@ -93,6 +94,16 @@ void PhobosToolTip::HelpText(BuildType& cameo)
 		this->HelpText(ObjectTypeClass::GetTechnoType(cameo.ItemType, cameo.ItemIndex));
 }
 
+inline int tickTimeToSeconds(int tickTime)
+{
+	if (false && !SessionClass::IsMultiplayer()) // TODO change when custom game speed gets merged
+		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
+	else if (GameOptionsClass::Instance->GameSpeed != 0)
+		return tickTime / (60 / GameOptionsClass::Instance->GameSpeed);
+	else
+		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
+}
+
 void PhobosToolTip::HelpText(TechnoTypeClass* pType)
 {
 	if (!pType)
@@ -101,9 +112,9 @@ void PhobosToolTip::HelpText(TechnoTypeClass* pType)
 	auto const pData = TechnoTypeExt::ExtMap.Find(pType);
 
 	int nBuildTime = this->GetBuildTime(pType);
-	int nSec = nBuildTime / 15 % 60;
-	int nMin = nBuildTime / 15 / 60 /* % 60*/;
-	// int nHour = pType->RechargeTime / 15 / 60 / 60;
+	int nSec = tickTimeToSeconds(nBuildTime) % 60;
+	int nMin = tickTimeToSeconds(nBuildTime) / 60 /* % 60*/;
+	// int nHour = tickTimeToSeconds(nBuildTime) / 60 / 60;
 
 	int cost = pType->GetActualCost(HouseClass::CurrentPlayer);
 
@@ -154,9 +165,9 @@ void PhobosToolTip::HelpText(SuperWeaponTypeClass* pType)
 		if (!showCost)
 			oss << L"\n";
 
-		int nSec = pType->RechargeTime / 15 % 60;
-		int nMin = pType->RechargeTime / 15 / 60 /* % 60*/;
-		// int nHour = pType->RechargeTime / 15 / 60 / 60;
+		int nSec = tickTimeToSeconds(pType->RechargeTime) % 60;
+		int nMin = tickTimeToSeconds(pType->RechargeTime) / 60 /* % 60*/;
+		// int nHour = tickTimeToSeconds(pType->RechargeTime) / 60 / 60;
 
 		oss << (showCost ? L" " : L"") << Phobos::UI::TimeLabel
 			// << std::setw(2) << std::setfill(L'0') << nHour << L":"

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -96,6 +96,9 @@ void PhobosToolTip::HelpText(BuildType& cameo)
 
 inline int tickTimeToSeconds(int tickTime)
 {
+	if (!Phobos::Config::RealTimeTimers)
+		return tickTime / 15;
+
 	if (false && !SessionClass::IsMultiplayer()) // TODO change when custom game speed gets merged
 		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
 	else if (GameOptionsClass::Instance->GameSpeed != 0)

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -102,7 +102,9 @@ inline int tickTimeToSeconds(int tickTime)
 	if (Phobos::Config::RealTimeTimers_Adaptive
 		|| GameOptionsClass::Instance->GameSpeed == 0
 		|| (false && !SessionClass::IsMultiplayer())) // TODO change when custom game speed gets merged
+	{
 		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
+	}
 
 	return tickTime / (60 / GameOptionsClass::Instance->GameSpeed);
 }

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -58,6 +58,7 @@ bool Phobos::Config::PrioritySelectionFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::ShowPlacementPreview = false;
+bool Phobos::Config::RealTimeTimers = false;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -204,6 +205,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::ToolTipBlur = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ToolTipBlur", false);
 	Phobos::Config::PrioritySelectionFiltering = CCINIClass::INI_RA2MD->ReadBool("Phobos", "PrioritySelectionFiltering", true);
 	Phobos::Config::ShowPlacementPreview = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowPlacementPreview", true);
+	Phobos::Config::RealTimeTimers = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers", false);
 
 	CCINIClass* pINI_UIMD = Phobos::OpenConfig(GameStrings::UIMD_INI);
 

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -59,6 +59,7 @@ bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::ShowPlacementPreview = false;
 bool Phobos::Config::RealTimeTimers = false;
+bool Phobos::Config::RealTimeTimers_Adaptive = false;
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
@@ -206,6 +207,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::PrioritySelectionFiltering = CCINIClass::INI_RA2MD->ReadBool("Phobos", "PrioritySelectionFiltering", true);
 	Phobos::Config::ShowPlacementPreview = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowPlacementPreview", true);
 	Phobos::Config::RealTimeTimers = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers", false);
+	Phobos::Config::RealTimeTimers_Adaptive = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers.Adaptive", false);
 
 	CCINIClass* pINI_UIMD = Phobos::OpenConfig(GameStrings::UIMD_INI);
 

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -69,5 +69,6 @@ public:
 		static bool ArtImageSwap;
 		static bool ShowPlacementPreview;
 		static bool RealTimeTimers;
+		static bool RealTimeTimers_Adaptive;
 	};
 };

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -68,5 +68,6 @@ public:
 		static bool DevelopmentCommands;
 		static bool ArtImageSwap;
 		static bool ShowPlacementPreview;
+		static bool RealTimeTimers;
 	};
 };


### PR DESCRIPTION
### Real time timers

- Timers can now display values in real time, taking game speed into account. This can be enabled with `RealTimeTimers=yes`.
- By default, time is calculated relative to desired framerate. Enabling `RealTimeTimers.Adaptive=yes` (always on for unlimited FPS) will calculate time relative to *current* FPS, accounting for lag.
  - When playing with unlimited FPS (or custom speed above 60 FPS), the timers might constantly change value because of the unstable nature.
- This option respects custom game speeds.

- This behavior is designed to be toggleable by users. For now you can only do that externally via client or manually.

In `ra2md.ini`:
```ini
[Phobos]
RealTimeTimers=no           ; boolean
RealTimeTimers.Adaptive=no  ; boolean
```