### PR TITLE
Fix some details in the transport script action code

### DIFF
--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -260,6 +260,13 @@ void ScriptExt::LoadIntoTransports(TeamClass* pTeam)
 					transports.emplace_back(pUnit);
 	}
 
+	if (transports.size() == 0)
+	{
+		// This action finished
+		pTeam->StepCompleted = true;
+		return;
+	}
+
 	// Now load units into transports
 	for (auto pTransport : transports)
 	{
@@ -309,9 +316,6 @@ void ScriptExt::LoadIntoTransports(TeamClass* pTeam)
 	}
 
 	// This action finished
-	if (pTeam->CurrentScript->HasNextMission())
-		++pTeam->CurrentScript->CurrentMission;
-
 	pTeam->StepCompleted = true;
 }
 


### PR DESCRIPTION
- If there are no transports in the vector it shouldn't continue and jump to the next mission.
- Removed the increment of current script line execution because it skips the next script line and the game will run the "next+1" instead.