### PR TITLE
Add AI script action 10104 Chronoshift to Enemy Base

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -128,6 +128,8 @@ This page lists all the individual contributions to the project by their author.
   - Initial strength for cloned infantry
 - **Starkku**:
   - Misc. minor bugfixes & improvements
+  - AI script actions:
+    - Chronoshift to Enemy Base
   - Warhead shield penetration & breaking
   - Strafing aircraft weapon customization
   - Vehicle `DeployFire` fixes/improvements

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -183,6 +183,16 @@ In `aimd.ini`:
 x=10103,0
 ```
 
+##### `10104` Chronoshift to Enemy Base
+
+- Chronoshifts the members of the TeamType using first available `Type=Chronosphere` superweapon to a location within `[General]` -> `AISafeDistance` (plus the additional distance defined in parameter, can be negative) cells from enemy house's base. The superweapon must be charged up to atleast `[General]` -> `AIMinorSuperReadyPercent` percentage of its recharge time to be available for use by this action.
+
+In `aimd.ini`:
+```ini
+[SOMESCRIPTTYPE]  ; ScriptType
+x=10104,n         ; integer, additional distance in cells
+```
+
 ### `12000-12999` Suplementary/Setup Pre-actions
 
 #### `12000` Wait if No Target Found

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -172,8 +172,10 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
   [ScriptsRA2]
   10100=Timed Area Guard,20,0,1,[LONG DESC]
-  10103=Load Onto Transports,0,0,1,[LONG DESC]
   10101=Wait until ammo is full,0,0,1,[LONG DESC]
+  10102=Regroup Temporarily Around the Team Leader,20,0,1,[LONG DESC]
+  10103=Load Onto Transports,0,0,1,[LONG DESC]
+  10104=Chronoshift to Enemy Base,20,0,1,[LONG DESC]
   18000=Local variable set,22,0,1,[LONG DESC]
   18001=Local variable add,22,0,1,[LONG DESC]
   18002=Local variable minus,22,0,1,[LONG DESC]
@@ -320,6 +322,7 @@ New:
 - Extra warhead detonations on weapon (by Starkku)
 - Customizable ElectricBolt Arcs (by Fryone, Kerbiter)
 - Chrono sparkle animation display customization and improvements (by Starkku)
+- Script action to Chronoshift teams to enemy base (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -87,6 +87,7 @@ public:
 	static int ActiveHarvesterCount(HouseClass* pThis);
 	static int TotalHarvesterCount(HouseClass* pThis);
 	static HouseClass* GetHouseKind(OwnerHouseKind kind, bool allowRandom, HouseClass* pDefault, HouseClass* pInvoker = nullptr, HouseClass* pVictim = nullptr);
+	static CellClass* GetEnemyBaseGatherCell(HouseClass* pTargetHouse, HouseClass* pCurrentHouse, CoordStruct defaultCurrentCoords, SpeedType speedTypeZone, int extraDistance = 0);
 
 	static bool IsDisabledFromShell(
 	HouseClass const* pHouse, BuildingTypeClass const* pItem);

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1,5 +1,6 @@
 #include "Body.h"
 
+#include <Ext/House/Body.h>
 #include <Ext/Techno/Body.h>
 #include <Ext/Scenario/Body.h>
 
@@ -208,6 +209,10 @@ void ScriptExt::ProcessAction(TeamClass* pTeam)
 	case PhobosScripts::SameLineForceJumpCountdown:
 		// Start Timed Jump that jumps to the same line when the countdown finish (in frames)
 		ScriptExt::Set_ForceJump_Countdown(pTeam, true, -1);
+		break;
+	case PhobosScripts::ChronoshiftToEnemyBase:
+		// Chronoshift to enemy base, argument is additional distance modifier
+		ScriptExt::ChronoshiftToEnemyBase(pTeam, argument);
 		break;
 	default:
 		// Do nothing because or it is a wrong Action number or it is an Ares/YR action...
@@ -1154,6 +1159,112 @@ void ScriptExt::Stop_ForceJump_Countdown(TeamClass* pTeam)
 	// This action finished
 	pTeam->StepCompleted = true;
 	ScriptExt::Log("AI Scripts - StopForceJumpCountdown: [%s] [%s](line: %d = %d,%d): Stopped Timed Jump\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
+}
+
+void ScriptExt::ChronoshiftToEnemyBase(TeamClass* pTeam, int extraDistance)
+{
+	if (!pTeam)
+		return;
+
+	auto pScript = pTeam->CurrentScript;
+	auto const pLeader = ScriptExt::FindTheTeamLeader(pTeam);
+
+	if (!pLeader)
+	{
+		ScriptExt::Log("AI Scripts - ChronoshiftToEnemyBase: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No Leader found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		pTeam->StepCompleted = true;
+		return;
+	}
+
+	int houseIndex = pLeader->Owner->EnemyHouseIndex;
+	HouseClass* pEnemy = houseIndex != -1 ? HouseClass::Array->GetItem(houseIndex) : nullptr;
+
+	if (!pEnemy)
+	{
+		ScriptExt::Log("AI Scripts - ChronoshiftToEnemyBase: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No enemy house found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		pTeam->StepCompleted = true;
+		return;
+	}
+
+	auto const pTargetCell = HouseExt::GetEnemyBaseGatherCell(pEnemy, pLeader->Owner, pLeader->GetCoords(), pLeader->GetTechnoType()->SpeedType, extraDistance);
+
+	if (!pTargetCell)
+	{
+		ScriptExt::Log("AI Scripts - ChronoshiftToEnemyBase: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No target cell found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		pTeam->StepCompleted = true;
+		return;
+	}
+
+	ScriptExt::ChronoshiftTeamToTarget(pTeam, pLeader, pTargetCell);
+}
+
+void ScriptExt::ChronoshiftTeamToTarget(TeamClass* pTeam, TechnoClass* pTeamLeader, AbstractClass* pTarget)
+{
+	if (!pTeam || !pTeamLeader || !pTarget)
+		return;
+
+	auto pScript = pTeam->CurrentScript;
+	HouseClass* pOwner = pTeamLeader->Owner;
+	SuperClass* pSuperChronosphere = nullptr;
+	SuperClass* pSuperChronowarp = nullptr;
+
+	for (auto const pSuper : pOwner->Supers)
+	{
+		if (!pSuperChronosphere && pSuper->Type->Type == SuperWeaponType::ChronoSphere)
+			pSuperChronosphere = pSuper;
+
+		if (!pSuperChronowarp && pSuper->Type->Type == SuperWeaponType::ChronoWarp)
+			pSuperChronowarp = pSuper;
+
+		if (pSuperChronosphere && pSuperChronowarp)
+			break;
+	}
+
+	if (!pSuperChronosphere || !pSuperChronowarp)
+	{
+		ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No Chronosphere or ChronoWarp superweapon found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		pTeam->StepCompleted = true;
+		return;
+	}
+
+	if (!pSuperChronosphere->IsCharged || (pSuperChronosphere->IsPowered() && !pOwner->Is_Powered()))
+	{
+		if (pSuperChronosphere->Granted)
+		{
+			int rechargeTime = pSuperChronosphere->GetRechargeTime();
+			int timeLeft = pSuperChronosphere->RechargeTimer.GetTimeLeft();
+
+			if (1.0 - RulesClass::Instance->AIMinorSuperReadyPercent < timeLeft / rechargeTime)
+			{
+				ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Chronosphere superweapon charge not at AIMinorSuperReadyPercent yet, not jumping to next line yet)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
+				return;
+			}
+		}
+		else
+		{
+			ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: Chronosphere superweapon not available)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+			pTeam->StepCompleted = true;
+			return;
+		}
+	}
+
+	auto pTargetCell = MapClass::Instance->TryGetCellAt(pTarget->GetCoords());
+
+	if (pTargetCell)
+	{
+		pOwner->Fire_SW(pSuperChronosphere->Type->ArrayIndex, pTeam->SpawnCell->MapCoords);
+		pOwner->Fire_SW(pSuperChronowarp->Type->ArrayIndex, pTargetCell->MapCoords);
+		pTeam->AssignMissionTarget(pTargetCell);
+		ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: Finished successfully)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+
+	}
+	else
+	{
+		ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No target cell found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+	}
+
+	pTeam->StepCompleted = true;
+	return;
 }
 
 bool ScriptExt::IsUnitAvailable(TechnoClass* pTechno, bool checkIfInTransportOrAbsorbed)

--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -1169,9 +1169,12 @@ void ScriptExt::ChronoshiftToEnemyBase(TeamClass* pTeam, int extraDistance)
 	auto pScript = pTeam->CurrentScript;
 	auto const pLeader = ScriptExt::FindTheTeamLeader(pTeam);
 
+	char logText[1024];
+	sprintf_s(logText, "AI Scripts - ChronoshiftToEnemyBase: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: %s)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument, "%s");
+
 	if (!pLeader)
 	{
-		ScriptExt::Log("AI Scripts - ChronoshiftToEnemyBase: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No Leader found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		ScriptExt::Log(logText, "No team leader found");
 		pTeam->StepCompleted = true;
 		return;
 	}
@@ -1181,7 +1184,7 @@ void ScriptExt::ChronoshiftToEnemyBase(TeamClass* pTeam, int extraDistance)
 
 	if (!pEnemy)
 	{
-		ScriptExt::Log("AI Scripts - ChronoshiftToEnemyBase: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No enemy house found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		ScriptExt::Log(logText, "No enemy house found");
 		pTeam->StepCompleted = true;
 		return;
 	}
@@ -1190,7 +1193,7 @@ void ScriptExt::ChronoshiftToEnemyBase(TeamClass* pTeam, int extraDistance)
 
 	if (!pTargetCell)
 	{
-		ScriptExt::Log("AI Scripts - ChronoshiftToEnemyBase: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No target cell found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		ScriptExt::Log(logText, "No target cell found");
 		pTeam->StepCompleted = true;
 		return;
 	}
@@ -1220,9 +1223,17 @@ void ScriptExt::ChronoshiftTeamToTarget(TeamClass* pTeam, TechnoClass* pTeamLead
 			break;
 	}
 
+	char logTextBase[1024];
+	char logTextJump[1024];
+	char jump[256];
+
+	sprintf_s(jump, "Jump to next line: %d = %d,%d -> (Reason: %s)", pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument, "%s");
+	sprintf_s(logTextBase, "AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) %s\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, "%s");
+	sprintf_s(logTextJump, logTextBase, jump);
+
 	if (!pSuperChronosphere || !pSuperChronowarp)
 	{
-		ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No Chronosphere or ChronoWarp superweapon found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		ScriptExt::Log(logTextJump, "No Chronosphere or ChronoWarp superweapon found");
 		pTeam->StepCompleted = true;
 		return;
 	}
@@ -1236,13 +1247,13 @@ void ScriptExt::ChronoshiftTeamToTarget(TeamClass* pTeam, TechnoClass* pTeamLead
 
 			if (1.0 - RulesClass::Instance->AIMinorSuperReadyPercent < timeLeft / rechargeTime)
 			{
-				ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Chronosphere superweapon charge not at AIMinorSuperReadyPercent yet, not jumping to next line yet)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument);
+				ScriptExt::Log(logTextBase, "Chronosphere superweapon charge not at AIMinorSuperReadyPercent yet, not jumping to next line yet");
 				return;
 			}
 		}
 		else
 		{
-			ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: Chronosphere superweapon not available)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+			ScriptExt::Log(logTextJump, "Chronosphere superweapon is not available");
 			pTeam->StepCompleted = true;
 			return;
 		}
@@ -1255,12 +1266,11 @@ void ScriptExt::ChronoshiftTeamToTarget(TeamClass* pTeam, TechnoClass* pTeamLead
 		pOwner->Fire_SW(pSuperChronosphere->Type->ArrayIndex, pTeam->SpawnCell->MapCoords);
 		pOwner->Fire_SW(pSuperChronowarp->Type->ArrayIndex, pTargetCell->MapCoords);
 		pTeam->AssignMissionTarget(pTargetCell);
-		ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: Finished successfully)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
-
+		ScriptExt::Log(logTextJump, "Finished successfully");
 	}
 	else
 	{
-		ScriptExt::Log("AI Scripts - ChronoshiftTeamToTarget: [%s] [%s] (line: %d = %d,%d) Jump to next line: %d = %d,%d -> (Reason: No target cell found)\n", pTeam->Type->ID, pScript->Type->ID, pScript->CurrentMission, pScript->Type->ScriptActions[pScript->CurrentMission].Action, pScript->Type->ScriptActions[pScript->CurrentMission].Argument, pScript->CurrentMission + 1, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Action, pScript->Type->ScriptActions[pScript->CurrentMission + 1].Argument);
+		ScriptExt::Log(logTextJump, "No target cell found");
 	}
 
 	pTeam->StepCompleted = true;

--- a/src/Ext/Script/Body.h
+++ b/src/Ext/Script/Body.h
@@ -57,6 +57,7 @@ enum class PhobosScripts : unsigned int
 	WaitUntilFullAmmo = 10101,
 	GatherAroundLeader = 10102,
 	LoadIntoTransports = 10103,
+	ChronoshiftToEnemyBase = 10104,
 
 	// Range 12000-12999 are suplementary/setup pre-actions
 	WaitIfNoTarget = 12000,
@@ -165,18 +166,20 @@ public:
 
 		ExtData(ScriptClass* OwnerObject) : Extension<ScriptClass>(OwnerObject)
 			// Nothing yet
-		{ }
+		{
+		}
 
 		virtual ~ExtData() = default;
 
-		virtual void InvalidatePointer(void* ptr, bool bRemoved) override {}
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm);
 		virtual void SaveToStream(PhobosStreamWriter& Stm);
 
 	};
 
-	class ExtContainer final : public Container<ScriptExt> {
+	class ExtContainer final : public Container<ScriptExt>
+	{
 	public:
 		ExtContainer();
 		~ExtContainer();
@@ -184,23 +187,24 @@ public:
 
 	static ExtContainer ExtMap;
 
-	static void ProcessAction(TeamClass * pTeam);
-	static void ExecuteTimedAreaGuardAction(TeamClass * pTeam);
-	static void LoadIntoTransports(TeamClass * pTeam);
-	static void WaitUntilFullAmmoAction(TeamClass * pTeam);
-	static void Mission_Gather_NearTheLeader(TeamClass *pTeam, int countdown);
+	static void ProcessAction(TeamClass* pTeam);
+	static void ExecuteTimedAreaGuardAction(TeamClass* pTeam);
+	static void LoadIntoTransports(TeamClass* pTeam);
+	static void WaitUntilFullAmmoAction(TeamClass* pTeam);
+	static void Mission_Gather_NearTheLeader(TeamClass* pTeam, int countdown);
 	static void DecreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static void IncreaseCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
-	static void WaitIfNoTarget(TeamClass *pTeam, int attempts);
-	static void TeamWeightReward(TeamClass *pTeam, double award);
-	static void PickRandomScript(TeamClass * pTeam, int idxScriptsList);
-	static void UnregisterGreatSuccess(TeamClass * pTeam);
-	static void SetCloseEnoughDistance(TeamClass *pTeam, double distance);
+	static void WaitIfNoTarget(TeamClass* pTeam, int attempts);
+	static void TeamWeightReward(TeamClass* pTeam, double award);
+	static void PickRandomScript(TeamClass* pTeam, int idxScriptsList);
+	static void UnregisterGreatSuccess(TeamClass* pTeam);
+	static void SetCloseEnoughDistance(TeamClass* pTeam, double distance);
 	static void SetMoveMissionEndMode(TeamClass* pTeam, int mode);
 	static void SkipNextAction(TeamClass* pTeam, int successPercentage);
 	static FootClass* FindTheTeamLeader(TeamClass* pTeam);
-	static void Set_ForceJump_Countdown(TeamClass *pTeam, bool repeatLine, int count);
-	static void Stop_ForceJump_Countdown(TeamClass *pTeam);
+	static void Set_ForceJump_Countdown(TeamClass* pTeam, bool repeatLine, int count);
+	static void Stop_ForceJump_Countdown(TeamClass* pTeam);
+	static void ChronoshiftToEnemyBase(TeamClass* pTeam, int extraDistance);
 
 	static bool IsExtVariableAction(int action);
 	static void VariablesHandler(TeamClass* pTeam, PhobosScripts eAction, int nArg);
@@ -230,4 +234,5 @@ public:
 private:
 	static void ModifyCurrentTriggerWeight(TeamClass* pTeam, bool forceJumpLine, double modifier);
 	static bool MoveMissionEndStatus(TeamClass* pTeam, TechnoClass* pFocus, FootClass* pLeader, int mode);
+	static void ChronoshiftTeamToTarget(TeamClass* pTeam, TechnoClass* pTeamLeader, AbstractClass* pTarget);
 };


### PR DESCRIPTION
This is basically bastard child of script actions `53 Gather at Enemy Base` and `56/57 Chronoshift to Enemy Building/Target Type` 

Functions for Chronoshifting team to a specific target as well as acquiring the enemy base gather cell are separate so they can potentially be reused in future for something else if needed.

----------------------------------

##### `10104` Chronoshift to Enemy Base

- Chronoshifts the members of the TeamType using first available `Type=Chronosphere` superweapon to a location within `[General]` -> `AISafeDistance` (plus the additional distance defined in parameter, can be negative) cells from enemy house's base. The superweapon must be charged up to atleast `[General]` -> `AIMinorSuperReadyPercent` percentage of its recharge time to be available for use by this action.

In `aimd.ini`:
```ini
[SOMESCRIPTTYPE]  ; ScriptType
x=10104,n         ; integer, additional distance in cells
```