### PR TITLE
Misc `UndeploysInto` fixes and extensions

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -207,7 +207,12 @@ This page lists all the individual contributions to the project by their author.
    - Misc vanilla suicidal behavior fix
    - Post-type-conversion update
    - Units retaining orders after changing ownership bugfix
-   - Building EVA_StructureSold and SellSound dehardcode
+   - Several fixes and dehardcode related to building selling/undeploying:
+     - Building `EVA_StructureSold` and `SellSound` dehardcode
+     - Restore `EVA_StructureSold` for buildings with `UndeploysInto`
+     - Redeployable MCV in campaigns
+     - Allow buildings with `UndeploysInto` to be sold if `Unsellable=no` even if not conyard
+     - Trigger actions that allow/forbid MCV to redeploy in game
    - `AlternateFLH` of vehicles in `OpenTopped` transport.
    - Slaves' house customization when owner is killed
    - Trigger Action spawned team IFV/Opentopped logic fix

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -28,7 +28,6 @@
     <ClCompile Include="src\Ext\Anim\Body.cpp" />
     <ClCompile Include="src\Ext\Anim\Hooks.cpp" />
     <ClCompile Include="src\Ext\Anim\Hooks.AnimCreateUnit.cpp" />
-    <ClCompile Include="src\Ext\Building\Hooks.IncomeAndSelling.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\BombardTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.cpp" />
     <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
@@ -65,6 +64,9 @@
     <ClCompile Include="src\Ext\AnimType\Body.cpp" />
     <ClCompile Include="src\Ext\Building\Body.cpp" />
     <ClCompile Include="src\Ext\Building\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Building\Hooks.Grinding.cpp" />
+    <ClCompile Include="src\Ext\Building\Hooks.Refinery.cpp" />
+    <ClCompile Include="src\Ext\Building\Hooks.Selling.cpp" />
     <ClCompile Include="src\Ext\BulletType\Body.cpp" />
     <ClCompile Include="src\Ext\Bullet\Body.cpp" />
     <ClCompile Include="src\Ext\Bullet\Hooks.cpp" />
@@ -96,7 +98,6 @@
     <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Firing.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Shield.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.Grinding.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Transport.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -9,11 +9,20 @@ This page describes all AI scripting and mapping related additions and changes i
 - Map trigger action `125 Build At...` can now play buildup anim and becomes singleplayer-AI-repairable optionally (needs [following changes to `fadata.ini`](Whats-New.md#for-map-editor-final-alert-2).
 - Both Global Variables (`VariableNames` in `rulesmd.ini`) and Local Variables (`VariableNames` in map) are now unlimited.
 - Script action `Deploy` now has vehicles with `DeploysInto` searching for free space to deploy at if failing to do so at initial location, instead of simply getting stuck.
-- In singleplayer campaigns, AI can now repair the base nodes/buildings delivered by SW (Ares) by setting
+- In **singleplayer campaigns**:
+  - You can now decide whether AI can repair the base nodes/buildings delivered by SW (Ares) by setting
 ```ini
 [Country House]
 RepairBaseNodes=no,no,no ; 3 booleans indicating whether AI repair basenodes in Easy/ Normal/ Difficult game diffculty.
 ```
+
+  - You can now decide whether MCV can redeploy by setting
+```ini
+[Basic]
+MCVRedeploys=no  ; boolean
+```
+  - **Not that these only works within the map file**
+
 - Teams spawned by trigger action 7,80,107 can use IFV and opentopped logic normally.
   - `InitialPayload` logic from Ares is not supported yet.
 - If a pre-placed building has a `NaturalParticleSystem`, it used to always be created when the game starts. This has been removed.
@@ -468,6 +477,18 @@ In `mycampaign.map`:
 [Actions]
 ...
 ID=ActionCount,[Action1],506,0,0,[SuperWeaponTypesIndex],[HouseIndex],[WaypointIndex],0,A,[ActionX]
+...
+```
+
+### `510` Toggle MCV redeployablility
+
+- Force MCV's redeployablility by setting the third parameter.
+
+In `mycampaign.map`:
+```ini
+[Actions]
+...
+ID=ActionCount,[Action1],510,0,0,[MCVRedeploy],0,0,0,A,[ActionX]
 ...
 ```
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -110,6 +110,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Weapons with projectiles with `Level=true` now consider targets behind obstacles that cause the projectile to detonate (tiles belonging to non-water tilesets) as out of range and will attempt to reposition before firing.
 - Fixed infantry without `C4=true` being killed in water if paradropped, chronoshifted etc. even if they can normally enter water.
 - `AnimList` can now be made to create animations on Warheads dealing zero damage by setting `AnimList.ShowOnZeroDamage` to true.
+- Allowed MCV to redeploy in campaigns using a new toggle different from `[MultiplayerDialogSettings]->MCVRedeploys`.
+- Fixed buildings with `UndeploysInto` but `Unsellable=no` & `ConstructionYard=no` unable to be sold normally. Restored `EVA_StructureSold` for buildings with `UndeploysInto` when being selled.
 
 ## Animations
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -117,6 +117,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
   504=Binary operation,0,56,55,60,54,59,0,0,0,[LONG DESC],0,1,504,1
   505=Fire Super Weapon at specified location (Phobos),0,0,20,2,21,22,0,0,0,Launch a Super Weapon from [SuperWeaponTypes] list at a specified location. House=-1 means random target that isn't neutral. House=-2 means the first neutral house. House=-3 means random human target. Coordinate X=-1 means random. Coordinate Y=-1 means random,0,1,505
   506=Fire Super Weapon at specified waypoint (Phobos),0,0,20,2,30,0,0,0,0,Launch a Super Weapon from [SuperWeaponTypes] list at a specified waypoint. House=-1 means random target that isn't neutral. House=-2 means the first neutral house. House=-3 means random human target. Coordinate X=-1 means random. Coordinate Y=-1 means random,0,1,506
+  510=Toggle MCV Redeployablility (Phobos),0,0,15,0,0,0,0,0,0, Set MCVRedeploys to the given value,0,1,510
 
   ; FOLLOWING ENTRIES REQUIRE FA2SP.DLL (by secsome)
   [ScriptTypeLists]
@@ -285,6 +286,7 @@ New:
 - Projectile `SubjectToLand/Water` (by Starkku)
 - Real time timers (by Morton)
 - Default campaign game speed override and custom campaign game speed FPS (by Morton)
+- Trigger actions that allow/forbid MCV to redeploy in game (by Trsdy)
 - `AnimList` on zero damage Warheads toggle via `AnimList.ShowOnZeroDamage` (by Starkku)
 - Including INI files and inheriting INI sections (by Morton)
 
@@ -307,6 +309,9 @@ Vanilla fixes:
 - Fixed `NavalTargeting=6` not preventing from targeting empty water cells or TerrainTypes (trees etc.) on water (by Starkku)
 - Fixed `NavalTargeting=7` and/or `LandTargeting=2` resulting in still targeting TerrainTypes (trees etc.) on land with `Primary` weapon (by Starkku)
 - Fixed an issue that causes attached animations on flying objects not layer correctly (by Starkku)
+- Restored `EVA_StructureSold` for buildings with `UndeploysInto` (by Trsdy)
+- Allow MCV to redeploy in campaigns (by Trsdy)
+- Allow buildings with `UndeploysInto` to be sold if `Unsellable=no` but `ConstructionYard=no` (by Trsdy)
 - Fixed infantry without `C4=true` being killed in water if paradropped, chronoshifted etc. even if they can normally enter water (by Starkku)
 
 Phobos fixes:

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -2,7 +2,6 @@
 
 #include <BitFont.h>
 
-#include <Misc/FlyingStrings.h>
 #include <Utilities/EnumFunctions.h>
 
 template<> const DWORD Extension<BuildingClass>::Canary = 0x87654321;

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -8,6 +8,7 @@
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
 
+#include <Misc/FlyingStrings.h>
 #include <Ext/Techno/Body.h>
 #include <Ext/TechnoType/Body.h>
 #include <Ext/Building/Body.h>

--- a/src/Ext/Building/Hooks.Grinding.cpp
+++ b/src/Ext/Building/Hooks.Grinding.cpp
@@ -3,8 +3,6 @@
 #include <InfantryClass.h>
 #include <InputManagerClass.h>
 
-#include <Ext/Building/Body.h>
-
 DEFINE_HOOK(0x43C30A, BuildingClass_ReceiveMessage_Grinding, 0x6)
 {
 	enum { ReturnStatic = 0x43C31A, ReturnNegative = 0x43CB68, ReturnRoger = 0x43CCF2 };

--- a/src/Ext/Building/Hooks.Selling.cpp
+++ b/src/Ext/Building/Hooks.Selling.cpp
@@ -1,0 +1,105 @@
+#include "Body.h"
+#include <GameStrings.h>
+
+// SellSound and EVA dehardcode
+DEFINE_HOOK(0x4D9F7B, FootClass_Sell, 0x6)
+{
+	enum { ReadyToVanish = 0x4D9FCB };
+	GET(FootClass*, pThis, ESI);
+
+	int money = pThis->GetRefund();
+	pThis->Owner->GiveMoney(money);
+
+	if (pThis->Owner->IsControlledByCurrentPlayer())
+	{
+		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+		VoxClass::PlayIndex(pTypeExt->EVA_Sold.Get(VoxClass::FindIndex(GameStrings::EVA_UnitSold)));
+		//WW used VocClass::PlayGlobal to play the SellSound, why did they do that?
+		VocClass::PlayAt(pTypeExt->SellSound.Get(RulesClass::Instance->SellSound), pThis->Location);
+	}
+
+	if (RulesExt::Global()->DisplayIncome.Get())
+		FlyingStrings::AddMoneyString(money, pThis->Owner, RulesExt::Global()->DisplayIncome_Houses.Get(), pThis->Location);
+
+	return ReadyToVanish;
+}
+
+// Rewrite 0x449BC0
+// true: undeploy into vehicle; false: sell
+bool __forceinline BuildingCanUndeploy(BuildingClass* pThis)
+{
+	auto pType = pThis->Type;
+
+	if (!pType->UndeploysInto)
+		return false;
+
+	if (pType->ConstructionYard)
+	{
+		// Canyards can't undeploy if MCVRedeploy=no or MindControlledBy YURIX
+		if(!GameModeOptionsClass::Instance->MCVRedeploy || pThis->MindControlledBy || !pThis->Owner->IsControlledByHuman())
+			return false;
+	}
+	// Move Focus check outside Conyard check to allow generic Unsellable=no buildings to be sold
+	return pThis->Focus;
+}
+
+// Skip SessionClass::IsCampaign() checks, where inlined not exactly the function above but sth similar
+DEFINE_JUMP(LJMP, 0x443A9A, 0x443AA3); //BuildingClass_SetRallyPoint
+DEFINE_JUMP(LJMP, 0x44375E, 0x443767); //BuildingClass_CellClickedAction
+DEFINE_JUMP(LJMP, 0x44F602, 0x44F60B); //BuildingClass_IsControllable
+
+DEFINE_HOOK(0x449CC1, BuildingClass_Mi_Selling_EVASold_UndeploysInto, 0x6)
+{
+	enum { CreateUnit = 0x449D5E, SkipTheEntireShit = 0x44A1E8 };
+	GET(BuildingClass*, pThis, EBP);
+
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
+	// Fix Conyards can't play EVA_StructureSold
+	if (pThis->IsOwnedByCurrentPlayer && (!pThis->Focus || !pThis->Type->UndeploysInto))
+		VoxClass::PlayIndex(pTypeExt->EVA_Sold.Get(VoxClass::FindIndex(GameStrings::EVA_StructureSold)));
+
+	return BuildingCanUndeploy(pThis) ? CreateUnit : SkipTheEntireShit;
+}
+
+DEFINE_HOOK(0x44A7CF, BuildingClass_Mi_Selling_PlaySellSound, 0x6)
+{
+	enum { FinishPlaying = 0x44A85B };
+	GET(BuildingClass*, pThis, EBP);
+
+	if (!BuildingCanUndeploy(pThis))
+	{
+		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
+		VocClass::PlayAt(pTypeExt->SellSound.Get(RulesClass::Instance->SellSound), pThis->Location);
+	}
+
+	return FinishPlaying;
+}
+
+DEFINE_HOOK(0x44A8E5, BuildingClass_Mi_Selling_SetTarget, 0x6)
+{
+	enum { ResetTarget = 0x44A937, SkipShit = 0x44A95E };
+	GET(BuildingClass*, pThis, EBP);
+
+	return BuildingCanUndeploy(pThis) ? ResetTarget : SkipShit;
+}
+
+DEFINE_HOOK(0x44A964, BuildingClass_Mi_Selling_VoiceDeploy, 0x6)
+{
+	enum { CanDeploySound = 0x44A9CA, SkipShit = 0x44AA3D };
+	GET(BuildingClass*, pThis, EBP);
+
+	return BuildingCanUndeploy(pThis) ? CanDeploySound : SkipShit;
+}
+
+DEFINE_HOOK(0x44AB22, BuildingClass_Mi_Selling_EVASold_Plug, 0x6)
+{
+	enum { SkipVoxPlay = 0x44AB3B };
+	GET(BuildingClass*, pThis, EBP);
+
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
+
+	if (pThis->IsOwnedByCurrentPlayer)
+		VoxClass::PlayIndex(pTypeExt->EVA_Sold.Get(VoxClass::FindIndex(GameStrings::EVA_StructureSold)));
+
+	return SkipVoxPlay;
+}

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
 
 #include <SessionClass.h>
+#include <GameStrings.h>
 
 template<> const DWORD Extension<ScenarioClass>::Canary = 0xABCD1595;
 std::unique_ptr<ScenarioExt::ExtData> ScenarioExt::Data = nullptr;
@@ -81,9 +82,14 @@ void ScenarioExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 {
 	// auto pThis = this->OwnerObject();
 
-	// INI_EX exINI(pINI);
+	INI_EX exINI(pINI);
 
-
+	if (SessionClass::IsCampaign())
+	{
+		Nullable<bool> SP_MCVRedeploy;
+		SP_MCVRedeploy.Read(exINI, GameStrings::Basic, GameStrings::MCVRedeploys);
+		GameModeOptionsClass::Instance->MCVRedeploy = SP_MCVRedeploy.Get(false);
+	}
 
 }
 
@@ -188,10 +194,10 @@ DEFINE_HOOK(0x68945B, ScenarioClass_Save_Suffix, 0x8)
 	return 0;
 }
 
-DEFINE_HOOK(0x68AD62, ScenarioClass_LoadFromINI, 0x6)
+DEFINE_HOOK(0x68AD2F, ScenarioClass_LoadFromINI, 0x5)
 {
 	GET(ScenarioClass*, pItem, ESI);
-	GET_STACK(CCINIClass*, pINI, STACK_OFFSET(0x38, 0x8));
+	GET(CCINIClass*, pINI, EDI);
 
 	ScenarioExt::LoadFromINIFile(pItem, pINI);
 	return 0;

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -67,6 +67,10 @@ bool TActionExt::Execute(TActionClass* pThis, HouseClass* pHouse, ObjectClass* p
 		return TActionExt::RunSuperWeaponAtLocation(pThis, pHouse, pObject, pTrigger, location);
 	case PhobosTriggerAction::RunSuperWeaponAtWaypoint:
 		return TActionExt::RunSuperWeaponAtWaypoint(pThis, pHouse, pObject, pTrigger, location);
+
+	case PhobosTriggerAction::ToggleMCVRedeploy:
+		return TActionExt::ToggleMCVRedeploy(pThis, pHouse, pObject, pTrigger, location);
+
 	default:
 		bHandled = false;
 		return true;
@@ -430,6 +434,13 @@ bool TActionExt::RunSuperWeaponAt(TActionClass* pThis, int X, int Y)
 
 	return true;
 }
+
+bool TActionExt::ToggleMCVRedeploy(TActionClass* pThis, HouseClass* pHouse, ObjectClass* pObject, TriggerClass* pTrigger, CellStruct const& location)
+{
+	GameModeOptionsClass::Instance->MCVRedeploy = pThis->Param3 != 0;
+	return true;
+}
+
 
 // =============================
 // container

--- a/src/Ext/TAction/Body.h
+++ b/src/Ext/TAction/Body.h
@@ -18,6 +18,7 @@ enum class PhobosTriggerAction : unsigned int
 	BinaryOperation = 504,
 	RunSuperWeaponAtLocation = 505,
 	RunSuperWeaponAtWaypoint = 506,
+	ToggleMCVRedeploy = 510,
 };
 
 class TActionExt
@@ -59,6 +60,7 @@ public:
 	ACTION_FUNC(BinaryOperation);
 	ACTION_FUNC(RunSuperWeaponAtLocation);
 	ACTION_FUNC(RunSuperWeaponAtWaypoint);
+	ACTION_FUNC(ToggleMCVRedeploy);
 
 	static bool RunSuperWeaponAt(TActionClass* pThis, int X, int Y);
 


### PR DESCRIPTION
# Redeployable MCV in campaigns
You can now set 
```ini
[Basic]
MCVRedeploys=yes
```
within your *singleplayer campaign* **map file** to allow it

# Allow buildings with `UndeploysInto` to be sold even if not conyard
# Restore `EVA_StructureSold` for buildings with `UndeploysInto` 

(already in develop, only makes sense with this one)

# Trigger action that allow/forbid MCV to redeploy in game 
### `510` Toggle MCV redeployablility
- Force MCV's redeployablility by setting the third parameter.

In `mycampaign.map`:
```ini
[Actions]
...
ID=ActionCount,[Action1],510,0,0,[MCVRedeploy],0,0,0,A,[ActionX]
...
```

In fadata.ini
```ini
 [ActionsRA2]
 510=Toggle MCV Redeployablility (Phobos),0,0,15,0,0,0,0,0,0, Set MCVRedeploy to the given value. 1 for yes 0 for no,0,1,510
```