### PR TITLE
Fix arcing elevation bug for most part

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -205,6 +205,7 @@ This page lists all the individual contributions to the project by their author.
   - PipScale pip size & ammo pip frame customization
   - Extension class optimization
   - Additional sync logging
+  - `Arcing` elevation inaccuracy fix
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -206,6 +206,7 @@ This page lists all the individual contributions to the project by their author.
   - Extension class optimization
   - Additional sync logging
   - `Arcing` elevation inaccuracy fix
+  - `EMPulseCannon` projectile gravity fix
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -132,8 +132,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - They can also have map lighting apply on them if `AltPalette.ApplyLighting` is set to true.
 - Fixed `DeployToFire` not considering building placement rules for `DeploysInto` buildings and as a result not working properly with `WaterBound` buildings.
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy.
-- `Arcing=true` projectiles no longer massively overshoot targets at higher elevation. Old behaviour can be enabled by setting `Arcing.AllowElevationInaccuracy=true` on the projectile.
-- `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity`setting
+- `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`.
+- `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity` setting.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -132,6 +132,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - They can also have map lighting apply on them if `AltPalette.ApplyLighting` is set to true.
 - Fixed `DeployToFire` not considering building placement rules for `DeploysInto` buildings and as a result not working properly with `WaterBound` buildings.
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy.
+- `Arcing=true` projectiles no longer massively overshoot targets at higher elevation. Old behaviour can be enabled by setting `Arcing.AllowElevationInaccuracy=true` on the projectile.
+- `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity`setting
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -15,7 +15,6 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - Iron Curtain status is now preserved by default when converting between TechnoTypes via `DeploysInto`/`UndeploysInto`. This behavior can be turned off per-TechnoType and global basis using `[SOMETECHNOTYPE]/[CombatDamage]->IronCurtain.KeptOnDeploy=no`.
 - The obsolete `[General] WarpIn` has been enabled for the default anim type when technos are warping in. If you want to restore the vanilla behavior, use the same anim type as `WarpOut`.
 - Vehicles with `Crusher=true` + `OmniCrusher=true` / `MovementZone=CrusherAll` were hardcoded to tilt when crushing vehicles / walls respectively. This now obeys `TiltsWhenCrushes` but can be customized individually for these two scenarios using `TiltsWhenCrusher.Vehicles` and `TiltsWhenCrusher.Overlays`, which both default to `TiltsWhenCrushes`.
-- `Arcing=true` projectiles no longer massively overshoot when target is at higher elevation. Old behaviour can be enabled by setting `Arcing.AllowElevationInaccuracy=true` on the projectile.
 
 ### From older Phobos versions
 
@@ -372,8 +371,8 @@ Vanilla fixes:
 - Animations using `AltPalette` are now remapped to their owner's color scheme instead of first listed color scheme and no longer draw over shroud (by Starkku)
 - Fixed `DeployToFire` not considering building placement rules for `DeploysInto` buildings and as a result not working properly with `WaterBound` buildings (by Starkku)
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy (by Starkku)
-- `Arcing=true` projectiles no longer massively overshoot targets at higher elevation by default (by Starkku)
-- `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity`setting (by Starkku)
+- `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false` (by Starkku)
+- `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity` setting (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -15,6 +15,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - Iron Curtain status is now preserved by default when converting between TechnoTypes via `DeploysInto`/`UndeploysInto`. This behavior can be turned off per-TechnoType and global basis using `[SOMETECHNOTYPE]/[CombatDamage]->IronCurtain.KeptOnDeploy=no`.
 - The obsolete `[General] WarpIn` has been enabled for the default anim type when technos are warping in. If you want to restore the vanilla behavior, use the same anim type as `WarpOut`.
 - Vehicles with `Crusher=true` + `OmniCrusher=true` / `MovementZone=CrusherAll` were hardcoded to tilt when crushing vehicles / walls respectively. This now obeys `TiltsWhenCrushes` but can be customized individually for these two scenarios using `TiltsWhenCrusher.Vehicles` and `TiltsWhenCrusher.Overlays`, which both default to `TiltsWhenCrushes`.
+- `Arcing=true` projectiles no longer massively overshoot when target is at higher elevation. Old behaviour can be enabled by setting `Arcing.AllowElevationInaccuracy=true` on the projectile.
 
 ### From older Phobos versions
 
@@ -371,6 +372,8 @@ Vanilla fixes:
 - Animations using `AltPalette` are now remapped to their owner's color scheme instead of first listed color scheme and no longer draw over shroud (by Starkku)
 - Fixed `DeployToFire` not considering building placement rules for `DeploysInto` buildings and as a result not working properly with `WaterBound` buildings (by Starkku)
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy (by Starkku)
+- `Arcing=true` projectiles no longer massively overshoot targets at higher elevation by default (by Starkku)
+- `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity`setting (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Bullet/Body.h
+++ b/src/Ext/Bullet/Body.h
@@ -53,6 +53,7 @@ public:
 		void InterceptBullet(TechnoClass* pSource, WeaponTypeClass* pWeapon);
 		void ApplyRadiationToCell(CellStruct Cell, int Spread, int RadLevel);
 		void InitializeLaserTrails();
+		void ApplyArcingFix();
 
 	private:
 		template <typename T>

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -188,6 +188,36 @@ DEFINE_HOOK(0x6FECB2, TechnoClass_FireAt_ApplyGravity, 0x6)
 	return 0x6FECD1;
 }
 
+DEFINE_HOOK(0x44D074, BuildingClass_Mission_Missile_ApplyGravity1, 0x6)
+{
+	GET(WeaponTypeClass* const, pWeapon, EBP);
+
+	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeapon->Projectile);
+	__asm { fld nGravity };
+
+	return 0x44D07A;
+}
+
+DEFINE_HOOK(0x44D264, BuildingClass_Mission_Missile_ApplyGravity2, 0x6)
+{
+	GET(WeaponTypeClass* const, pWeapon, EBP);
+
+	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeapon->Projectile);
+	__asm { fld nGravity };
+
+	return 0x44D26A;
+}
+
+DEFINE_HOOK(0x44D2AE, BuildingClass_Mission_Missile_ApplyGravity3, 0x6)
+{
+	GET(WeaponTypeClass* const, pWeapon, EBP);
+
+	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeapon->Projectile);
+	__asm { fld nGravity };
+
+	return 0x44D2B4;
+}
+
 DEFINE_HOOK(0x46A3D6, BulletClass_Shrapnel_Forced, 0xA)
 {
 	enum { Shrapnel = 0x46A40C, Skip = 0x46ADCD };
@@ -508,6 +538,42 @@ DEFINE_HOOK(0x46A290, BulletClass_Logics_ExtraWarheads, 0x5)
 
 			WarheadTypeExt::DetonateAt(pWH, *coords, pThis->Owner, damage, pOwner);
 		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6FE657, TechnoClass_FireAt_ArcingFix, 0x6)
+{
+	GET_STACK(BulletTypeClass*, pBulletType, STACK_OFFSET(0xB0, -0x48));
+	GET(int, targetHeight, EDI);
+	GET(int, fireHeight, EAX);
+
+	if (pBulletType->Arcing && targetHeight > fireHeight)
+	{
+		auto const pBulletTypeExt = BulletTypeExt::ExtMap.Find(pBulletType);
+
+		if (!pBulletTypeExt->Arcing_AllowElevationInaccuracy)
+			R->EAX(targetHeight);
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x44D23C, BuildingClass_Mission_Missile_ArcingFix, 0x7)
+{
+	GET(WeaponTypeClass*, pWeapon, EBP);
+	GET(int, targetHeight, EBX);
+	GET(int, fireHeight, EAX);
+
+	auto const pBulletType = pWeapon->Projectile;
+
+	if (pBulletType->Arcing && targetHeight > fireHeight)
+	{
+		auto const pBulletTypeExt = BulletTypeExt::ExtMap.Find(pBulletType);
+
+		if (!pBulletTypeExt->Arcing_AllowElevationInaccuracy)
+			R->EAX(targetHeight);
 	}
 
 	return 0;

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -148,12 +148,17 @@ DEFINE_HOOK(0x4692BD, BulletClass_Logics_ApplyMindControl, 0x6)
 	return 0x4692D5;
 }
 
+#pragma region Gravity
+
+#define APPLYGRAVITY(pType)\
+auto const nGravity = BulletTypeExt::GetAdjustedGravity(pType);\
+__asm { fld nGravity };\
+
 DEFINE_HOOK(0x4671B9, BulletClass_AI_ApplyGravity, 0x6)
 {
 	GET(BulletTypeClass* const, pType, EAX);
 
-	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pType);
-	__asm { fld nGravity };
+	APPLYGRAVITY(pType);
 
 	return 0x4671BF;
 }
@@ -162,8 +167,7 @@ DEFINE_HOOK(0x6F7481, TechnoClass_Targeting_ApplyGravity, 0x6)
 {
 	GET(WeaponTypeClass* const, pWeaponType, EDX);
 
-	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeaponType->Projectile);
-	__asm { fld nGravity };
+	APPLYGRAVITY(pWeaponType->Projectile);
 
 	return 0x6F74A4;
 }
@@ -172,8 +176,7 @@ DEFINE_HOOK(0x6FDAA6, TechnoClass_FireAngle_6FDA00_ApplyGravity, 0x5)
 {
 	GET(WeaponTypeClass* const, pWeaponType, EDI);
 
-	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeaponType->Projectile);
-	__asm { fld nGravity };
+	APPLYGRAVITY(pWeaponType->Projectile);
 
 	return 0x6FDACE;
 }
@@ -182,41 +185,34 @@ DEFINE_HOOK(0x6FECB2, TechnoClass_FireAt_ApplyGravity, 0x6)
 {
 	GET(BulletTypeClass* const, pType, EAX);
 
-	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pType);
-	__asm { fld nGravity };
+	APPLYGRAVITY(pType);
 
 	return 0x6FECD1;
 }
 
-DEFINE_HOOK(0x44D074, BuildingClass_Mission_Missile_ApplyGravity1, 0x6)
+DEFINE_HOOK_AGAIN(0x44D2AE, BuildingClass_Mission_Missile_ApplyGravity, 0x6)
+DEFINE_HOOK_AGAIN(0x44D264, BuildingClass_Mission_Missile_ApplyGravity, 0x6)
+DEFINE_HOOK(0x44D074, BuildingClass_Mission_Missile_ApplyGravity, 0x6)
 {
-	GET(WeaponTypeClass* const, pWeapon, EBP);
+	GET(WeaponTypeClass* const, pWeaponType, EBP);
 
-	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeapon->Projectile);
-	__asm { fld nGravity };
+	APPLYGRAVITY(pWeaponType->Projectile);
 
-	return 0x44D07A;
+	switch (R->Origin())
+	{
+	case 0x44D074:
+		return 0x44D07A;
+		break;
+	case 0x44D264:
+		return 0x44D26A;
+		break;
+	case 0x44D2AE:
+		return 0x44D2B4;
+		break;
+	}
 }
 
-DEFINE_HOOK(0x44D264, BuildingClass_Mission_Missile_ApplyGravity2, 0x6)
-{
-	GET(WeaponTypeClass* const, pWeapon, EBP);
-
-	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeapon->Projectile);
-	__asm { fld nGravity };
-
-	return 0x44D26A;
-}
-
-DEFINE_HOOK(0x44D2AE, BuildingClass_Mission_Missile_ApplyGravity3, 0x6)
-{
-	GET(WeaponTypeClass* const, pWeapon, EBP);
-
-	auto const nGravity = BulletTypeExt::GetAdjustedGravity(pWeapon->Projectile);
-	__asm { fld nGravity };
-
-	return 0x44D2B4;
-}
+#pragma endregion
 
 DEFINE_HOOK(0x46A3D6, BulletClass_Shrapnel_Forced, 0xA)
 {
@@ -470,7 +466,7 @@ DEFINE_HOOK(0x4687F8, BulletClass_Unlimbo_FlakScatter, 0x6)
 
 DEFINE_HOOK(0x469D1A, BulletClass_Logics_Debris_Checks, 0x6)
 {
-	enum { SkipGameCode = 0x469EBA, SetDebrisCount=0x469D36 };
+	enum { SkipGameCode = 0x469EBA, SetDebrisCount = 0x469D36 };
 
 	GET(BulletClass*, pThis, ESI);
 

--- a/src/Ext/BulletType/Body.cpp
+++ b/src/Ext/BulletType/Body.cpp
@@ -50,6 +50,7 @@ void BulletTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SubjectToWater.Read(exINI, pSection, "SubjectToWater");
 	this->SubjectToWater_Detonate.Read(exINI, pSection, "SubjectToWater.Detonate");
 	this->AAOnly.Read(exINI, pSection, "AAOnly");
+	this->Arcing_AllowElevationInaccuracy.Read(exINI, pSection, "Arcing.AllowElevationInaccuracy");
 
 	// Ares 0.7
 	this->BallisticScatter_Min.Read(exINI, pSection, "BallisticScatter.Min");
@@ -85,6 +86,7 @@ void BulletTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SubjectToWater)
 		.Process(this->SubjectToWater_Detonate)
 		.Process(this->AAOnly)
+		.Process(this->Arcing_AllowElevationInaccuracy)
 		;
 
 	this->TrajectoryType = PhobosTrajectoryType::ProcessFromStream(Stm, this->TrajectoryType);

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -68,7 +68,7 @@ public:
 			, SubjectToWater {}
 			, SubjectToWater_Detonate { true }
 			, AAOnly { false }
-			, Arcing_AllowElevationInaccuracy { false }
+			, Arcing_AllowElevationInaccuracy { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -42,6 +42,7 @@ public:
 		Nullable<Leptons> ClusterScatter_Max;
 
 		Valueable<bool> AAOnly;
+		Valueable<bool> Arcing_AllowElevationInaccuracy;
 
 		// Ares 0.7
 		Nullable<Leptons> BallisticScatter_Min;
@@ -67,6 +68,7 @@ public:
 			, SubjectToWater {}
 			, SubjectToWater_Detonate { true }
 			, AAOnly { false }
+			, Arcing_AllowElevationInaccuracy { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`
- `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity`setting.

It is not a perfect solution as the projectiles will still miss by like 1 cell with large elevation difference. Presumably this entire problem is caused by some faulty math in `0x48A8D0` or the functions it calls as changing the fourth passed param (target height - firing height) to make it so that it never goes above zero is how I achieved these results. Figuring out the root cause is beyond me, however.