### PR TITLE
Сustomizing Electric Bolt Arcs

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,6 +40,7 @@ This page lists all the individual contributions to the project by their author.
   - Official docs
   - VSCode configs
   - Code style
+  - Customizable ElectricBolt Arcs
 - **Uranusian (Thrifinesma)**:
   - Mind Control enhancement
   - Custom warhead splash list
@@ -271,6 +272,8 @@ This page lists all the individual contributions to the project by their author.
   - Custom slaves free sound
   - Jumpjet crash rotation control
   - Vehicle voxel turret shadows & body multi-section shadows
+- **Fryone**
+  - Customizable ElectricBolt Arcs
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares
   - unfinished RadTypes code

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -789,6 +789,17 @@ Bolt.Disable2=false    ; boolean
 Bolt.Disable3=false    ; boolean
 ```
 
+### Customizable ElectricBolt Arcs
+
+- By default, Electric Bolt has 8 Arcs. Now it can be customized per weapon with `IsElectricBolt=yes`. Zero value draws straight line.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWEAPONTYPE]       ; WeaponType
+IsElectricBolt=true    ; an ElectricBolt Weapon, vanilla tag
+Bolt.Arcs=32
+```
+
 ## RadialIndicator visibility
 
 In vanilla game, a structure's radial indicator can be drawn only when it belongs to the player. Now it can also be visible to observer.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -796,8 +796,8 @@ Bolt.Disable3=false    ; boolean
 In `rulesmd.ini`:
 ```ini
 [SOMEWEAPONTYPE]       ; WeaponType
-IsElectricBolt=true    ; an ElectricBolt Weapon, vanilla tag
-Bolt.Arcs=32
+IsElectricBolt=true    ; boolean, vanilla tag
+Bolt.Arcs=8            ; integer, number of arcs in a bolt
 ```
 
 ## RadialIndicator visibility

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -316,6 +316,7 @@ New:
 - Example custom locomotor that circles around the target (by Kerbiter, CCHyper, with help from Otamaa; based on earlier experiment by CnCVK)
 - Vehicle voxel turret shadows & body multi-section shadows (by TwinkleStar)
 - Crushing tilt and slowdown customization (by Starkku)
+- Customizable ElectricBolt Arcs (by Fryone, Kerbiter)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -43,6 +43,8 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Bolt_Disable2.Read(exINI, pSection, "Bolt.Disable2");
 	this->Bolt_Disable3.Read(exINI, pSection, "Bolt.Disable3");
 
+	this->Bolt_Arcs.Read(exINI, pSection, "Bolt.Arcs");
+
 	this->RadType.Read(exINI, pSection, "RadType", true);
 
 	this->Strafing_Shots.Read(exINI, pSection, "Strafing.Shots");
@@ -66,6 +68,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Bolt_Disable1)
 		.Process(this->Bolt_Disable2)
 		.Process(this->Bolt_Disable3)
+		.Process(this->Bolt_Arcs)
 		.Process(this->Strafing_Shots)
 		.Process(this->Strafing_SimulateBurst)
 		.Process(this->CanTarget)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -22,6 +22,7 @@ public:
 		Valueable<bool> Bolt_Disable1;
 		Valueable<bool> Bolt_Disable2;
 		Valueable<bool> Bolt_Disable3;
+		Valueable<int> Bolt_Arcs;
 		Valueable<int> Strafing_Shots;
 		Valueable<bool> Strafing_SimulateBurst;
 		Valueable<AffectedTarget> CanTarget;
@@ -40,6 +41,7 @@ public:
 			, Bolt_Disable1 { false }
 			, Bolt_Disable2 { false }
 			, Bolt_Disable3 { false }
+			, Bolt_Arcs { 8 }
 			, Strafing_Shots { 5 }
 			, Strafing_SimulateBurst { false }
 			, CanTarget { AffectedTarget::All }

--- a/src/Ext/WeaponType/Hook.EBolt.cpp
+++ b/src/Ext/WeaponType/Hook.EBolt.cpp
@@ -29,17 +29,17 @@ DEFINE_HOOK(0x4C2951, EBolt_DTOR, 0x5)
 	return 0;
 }
 
-DEFINE_HOOK(0x4C20BC, EBolt_Draw_ArcsAmount, 0x0)
+DEFINE_HOOK(0x4C20BC, EBolt_DrawArcs, 0xB)
 {
+	enum { DoLoop = 0x4C20C7, Break = 0x4C2400 };
+
 	GET_STACK(EBolt*, pBolt, 0x40);
 	BoltTemp::pType = BoltTemp::boltWeaponTypeExt.get_or_default(pBolt);
 
-	int a = 32;
-	if(BoltTemp::pType){ a = BoltTemp::pType->Bolt_Arcs;}
-	byte BoltArcsP2B[] = { 0x83, 0x7C, 0x24, 0x28, 0x08};
-	memcpy(&BoltArcsP2B[4], &a, sizeof(&a));
-    Patch(0x4C20BC, 5, BoltArcsP2B).Apply();
-	return 0;
+	GET_STACK(int, plotIndex, STACK_OFFSET(0x408, -0x3E0))
+
+	return plotIndex < BoltTemp::pType->Bolt_Arcs
+        ? DoLoop : Break;
 }
 
 DEFINE_HOOK(0x4C24E4, Ebolt_DrawFist_Disable, 0x8)

--- a/src/Ext/WeaponType/Hook.EBolt.cpp
+++ b/src/Ext/WeaponType/Hook.EBolt.cpp
@@ -1,5 +1,7 @@
 #include "Body.h"
 #include <EBolt.h>
+#include <Utilities/Macro.h>
+#include <Helpers/Macro.h>
 
 namespace BoltTemp
 {
@@ -24,6 +26,19 @@ DEFINE_HOOK(0x4C2951, EBolt_DTOR, 0x5)
 
 	BoltTemp::boltWeaponTypeExt.erase(pBolt);
 
+	return 0;
+}
+
+DEFINE_HOOK(0x4C20BC, EBolt_Draw_ArcsAmount, 0x0)
+{
+	GET_STACK(EBolt*, pBolt, 0x40);
+	BoltTemp::pType = BoltTemp::boltWeaponTypeExt.get_or_default(pBolt);
+
+	int a = 32;
+	if(BoltTemp::pType){ a = BoltTemp::pType->Bolt_Arcs;}
+	byte BoltArcsP2B[] = { 0x83, 0x7C, 0x24, 0x28, 0x08};
+	memcpy(&BoltArcsP2B[4], &a, sizeof(&a));
+    Patch(0x4C20BC, 5, BoltArcsP2B).Apply();
 	return 0;
 }
 

--- a/src/Ext/WeaponType/Hook.EBolt.cpp
+++ b/src/Ext/WeaponType/Hook.EBolt.cpp
@@ -39,7 +39,7 @@ DEFINE_HOOK(0x4C20BC, EBolt_DrawArcs, 0xB)
 	GET_STACK(int, plotIndex, STACK_OFFSET(0x408, -0x3E0))
 
 	return plotIndex < BoltTemp::pType->Bolt_Arcs
-        ? DoLoop : Break;
+		? DoLoop : Break;
 }
 
 DEFINE_HOOK(0x4C24E4, Ebolt_DrawFist_Disable, 0x8)


### PR DESCRIPTION
By default, Electric Bolt has 8 Arcs. Now it can be customized per weapon with `IsElectricBolt=yes`
Here is example of Tesla Coil using 1 arc for primary and 32 for secondary weapon.

https://github.com/Phobos-developers/Phobos/assets/30149531/7a88a52c-e26d-44e3-b812-5e698ec0e639

Created with big help from Kerbiter

