### PR TITLE
WIP Reimplement INI inheritance

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -188,6 +188,7 @@ This page lists all the individual contributions to the project by their author.
   - SpyEffects expansion, launching Super Weapons on building infiltration
   - Real time timers
   - Default campaign game speed override and custom campaign game speed FPS
+  - INI section inheritance
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -188,7 +188,7 @@ This page lists all the individual contributions to the project by their author.
   - SpyEffects expansion, launching Super Weapons on building infiltration
   - Real time timers
   - Default campaign game speed override and custom campaign game speed FPS
-  - INI section inheritance
+  - Including INI files and inheriting INI sections
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
     <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
     <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
+	<ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
     <ClCompile Include="src\Phobos.CRT.cpp" />
     <ClCompile Include="src\Phobos.Ext.cpp" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -124,7 +124,7 @@
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
     <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
     <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
-	<ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
+    <ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
     <ClCompile Include="src\Phobos.CRT.cpp" />
     <ClCompile Include="src\Phobos.Ext.cpp" />

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -123,14 +123,33 @@ function onInput() {
 
 ## INI
 
-### Section inheritance
-- You can now make sections (children) inherit entries from other sections (parents) with `$Inherits`.
-  - Every parent entry will be inherited verbatim, without checking if it is valid.
-  - When there are multiple parents, they will be inherited in the order they were given.
-  - In the child entry, entries before `$Inherits` can be overwritten if they are defined inside parents. **It is advised to always keep `$Inherits` as the first entry in a section.**
+### Include files
+- INI files can now include other files (merge them into self) using `[$Include]` section.
+  - `[$Include]` section contains a list of files to read and include. Files can be directly in the Red Alert 2 directory or in a loaded MIX file.
+  - Files will be added in the same order they are defined. Index of each file **must be unique among all included files**.
+  - Inclusion can be nested recursively (included files can include files further). Recursion is depth-first (before including next file, check if the current one includes anything).
+  - When the same entry exists in two files, then the one read later will overwrite the value.
+  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini` or others.
 
 ```{warning}
-Currently, this feature only works in files included by [Ares #include feature](https://ares-developers.github.io/Ares-docs/new/misc/include.html).
+When Phobos is present, the [Ares equivalent of $Include](https://ares-developers.github.io/Ares-docs/new/misc/include.html) is disabled!
+```
+
+In any file:
+```ini
+[$Include]
+0=somefile.ini	; file name
+```
+
+### Section inheritance
+- You can now make sections (children) inherit entries from other sections (parents) with `$Inherits`.
+  - When a section has no value set for an entry (or an entry is missing), the game will attempt to use parent's value. If no value is found, only then the default will be used.
+  - When multiple parents are specified, the order of inheritance is "first come, first served", looking up comma separated parents from left to right.
+  - Inheritance can be nested recursively (parent sections can have their own parents). Recursion is depth-first (before inheriting from the next parent, check if the current parent has parents).
+  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini` or others.
+
+```{warning}
+When Phobos is present, the Ares equivalent of $Inherits (undocumented) is disabled!
 ```
 
 In any file:

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -129,7 +129,7 @@ function onInput() {
   - Files will be added in the same order they are defined. Index of each file **must be unique among all included files**.
   - Inclusion can be nested recursively (included files can include files further). Recursion is depth-first (before including next file, check if the current one includes anything).
   - When the same entry exists in two files, then the one read later will overwrite the value.
-  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini` or others.
+  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini`, map file or anything else.
 
 ```{warning}
 When Phobos is present, the [Ares equivalent of $Include](https://ares-developers.github.io/Ares-docs/new/misc/include.html) is disabled!
@@ -146,7 +146,7 @@ In any file:
   - When a section has no value set for an entry (or an entry is missing), the game will attempt to use parent's value. If no value is found, only then the default will be used.
   - When multiple parents are specified, the order of inheritance is "first come, first served", looking up comma separated parents from left to right.
   - Inheritance can be nested recursively (parent sections can have their own parents). Recursion is depth-first (before inheriting from the next parent, check if the current parent has parents).
-  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini` or others.
+  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini`, map file or anything else.
 
 ```{warning}
 When Phobos is present, the Ares equivalent of $Inherits (undocumented) is disabled!

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -120,3 +120,25 @@ function onInput() {
 	}
 }
 </script>
+
+## INI
+
+### Section inheritance
+- You can now make sections (children) inherit entries from other sections (parents) with `$Inherits`.
+  - Every parent entry will be inherited verbatim, without checking if it is valid.
+  - When there are multiple parents, they will be inherited in the order they were given.
+  - In the child entry, entries before `$Inherits` can be overwritten if they are defined inside parents. **It is advised to always keep `$Inherits` as the first entry in a section.**
+
+```{warning}
+Currently, this feature only works in files included by [Ares #include feature](https://ares-developers.github.io/Ares-docs/new/misc/include.html).
+```
+
+In any file:
+```ini
+[PARENT1SECTION]
+
+[PARENT2SECTION]
+
+[CHILDSECTION]
+$Inherits=PARENT1SECTION,PARENT2SECTION...  ; section names
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -282,7 +282,7 @@ New:
 - Real time timers (by Morton)
 - Default campaign game speed override and custom campaign game speed FPS (by Morton)
 - `AnimList` on zero damage Warheads toggle via `AnimList.ShowOnZeroDamage` (by Starkku)
-- INI section inheritance (by Morton)
+- Including INI files and inheriting INI sections (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -14,6 +14,10 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - Translucent RLE SHPs will now be drawn using a more precise and performant algorithm that has no green tint and banding. Can be disabled with `rulesmd.ini->[General]->FixTransparencyBlitters=no`.
 - Iron Curtain status is now preserved by default when converting between TechnoTypes via `DeploysInto`/`UndeploysInto`. This behavior can be turned off per-TechnoType and global basis using `[SOMETECHNOTYPE]/[CombatDamage]->IronCurtain.KeptOnDeploy=no`.
 
+### From Ares
+
+- `[#include]` section and `[CHILD]:[PARENT]` section inheritance notation are disabled, replaced by Phobos `[$Include]` and `$Inherits`.
+
 ### From older Phobos versions
 
 #### From 0.3

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -282,6 +282,7 @@ New:
 - Real time timers (by Morton)
 - Default campaign game speed override and custom campaign game speed FPS (by Morton)
 - `AnimList` on zero damage Warheads toggle via `AnimList.ShowOnZeroDamage` (by Starkku)
+- INI section inheritance (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Misc/Hooks.INIInheritance.cpp
+++ b/src/Misc/Hooks.INIInheritance.cpp
@@ -1,7 +1,119 @@
 #include <Utilities/Debug.h>
+#include <Utilities/Macro.h>
 #include <Helpers/Macro.h>
 #include <CCINIClass.h>
 
+#include <vector>
+
+namespace INIInheritance
+{
+	const char* Empty = "";
+	std::vector<char*> SavedEntries;
+	std::vector<char*> SavedSections;
+	int ReadString(REGISTERS* R, int address);
+}
+
+int INIInheritance::ReadString(REGISTERS* R, int address)
+{
+	const int stackOffset = 0x1C;
+	GET(CCINIClass*, ini, EBP);
+	GET_STACK(int, length, STACK_OFFSET(stackOffset, 0x14));
+	GET_STACK(char*, buffer, STACK_OFFSET(stackOffset, 0x10));
+	GET_STACK(const char*, defaultValue, STACK_OFFSET(stackOffset, 0xC));
+	//GET_STACK(char*, entryName, STACK_OFFSET(stackOffset, 0x8));
+	//GET_STACK(const char*, sectionName, STACK_OFFSET(stackOffset, 0x4));
+
+	char* entryName = INIInheritance::SavedEntries.back();
+	char* sectionName = INIInheritance::SavedSections.back();
+
+	auto finalize = [R, buffer, entryName, address](const char* value)
+	{
+		R->EDI(buffer);
+		R->EAX(0);
+		R->ECX(value);
+		return address;
+	};
+
+	if (strncmp(entryName, "$Inherits", 10) == 0)
+	{
+		auto section = ini->GetSection(sectionName);
+		if (!section)
+			return finalize(defaultValue);
+		for (auto entryNode : section->EntryIndex)
+		{
+			if (strncmp(entryNode.Data->Key, "$Inherits", 10) == 0)
+			{
+				return finalize(entryNode.Data->Value);
+			}
+		}
+		return finalize(defaultValue);
+	}
+
+	// search for $Inherits entry
+	char inheritSectionsString[0x100];
+	if (ini->ReadString(sectionName, "$Inherits", INIInheritance::Empty, inheritSectionsString, 0x100) == 0)
+		return finalize(defaultValue);
+
+	// for each section in csv, search for entry
+	char bufferStart = NULL;
+	char* split = strtok(inheritSectionsString, ",");
+	do
+	{
+		if (ini->ReadString(split, entryName, defaultValue, buffer, length) != 0)
+			bufferStart = buffer[0];
+		else
+			buffer[0] = bufferStart;
+	}
+	while (split = strtok(NULL, ","));
+
+	return finalize(buffer);
+}
+
+// INIClass_GetString_DisableAres
+DEFINE_PATCH(0x528A10, 0x83, 0xEC, 0x0C, 0x33, 0xC0);
+// INIClass_GetKeyName_DisableAres
+DEFINE_PATCH(0x526CC0, 0x8B, 0x54, 0x24, 0x04, 0x83, 0xEC, 0x0C);
+
+DEFINE_HOOK(0x528A18, INIClass_GetString_SaveEntry, 0x6)
+{
+	GET_STACK(char*, entryName, STACK_OFFSET(0x18, 0x8));
+	GET_STACK(char*, sectionName, STACK_OFFSET(0x18, 0x4));
+	INIInheritance::SavedEntries.push_back(_strdup(entryName));
+	INIInheritance::SavedSections.push_back(_strdup(sectionName));
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x528BC9, INIClass_GetString_FreeEntry, 0x5)
+DEFINE_HOOK(0x528BBE, INIClass_GetString_FreeEntry, 0x5)
+{
+	char* entry = INIInheritance::SavedEntries.back();
+	if (entry)
+		free(entry);
+	INIInheritance::SavedEntries.pop_back();
+
+	char* section = INIInheritance::SavedSections.back();
+	if (section)
+		free(section);
+	INIInheritance::SavedSections.pop_back();
+
+	return 0;
+}
+
+// kind of useless in our case? if there's no section, there's no $Inherits entry either
+/*
+DEFINE_HOOK(0x528B80, INIClass_GetString_Inheritance_NoSection, 0x8)
+{
+	return INIInheritance::ReadString(R, 0x528B88);
+}
+*/
+
+DEFINE_HOOK(0x528BAC, INIClass_GetString_Inheritance_NoEntry, 0xA)
+{
+	return INIInheritance::ReadString(R, 0x528BB6);
+}
+
+// piggyback on top of Ares version
+/*
 DEFINE_HOOK(0x525D23, INIClass_Load_Inherits, 0x5)
 {
 	LEA_STACK(char*, entry, STACK_OFFSET(0x478, -0x400));
@@ -28,3 +140,36 @@ DEFINE_HOOK(0x525D23, INIClass_Load_Inherits, 0x5)
 
 	return 0;
 }
+*/
+
+// a parital attempt at reversing Ares
+/*
+DEFINE_HOOK(0x528A10, INIClass_GetString_Inheritance, 0x5)
+{
+	enum { End = 0x528BFA };
+	const int stackOffset = 0x0;
+	GET(CCINIClass*, ini, EBP);
+	GET_STACK(int, bufferSize, STACK_OFFSET(stackOffset, 0x14));
+	GET_STACK(char*, buffer, STACK_OFFSET(stackOffset, 0x10));
+	GET_STACK(const char*, defaultValue, STACK_OFFSET(stackOffset, 0xC));
+	GET_STACK(char*, entryName, STACK_OFFSET(stackOffset, 0x8));
+	GET_STACK(const char*, sectionName, STACK_OFFSET(stackOffset, 0x4));
+
+	if (!buffer || bufferSize < 2 || !sectionName || !entryName)
+		return End;
+
+	int len = INIInheritance::PhobosGetString(ini, sectionName, entryName, defaultValue, buffer);
+	if(!len)
+		return 0;
+
+	// trim both sides
+	while (*buffer && *buffer++ <= ' ');
+	char* back = buffer + strlen(buffer);
+	while (*--back && *back <= ' ');
+	// set new size and null terminate the result
+	bufferSize = std::min(back - buffer, bufferSize - 1);
+	*(back + 1) = NULL;
+
+	return End;
+}
+*/

--- a/src/Misc/Hooks.INIInheritance.cpp
+++ b/src/Misc/Hooks.INIInheritance.cpp
@@ -1,0 +1,30 @@
+#include <Utilities/Debug.h>
+#include <Helpers/Macro.h>
+#include <CCINIClass.h>
+
+DEFINE_HOOK(0x525D23, INIClass_Load_Inherits, 0x5)
+{
+	LEA_STACK(char*, entry, STACK_OFFSET(0x478, -0x400));
+	LEA_STACK(char*, section, STACK_OFFSET(0x478, -0x200));
+	GET(char*, value, ESI);
+	GET(CCINIClass*, ini, EBP);
+
+	if (strncmp(entry, "$Inherits", 10) != 0)
+		return 0;
+
+	// for each name in csv, find and copy section
+	char* valueCopy = _strdup(value);
+	char* split = strtok(valueCopy, ",");
+	do
+	{
+		auto copiedSection = ini->GetSection(split);
+		if (!copiedSection)
+			continue;
+		for (auto entryNode: copiedSection->EntryIndex)
+			ini->WriteString(section, entryNode.Data->Key, entryNode.Data->Value);
+	}
+	while (split = strtok(NULL, ","));
+	free(valueCopy);
+
+	return 0;
+}


### PR DESCRIPTION
### Include files
- INI files can now include other files (merge them into self) using `[$Include]` section.
  - `[$Include]` section contains a list of files to read and include. Files can be directly in the Red Alert 2 directory or in a loaded MIX file.
  - Files will be added in the same order they are defined. Index of each file **must be unique among all included files**.
  - Inclusion can be nested recursively (included files can include files further). Recursion is depth-first (before including next file, check if the current one includes anything).
  - When the same entry exists in two files, then the one read later will overwrite the value.
  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini` or others.

```{warning}
When Phobos is present, the [Ares equivalent of $Include](https://ares-developers.github.io/Ares-docs/new/misc/include.html) is disabled!
```

In any file:
```ini
[$Include]
0=somefile.ini	; file name
```

### Section inheritance
- You can now make sections (children) inherit entries from other sections (parents) with `$Inherits`.
  - When a section has no value set for an entry (or an entry is missing), the game will attempt to use parent's value. If no value is found, only then the default will be used.
  - When multiple parents are specified, the order of inheritance is "first come, first served", looking up comma separated parents from left to right.
  - Inheritance can be nested recursively (parent sections can have their own parents). Recursion is depth-first (before inheriting from the next parent, check if the current parent has parents).
  - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini` or others.

```{warning}
When Phobos is present, the Ares equivalent of $Inherits (undocumented) is disabled!
```

In any file:
```ini
[PARENT1SECTION]

[PARENT2SECTION]

[CHILDSECTION]
$Inherits=PARENT1SECTION,PARENT2SECTION...  ; section names
```