### PR TITLE
Fix issues with AutoDeath and limbo interactions

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -823,7 +823,7 @@ Both `InitialStrength` and `InitialStrength.Cloning` never surpass the type's `S
   - `AfterDelay`: The object will die if the countdown (in frames) reaches 0.
   - `TechnosExist` / `TechnosDontExist`: The object will die if TechnoTypes exist or do not exist, respectively.
     - `Technos(Dont)Exist.Any` controls whether or not a single listed TechnoType is enough to satisfy the requirement or if all are required.
-    - `Technos(Dont)Exist.AllowLimboed` controls whether or not limboed TechnoTypes (f.ex those in transports) are counted. Note that this may count TechnoTypes that are still being built.
+    - `Technos(Dont)Exist.AllowLimboed` controls whether or not limboed TechnoTypes (f.ex those in transports) are counted.
     - `Technos(Dont)Exist.Houses` controls which houses are checked.
 
 - The auto-death behavior can be chosen from the following:
@@ -832,11 +832,12 @@ Both `InitialStrength` and `InitialStrength.Cloning` never surpass the type's `S
   - `sell`: If the object is a **building** with buildup, it will be sold instead of destroyed.
 
 If this option is not set, the self-destruction logic will not be enabled. `AutoDeath.VanishAnimation` can be set to animation to play at object's location if `vanish` behaviour is chosen.
+
 ```{note}
 Please notice that if the object is a unit which carries passengers, they will not be released even with the `kill` option **if you are not using Ares 3.0+**.
 ```
 
-This logic also supports buildings delivered by [LimboDelivery](#LimboDelivery)
+This logic also supports buildings delivered by [LimboDelivery](#LimboDelivery). However in this case, all `AutoDeath.Behavior` values produce identical result where the building is simply deleted.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -330,6 +330,7 @@ New:
 - Customizing shield self-healing timer restart when shield is damaged (by Starkku)
 - Customizing minimum & maximum amount of damage shield can take from a single hit (by Starkku)
 - Players can now be given ownership of preplaced buildings in Skirmish and Multiplayer in maps using houses of the format <Player @ X> where X goes from A to H for spawn positions 1-8 (by ZivDero)
+- `AutoDeath.Technos(Dont)Exist` can optionally track limboed (not physically on map, e.g transports etc) technos (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
@@ -394,6 +395,7 @@ Phobos fixes:
 - Fixed `Interceptor` not resetting target if the intercepted projectile changes type to non-interceptable one afterwards (by Starkku)
 - Fixed `PlacementPreview` setting for BuildingTypes not being parsed from INI (by Starkku)
 - Fixed Phobos animation additions that support `CreateUnit.Owner` not also checking `MakeInfantryOwner` (by Starkku)
+- Fixed `AutoDeath` to consider all conditions for objects in limbo (by Starkku)
 
 Fixes / interactions with other extensions:
 - Fixed an issue introduced by Ares that caused `Grinding=true` building `ActiveAnim` to be incorrectly restored while `SpecialAnim` was playing and the building was sold, erased or destroyed (by Starkku)

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -334,6 +334,7 @@ void BuildingExt::ExtData::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->TypeExtData)
+		.Process(this->TechnoExtData)
 		.Process(this->DeployedTechno)
 		.Process(this->IsCreatedFromMapFile)
 		.Process(this->LimboID)
@@ -386,7 +387,10 @@ DEFINE_HOOK(0x43BCBD, BuildingClass_CTOR, 0x6)
 	auto const pExt = BuildingExt::ExtMap.TryAllocate(pItem);
 
 	if (pExt)
+	{
 		pExt->TypeExtData = BuildingTypeExt::ExtMap.Find(pItem->Type);
+		pExt->TechnoExtData = TechnoExt::ExtMap.Find(pItem);
+	}
 
 	return 0;
 }

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -26,6 +26,7 @@ public:
 	{
 	public:
 		BuildingTypeExt::ExtData* TypeExtData;
+		TechnoExt::ExtData* TechnoExtData;
 		bool DeployedTechno;
 		bool IsCreatedFromMapFile;
 		int LimboID;
@@ -36,6 +37,7 @@ public:
 
 		ExtData(BuildingClass* OwnerObject) : Extension<BuildingClass>(OwnerObject)
 			, TypeExtData { nullptr }
+			, TechnoExtData { nullptr }
 			, DeployedTechno { false }
 			, IsCreatedFromMapFile { false }
 			, LimboID { -1 }

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -48,7 +48,7 @@ int BuildingTypeExt::GetEnhancedPower(BuildingClass* pBuilding, HouseClass* pHou
 
 	auto const pHouseExt = HouseExt::ExtMap.Find(pHouse);
 
-	for (const auto& [pExt, nCount] : pHouseExt->BuildingCounter)
+	for (const auto& [pExt, nCount] : pHouseExt->PowerPlantEnhancers)
 	{
 		if (pExt->PowerPlantEnhancer_Buildings.Contains(pBuilding->Type))
 		{

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -388,22 +388,100 @@ HouseClass* HouseExt::GetHouseKind(OwnerHouseKind const kind, bool const allowRa
 
 void HouseExt::ExtData::UpdateAutoDeathObjectsInLimbo()
 {
-	for (auto pExt : this->OwnedTimedAutoDeathObjects)
+	for (auto it = this->OwnedLimboDeliveredBuildings.begin(); it != this->OwnedLimboDeliveredBuildings.end(); )
 	{
-		auto pItem = pExt->OwnerObject();
+		auto const pBuilding = it->first;
+		auto const pExt = it->second;
 
-		if (!pItem->IsInLogic && pItem->IsAlive && pExt->TypeExtData->AutoDeath_Behavior.isset() && pExt->AutoDeathTimer.Completed())
+		if (!pBuilding->IsInLogic && pBuilding->IsAlive)
 		{
-			auto const pBuilding = abstract_cast<BuildingClass*>(pItem);
-
-			if (this->OwnedLimboDeliveredBuildings.contains(pBuilding))
-				this->OwnedLimboDeliveredBuildings.erase(pBuilding);
-
-			pItem->RegisterDestruction(nullptr);
-			// I doubt those in LimboDelete being really necessary, they're gonna be updated either next frame or after uninit anyway
-			pItem->UnInit();
+			if (pExt->TechnoExtData->CheckDeathConditions(true))
+			{
+				this->OwnedLimboDeliveredBuildings.erase(it++);
+				this->RemoveFromLimboTracking(pBuilding->Type);
+			}
+			else
+				it++;
 		}
 	}
+}
+
+void HouseExt::ExtData::AddToLimboTracking(TechnoTypeClass* pTechnoType)
+{
+	if (pTechnoType)
+	{
+		int arrayIndex = pTechnoType->GetArrayIndex();
+
+		switch (pTechnoType->WhatAmI())
+		{
+		case AbstractType::AircraftType:
+			this->LimboAircraft.Increment(arrayIndex);
+			break;
+		case AbstractType::BuildingType:
+			this->LimboBuildings.Increment(arrayIndex);
+			break;
+		case AbstractType::InfantryType:
+			this->LimboInfantry.Increment(arrayIndex);
+			break;
+		case AbstractType::UnitType:
+			this->LimboVehicles.Increment(arrayIndex);
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+void HouseExt::ExtData::RemoveFromLimboTracking(TechnoTypeClass* pTechnoType)
+{
+	if (pTechnoType)
+	{
+		int arrayIndex = pTechnoType->GetArrayIndex();
+
+		switch (pTechnoType->WhatAmI())
+		{
+		case AbstractType::AircraftType:
+			this->LimboAircraft.Decrement(arrayIndex);
+			break;
+		case AbstractType::BuildingType:
+			this->LimboBuildings.Decrement(arrayIndex);
+			break;
+		case AbstractType::InfantryType:
+			this->LimboInfantry.Decrement(arrayIndex);
+			break;
+		case AbstractType::UnitType:
+			this->LimboVehicles.Decrement(arrayIndex);
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+int HouseExt::ExtData::CountOwnedPresentAndLimboed(TechnoTypeClass* pTechnoType)
+{
+	int count = this->OwnerObject()->CountOwnedAndPresent(pTechnoType);
+	int arrayIndex = pTechnoType->GetArrayIndex();
+
+	switch (pTechnoType->WhatAmI())
+	{
+	case AbstractType::AircraftType:
+		count += this->LimboAircraft.GetItemCount(arrayIndex);
+		break;
+	case AbstractType::BuildingType:
+		count += this->LimboBuildings.GetItemCount(arrayIndex);
+		break;
+	case AbstractType::InfantryType:
+		count += this->LimboInfantry.GetItemCount(arrayIndex);
+		break;
+	case AbstractType::UnitType:
+		count += this->LimboVehicles.GetItemCount(arrayIndex);
+		break;
+	default:
+		break;
+	}
+
+	return count;
 }
 
 void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
@@ -423,7 +501,6 @@ void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 }
 
-
 // =============================
 // load / save
 
@@ -431,9 +508,13 @@ template <typename T>
 void HouseExt::ExtData::Serialize(T& Stm)
 {
 	Stm
-		.Process(this->BuildingCounter)
+		.Process(this->PowerPlantEnhancers)
 		.Process(this->OwnedLimboDeliveredBuildings)
 		.Process(this->OwnedTimedAutoDeathObjects)
+		.Process(this->LimboAircraft)
+		.Process(this->LimboBuildings)
+		.Process(this->LimboInfantry)
+		.Process(this->LimboVehicles)
 		.Process(this->Factory_BuildingType)
 		.Process(this->Factory_InfantryType)
 		.Process(this->Factory_VehicleType)

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -401,7 +401,9 @@ void HouseExt::ExtData::UpdateAutoDeathObjectsInLimbo()
 				this->RemoveFromLimboTracking(pBuilding->Type);
 			}
 			else
+			{
 				it++;
+			}
 		}
 	}
 }

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -20,9 +20,14 @@ public:
 	class ExtData final : public Extension<HouseClass>
 	{
 	public:
-		std::map<BuildingTypeExt::ExtData*, int> BuildingCounter;
+		std::map<BuildingTypeExt::ExtData*, int> PowerPlantEnhancers;
 		std::map<BuildingClass*, BuildingExt::ExtData*> OwnedLimboDeliveredBuildings;
 		std::vector<TechnoExt::ExtData*> OwnedTimedAutoDeathObjects;
+
+		CounterClass LimboAircraft;  // Currently owned aircraft in limbo
+		CounterClass LimboBuildings; // Currently owned buildings in limbo
+		CounterClass LimboInfantry;  // Currently owned infantry in limbo
+		CounterClass LimboVehicles;  // Currently owned vehicles in limbo
 
 		BuildingClass* Factory_BuildingType;
 		BuildingClass* Factory_InfantryType;
@@ -37,9 +42,13 @@ public:
 		int ProducingNavalUnitTypeIndex;
 
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
-			, BuildingCounter {}
+			, PowerPlantEnhancers {}
 			, OwnedLimboDeliveredBuildings {}
 			, OwnedTimedAutoDeathObjects {}
+			, LimboAircraft {}
+			, LimboBuildings {}
+			, LimboInfantry {}
+			, LimboVehicles {}
 			, Factory_BuildingType { nullptr }
 			, Factory_InfantryType { nullptr }
 			, Factory_VehicleType { nullptr }
@@ -52,6 +61,9 @@ public:
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding);
 		void UpdateAutoDeathObjectsInLimbo();
+		void AddToLimboTracking(TechnoTypeClass* pTechnoType);
+		void RemoveFromLimboTracking(TechnoTypeClass* pTechnoType);
+		int CountOwnedPresentAndLimboed(TechnoTypeClass* pTechnoType);
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -105,8 +105,12 @@ inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 			pBuildingExt->LimboID = ID;
 
 			if (auto pOwnerExt = HouseExt::ExtMap.Find(pOwner))
-			{	// Add building to list of owned limbo buildings
+			{
+				// Add building to list of owned limbo buildings
 				pOwnerExt->OwnedLimboDeliveredBuildings.insert({ pBuilding, pBuildingExt });
+
+				if (!pBuilding->Type->Insignificant && !pBuilding->Type->DontScore)
+					pOwnerExt->AddToLimboTracking(pBuilding->Type);
 
 				auto const pTechnoExt = TechnoExt::ExtMap.Find(pBuilding);
 				auto const pTechnoTypeExt = pTechnoExt->TypeExtData;
@@ -129,7 +133,10 @@ inline void LimboDelete(BuildingClass* pBuilding, HouseClass* pTargetHouse)
 
 	// Remove building from list of owned limbo buildings
 	if (pOwnerExt)
+	{
 		pOwnerExt->OwnedLimboDeliveredBuildings.erase(pBuilding);
+		pOwnerExt->RemoveFromLimboTracking(pBuilding->Type);
+	}
 
 	// Mandatory
 	pBuilding->InLimbo = true;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -66,7 +66,7 @@ void TechnoExt::ExtData::ApplyInterceptor()
 }
 
 // TODO : Merge into new AttachEffects
-bool TechnoExt::ExtData::CheckDeathConditions()
+bool TechnoExt::ExtData::CheckDeathConditions(bool isInLimbo)
 {
 	auto const pTypeExt = this->TypeExtData;
 
@@ -83,7 +83,7 @@ bool TechnoExt::ExtData::CheckDeathConditions()
 	// Death if no ammo
 	if (pType->Ammo > 0 && pThis->Ammo <= 0 && pTypeExt->AutoDeath_OnAmmoDepletion)
 	{
-		TechnoExt::KillSelf(pThis, howToDie, pVanishAnim);
+		TechnoExt::KillSelf(pThis, howToDie, pVanishAnim, isInLimbo);
 		return true;
 	}
 
@@ -97,20 +97,20 @@ bool TechnoExt::ExtData::CheckDeathConditions()
 		}
 		else if (this->AutoDeathTimer.Completed())
 		{
-			TechnoExt::KillSelf(pThis, howToDie, pVanishAnim);
+			TechnoExt::KillSelf(pThis, howToDie, pVanishAnim, isInLimbo);
 			return true;
 		}
 
 	}
-	// TODO : Not working correctly, FIX THIS
+
 	auto existTechnoTypes = [pThis](const ValueableVector<TechnoTypeClass*>& vTypes, AffectedHouse affectedHouse, bool any, bool allowLimbo)
 	{
-		auto existSingleType = [pThis, affectedHouse, allowLimbo](const TechnoTypeClass* pType)
+		auto existSingleType = [pThis, affectedHouse, allowLimbo](TechnoTypeClass* pType)
 		{
 			for (HouseClass* pHouse : *HouseClass::Array)
 			{
 				if (EnumFunctions::CanTargetHouse(affectedHouse, pThis->Owner, pHouse)
-					&& (allowLimbo ? pHouse->CountOwnedNow(pType) > 0 : pHouse->CountOwnedAndPresent(pType) > 0))
+					&& (allowLimbo ? HouseExt::ExtMap.Find(pHouse)->CountOwnedPresentAndLimboed(pType) > 0 : pHouse->CountOwnedAndPresent(pType) > 0))
 					return true;
 			}
 
@@ -127,7 +127,7 @@ bool TechnoExt::ExtData::CheckDeathConditions()
 	{
 		if (!existTechnoTypes(pTypeExt->AutoDeath_TechnosDontExist, pTypeExt->AutoDeath_TechnosDontExist_Houses, !pTypeExt->AutoDeath_TechnosDontExist_Any, pTypeExt->AutoDeath_TechnosDontExist_AllowLimboed))
 		{
-			TechnoExt::KillSelf(pThis, howToDie, pVanishAnim);
+			TechnoExt::KillSelf(pThis, howToDie, pVanishAnim, isInLimbo);
 
 			return true;
 		}
@@ -138,7 +138,7 @@ bool TechnoExt::ExtData::CheckDeathConditions()
 	{
 		if (existTechnoTypes(pTypeExt->AutoDeath_TechnosExist, pTypeExt->AutoDeath_TechnosExist_Houses, pTypeExt->AutoDeath_TechnosExist_Any, pTypeExt->AutoDeath_TechnosDontExist_AllowLimboed))
 		{
-			TechnoExt::KillSelf(pThis, howToDie, pVanishAnim);
+			TechnoExt::KillSelf(pThis, howToDie, pVanishAnim, isInLimbo);
 
 			return true;
 		}
@@ -543,8 +543,15 @@ void TechnoExt::ApplyMindControlRangeLimit(TechnoClass* pThis)
 	}
 }
 
-void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation)
+void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation, bool isInLimbo)
 {
+	if (isInLimbo)
+	{
+		pThis->RegisterKill(pThis->Owner);
+		pThis->UnInit();
+		return;
+	}
+
 	switch (deathOption)
 	{
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -60,7 +60,7 @@ public:
 		{ }
 
 		void ApplyInterceptor();
-		bool CheckDeathConditions();
+		bool CheckDeathConditions(bool isInLimbo = false);
 		void EatPassengers();
 		void UpdateShield();
 		void UpdateOnTunnelEnter();
@@ -121,7 +121,7 @@ public:
 	static CoordStruct GetSimpleFLH(InfantryClass* pThis, int weaponIndex, bool& FLHFound);
 
 	static void ChangeOwnerMissionFix(FootClass* pThis);
-	static void KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation);
+	static void KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation, bool isInLimbo = false);
 	static void TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo);
 	static void ApplyMindControlRangeLimit(TechnoClass* pThis);
 	static void ObjectKilledBy(TechnoClass* pThis, TechnoClass* pKiller);


### PR DESCRIPTION
- All AutoDeath conditions are now considered for LimboDelivery objects.
- Technos(Dont)Exist.AllowLimboed now works as expected and doesn't count units still being built.
  - This required adding a new tracker and bunch of bullshit, I tested most cases but I wouldn't be surprised if I missed something.