### PR TITLE
[Enhancement]Reveal Warhead On Impact

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -229,7 +229,9 @@ This page lists all the individual contributions to the project by their author.
 - **FlyStar**
    - Campaign load screen PCX support
    - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist
-- **NetsuNegi** - Forbidding parallel AI queues by type
+- **NetsuNegi**
+   - Forbidding parallel AI queues by type
+   - Reveal area warhead
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**
    - Customizable ShowTimer priority of superweapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1011,15 +1011,15 @@ In `rulesmd.ini`:
 RemoveDisguise=false  ; boolean
 ```
 
-### Reveal map for owner on impact
+### Reveal area for owner on impact
 
-- Warheads can now reveal the entire map on impact.
+- Warheads can now reveal some area in range or entire map on impact.
   - Reveal only applies to the owner of the warhead.
 
 In `rulesmd.ini`:
 ```ini
 [SOMEWARHEAD]  ; Warhead
-SpySat=false   ; boolean
+Reveal=0   ; integer, positive value specific range of reveal, negative value means entire map
 ```
 
 ### Shroud map for enemies on impact

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -98,7 +98,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	INI_EX exINI(pINI);
 
 	// Miscs
-	this->SpySat.Read(exINI, pSection, "SpySat");
+	this->Reveal.Read(exINI, pSection, "Reveal");
 	this->BigGap.Read(exINI, pSection, "BigGap");
 	this->TransactMoney.Read(exINI, pSection, "TransactMoney");
 	this->TransactMoney_Display.Read(exINI, pSection, "TransactMoney.Display");
@@ -182,7 +182,7 @@ template <typename T>
 void WarheadTypeExt::ExtData::Serialize(T& Stm)
 {
 	Stm
-		.Process(this->SpySat)
+		.Process(this->Reveal)
 		.Process(this->BigGap)
 		.Process(this->TransactMoney)
 		.Process(this->TransactMoney_Display)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -16,7 +16,7 @@ public:
 	{
 	public:
 
-		Valueable<bool> SpySat;
+		Valueable<int> Reveal;
 		Valueable<bool> BigGap;
 		Valueable<int> TransactMoney;
 		Valueable<bool> TransactMoney_Display;
@@ -103,7 +103,7 @@ public:
 
 	public:
 		ExtData(WarheadTypeClass* OwnerObject) : Extension<WarheadTypeClass>(OwnerObject)
-			, SpySat { false }
+			, Reveal { 0 }
 			, BigGap { false }
 			, TransactMoney { 0 }
 			, TransactMoney_Display { false }

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -47,7 +47,9 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 			}
 		}
 
-		if (this->SpySat)
+		if (this->Reveal > 0)
+			MapClass::Instance->RevealArea1(&coords, this->Reveal, pHouse, CellStruct::Empty, 0, 0, 0, 1);
+		else if (this->Reveal < 0)
 			MapClass::Instance->Reveal(pHouse);
 
 		if (this->TransactMoney)


### PR DESCRIPTION
Now we can specific range of reveal, or just show entire map again.

[Warhead]>SpySat is obsolete.

In `rulesmd.ini`:
```ini
[SOMEWARHEAD]  ; Warhead
Reveal=0   ; integer, positive value specific range of reveal, negative value means entire map
```