### PR TITLE
Chrono sparkle display customization & improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -198,6 +198,7 @@ This page lists all the individual contributions to the project by their author.
   - AI naval vehicle production fix
   - Crushing tilt and slowdown customization
   - Extra warhead detonations on weapons
+  - Chrono sparkle animation display customization and improvements
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -333,6 +333,21 @@ Pips.SelfHeal.Buildings.Offset=15,10   ; X,Y, pixels relative to default
 SelfHealGainType=                      ; Self-Heal Gain Type Enumeration (none|infantry|units)
 ```
 
+### Chrono sparkle animation customization & improvements
+
+- It is now possible to customize the frame delay between instances of `[General]` -> `ChronoSparkle1` animations created on objects being warped by setting `[General]` -> `ChronoSparkleDisplayDelay`.
+- By default on buildings with `MaxOccupants` higher than 0, chrono sparkle animation would be shown at each of the `MuzzleFlashN` coordinates. This behaviour is now customizable, and supports `MuzzleFlashN` indices higher than 10.
+  - `[General]` -> `ChronoSparkleBuildingDisplayPositions` can be set to show the sparkle animation on the building (`building`), muzzle flash coordinates of current occupants (`occupants`), muzzle flash coordinates of all occupant slots (`occupantslots`) or any combination of these.
+    - If `occupants` or `occupantslots` is listed without `building`, a single chrono sparkle animation is still displayed on building if it doesn't have any occupants or it has `MaxOccupants` value less than 1, respectively.
+- The chrono sparkle animation that is displayed on building itself is also now displayed at the center of it rather than at center of its topmost cell.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ChronoSparkleDisplayDelay=24                         ; integer, game frames
+ChronoSparkleBuildingDisplayPositions=occupantslots  ; list of chrono sparkle position enum (building | occupants | occupantslots | all)
+```
+
 ### Customizable veterancy insignias
 
 - You can now customize veterancy insignia of TechnoTypes.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -319,6 +319,7 @@ New:
 - Crushing tilt and slowdown customization (by Starkku)
 - Extra warhead detonations on weapon (by Starkku)
 - Customizable ElectricBolt Arcs (by Fryone, Kerbiter)
+- Chrono sparkle animation display customization and improvements (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -101,3 +101,9 @@ DEFINE_HOOK(0x414F10, AircraftClass_AI_Trailer, 0x5)
 
 	return SkipGameCode;
 }
+
+DEFINE_HOOK(0x414C0B, AircraftClass_ChronoSparkleDelay, 0x5)
+{
+	R->ECX(RulesExt::Global()->ChronoSparkleDisplayDelay);
+	return 0x414C10;
+}

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -6,6 +6,7 @@
 #include <GameOptionsClass.h>
 #include <Ext/House/Body.h>
 #include <Ext/WarheadType/Body.h>
+#include <TacticalClass.h>
 
 //After TechnoClass_AI?
 DEFINE_HOOK(0x43FE69, BuildingClass_AI, 0xA)
@@ -28,6 +29,53 @@ DEFINE_HOOK(0x43FE69, BuildingClass_AI, 0xA)
 	pExt->ApplyPoweredKillSpawns();
 
 	return 0;
+}
+
+DEFINE_HOOK(0x4403D4, BuildingClass_AI_ChronoSparkle, 0x6)
+{
+	enum { SkipGameCode = 0x44055D };
+
+	GET(BuildingClass*, pThis, ESI);
+
+	if (RulesClass::Instance->ChronoSparkle1)
+	{
+		auto const displayPositions = RulesExt::Global()->ChronoSparkleBuildingDisplayPositions;
+		auto const pType = pThis->Type;
+		bool displayOnBuilding = (displayPositions & ChronoSparkleDisplayPosition::Building) != ChronoSparkleDisplayPosition::None;
+		bool displayOnSlots = (displayPositions & ChronoSparkleDisplayPosition::OccupantSlots) != ChronoSparkleDisplayPosition::None;
+		bool displayOnOccupants = (displayPositions & ChronoSparkleDisplayPosition::Occupants) != ChronoSparkleDisplayPosition::None;
+		int occupantCount = displayOnSlots ? pType->MaxNumberOccupants : pThis->GetOccupantCount();
+		bool showOccupy = occupantCount && (displayOnOccupants || displayOnSlots);
+
+		if (showOccupy)
+		{
+			for (int i = 0; i < occupantCount; i++)
+			{
+				if (!((Unsorted::CurrentFrame + i) % RulesExt::Global()->ChronoSparkleDisplayDelay))
+				{
+					auto muzzleOffset = pType->MaxNumberOccupants <= 10 ? pType->MuzzleFlash[i] : BuildingTypeExt::ExtMap.Find(pType)->OccupierMuzzleFlashes.at(i);
+					auto offset = Point2D::Empty;
+					auto coords = CoordStruct::Empty;
+					auto const renderCoords = pThis->GetRenderCoords();
+					offset = *TacticalClass::Instance->ApplyMatrix_Pixel(&offset, &muzzleOffset);
+					coords.X += offset.X;
+					coords.Y += offset.Y;
+					coords += renderCoords;
+
+					if (auto const pAnim = GameCreate<AnimClass>(RulesClass::Instance->ChronoSparkle1, coords))
+						pAnim->ZAdjust = -200;
+				}
+			}
+		}
+
+		if ((!showOccupy || displayOnBuilding) && !(Unsorted::CurrentFrame % RulesExt::Global()->ChronoSparkleDisplayDelay))
+		{
+			GameCreate<AnimClass>(RulesClass::Instance->ChronoSparkle1, pThis->GetCenterCoords());
+		}
+
+	}
+
+	return SkipGameCode;
 }
 
 DEFINE_HOOK(0x7396D2, UnitClass_TryToDeploy_Transfer, 0x5)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -71,6 +71,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->UnitsGainSelfHealCap.Read(exINI, GameStrings::General, "UnitsGainSelfHealCap");
 	this->EnemyInsignia.Read(exINI, GameStrings::General, "EnemyInsignia");
 	this->DisguiseBlinkingVisibility.Read(exINI, GameStrings::General, "DisguiseBlinkingVisibility");
+	this->ChronoSparkleDisplayDelay.Read(exINI, GameStrings::General, "ChronoSparkleDisplayDelay");
+	this->ChronoSparkleBuildingDisplayPositions.Read(exINI, GameStrings::General, "ChronoSparkleBuildingDisplayPositions");
 	this->UseGlobalRadApplicationDelay.Read(exINI, GameStrings::Radiation, "UseGlobalRadApplicationDelay");
 	this->RadApplicationDelay_Building.Read(exINI, GameStrings::Radiation, "RadApplicationDelay.Building");
 	this->RadWarhead_Detonate.Read(exINI, GameStrings::Radiation, "RadSiteWarhead.Detonate");
@@ -189,6 +191,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->UnitsGainSelfHealCap)
 		.Process(this->EnemyInsignia)
 		.Process(this->DisguiseBlinkingVisibility)
+		.Process(this->ChronoSparkleDisplayDelay)
+		.Process(this->ChronoSparkleBuildingDisplayPositions)
 		.Process(this->UseGlobalRadApplicationDelay)
 		.Process(this->RadApplicationDelay_Building)
 		.Process(this->RadWarhead_Detonate)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -34,6 +34,8 @@ public:
 		Nullable<int> UnitsGainSelfHealCap;
 		Valueable<bool> EnemyInsignia;
 		Valueable<AffectedHouse> DisguiseBlinkingVisibility;
+		Valueable<int> ChronoSparkleDisplayDelay;
+		Valueable<ChronoSparkleDisplayPosition> ChronoSparkleBuildingDisplayPositions;
 		Valueable<bool> UseGlobalRadApplicationDelay;
 		Valueable<int> RadApplicationDelay_Building;
 		Valueable<bool> RadWarhead_Detonate;
@@ -87,6 +89,8 @@ public:
 			, UnitsGainSelfHealCap {}
 			, EnemyInsignia { true }
 			, DisguiseBlinkingVisibility { AffectedHouse::Owner }
+			, ChronoSparkleDisplayDelay { 24 }
+			, ChronoSparkleBuildingDisplayPositions { ChronoSparkleDisplayPosition::OccupantSlots }
 			, UseGlobalRadApplicationDelay { true }
 			, RadApplicationDelay_Building { 0 }
 			, RadWarhead_Detonate { false }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -471,3 +471,17 @@ DEFINE_HOOK(0x4CD4E1, FlyLocomotionClass_Update_LayerUpdate, 0x6)
 
 	return 0;
 }
+
+// Move to UnitClass hooks file if it is ever created.
+DEFINE_HOOK(0x736234, UnitClass_ChronoSparkleDelay, 0x5)
+{
+	R->ECX(RulesExt::Global()->ChronoSparkleDisplayDelay);
+	return 0x736239;
+}
+
+// Move to InfantryClass hooks file if it is ever created.
+DEFINE_HOOK(0x51BAFB, InfantryClass_ChronoSparkleDelay, 0x5)
+{
+	R->ECX(RulesExt::Global()->ChronoSparkleDisplayDelay);
+	return 0x51BB00;
+}

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -194,6 +194,18 @@ enum class TargetZoneScanType
 	InRange = 2
 };
 
+enum class ChronoSparkleDisplayPosition : unsigned char
+{
+	None = 0x0,
+	Building= 0x1,
+	Occupants = 0x2,
+	OccupantSlots = 0x4,
+
+	All = 0xFF,
+};
+
+MAKE_ENUM_FLAGS(ChronoSparkleDisplayPosition);
+
 class MouseCursorHotSpotX
 {
 public:

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -976,6 +976,47 @@ namespace detail
 	}
 
 	template <>
+	inline bool read<ChronoSparkleDisplayPosition>(ChronoSparkleDisplayPosition& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			auto parsed = ChronoSparkleDisplayPosition::None;
+
+			auto str = parser.value();
+			char* context = nullptr;
+			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
+				if (!_strcmpi(cur, "building"))
+				{
+					parsed |= ChronoSparkleDisplayPosition::Building;
+				}
+				else if (!_strcmpi(cur, "occupants"))
+				{
+					parsed |= ChronoSparkleDisplayPosition::Occupants;
+				}
+				else if (!_strcmpi(cur, "occupantslots"))
+				{
+					parsed |= ChronoSparkleDisplayPosition::OccupantSlots;
+				}
+				else if (!_strcmpi(cur, "all") )
+				{
+					parsed |= ChronoSparkleDisplayPosition::All;
+				}
+				else if (_strcmpi(cur, "none"))
+				{
+					Debug::INIParseFailed(pSection, pKey, parser.value(), "Expected a chrono sparkle position type");
+					return false;
+				}
+			}
+
+			value = parsed;
+			return true;
+		}
+
+		return false;
+	}
+
+	template <>
 	inline bool read<CLSID>(CLSID& value, INI_EX& parser, const char* pSection, const char* pKey, bool allocate)
 	{
 		if (!parser.ReadString(pSection, pKey))


### PR DESCRIPTION
### Chrono sparkle animation customization & improvements

- It is now possible to customize the frame delay between instances of `[General]` -> `ChronoSparkle1` animations created on objects being warped by setting `[General]` -> `ChronoSparkleDisplayDelay`.
- By default on buildings with `MaxOccupants` higher than 0, chrono sparkle animation would be shown at each of the `MuzzleFlashN` coordinates. This behaviour is now customizable, and supports `MuzzleFlashN` indices higher than 10.
  - `[General]` -> `ChronoSparkleBuildingDisplayPositions` can be set to show the sparkle animation on the building (`building`), muzzle flash coordinates of current occupants (`occupants`), muzzle flash coordinates of all occupant slots (`occupantslots`) or any combination of these.
    - If `occupants` or `occupantslots` is listed without `building`, a single chrono sparkle animation is still displayed on building if it doesn't have any occupants or it has `MaxOccupants` value less than 1, respectively. 
- The chrono sparkle animation that is displayed on building itself is also now displayed at the center of it rather than at center of its topmost cell.

In `rulesmd.ini`:
```ini
[General]
ChronoSparkleDisplayDelay=24                         ; integer, game frames
ChronoSparkleBuildingDisplayPositions=occupantslots  ; list of chrono sparkle position enum (building | occupants | occupantslots | all)
```