### PR TITLE
[Minor] Re-fix jumpjet initial facing

### DIFF
--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -157,3 +157,26 @@ FireError __stdcall JumpjetLocomotionClass_Can_Fire(ILocomotion* pThis)
 DEFINE_JUMP(VTABLE, 0x7ECDF4, GET_OFFSET(JumpjetLocomotionClass_Can_Fire));
 
 //TODO : Issue #690 #655
+
+// Fix initial facing when jumpjet locomotor is being attached
+DEFINE_HOOK(0x54AE44, JumpjetLocomotionClass_LinkToObject_FixFacing, 0x7)
+{
+	GET(ILocomotion*, iLoco, EBP);
+	auto const pThis = static_cast<JumpjetLocomotionClass*>(iLoco);
+
+	pThis->LocomotionFacing.SetCurrent(pThis->LinkedTo->PrimaryFacing.Current());
+	pThis->LocomotionFacing.SetDesired(pThis->LinkedTo->PrimaryFacing.Desired());
+
+	return 0;
+}
+
+// Fix initial facing when jumpjet locomotor on unlimbo
+void __stdcall JumpjetLocomotionClass_Unlimbo(ILocomotion* pThis)
+{
+	auto const pThisLoco = static_cast<JumpjetLocomotionClass*>(pThis);
+
+	pThisLoco->LocomotionFacing.SetCurrent(pThisLoco->LinkedTo->PrimaryFacing.Current());
+	pThisLoco->LocomotionFacing.SetDesired(pThisLoco->LinkedTo->PrimaryFacing.Desired());
+}
+
+DEFINE_JUMP(VTABLE, 0x7ECDB8, GET_OFFSET(JumpjetLocomotionClass_Unlimbo))

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -694,15 +694,3 @@ DEFINE_HOOK(0x451033, BuildingClass_AnimationAI_SuperAnim, 0x6)
 
 // Stops INI parsing for Anim/BuildingTypeClass on game startup, will only be read on scenario load later like everything else.
 DEFINE_JUMP(LJMP, 0x52C9C4, 0x52CA37);
-
-// Fix initial facing when jumpjet locomotor is being attached
-DEFINE_HOOK(0x54AE44, JumpjetLocomotionClass_LinkToObject_FixFacing, 0x7)
-{
-	GET(ILocomotion*, iLoco, EBP);
-	auto const pThis = static_cast<JumpjetLocomotionClass*>(iLoco);
-
-	pThis->LocomotionFacing.SetCurrent(pThis->LinkedTo->PrimaryFacing.Current());
-	pThis->LocomotionFacing.SetDesired(pThis->LinkedTo->PrimaryFacing.Desired());
-
-	return 0;
-}


### PR DESCRIPTION
https://github.com/Phobos-developers/Phobos/issues/1084#issuecomment-1613371056

How to test:
- pre-place jumpjet units on a map and move them, they should keep their direction and not snap into any other dir;
- use jumpjets as starting units, they also should keep the initial direction

@mevitar