### PR TITLE
Disable AnimType/BuildingTypeClass first INI parsing pass

### DIFF
--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -653,3 +653,6 @@ DEFINE_HOOK(0x6FC87D, TechnoClass_CanFire_AG, 0x6)
 
 	return 0;
 }
+
+// Stops INI parsing for Anim/BuildingTypeClass on game startup, will only be read on scenario load later like everything else.
+DEFINE_JUMP(LJMP, 0x52C9C4, 0x52CA37);


### PR DESCRIPTION
Disables the seemingly unnecessary first parsing pass for AnimType/BuildingTypeClass on game initialization. Gets rid of certain parsing errors and speeds up starting the game a little bit. This is a PR instead of pushed straight to develop despite being a seemingly minor change to allow testing it separately to see if there are any unforeseen consequences.