### PR TITLE
Improve INI inheritance performance & add a toggle

### DIFF
--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -125,7 +125,7 @@ function onInput() {
 
 ### Include files
 - INI files can now include other files (merge them into self) using `[$Include]` section.
-  - This feature must be enabled via a command line argument `-Include` or `-Inheritance`.
+  - This feature must be enabled via a command line argument `-Include`.
   - `[$Include]` section contains a list of files to read and include. Files can be directly in the Red Alert 2 directory or in a loaded MIX file.
   - Files will be added in the same order they are defined. Index of each file **must be unique among all included files**.
   - Inclusion can be nested recursively (included files can include files further). Recursion is depth-first (before including next file, check if the current one includes anything).
@@ -148,7 +148,7 @@ In any file:
 
 ### Section inheritance
 - You can now make sections (children) inherit entries from other sections (parents) with `$Inherits` entry.
-  - This feature must be enabled via a command line argument `-Inheritance`. Enabling this feature also enables `-Include`.
+  - This feature must be enabled via a command line argument `-Inheritance`.
   - When a section has no value set for an entry (or an entry is missing), the game will attempt to use parent's value. If no value is found, only then the default will be used.
   - When multiple parents are specified, the order of inheritance is "first come, first served", looking up comma separated parents from left to right.
   - Inheritance can be nested recursively (parent sections can have their own parents). Recursion is depth-first (before inheriting from the next parent, check if the current parent has parents).

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -124,8 +124,12 @@ function onInput() {
 ## INI
 
 ### Include files
+
+```{note}
+This feature must be enabled via a command line argument `-Include`.
+```
+
 - INI files can now include other files (merge them into self) using `[$Include]` section.
-  - This feature must be enabled via a command line argument `-Include`.
   - `[$Include]` section contains a list of files to read and include. Files can be directly in the Red Alert 2 directory or in a loaded MIX file.
   - Files will be added in the same order they are defined. Index of each file **must be unique among all included files**.
   - Inclusion can be nested recursively (included files can include files further). Recursion is depth-first (before including next file, check if the current one includes anything).
@@ -137,7 +141,7 @@ Due to a technical issue, there is a chance that ***the first line of a included
 ```
 
 ```{warning}
-When this feature is enabled, the [Ares equivalent of $Include](https://ares-developers.github.io/Ares-docs/new/misc/include.html) is disabled!
+When this feature is enabled, the [Ares equivalent of `[$Include]`](https://ares-developers.github.io/Ares-docs/new/misc/include.html) is disabled!
 ```
 
 In any file:
@@ -147,15 +151,19 @@ In any file:
 ```
 
 ### Section inheritance
+
+```{note}
+This feature must be enabled via a command line argument `-Inheritance`.
+```
+
 - You can now make sections (children) inherit entries from other sections (parents) with `$Inherits` entry.
-  - This feature must be enabled via a command line argument `-Inheritance`.
   - When a section has no value set for an entry (or an entry is missing), the game will attempt to use parent's value. If no value is found, only then the default will be used.
   - When multiple parents are specified, the order of inheritance is "first come, first served", looking up comma separated parents from left to right.
   - Inheritance can be nested recursively (parent sections can have their own parents). Recursion is depth-first (before inheriting from the next parent, check if the current parent has parents).
   - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini`, map file or anything else.
 
 ```{warning}
-When this feature is enabled, the Ares equivalent of $Inherits (undocumented) is disabled!
+When this feature is enabled, the Ares equivalent of `$Inherits` (undocumented) is disabled!
 ```
 
 ```{warning}

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -146,14 +146,19 @@ In any file:
 ```
 
 ### Section inheritance
-- You can now make sections (children) inherit entries from other sections (parents) with `$Inherits`.
+- You can now make sections (children) inherit entries from other sections (parents) with `$Inherits` entry.
+  - This feature must be enabled via a command line argument `-Inheritance`.
   - When a section has no value set for an entry (or an entry is missing), the game will attempt to use parent's value. If no value is found, only then the default will be used.
   - When multiple parents are specified, the order of inheritance is "first come, first served", looking up comma separated parents from left to right.
   - Inheritance can be nested recursively (parent sections can have their own parents). Recursion is depth-first (before inheriting from the next parent, check if the current parent has parents).
   - This feature can be used in *any* INI file, be it `rulesmd.ini`, `artmd.ini`, `soundmd.ini`, map file or anything else.
 
 ```{warning}
-When Phobos is present, the Ares equivalent of $Inherits (undocumented) is disabled!
+When this feature is enabled, the Ares equivalent of $Inherits (undocumented) is disabled!
+```
+
+```{warning}
+This feature may noticeably increase game loading time, depending on the size of game rules and used hardware.
 ```
 
 In any file:

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -125,6 +125,7 @@ function onInput() {
 
 ### Include files
 - INI files can now include other files (merge them into self) using `[$Include]` section.
+  - This feature must be enabled via a command line argument `-Include` or `-Inheritance`.
   - `[$Include]` section contains a list of files to read and include. Files can be directly in the Red Alert 2 directory or in a loaded MIX file.
   - Files will be added in the same order they are defined. Index of each file **must be unique among all included files**.
   - Inclusion can be nested recursively (included files can include files further). Recursion is depth-first (before including next file, check if the current one includes anything).
@@ -136,7 +137,7 @@ Due to a technical issue, there is a chance that ***the first line of a included
 ```
 
 ```{warning}
-When Phobos is present, the [Ares equivalent of $Include](https://ares-developers.github.io/Ares-docs/new/misc/include.html) is disabled!
+When this feature is enabled, the [Ares equivalent of $Include](https://ares-developers.github.io/Ares-docs/new/misc/include.html) is disabled!
 ```
 
 In any file:
@@ -147,7 +148,7 @@ In any file:
 
 ### Section inheritance
 - You can now make sections (children) inherit entries from other sections (parents) with `$Inherits` entry.
-  - This feature must be enabled via a command line argument `-Inheritance`.
+  - This feature must be enabled via a command line argument `-Inheritance`. Enabling this feature also enables `-Include`.
   - When a section has no value set for an entry (or an entry is missing), the game will attempt to use parent's value. If no value is found, only then the default will be used.
   - When multiple parents are specified, the order of inheritance is "first come, first served", looking up comma separated parents from left to right.
   - Inheritance can be nested recursively (parent sections can have their own parents). Recursion is depth-first (before inheriting from the next parent, check if the current parent has parents).

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -17,6 +17,10 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 ### From older Phobos versions
 
+#### From post-0.3 devbuilds
+
+- INI inclusion and inheritance are now turned off by default and need to be turned on via command line flags `-Include` and `-Inheritance`.
+
 #### From 0.3
 
 - `LaunchSW.RealLaunch=false` now checks if firing house has enough credits to satisfy SW's `Money.Amount` in order to be fired.
@@ -29,7 +33,6 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - `[JumpjetControls]->TurnToTarget` and `JumpjetTurnToTarget` are obsolete. Jumpjet units who fire `OmniFire=no` weapons **always** turn to targets as other units do.
   - `OmniFire.TurnToTarget` is recommended for jumpjet units' omnifiring weapons for facing turning.
 - Buildings delivered by trigger action 125 will now **always** play buildup anim as long as it exists. `[ParamTypes]->53` is deprecated.
-- INI inclusion and inheritance are now turned off by default and need to be turned on via command line flags `-Include` and `-Inheritance`.
 
 #### From pre-0.3 devbuilds
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -15,10 +15,6 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - Iron Curtain status is now preserved by default when converting between TechnoTypes via `DeploysInto`/`UndeploysInto`. This behavior can be turned off per-TechnoType and global basis using `[SOMETECHNOTYPE]/[CombatDamage]->IronCurtain.KeptOnDeploy=no`.
 - The obsolete `[General] WarpIn` has been enabled for the default anim type when technos are warping in. If you want to restore the vanilla behavior, use the same anim type as `WarpOut`.
 
-### From Ares
-
-- `[#include]` section and `[CHILD]:[PARENT]` section inheritance notation are disabled, replaced by Phobos `[$Include]` and `$Inherits`.
-
 ### From older Phobos versions
 
 #### From 0.3
@@ -33,6 +29,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - `[JumpjetControls]->TurnToTarget` and `JumpjetTurnToTarget` are obsolete. Jumpjet units who fire `OmniFire=no` weapons **always** turn to targets as other units do.
   - `OmniFire.TurnToTarget` is recommended for jumpjet units' omnifiring weapons for facing turning.
 - Buildings delivered by trigger action 125 will now **always** play buildup anim as long as it exists. `[ParamTypes]->53` is deprecated.
+- INI inclusion and inheritance are now turned off by default and need to be turned on via command line flags `-Include` and `-Inheritance`.
 
 #### From pre-0.3 devbuilds
 

--- a/src/Misc/Hooks.INIInheritance.cpp
+++ b/src/Misc/Hooks.INIInheritance.cpp
@@ -123,6 +123,7 @@ int INIInheritance::ReadString(REGISTERS* R, int address)
 		split = strtok_s(NULL, ",", &state);
 	}
 	while (split);
+	free(inherits);
 
 	return finalize(buffer[0] ? buffer : defaultValue);
 }

--- a/src/Misc/Hooks.INIInheritance.cpp
+++ b/src/Misc/Hooks.INIInheritance.cpp
@@ -177,10 +177,6 @@ int INIInheritance::ReadString(REGISTERS* R, int address)
 	return finalize(buffer[0] ? buffer : defaultValue);
 }
 
-// INIClass_GetString_DisableAres
-DEFINE_PATCH(0x528A10, 0x83, 0xEC, 0x0C, 0x33, 0xC0);
-// INIClass_GetKeyName_DisableAres
-DEFINE_PATCH(0x526CC0, 0x8B, 0x54, 0x24, 0x04, 0x83, 0xEC, 0x0C);
 // INIClass__GetInt__Hack // pop edi, jmp + 6, nop
 DEFINE_PATCH(0x5278C6, 0x5F, 0xEB, 0x06, 0x90);
 // CCINIClass_ReadCCFile1_DisableAres

--- a/src/Misc/Hooks.INIInheritance.cpp
+++ b/src/Misc/Hooks.INIInheritance.cpp
@@ -179,10 +179,6 @@ int INIInheritance::ReadString(REGISTERS* R, int address)
 
 // INIClass__GetInt__Hack // pop edi, jmp + 6, nop
 DEFINE_PATCH(0x5278C6, 0x5F, 0xEB, 0x06, 0x90);
-// CCINIClass_ReadCCFile1_DisableAres
-DEFINE_PATCH(0x474200, 0x8B, 0xF1, 0x8D, 0x54, 0x24, 0x0C)
-// CCINIClass_ReadCCFile2_DisableAres
-DEFINE_PATCH(0x474314, 0x81, 0xC4, 0xA8, 0x00, 0x00, 0x00)
 
 DEFINE_HOOK(0x528BAC, INIClass_GetString_Inheritance_NoEntry, 0xA)
 {

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -32,6 +32,8 @@ const wchar_t* Phobos::VersionDescription = L"Phobos development build #" _STR(B
 
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
+	bool foundInheritance = false;
+
 	// > 1 because the exe path itself counts as an argument, too!
 	for (int i = 1; i < nNumArgs; i++)
 	{
@@ -47,6 +49,26 @@ void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 			HideWarning = true;
 		}
 #endif
+		if (_stricmp(pArg, "-Inheritance") == 0)
+		{
+			foundInheritance = true;
+		}
+	}
+
+	if (foundInheritance)
+	{
+		// Apply INIClass_GetString_DisableAres
+		byte patchBytes[] = { 0x83, 0xEC, 0x0C, 0x33, 0xC0 };
+		Patch(0x528A10, 5, patchBytes).Apply();
+		// Apply INIClass_GetKeyName_DisableAres
+		byte patch2Bytes[] = { 0x8B, 0x54, 0x24, 0x04, 0x83, 0xEC, 0x0C };
+		Patch(0x526CC0, 7, patch2Bytes).Apply();
+	}
+	else
+	{
+		// Revert INIClass_GetString_Inheritance_NoEntry
+		byte originalBytes[] = { 0x8B, 0x7C, 0x24, 0x2C, 0x33, 0xC0, 0x8B, 0x4C, 0x24, 0x28 };
+		Patch(0x528BAC, 10, originalBytes).Apply();
 	}
 
 	Debug::Log("Initialized version: " PRODUCT_VERSION "\n");

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -70,11 +70,11 @@ void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 		Patch(0x474314, 6, patch2Bytes).Apply();
 	}
 	else
-    {
-        // Revert CCINIClass_Load_Inheritance
-        byte originalBytes[] = { 0x8B, 0xE8, 0x88, 0x5E, 0x40 };
-        Patch(0x474230, 5, originalBytes).Apply();
-    }
+	{
+		// Revert CCINIClass_Load_Inheritance
+		byte originalBytes[] = { 0x8B, 0xE8, 0x88, 0x5E, 0x40 };
+		Patch(0x474230, 5, originalBytes).Apply();
+	}
 
 	if (foundInheritance)
 	{

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -33,6 +33,7 @@ const wchar_t* Phobos::VersionDescription = L"Phobos development build #" _STR(B
 void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 {
 	bool foundInheritance = false;
+	bool foundInclude = false;
 
 	// > 1 because the exe path itself counts as an argument, too!
 	for (int i = 1; i < nNumArgs; i++)
@@ -53,6 +54,20 @@ void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 		{
 			foundInheritance = true;
 		}
+		if (_stricmp(pArg, "-Include") == 0)
+		{
+			foundInclude = true;
+		}
+	}
+
+	if (foundInclude || foundInheritance)
+	{
+		// Apply CCINIClass_ReadCCFile1_DisableAres
+		byte patchBytes[] = { 0x8B, 0xF1, 0x8D, 0x54, 0x24, 0x0C };
+		Patch(0x474200, 6, patchBytes).Apply();
+		// Apply CCINIClass_ReadCCFile2_DisableAres
+		byte patch2Bytes[] = { 0x81, 0xC4, 0xA8, 0x00, 0x00, 0x00 };
+		Patch(0x474314, 6, patch2Bytes).Apply();
 	}
 
 	if (foundInheritance)

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -60,7 +60,7 @@ void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 		}
 	}
 
-	if (foundInclude || foundInheritance)
+	if (foundInclude)
 	{
 		// Apply CCINIClass_ReadCCFile1_DisableAres
 		byte patchBytes[] = { 0x8B, 0xF1, 0x8D, 0x54, 0x24, 0x0C };

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -69,6 +69,12 @@ void Phobos::CmdLineParse(char** ppArgs, int nNumArgs)
 		byte patch2Bytes[] = { 0x81, 0xC4, 0xA8, 0x00, 0x00, 0x00 };
 		Patch(0x474314, 6, patch2Bytes).Apply();
 	}
+	else
+    {
+        // Revert CCINIClass_Load_Inheritance
+        byte originalBytes[] = { 0x8B, 0xE8, 0x88, 0x5E, 0x40 };
+        Patch(0x474230, 5, originalBytes).Apply();
+    }
 
 	if (foundInheritance)
 	{


### PR DESCRIPTION
Greatly improves performance of INIsection inheritance.

Introduces "-Include" and "-Inheritance" command line arguments that enable INI file inclusion and INI section inheritance respectively, which are now disabled by default.