### PR TITLE
Prevent crashing jumpjet units from firing

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -208,6 +208,7 @@ This page lists all the individual contributions to the project by their author.
       - Turret direction in idle state fix
       - Sensor fix
       - Allow to tilt on ground
+      - Forbid firing when crashing
    - OmniFire.TurnToTarget
    - Object Self-destruction logic
    - Misc vanilla suicidal behavior fix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -24,6 +24,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug when occupied building's `MuzzleFlashX` is drawn on the center of the building when `X` goes past 10.
 - Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead.
 - Fixed jumpjet units being unable to turn to the target when firing from a different direction.
+- Fixed jumpjet units being able to continue firing at enemy target when crashing.
 
 ![image](_static/images/jumpjet-turning.gif)
 *Jumpjet turning to target applied in [Robot Storm X](https://www.moddb.com/mods/cc-robot-storm-x)*

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -331,6 +331,7 @@ Vanilla fixes:
 - Buildings with primary weapon that has `AG=false` projectile now have attack cursor when selected (by Starkku)
 - Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and passengers firing out no longer have the passenger firing offset shift lateral position based on burst index (by Starkku)
 - Light tint created by a building is now able to be removed after loading the game (by Trsdy)
+- Prevented crashing jumpjet units from firing (by Trsdy)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -1,6 +1,6 @@
 #include <JumpjetLocomotionClass.h>
 #include <UnitClass.h>
-
+#include <Utilities/Macro.h>
 #include <Ext/TechnoType/Body.h>
 #include <Ext/WeaponType/Body.h>
 
@@ -145,4 +145,15 @@ DEFINE_HOOK(0x54DD3D, JumpjetLocomotionClass_DrawMatrix_AxisCenterInAir, 0x5)
 	return 0;
 }
 */
+
+FireError __stdcall JumpjetLocomotionClass_Can_Fire(ILocomotion* pThis)
+{
+	// do not use explicit toggle for this
+	if (static_cast<JumpjetLocomotionClass*>(pThis)->State == JumpjetLocomotionClass::State::Crashing)
+		return FireError::CANT;
+	return FireError::OK;
+}
+
+DEFINE_JUMP(VTABLE, 0x7ECDF4, GET_OFFSET(JumpjetLocomotionClass_Can_Fire));
+
 //TODO : Issue #690 #655


### PR DESCRIPTION
As required from some MO players, the vanilla behavior is completely undesirable. Hence hardcode fix