### PR TITLE
Additional desync logging

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -204,6 +204,7 @@ This page lists all the individual contributions to the project by their author.
   - Chrono sparkle animation display customization and improvements
   - PipScale pip size & ammo pip frame customization
   - Extension class optimization
+  - Additional sync logging
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -155,6 +155,7 @@
     <ClCompile Include="src\Utilities\Patch.cpp" />
     <ClCompile Include="src\Utilities\AresHelper.cpp" />
     <ClCompile Include="src\Utilities\AresAddressTable.cpp" />
+    <ClCompile Include="src\Misc\SyncLogging.cpp" />
     <ClCompile Include="YRpp\StaticInits.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -181,6 +182,7 @@
     <ClInclude Include="src\Ext\CaptureManager\Body.h" />
     <ClInclude Include="src\Misc\FlyingStrings.h" />
     <ClInclude Include="src\Misc\PhobosToolTip.h" />
+    <ClInclude Include="src\Misc\SyncLogging.h" />
     <ClInclude Include="src\Misc\TypeConvertHelper.h" />
     <ClInclude Include="src\New\Type\DigitalDisplayTypeClass.h" />
     <ClInclude Include="src\New\Type\RadTypeClass.h" />

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -10,6 +10,7 @@ This page describes every change in Phobos that wasn't categorized into a proper
 - This feature must be enabled with `SkirmishUnlimitedColors=true` in `[General]` section of game rules.
 - When enabled, the game will treat color indices passed from spawner as indices for `[Colors]` section entries.
   - In example, with original rules, index 6 will correspond to color `Orange=25,230,255`.
+- Phobos writes additional information to the `SYNC#.txt` log files when a desynchronization occurs such as calls to random number generator functions, facing / target / destination changes etc.
 
 ```{note}
 This feature should only be used if you use a spawner/outside client (i.e. CNCNet client). Using it in the original YR launcher will produce undesireable effects.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -324,6 +324,7 @@ New:
 - Chrono sparkle animation display customization and improvements (by Starkku)
 - Script action to Chronoshift teams to enemy base (by Starkku)
 - PipScale pip size & ammo pip frame customization (by Starkku)
+- Additional sync logging in case of desync errors occuring (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -1,0 +1,153 @@
+#include <Misc/SyncLogging.h>
+
+#include <HouseClass.h>
+#include <Unsorted.h>
+
+#include <Utilities/Debug.h>
+#include <Utilities/Macro.h>
+
+SyncLogEventTracker<RNGCallSyncLogEvent, RNGCalls_Size> SyncLogger::RNGCalls;
+
+void SyncLogger::AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsigned int callerAddress, int min, int max)
+{
+	// Don't log non-critical RNG calls.
+	if (pRandomizer == &ScenarioClass::Instance->Random)
+		SyncLogger::RNGCalls.Add(RNGCallSyncLogEvent(type, true, pRandomizer->Next1, pRandomizer->Next2, callerAddress, Unsorted::CurrentFrame, min, max));
+}
+
+void SyncLogger::WriteSyncLog(const char* logFilename)
+{
+	auto const pLogFile = fopen(logFilename, "at");
+
+	if (pLogFile)
+	{
+		Debug::Log("Writing to sync log file '%s'.", logFilename);
+
+		fprintf(pLogFile, "\nPhobos synchronization log:\n\n");
+
+		int frameDigits = 0;
+		int frame = Unsorted::CurrentFrame;
+
+		while (frame)
+		{
+			frame /= 10;
+			frameDigits++;
+		}
+
+		WriteRNGCalls(pLogFile, frameDigits);
+
+		fclose(pLogFile);
+	}
+	else
+	{
+		Debug::Log("Failed to open sync log file '%s'.", logFilename);
+	}
+}
+
+void SyncLogger::WriteRNGCalls(FILE* const pLogFile, int frameDigits)
+{
+	fprintf(pLogFile, "RNG Calls:\n");
+
+	for (size_t i = 0; i < SyncLogger::RNGCalls.Size(); i++)
+	{
+		auto const& rngCall = SyncLogger::RNGCalls.Get(i);
+
+		if (rngCall.Type == 1)
+		{
+			fprintf(pLogFile, "#%05d: Single | Caller: %08x | Frame: %*d | Index1: %3d | Index2: %3d\n",
+				i, rngCall.Caller, frameDigits, rngCall.Frame, rngCall.Seed, rngCall.Index);
+		}
+		else if (rngCall.Type == 2)
+		{
+			fprintf(pLogFile, "#%05d: Ranged | Caller: %08x | Frame: %*d | Index1: %3d | Index2: %3d | Min: %d | Max: %d\n",
+				i, rngCall.Caller, frameDigits, rngCall.Frame, rngCall.Seed, rngCall.Index, rngCall.Min, rngCall.Max);
+		}
+	}
+
+	fprintf(pLogFile, "\n\n");
+}
+
+// Hooks
+
+// Sync file writing
+
+DEFINE_HOOK(0x64736D, Queue_AI_WriteDesyncLog, 0x5)
+{
+	GET(int, frame, ECX);
+
+	char logFilename[0x40];
+
+	if (Game::EnableMPSyncDebug)
+		_snprintf_s(logFilename, _TRUNCATE, "SYNC%01d_%03d.TXT", HouseClass::CurrentPlayer->ArrayIndex, frame % 256);
+	else
+		_snprintf_s(logFilename, _TRUNCATE, "SYNC%01d.TXT", HouseClass::CurrentPlayer->ArrayIndex);
+
+	SyncLogger::WriteSyncLog(logFilename);
+
+	// Replace overridden instructions.
+	JMP_STD(0x6BEC60);
+
+	return 0x647374;
+}
+
+DEFINE_HOOK(0x64CD11, ExecuteDoList_WriteDesyncLog, 0x8)
+{
+	char logFilename[0x40];
+
+	if (Game::EnableMPSyncDebug)
+	{
+		for (int i = 0; i < 256; i++)
+		{
+			_snprintf_s(logFilename, _TRUNCATE, "SYNC%01d_%03d.TXT", HouseClass::CurrentPlayer->ArrayIndex, i);
+			SyncLogger::WriteSyncLog(logFilename);
+		}
+	}
+	else
+	{
+		_snprintf_s(logFilename, _TRUNCATE, "SYNC%01d.TXT", HouseClass::CurrentPlayer->ArrayIndex);
+		SyncLogger::WriteSyncLog(logFilename);
+	}
+
+	return 0;
+}
+
+// RNG call logging
+
+DEFINE_HOOK(0x65C7D0, Random2Class_Random_SyncLog, 0x6)
+{
+	GET(Randomizer*, pThis, ECX);
+	GET_STACK(unsigned int, callerAddress, 0x0);
+
+	SyncLogger::AddRNGCallSyncLogEvent(pThis, 1, callerAddress);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x65C88A, Random2Class_RandomRanged_SyncLog, 0x6)
+{
+	GET(Randomizer*, pThis, EDX);
+	GET_STACK(unsigned int, callerAddress, 0x0);
+	GET_STACK(int, min, 0x4);
+	GET_STACK(int, max, 0x8);
+
+	SyncLogger::AddRNGCallSyncLogEvent(pThis, 2, callerAddress, min, max);
+
+	return 0;
+}
+
+// Disable sync logging hooks in non-MP games
+DEFINE_HOOK(0x683AB0, ScenarioClass_Start_DisableSyncLog, 0x6)
+{
+	if (SessionClass::Instance->IsMultiplayer())
+		return 0;
+
+	Patch::Apply_RAW(0x65C7D0, // Disable Random2Class_Random_SyncLog
+	{ 0xC3, 0x90, 0x90, 0x90, 0x90, 0x90 }
+	);
+
+	Patch::Apply_RAW(0x65C88A, // Disable Random2Class_RandomRanged_SyncLog
+	{ 0xC2, 0x08, 0x00, 0x90, 0x90, 0x90 }
+	);
+
+	return 0;
+}

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -100,7 +100,7 @@ void SyncLogger::WriteRNGCalls(FILE* const pLogFile, int frameDigits)
 	{
 		auto const& rngCall = SyncLogger::RNGCalls.Get(i);
 
-		if (!rngCall.Frame)
+		if (!rngCall.Initialized)
 			continue;
 
 		if (rngCall.Type == 1)
@@ -126,7 +126,7 @@ void SyncLogger::WriteFacingChanges(FILE* const pLogFile, int frameDigits)
 	{
 		auto const& facingChange = SyncLogger::FacingChanges.Get(i);
 
-		if (!facingChange.Frame)
+		if (!facingChange.Initialized)
 			continue;
 
 		fprintf(pLogFile, "#%05d: Facing: %5d | Caller: %08x | Frame: %*d\n",
@@ -144,7 +144,7 @@ void SyncLogger::WriteTargetChanges(FILE* const pLogFile, int frameDigits)
 	{
 		auto const& targetChange = SyncLogger::TargetChanges.Get(i);
 
-		if (!targetChange.Frame)
+		if (!targetChange.Initialized)
 			continue;
 
 		fprintf(pLogFile, "#%05d: RTTI: %02d | ID: %08d | TargetRTTI: %02d | TargetID: %08d | Caller: %08x | Frame: %*d\n",
@@ -162,7 +162,7 @@ void SyncLogger::WriteDestinationChanges(FILE* const pLogFile, int frameDigits)
 	{
 		auto const& destChange = SyncLogger::DestinationChanges.Get(i);
 
-		if (!destChange.Frame)
+		if (!destChange.Initialized)
 			continue;
 
 		fprintf(pLogFile, "#%05d: RTTI: %02d | ID: %08d | TargetRTTI: %02d | TargetID: %08d | Caller: %08x | Frame: %*d\n",

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -1,5 +1,6 @@
 #include <Misc/SyncLogging.h>
 
+#include <InfantryClass.h>
 #include <HouseClass.h>
 #include <Unsorted.h>
 
@@ -8,6 +9,7 @@
 
 SyncLogEventTracker<RNGCallSyncLogEvent, RNGCalls_Size> SyncLogger::RNGCalls;
 SyncLogEventTracker<FacingChangeSyncLogEvent, FacingChanges_Size> SyncLogger::FacingChanges;
+SyncLogEventTracker<TargetChangeSyncLogEvent, TargetChanges_Size> SyncLogger::TargetChanges;
 
 void SyncLogger::AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsigned int callerAddress, int min, int max)
 {
@@ -19,6 +21,12 @@ void SyncLogger::AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsig
 void SyncLogger::AddFacingChangeSyncLogEvent(unsigned short facing, unsigned int callerAddress)
 {
 	SyncLogger::FacingChanges.Add(FacingChangeSyncLogEvent(facing, callerAddress, Unsorted::CurrentFrame));
+}
+
+void SyncLogger::AddTargetChangeSyncLogEvent(AbstractClass* pObject, AbstractClass* pTarget, unsigned int callerAddress)
+{
+	if (pObject && pTarget)
+		SyncLogger::TargetChanges.Add(TargetChangeSyncLogEvent(pObject->WhatAmI(), pObject->UniqueID, pTarget->WhatAmI(), pTarget->UniqueID, callerAddress, Unsorted::CurrentFrame));
 }
 
 void SyncLogger::WriteSyncLog(const char* logFilename)
@@ -42,6 +50,7 @@ void SyncLogger::WriteSyncLog(const char* logFilename)
 
 		WriteRNGCalls(pLogFile, frameDigits);
 		WriteFacingChanges(pLogFile, frameDigits);
+		WriteTargetChanges(pLogFile, frameDigits);
 
 		fclose(pLogFile);
 	}
@@ -90,6 +99,24 @@ void SyncLogger::WriteFacingChanges(FILE* const pLogFile, int frameDigits)
 
 		fprintf(pLogFile, "#%05d: Facing: %5d | Caller: %08x | Frame: %*d\n",
 			i, facingChange.Facing, facingChange.Caller, frameDigits, facingChange.Frame);
+	}
+
+	fprintf(pLogFile, "\n");
+}
+
+void SyncLogger::WriteTargetChanges(FILE* const pLogFile, int frameDigits)
+{
+	fprintf(pLogFile, "Target changes:\n");
+
+	for (size_t i = 0; i < SyncLogger::TargetChanges.Size(); i++)
+	{
+		auto const& targetChange = SyncLogger::TargetChanges.Get(i);
+
+		if (!targetChange.Frame)
+			continue;
+
+		fprintf(pLogFile, "#%05d: RTTI: %02d | ID: %08d | TargetRTTI: %02d | TargetID: %08d | Caller: %08x | Frame: %*d\n",
+			i, targetChange.Type, targetChange.ID, targetChange.TargetType, targetChange.ID, targetChange.Caller, frameDigits, targetChange.Frame);
 	}
 
 	fprintf(pLogFile, "\n");
@@ -175,6 +202,44 @@ DEFINE_HOOK(0x4C9300, FacingClass_Set_SyncLog, 0x5)
 	return 0;
 }
 
+// Target change logging
+
+DEFINE_HOOK(0x51B1F0, InfantryClass_AssignTarget_SyncLog, 0x5)
+{
+	GET(InfantryClass*, pThis, ECX);
+	GET_STACK(AbstractClass*, pTarget, 0x4);
+	GET_STACK(unsigned int, callerAddress, 0x0);
+
+	SyncLogger::AddTargetChangeSyncLogEvent(pThis, pTarget, callerAddress);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x443B90, BuildingClass_AssignTarget_SyncLog, 0xB)
+{
+	GET(BuildingClass*, pThis, ECX);
+	GET_STACK(AbstractClass*, pTarget, 0x4);
+	GET_STACK(unsigned int, callerAddress, 0x0);
+
+	SyncLogger::AddTargetChangeSyncLogEvent(pThis, pTarget, callerAddress);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6FCDB0, TechnoClass_AssignTarget_SyncLog, 0x5)
+{
+	GET(TechnoClass*, pThis, ECX);
+	GET_STACK(AbstractClass*, pTarget, 0x4);
+	GET_STACK(unsigned int, callerAddress, 0x0);
+
+	auto const RTTI = pThis->WhatAmI();
+
+	if (RTTI != AbstractType::Building && RTTI != AbstractType::Infantry)
+		SyncLogger::AddTargetChangeSyncLogEvent(pThis, pTarget, callerAddress);
+
+	return 0;
+}
+
 // Disable sync logging hooks in non-MP games
 DEFINE_HOOK(0x683AB0, ScenarioClass_Start_DisableSyncLog, 0x6)
 {
@@ -191,6 +256,18 @@ DEFINE_HOOK(0x683AB0, ScenarioClass_Start_DisableSyncLog, 0x6)
 
 	Patch::Apply_RAW(0x65C88A, // Disable FacingClass_Set_SyncLog
 	{ 0x83, 0xEC, 0x10, 0x53, 0x56 }
+	);
+
+	Patch::Apply_RAW(0x65C88A, // Disable InfantryClass_AssignTarget_SyncLog
+	{ 0x53, 0x56, 0x8B, 0xF1, 0x57 }
+	);
+
+	Patch::Apply_RAW(0x65C88A, // Disable BuildingClass_AssignTarget_SyncLog
+	{ 0x56, 0x8B, 0xF1, 0x57, 0x83, 0xBE, 0xAC, 0x0, 0x0, 0x0, 0x13 }
+	);
+
+	Patch::Apply_RAW(0x65C88A, // Disable TechnoClass_AssignTarget_SyncLog
+	{ 0x83, 0xEC, 0x0C, 0x53, 0x56 }
 	);
 
 	return 0;

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -7,6 +7,7 @@
 #include <Utilities/Debug.h>
 #include <Utilities/Macro.h>
 
+bool SyncLogger::HooksDisabled = false;
 SyncLogEventTracker<RNGCallSyncLogEvent, RNGCalls_Size> SyncLogger::RNGCalls;
 SyncLogEventTracker<FacingChangeSyncLogEvent, FacingChanges_Size> SyncLogger::FacingChanges;
 SyncLogEventTracker<TargetChangeSyncLogEvent, TargetChanges_Size> SyncLogger::TargetChanges;
@@ -243,8 +244,10 @@ DEFINE_HOOK(0x6FCDB0, TechnoClass_AssignTarget_SyncLog, 0x5)
 // Disable sync logging hooks in non-MP games
 DEFINE_HOOK(0x683AB0, ScenarioClass_Start_DisableSyncLog, 0x6)
 {
-	if (SessionClass::Instance->IsMultiplayer())
+	if (SessionClass::Instance->IsMultiplayer() || SyncLogger::HooksDisabled)
 		return 0;
+
+	SyncLogger::HooksDisabled = true;
 
 	Patch::Apply_RAW(0x65C7D0, // Disable Random2Class_Random_SyncLog
 	{ 0xC3, 0x90, 0x90, 0x90, 0x90, 0x90 }

--- a/src/Misc/SyncLogging.h
+++ b/src/Misc/SyncLogging.h
@@ -9,6 +9,7 @@
 static constexpr unsigned int RNGCalls_Size = 4096;
 static constexpr unsigned int FacingChanges_Size = 1024;
 static constexpr unsigned int TargetChanges_Size = 1024;
+static constexpr unsigned int DestinationChanges_Size = 1024;
 
 template <typename T, unsigned int size>
 class SyncLogEventTracker
@@ -95,15 +96,18 @@ private:
 	static SyncLogEventTracker<RNGCallSyncLogEvent, RNGCalls_Size> RNGCalls;
 	static SyncLogEventTracker<FacingChangeSyncLogEvent, FacingChanges_Size> FacingChanges;
 	static SyncLogEventTracker<TargetChangeSyncLogEvent, TargetChanges_Size> TargetChanges;
+	static SyncLogEventTracker<TargetChangeSyncLogEvent, DestinationChanges_Size> DestinationChanges;
 
 	static void WriteRNGCalls(FILE* const pLogFile, int frameDigits);
 	static void WriteFacingChanges(FILE* const pLogFile, int frameDigits);
 	static void WriteTargetChanges(FILE* const pLogFile, int frameDigits);
+	static void WriteDestinationChanges(FILE* const pLogFile, int frameDigits);
 public:
 	static bool HooksDisabled;
 
 	static void AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsigned int callerAddress, int min = 0, int max = 0);
 	static void AddFacingChangeSyncLogEvent(unsigned short facing, unsigned int callerAddress);
 	static void AddTargetChangeSyncLogEvent(AbstractClass* pObject, AbstractClass* pTarget, unsigned int callerAddress);
+	static void AddDestinationChangeSyncLogEvent(AbstractClass* pObject, AbstractClass* pTarget, unsigned int callerAddress);
 	static void WriteSyncLog(const char* logFilename);
 };

--- a/src/Misc/SyncLogging.h
+++ b/src/Misc/SyncLogging.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AbstractClass.h>
 #include <GeneralDefinitions.h>
 #include <Randomizer.h>
 
@@ -7,6 +8,7 @@
 
 static constexpr unsigned int RNGCalls_Size = 4096;
 static constexpr unsigned int FacingChanges_Size = 1024;
+static constexpr unsigned int TargetChanges_Size = 1024;
 
 template <typename T, unsigned int size>
 class SyncLogEventTracker
@@ -70,16 +72,36 @@ struct FacingChangeSyncLogEvent
 	}
 };
 
+struct TargetChangeSyncLogEvent
+{
+	AbstractType Type;
+	DWORD ID;
+	AbstractType TargetType;
+	DWORD TargetID;
+	unsigned int Caller;
+	unsigned int Frame;
+
+	TargetChangeSyncLogEvent() = default;
+
+	TargetChangeSyncLogEvent(const AbstractType& Type, const DWORD& ID, const AbstractType& TargetType, const DWORD& TargetID, unsigned int Caller, unsigned int Frame)
+		: Type(Type), ID(ID), TargetType(TargetType), TargetID(TargetID), Caller(Caller), Frame(Frame)
+	{
+	}
+};
+
 class SyncLogger
 {
 private:
 	static SyncLogEventTracker<RNGCallSyncLogEvent, RNGCalls_Size> RNGCalls;
 	static SyncLogEventTracker<FacingChangeSyncLogEvent, FacingChanges_Size> FacingChanges;
+	static SyncLogEventTracker<TargetChangeSyncLogEvent, TargetChanges_Size> TargetChanges;
 
 	static void WriteRNGCalls(FILE* const pLogFile, int frameDigits);
 	static void WriteFacingChanges(FILE* const pLogFile, int frameDigits);
+	static void WriteTargetChanges(FILE* const pLogFile, int frameDigits);
 public:
 	static void AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsigned int callerAddress, int min = 0, int max = 0);
 	static void AddFacingChangeSyncLogEvent(unsigned short facing, unsigned int callerAddress);
+	static void AddTargetChangeSyncLogEvent(AbstractClass* pObject, AbstractClass* pTarget, unsigned int callerAddress);
 	static void WriteSyncLog(const char* logFilename);
 };

--- a/src/Misc/SyncLogging.h
+++ b/src/Misc/SyncLogging.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <GeneralDefinitions.h>
+#include <Randomizer.h>
+
+#include <vector>
+
+static constexpr unsigned int RNGCalls_Size = 4096;
+
+template <typename T, unsigned int size>
+class SyncLogEventTracker
+{
+	using iterator = typename std::vector<T>::iterator;
+	using const_iterator = typename std::vector<T>::const_iterator;
+private:
+	std::vector<T> Data;
+	unsigned int LastPosition;
+public:
+	SyncLogEventTracker() : Data(size), LastPosition(0) { };
+
+	void Add(T item)
+	{
+		Data[LastPosition] = item;
+		LastPosition++;
+
+		if (LastPosition >= Data.size())
+			LastPosition = 0;
+	}
+
+	T Get(int index) { return Data[index]; }
+	size_t Size() { return Data.size(); }
+
+	iterator begin() { return Data.begin(); }
+	iterator end() { return Data.end(); }
+	const_iterator begin() const { return Data.begin(); }
+	const_iterator end() const { return Data.end(); }
+};
+
+struct RNGCallSyncLogEvent
+{
+	int Type; // 0 = Invalid, 1 = Unranged, 2 = Ranged
+	bool IsCritical;
+	unsigned int Seed;
+	unsigned int Index;
+	unsigned int Caller;
+	unsigned int Frame;
+	int Min;
+	int Max;
+
+	RNGCallSyncLogEvent() = default;
+
+	RNGCallSyncLogEvent(int Type, bool IsCritical, unsigned int Seed, unsigned int Index, unsigned int Caller, unsigned int Frame, int Min, int Max)
+		: Type(Type), IsCritical(IsCritical), Seed(Seed), Index(Index), Caller(Caller), Frame(Frame), Min(Min), Max(Max)
+	{
+	}
+};
+
+class SyncLogger
+{
+private:
+	static SyncLogEventTracker<RNGCallSyncLogEvent, RNGCalls_Size> RNGCalls;
+
+	static void WriteRNGCalls(FILE* const pLogFile, int frameDigits);
+public:
+	static void AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsigned int callerAddress, int min = 0, int max = 0);
+	static void WriteSyncLog(const char* logFilename);
+};

--- a/src/Misc/SyncLogging.h
+++ b/src/Misc/SyncLogging.h
@@ -42,6 +42,7 @@ public:
 
 struct RNGCallSyncLogEvent
 {
+	bool Initialized;
 	int Type; // 0 = Invalid, 1 = Unranged, 2 = Ranged
 	bool IsCritical;
 	unsigned int Seed;
@@ -56,11 +57,13 @@ struct RNGCallSyncLogEvent
 	RNGCallSyncLogEvent(int Type, bool IsCritical, unsigned int Seed, unsigned int Index, unsigned int Caller, unsigned int Frame, int Min, int Max)
 		: Type(Type), IsCritical(IsCritical), Seed(Seed), Index(Index), Caller(Caller), Frame(Frame), Min(Min), Max(Max)
 	{
+		Initialized = true;
 	}
 };
 
 struct FacingChangeSyncLogEvent
 {
+	bool Initialized;
 	unsigned short Facing;
 	unsigned int Caller;
 	unsigned int Frame;
@@ -70,11 +73,13 @@ struct FacingChangeSyncLogEvent
 	FacingChangeSyncLogEvent(unsigned short Facing, unsigned int Caller, unsigned int Frame)
 		: Facing(Facing), Caller(Caller), Frame(Frame)
 	{
+		Initialized = true;
 	}
 };
 
 struct TargetChangeSyncLogEvent
 {
+	bool Initialized;
 	AbstractType Type;
 	DWORD ID;
 	AbstractType TargetType;
@@ -87,6 +92,7 @@ struct TargetChangeSyncLogEvent
 	TargetChangeSyncLogEvent(const AbstractType& Type, const DWORD& ID, const AbstractType& TargetType, const DWORD& TargetID, unsigned int Caller, unsigned int Frame)
 		: Type(Type), ID(ID), TargetType(TargetType), TargetID(TargetID), Caller(Caller), Frame(Frame)
 	{
+		Initialized = true;
 	}
 };
 

--- a/src/Misc/SyncLogging.h
+++ b/src/Misc/SyncLogging.h
@@ -100,6 +100,8 @@ private:
 	static void WriteFacingChanges(FILE* const pLogFile, int frameDigits);
 	static void WriteTargetChanges(FILE* const pLogFile, int frameDigits);
 public:
+	static bool HooksDisabled;
+
 	static void AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsigned int callerAddress, int min = 0, int max = 0);
 	static void AddFacingChangeSyncLogEvent(unsigned short facing, unsigned int callerAddress);
 	static void AddTargetChangeSyncLogEvent(AbstractClass* pObject, AbstractClass* pTarget, unsigned int callerAddress);

--- a/src/Misc/SyncLogging.h
+++ b/src/Misc/SyncLogging.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 static constexpr unsigned int RNGCalls_Size = 4096;
+static constexpr unsigned int FacingChanges_Size = 1024;
 
 template <typename T, unsigned int size>
 class SyncLogEventTracker
@@ -55,13 +56,30 @@ struct RNGCallSyncLogEvent
 	}
 };
 
+struct FacingChangeSyncLogEvent
+{
+	unsigned short Facing;
+	unsigned int Caller;
+	unsigned int Frame;
+
+	FacingChangeSyncLogEvent() = default;
+
+	FacingChangeSyncLogEvent(unsigned short Facing, unsigned int Caller, unsigned int Frame)
+		: Facing(Facing), Caller(Caller), Frame(Frame)
+	{
+	}
+};
+
 class SyncLogger
 {
 private:
 	static SyncLogEventTracker<RNGCallSyncLogEvent, RNGCalls_Size> RNGCalls;
+	static SyncLogEventTracker<FacingChangeSyncLogEvent, FacingChanges_Size> FacingChanges;
 
 	static void WriteRNGCalls(FILE* const pLogFile, int frameDigits);
+	static void WriteFacingChanges(FILE* const pLogFile, int frameDigits);
 public:
 	static void AddRNGCallSyncLogEvent(Randomizer* pRandomizer, int type, unsigned int callerAddress, int min = 0, int max = 0);
+	static void AddFacingChangeSyncLogEvent(unsigned short facing, unsigned int callerAddress);
 	static void WriteSyncLog(const char* logFilename);
 };

--- a/src/Misc/SyncLogging.h
+++ b/src/Misc/SyncLogging.h
@@ -19,8 +19,8 @@ class SyncLogEventBuffer
 {
 private:
 	std::vector<T> Data;
-	unsigned int LastWritePosition;
-	unsigned int LastReadPosition;
+	int LastWritePosition;
+	int LastReadPosition;
 	bool HasBeenFilled = true;
 public:
 	SyncLogEventBuffer() : Data(size), LastWritePosition(0), LastReadPosition(-1), HasBeenFilled(false) { };

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -148,3 +148,16 @@ std::string GeneralUtils::IntToDigits(int num)
 
 	return digits;
 }
+
+int GeneralUtils::CountDigitsInNumber(int number)
+{
+	int digits = 0;
+
+	while (number)
+	{
+		number /= 10;
+		digits++;
+	}
+
+	return digits;
+}

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -32,6 +32,7 @@ public:
 	static bool HasHealthRatioThresholdChanged(double oldRatio, double newRatio);
 	static bool ApplyTheaterSuffixToString(char* str);
 	static std::string IntToDigits(int num);
+	static int CountDigitsInNumber(int number);
 
 	template<typename T>
 	static T FastPow(T x, size_t n)


### PR DESCRIPTION
This adds following things, including relevant parameters, function caller/return address and current frame to be appended to `SYNC#.txt` log files upon desynchronization occuring:

- Last 4096 calls to game's synced random number generator function (the one that is `ScenarioClass` member) 
- Last 1024 `FacingClass::Set()` calls
- Last 1024 `TechnoClass::AssignTarget()` calls (including overrides)
- Last 1024 `TechnoClass::AssignDestination()` calls (including overrides)
- Last 256 `TechnoClass::OverrideMission()` calls
- Last 512 `AnimClass` constructor calls

These numbers can be amended later if needed. This feature is also currently enabled by default in multiplayer games only (the hooks that log this information are disabled in singleplayer/skirmish), and can incur a performance decrease. A toggle can be added later if needed.