### PR TITLE
Infantry and Units health bar customizations

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -284,6 +284,7 @@ This page lists all the individual contributions to the project by their author.
   - Vehicle voxel turret shadows & body multi-section shadows
 - **Fryone**
   - Customizable ElectricBolt Arcs
+  - Infantry and Units health bar customizations
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares
   - unfinished RadTypes code

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -542,6 +542,28 @@ PipWrapAmmoPip=14                ; integer, frame of pips2.shp (zero-based)
 AmmoPipSize=                     ; X,Y, increment in pixels to next pip
 ```
 
+### Infantry and Units health bar customizations
+
+- The length of health bar can be changed per techno type using `HealthBar.Sections`.
+  - `HealthBar.Sections`, amount of sections in health bar. Defaults to 8 for Infantry and 17 for Units.
+- Health bar border can be customized per techno type.
+  - `HealthBar.Border`, used to set a custom border file for health bar, can be used without `HealthBar.Sections`.
+  - `HealthBar.BorderFrame`, frame index of `HealthBar.Border` file.
+  - `HealthBar.BorderAdjust`, adjusts vertical position of health bar border.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                      ; TechnoType
+HealthBar.Sections=17             ; integer, sections in health bar
+HealthBar.Border=PIPBRD           ; filename in .shp format without `.shp` extension
+HealthBar.BorderFrame=0           ; integer, frame of `HealthBar.Border` (zero-based)
+HealthBar.BorderAdjust=0          ; integer, horizontal position adjustment
+```
+
+```{note}
+Vertical position of health bar can be adjusted using tag `PixelSelectionBracketDelta`.
+```
+
 ### Re-enable obsolete [JumpjetControls]
 
 - Re-enable obsolete [JumpjetControls], the keys in it will be as the default value of jumpjet units.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -326,6 +326,7 @@ New:
 - Digital display of HP and SP (by ststl, FlyStar, Saigyouji, JunJacobYoung)
 - PipScale pip size & ammo pip frame customization (by Starkku)
 - Additional sync logging in case of desync errors occuring (by Starkku)
+- Infantry and Units health bar customizations (by Fryone)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -323,16 +323,17 @@ Point2D TechnoExt::GetScreenLocation(TechnoClass* pThis)
 
 Point2D TechnoExt::GetFootSelectBracketPosition(TechnoClass* pThis, Anchor anchor)
 {
-	int length = 17;
 	Point2D position = GetScreenLocation(pThis);
+	int length = pThis->WhatAmI() == AbstractType::Infantry ? 8 : 17;
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
 
-	if (pThis->WhatAmI() == AbstractType::Infantry)
-		length = 8;
+	if(pTypeExt->HealthBar_Sections > 0)
+		length = pTypeExt->HealthBar_Sections;
 
 	RectangleStruct bracketRect =
 	{
-		position.X - length + (length == 8) + 1,
-		position.Y - 28 + (length == 8),
+		position.X - length + (length % 2 == 0) + 1,
+		position.Y - 28 + (length % 2 == 0),
 		length * 2,
 		length * 3
 	};

--- a/src/Ext/Techno/Hooks.Shield.cpp
+++ b/src/Ext/Techno/Hooks.Shield.cpp
@@ -161,9 +161,7 @@ DEFINE_HOOK(0x6F683C, TechnoClass_DrawHealthBar_DrawOtherShieldBar, 0x7)
 	{
 		if (pShieldData->IsAvailable())
 		{
-			const int length = pThis->WhatAmI() == AbstractType::Infantry ? 8 : 17;
-			if(pExt->TypeExtData->HealthBar_Sections > 0)
-				length = pExt->TypeExtData->HealthBar_Sections;
+			const int length = (pExt->TypeExtData->HealthBar_Sections > 0) ? pExt->TypeExtData->HealthBar_Sections : (pThis->WhatAmI() == AbstractType::Infantry ? 8 : 17);
 			pShieldData->DrawShieldBar(length, pLocation, pBound);
 		}
 	}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -253,6 +253,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->PipWrapAmmoPip.Read(exINI, pSection, "PipWrapAmmoPip");
 	this->AmmoPipSize.Read(exINI, pSection, "AmmoPipSize");
 
+	this->HealthBar_Sections.Read(exINI, pSection, "HealthBar.Sections");
+	this->HealthBar_Border.Read(exINI, pSection, "HealthBar.Border");
+	this->HealthBar_BorderFrame.Read(exINI, pSection, "HealthBar.BorderFrame");
+	this->HealthBar_BorderAdjust.Read(exINI, pSection, "HealthBar.BorderAdjust");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -529,6 +534,11 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->EmptyAmmoPip)
 		.Process(this->PipWrapAmmoPip)
 		.Process(this->AmmoPipSize)
+
+		.Process(this->HealthBar_Sections)
+		.Process(this->HealthBar_Border)
+		.Process(this->HealthBar_BorderFrame)
+		.Process(this->HealthBar_BorderAdjust)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -162,6 +162,11 @@ public:
 		Valueable<int> PipWrapAmmoPip;
 		Nullable<Point2D> AmmoPipSize;
 
+		Valueable<int> HealthBar_Sections;
+		Nullable<SHPStruct*> HealthBar_Border;
+		Valueable<int> HealthBar_BorderFrame;
+		Valueable<int> HealthBar_BorderAdjust;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -322,6 +327,11 @@ public:
 			, EmptyAmmoPip { -1 }
 			, PipWrapAmmoPip { 14 }
 			, AmmoPipSize {}
+
+			, HealthBar_Sections { 0 }
+			, HealthBar_Border { }
+			, HealthBar_BorderFrame { 0 }
+			, HealthBar_BorderAdjust { 0 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/New/Entity/ShieldClass.cpp
+++ b/src/New/Entity/ShieldClass.cpp
@@ -806,10 +806,10 @@ void ShieldClass::DrawShieldBar_Other(const int length, Point2D* pLocation, Rect
 
 	if (this->Techno->IsSelected)
 	{
-		position.X += length + 1 + (length == 8 ? length + 1 : 0);
+		position.X += length + 1 + (length % 2 == 0 ? length + 1 : 0);
 		DSurface::Temp->DrawSHP(FileSystem::PALETTE_PAL, pipBoard,
 			frame, &position, pBound, BlitterFlags(0xE00), 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
-		position.X -= length + 1 + (length == 8 ? length + 1 : 0);
+		position.X -= length + 1 + (length % 2 == 0 ? length + 1 : 0);
 	}
 
 	frame = this->DrawShieldBar_Pip(false);


### PR DESCRIPTION
HealthBar.Sections=17           -     sections in health bar
HealthBar.Border=PIPBRD      -     filename in .shp format
HealthBar.BorderFrame=0      -     frame index of border
HealthBar.BorderAdjust=0      -     horizontal position adjustment


![image](https://github.com/Phobos-developers/Phobos/assets/30149531/55695729-7758-4aef-a848-586ee4043274)
