### PR TITLE
Fix PR #139

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -244,6 +244,7 @@ This page lists all the individual contributions to the project by their author.
    - The option to allow DieSound/VoiceDie being played when grinding
    - Allow iron-curtain effects on infantries
    - Break the mindcontrol link when capturing a mind-controlled building with engineer
+   - Remove sound events when mind-controlled vehicles deploy into buildings or when buildings considered as vehicles get captured
    - Building LightSource tint S/L fix
    - Permanent healthbar display on units targeted by temporal weapons fix
    - Misc code refactor & maintenance, CN doc fixes, bugfixes

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -10,6 +10,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug when retinting map lighting with a map action corrupted light sources.
 - Fixed the bug when deploying mindcontrolled vehicle into a building permanently transferred the control to the house which mindcontrolled it.
 - Fixed the bug when capturing a mind-controlled building with an engineer fail to break the mind-control link.
+- Removed the EVA_BuildingCaptured event when capturing a building considered as a vehicle.
 - Fixed the bug when units are already dead but still in map (for sinking, crashing, dying animation, etc.), they could die again.
 - Fixed the bug when cloaked Desolator was unable to fire his deploy weapon.
 - Fixed the bug that temporaryed unit cannot be erased correctly and no longer raise an error.
@@ -226,6 +227,7 @@ ZShapePointMove.OnBuildup=false  ; boolean
 ### Buildings considered as vehicles
 
 - By default game considers buildings with both `UndeploysInto` set and `Foundation` equaling `1x1` as vehicles, in a manner of speaking. This behaviour can now be toggled individually of these conditions by setting `ConsideredVehicle`. These buildings are counted as vehicles for unit count tracking, are not considered as base under attack when damaged and can be mass selected by default, for an example.
+- When capturing such "buildings", the player won't be notified by EVA capture event.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -345,6 +345,7 @@ Vanilla fixes:
 - Fixed permanent health bar display for units targeted by temporal weapons upon mouse hover (by Trsdy)
 - Buildings with superweapons no longer display `SuperAnimThree` at beginning of match if pre-placed on the map (by Starkku)
 - AI players can now build `Naval=true` and `Naval=false` vehicles concurrently like human players do (by Starkku)
+- Suppressed the BuildingCaptured EVA events when capturing a building considered as a vehicle (by Trsdy)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)
@@ -364,6 +365,7 @@ Phobos fixes:
 - Fixed `Layer.UseObjectLayer=true` to work correctly for all cases where object changes layer (by Starkku)
 - Fixed floating point value parsing precision to match the game (by Starkku)
 - Fixed `DetonateOnAllMapObjects.RequireVerses` not considering shield armor types (by Starkku)
+- Used `MindControl.Anim` for buildings deployed from mind-controlled vehicles (by Trsdy)
 
 Fixes / interactions with other extensions:
 - Fixed an issue introduced by Ares that caused `Grinding=true` building `ActiveAnim` to be incorrectly restored while `SpecialAnim` was playing and the building was sold, erased or destroyed (by Starkku)

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -173,21 +173,17 @@ DEFINE_HOOK(0x51EAF2, TechnoClass_WhatAction_AllowAirstrike, 0x6)
 	return SkipGameCode;
 }
 
-DEFINE_HOOK(0x465D40, BuildingTypeClass_IsUndeployable_ConsideredVehicle, 0x6)
+// Rewritten
+DEFINE_HOOK(0x465D40, BuildingTypeClass_IsVehicle, 0x6)
 {
 	enum { ReturnFromFunction = 0x465D6A };
 
 	GET(BuildingTypeClass*, pThis, ECX);
 
 	const auto pExt = BuildingTypeExt::ExtMap.Find(pThis);
+	R->EAX(pExt->ConsideredVehicle.Get(pThis->UndeploysInto && pThis->Foundation == Foundation::_1x1));
 
-	if (pExt->ConsideredVehicle.isset() && pExt->ConsideredVehicle.Get())
-	{
-		R->EAX(true);
-		return ReturnFromFunction;
-	}
-
-	return 0;
+	return ReturnFromFunction;
 }
 
 DEFINE_HOOK(0x5F5416, ObjectClass_ReceiveDamage_CanC4DamageRounding, 0x6)

--- a/src/Ext/CaptureManager/Body.cpp
+++ b/src/Ext/CaptureManager/Body.cpp
@@ -47,7 +47,7 @@ bool CaptureManagerExt::FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTa
 				auto pOriginOwner = pNode->OriginalOwner->Defeated ?
 					HouseClass::FindNeutral() : pNode->OriginalOwner;
 
-				pTarget->SetOwningHouse(pOriginOwner);
+				pTarget->SetOwningHouse(pOriginOwner, !bSilent);
 				pManager->DecideUnitFate(pTarget);
 				pTarget->MindControlledBy = nullptr;
 
@@ -65,7 +65,7 @@ bool CaptureManagerExt::FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTa
 }
 
 bool CaptureManagerExt::CaptureUnit(CaptureManagerClass* pManager, TechnoClass* pTarget,
-	bool bRemoveFirst, AnimTypeClass* pControlledAnimType)
+	bool bRemoveFirst, AnimTypeClass* pControlledAnimType, bool bSilent)
 {
 	if (CaptureManagerExt::CanCapture(pManager, pTarget))
 	{
@@ -90,7 +90,7 @@ bool CaptureManagerExt::CaptureUnit(CaptureManagerClass* pManager, TechnoClass* 
 			pManager->ControlNodes.AddItem(pControlNode);
 			pControlNode->LinkDrawTimer.Start(RulesClass::Instance->MindControlAttackLineFrames);
 
-			if (pTarget->SetOwningHouse(pManager->Owner->Owner))
+			if (pTarget->SetOwningHouse(pManager->Owner->Owner,!bSilent))
 			{
 				pTarget->MindControlledBy = pManager->Owner;
 
@@ -128,7 +128,7 @@ bool CaptureManagerExt::CaptureUnit(CaptureManagerClass* pManager, TechnoClass* 
 
 bool CaptureManagerExt::CaptureUnit(CaptureManagerClass* pManager, AbstractClass* pTechno, AnimTypeClass* pControlledAnimType)
 {
-	if (const auto pTarget = abstract_cast<TechnoClass*>(pTechno))
+	if (const auto pTarget = generic_cast<TechnoClass*>(pTechno))
 	{
 		bool bRemoveFirst = false;
 		if (auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pManager->Owner->GetTechnoType()))

--- a/src/Ext/CaptureManager/Body.cpp
+++ b/src/Ext/CaptureManager/Body.cpp
@@ -18,7 +18,7 @@ bool CaptureManagerExt::CanCapture(CaptureManagerClass* pManager, TechnoClass* p
 	return pManager->CanCapture(pTarget);
 }
 
-bool CaptureManagerExt::FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool bSilent)
+bool CaptureManagerExt::FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool silent)
 {
 	if (pTarget)
 	{
@@ -33,7 +33,7 @@ bool CaptureManagerExt::FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTa
 					pTarget->MindControlRingAnim = nullptr;
 				}
 
-				if (!bSilent)
+				if (!silent)
 				{
 					int nSound = pTarget->GetTechnoType()->MindClearedSound;
 
@@ -47,7 +47,7 @@ bool CaptureManagerExt::FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTa
 				auto pOriginOwner = pNode->OriginalOwner->Defeated ?
 					HouseClass::FindNeutral() : pNode->OriginalOwner;
 
-				pTarget->SetOwningHouse(pOriginOwner, !bSilent);
+				pTarget->SetOwningHouse(pOriginOwner, !silent);
 				pManager->DecideUnitFate(pTarget);
 				pTarget->MindControlledBy = nullptr;
 
@@ -65,7 +65,7 @@ bool CaptureManagerExt::FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTa
 }
 
 bool CaptureManagerExt::CaptureUnit(CaptureManagerClass* pManager, TechnoClass* pTarget,
-	bool bRemoveFirst, AnimTypeClass* pControlledAnimType, bool bSilent)
+	bool bRemoveFirst, AnimTypeClass* pControlledAnimType, bool silent)
 {
 	if (CaptureManagerExt::CanCapture(pManager, pTarget))
 	{
@@ -90,7 +90,7 @@ bool CaptureManagerExt::CaptureUnit(CaptureManagerClass* pManager, TechnoClass* 
 			pManager->ControlNodes.AddItem(pControlNode);
 			pControlNode->LinkDrawTimer.Start(RulesClass::Instance->MindControlAttackLineFrames);
 
-			if (pTarget->SetOwningHouse(pManager->Owner->Owner,!bSilent))
+			if (pTarget->SetOwningHouse(pManager->Owner->Owner, !silent))
 			{
 				pTarget->MindControlledBy = pManager->Owner;
 

--- a/src/Ext/CaptureManager/Body.h
+++ b/src/Ext/CaptureManager/Body.h
@@ -13,9 +13,9 @@ class CaptureManagerExt
 {
 public:
 	static bool CanCapture(CaptureManagerClass* pManager, TechnoClass* pTarget);
-	static bool FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool bSilent = false);
+	static bool FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool silent = false);
 	static bool CaptureUnit(CaptureManagerClass* pManager, TechnoClass* pTarget,
-		bool bRemoveFirst, AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType, bool bSilent = false);
+		bool bRemoveFirst, AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType, bool silent = false);
 	static bool CaptureUnit(CaptureManagerClass* pManager, AbstractClass *pTechno,
 		AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType);
 	static void DecideUnitFate(CaptureManagerClass* pManager, FootClass* pFoot);

--- a/src/Ext/CaptureManager/Body.h
+++ b/src/Ext/CaptureManager/Body.h
@@ -15,7 +15,7 @@ public:
 	static bool CanCapture(CaptureManagerClass* pManager, TechnoClass* pTarget);
 	static bool FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool bSilent = false);
 	static bool CaptureUnit(CaptureManagerClass* pManager, TechnoClass* pTarget,
-		bool bRemoveFirst, AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType);
+		bool bRemoveFirst, AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType, bool bSilent = false);
 	static bool CaptureUnit(CaptureManagerClass* pManager, AbstractClass *pTechno,
 		AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType);
 	static void DecideUnitFate(CaptureManagerClass* pManager, FootClass* pFoot);

--- a/src/Ext/Techno/Hooks.DeploysInto.cpp
+++ b/src/Ext/Techno/Hooks.DeploysInto.cpp
@@ -14,7 +14,7 @@ void TechnoExt::TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClas
 			auto decidedMindControlAnim = [Controller, pTechnoTo](AnimTypeClass* const animDefault = RulesClass::Instance->ControlledAnimationType)
 			{
 				int wpidx = Controller->SelectWeapon(pTechnoTo);
-				if (wpidx > 0)
+				if (wpidx >= 0)
 				{
 					if (auto pWH = Controller->GetWeapon(wpidx)->WeaponType->Warhead)
 						return WarheadTypeExt::ExtMap.Find(pWH)->MindControl_Anim.Get(animDefault);

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -104,6 +104,18 @@ DEFINE_HOOK(0x4DBF13, FootClass_SetOwningHouse, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x4483C0, BuildingClass_SetOwningHouse_MuteSound, 0x6)
+{
+	GET(BuildingClass* const, pThis, ESI);
+	REF_STACK(bool, announce, STACK_OFFSET(0x60, 0x8));
+
+	pThis->NextMission();
+
+	announce = announce && !pThis->Type->IsVehicle();
+
+	return 0;
+}
+
 DEFINE_HOOK_AGAIN(0x7355C0, TechnoClass_Init_InitialStrength, 0x6) // UnitClass_Init
 DEFINE_HOOK_AGAIN(0x517D69, TechnoClass_Init_InitialStrength, 0x6) // InfantryClass_Init
 DEFINE_HOOK_AGAIN(0x442C7B, TechnoClass_Init_InitialStrength, 0x6) // BuildingClass_Init


### PR DESCRIPTION
* Suppressed all capture events for buildings considered vehicles.
* Use `MindControl.Anim` for buildings deployed from mindcontrolled vehicles