### PR TITLE
Wall overlay custom palette support

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -206,8 +206,193 @@ This page lists all the individual contributions to the project by their author.
   - PipScale pip size & ammo pip frame customization
   - Extension class optimization
   - Additional sync logging
+- **Kerbiter (Metadorius)**:
+  - SHP debris respect `Shadow` fix
+  - Building upgrades enhancement
+  - Extended tooltips
+  - Selection priority filtering
+  - `TurretOffset` enhancement
+  - Customizable ore spawners
+  - Select next idle harvester hotkey
+  - Interceptor enhancement
+  - Zero size map previews fix
+  - LaserTrails port and rework
+  - Laser graphics fixes
+  - Recursive transport killer fix
+  - Custom locomotors example implementation and piggybacking test warheads
+  - Jumpjet initial facing fix
+  - Migration utility
+  - GitHub Actions setup
+  - Official docs
+  - VSCode configs
+  - Code style
+  - Customizable ElectricBolt Arcs
+- **Uranusian (Thrifinesma)**:
+  - Mind Control enhancement
+  - Custom warhead splash list
+  - Harvester counter
+  - Spawns promotion
+  - Shield logic
+  - Multiple death fix
+  - Customizable missing cameo
+  - Cameo sorting priority
+  - Tab hotkey placement fix
+  - Producing progress indicators
+  - Custom ore gathering anim
+  - `NoManualMove`
+  - Weapon target house filtering
+  - `DeathWeapon` fix
+  - Re-enable obsolete `JumpjetControls`
+  - `AITrigger` Building Upgrades support
+  - Wall-Gate links
+  - Ability for deployed infantry to use both weapons
+  - Observer PCX loading screen
+  - Official CN docs
+- **secsome (SEC-SOME)**:
+  - Debug info dump hotkey
+  - Refactoring & porting of Ares helper code
+  - Disguise removal warhead
+  - Mind Control removal warhead
+  - Mind Control enhancement
+  - Shields logic help
+  - `AnimList.PickRandom`
+  - `MoveToCell` fix
+  - Unlimited waypoints
+  - `Build At` trigger action buildup anim fix
+  - Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix
+  - Custom ore gathering anim
+  - `TemporalClass` related crash
+  - Retry dialog on mission failure
+  - Default disguise for individual InfantryTypes
+  - PowerPlant Enhancer
+  - SaveGame Trigger Action
+  - QuickSave command
+  - Numeric variables
+  - Custom gravity for projectiles
+  - Retint map actions bugfix
+  - Sharpnel enhancement
+  - Vanilla map preview reading bugfix
+  - Customizable tooltip background
+  - Parts of Ares calling code
+- **Otamaa (Fahroni, BoredEXE)**:
+  - Help with CellSpread
+  - Ported and fixed custom RadType code
+  - Togglable ElectricBolt bolts
+  - Customizable Chrono Locomotor properties per TechnoClass
+  - Building Placement Preview
+  - `DebrisMaximums` fixes
+  - Anim-to-Unit
+  - `NotHuman` anim sequences improvements
+  - Customizable `OpenTopped` Properties
+  - Hooks for ScriptType Actions 92 & 93
+  - Ore stage threshold for `HideIfNoOre`
+  - Occupied building `MuzzleFlashX` bugfix
+  - `EnemyUIName=` for other TechnoTypes
+  - TerrainType `DestroyAnim` & `DestroySound`
+  - Laser trails for VoxelAnims
+  - MakeInfantry logic on BombClass bugfix
+  - Debris & meteor impact behaviour settings
+  - Upgrade logic to allow altering of SpySat status
+  - Ares detection and integration
+  - Help with custom locomotors
+  - Extension class optimization
+- **FS-21**:
+  - Dump Object Info enhancements
+  - `Powered.KillSpawns`
+  - `Spawner.LimitRange`
+  - Majority of ScriptType actions
+  - MC deployer fixes
+  - Help with docs
+  - Automatic Passenger Deletion logic
+  - `Fire SW At Location/Waypoint` Trigger Action
+  - Kill Object Automatically logic prototype
+  - Customizable resource storage
+  - Override uncloaked underwater attack behavior
+  - AI Aircraft docks fix
+  - Shared ammo logic
+  - Customizable FLH when infantry is prone or deployed
+  - Initial strength for cloned infantry
+- **Starkku**:
+  - Misc. minor bugfixes & improvements
+  - AI script actions:
+    - Chronoshift to Enemy Base
+  - Warhead shield penetration & breaking
+  - Strafing aircraft weapon customization
+  - Vehicle `DeployFire` fixes/improvements
+  - Stationary VehicleTypes
+  - Burst logic improvements
+  - TechnoType auto-firing weapons
+  - Secondary weapon fallback customization
+  - Weapon target type filtering
+  - `AreaFire` targeting customization
+  - `CreateUnit` improvements
+  - Attached animation & jumpjet unit layer customization
+  - `IsSimpleDeployer` improvements
+  - Shield modification warheads
+  - Warhead decloaking toggle
+  - Warp(In/Out)Weapon
+  - Grinder improvements / additions
+  - Attached animation position customization
+  - Critical hit logic additions
+  - Aircraft & jumpjet speed modifiers fix
+  - Local warhead screen shaking
+  - Vehicle custom palette fix
+  - Feedback weapon
+  - TerrainType & ore minimap color customization
+  - Laser fixes & improvements
+  - Mind control indicator animation cloak fix
+  - Warhead / Play animation trigger animation owner fix
+  - Nuke carrier & payload Bright fix
+  - Display damage numbers hotkey command
+  - TransactMoney.Display
+  - Building-provided self-heal customization
+  - AI deploy script DeploysInto fix
+  - Passable & buildable-upon TerrainTypes
+  - Automatic passenger owner change toggle
+  - Interceptor improvements
+  - OpenTopped transport behaviour customizations
+  - Animation damage / weapon improvements
+  - Warhead self-damaging toggle
+  - Trailer animation owner inheritance
+  - Warhead detonation on all objects on map
+  - Animated TerrainTypes extension
+  - Exploding unit passenger killing customization
+  - Railgun particle target coordinate fix
+  - Building target coordinate offset fix
+  - Warhead / weapon detonation at superweapon target cell
+  - Cloaked & disguised objects displaying to observers
+  - Building airstrike target eligibility customization
+  - IvanBomb detonation & image display centered on buildings
+  - Customizable ROF random delay
+  - BibShape drawing during buildup fix
+  - Spawner spawn delay customization
+  - Cluster scatter distance customization
+  - FlakScatter distance customization
+  - Debris & meteor impact behaviour settings
+  - Custom warhead debris animations
+  - Attached particle system for animations
+  - Removal of hardcoded AA & Gattling weapon selection restrictions
+  - Projectile obstacle logic additions
+  - `AnimList` on zero damage Warheads toggle
+  - Additions to automatic passenger deletion
+  - Buildings considered as vehicles
+  - TechnoType target evaluation map zone check behaviour customization
+  - CanC4 damage rounding fix & toggle
+  - Option to center pause menu background
+  - Disguise logic improvements
+  - Custom insignias
+  - `ZShapePointMove` buildup toggle
+  - `UndeploysInto` building selling buildup sequence length customization
+  - AI naval vehicle production fix
+  - Crushing tilt and slowdown customization
+  - Extra warhead detonations on weapons
+  - Chrono sparkle animation display customization and improvements
+  - PipScale pip size & ammo pip frame customization
+  - Extension class optimization
+  - Additional sync logging
   - `Arcing` elevation inaccuracy fix
   - `EMPulseCannon` projectile gravity fix
+  - Custom palette support for wall overlays
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -34,6 +34,8 @@
     <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
     <ClCompile Include="src\Ext\CaptureManager\Hooks.cpp" />
     <ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
+    <ClCompile Include="src\Ext\OverlayType\Body.cpp" />
+    <ClCompile Include="src\Ext\OverlayType\Hooks.cpp" />
     <ClCompile Include="src\Ext\Scenario\Hooks.Variables.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />
@@ -172,6 +174,7 @@
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />
+    <ClInclude Include="src\Ext\OverlayType\Body.h" />
     <ClInclude Include="src\Ext\Sidebar\Body.h" />
     <ClInclude Include="src\Ext\Anim\Body.h" />
     <ClInclude Include="src\Ext\Surface\Body.h" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -135,7 +135,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`.
 - `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity` setting.
 - You can now specify houses named `<Player @ A>` through `<Player @ H>` as the owner of TechnoTypes preplaced on the map in the editor, and they will be correctly given to players starting on points 1-8. Originally, it was only possible to use these house names in events, actions and teams.
-
+- Wall overlays are now drawn with the custom palette defined in `Palette` in `artmd.ini` if possible.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -331,6 +331,7 @@ New:
 - Customizing minimum & maximum amount of damage shield can take from a single hit (by Starkku)
 - Players can now be given ownership of preplaced buildings in Skirmish and Multiplayer in maps using houses of the format <Player @ X> where X goes from A to H for spawn positions 1-8 (by ZivDero)
 - `AutoDeath.Technos(Dont)Exist` can optionally track limboed (not physically on map, e.g transports etc) technos (by Starkku)
+- Wall overlay `Palette` support (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/OverlayType/Body.cpp
+++ b/src/Ext/OverlayType/Body.cpp
@@ -1,0 +1,124 @@
+#include "Body.h"
+
+#include <OverlayTypeClass.h>
+#include <TacticalClass.h>
+
+#include <Utilities/GeneralUtils.h>
+
+OverlayTypeExt::ExtContainer OverlayTypeExt::ExtMap;
+
+// =============================
+// load / save
+
+template <typename T>
+void OverlayTypeExt::ExtData::Serialize(T& Stm)
+{
+	Stm
+		.Process(this->PaletteFile)
+		.Process(this->Palette)
+		;
+}
+
+void OverlayTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
+{
+	auto pThis = this->OwnerObject();
+
+	//const char* pSection = pThis->ID;
+	//
+	//if (!pINI->GetSection(pSection))
+	//	return;
+	//
+	//INI_EX exINI(pINI);
+
+	auto const pArtINI = &CCINIClass::INI_Art();
+	auto pArtSection = pThis->ImageFile;
+
+	this->PaletteFile.Read(pArtINI, pArtSection, "Palette");
+
+	if (GeneralUtils::IsValidString(this->PaletteFile))
+	{
+		char pFilename[0x20];
+		strcpy_s(pFilename, this->PaletteFile.data());
+
+		this->Palette = ColorScheme::GeneratePalette(pFilename);
+	}
+}
+
+void OverlayTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
+{
+	Extension<OverlayTypeClass>::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void OverlayTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
+{
+	Extension<OverlayTypeClass>::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+bool OverlayTypeExt::LoadGlobals(PhobosStreamReader& Stm)
+{
+	return Stm
+		.Success();
+}
+
+bool OverlayTypeExt::SaveGlobals(PhobosStreamWriter& Stm)
+{
+	return Stm
+		.Success();
+}
+
+// =============================
+// container
+
+OverlayTypeExt::ExtContainer::ExtContainer() : Container("OverlayTypeClass") { }
+OverlayTypeExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// container hooks
+
+DEFINE_HOOK_AGAIN(0x5FE3AF, OverlayTypeClass_CTOR, 0x5)
+DEFINE_HOOK(0x5FE3A2, OverlayTypeClass_CTOR, 0x5)
+{
+	GET(OverlayTypeClass*, pItem, EAX);
+
+	OverlayTypeExt::ExtMap.TryAllocate(pItem);
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x5FEAF0, OverlayTypeClass_SaveLoad_Prefix, 0xA)
+DEFINE_HOOK(0x5FEC10, OverlayTypeClass_SaveLoad_Prefix, 0x8)
+{
+	GET_STACK(OverlayTypeClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	OverlayTypeExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x5FEBFA, OverlayTypeClass_Load_Suffix, 0x6)
+{
+	OverlayTypeExt::ExtMap.LoadStatic();
+
+	return 0;
+}
+
+DEFINE_HOOK(0x5FEC2A, OverlayTypeClass_Save_Suffix, 0x6)
+{
+	OverlayTypeExt::ExtMap.SaveStatic();
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x5FEA11, OverlayTypeClass_LoadFromINI, 0xA)
+DEFINE_HOOK(0x5FEA1E, OverlayTypeClass_LoadFromINI, 0xA)
+{
+	GET(OverlayTypeClass*, pItem, ESI);
+	GET_STACK(CCINIClass*, pINI, STACK_OFFSET(0x28C, 0x4));
+
+	OverlayTypeExt::ExtMap.LoadFromINI(pItem, pINI);
+
+	return 0;
+}

--- a/src/Ext/OverlayType/Body.h
+++ b/src/Ext/OverlayType/Body.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <OverlayTypeClass.h>
+
+#include <Helpers/Macro.h>
+#include <Utilities/Container.h>
+#include <Utilities/TemplateDef.h>
+#include <Utilities/Macro.h>
+
+class OverlayTypeExt
+{
+public:
+	using base_type = OverlayTypeClass;
+
+	static constexpr DWORD Canary = 0xADF48498;
+	static constexpr size_t ExtPointerOffset = 0x18;
+
+	class ExtData final : public Extension<OverlayTypeClass>
+	{
+	public:
+		PhobosFixedString<32u> PaletteFile;
+		DynamicVectorClass<ColorScheme*>* Palette;
+
+		ExtData(OverlayTypeClass* OwnerObject) : Extension<OverlayTypeClass>(OwnerObject)
+			, PaletteFile {}
+			, Palette {}
+		{ }
+
+		virtual ~ExtData() = default;
+
+		virtual void LoadFromINIFile(CCINIClass* pINI) override;
+
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
+
+		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+	private:
+		template <typename T>
+		void Serialize(T& Stm);
+	};
+
+	class ExtContainer final : public Container<OverlayTypeExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+	};
+
+	static ExtContainer ExtMap;
+
+	static bool LoadGlobals(PhobosStreamReader& Stm);
+	static bool SaveGlobals(PhobosStreamWriter& Stm);
+};

--- a/src/Ext/OverlayType/Hooks.cpp
+++ b/src/Ext/OverlayType/Hooks.cpp
@@ -1,0 +1,36 @@
+#include "Body.h"
+
+#include <HouseClass.h>
+
+
+// Replaces an Ares hook at 0x47F9A4
+DEFINE_HOOK(0x47F974, CellClass_DrawOverlay_Walls, 0x5)
+{
+	enum { SkipGameCode = 0x47FB86 };
+
+	GET(CellClass*, pThis, ESI);
+	GET(SHPStruct*, pShape, EAX);
+	GET(RectangleStruct*, pBounds, EBP);
+	GET(int, zAdjust, EDI);
+	GET_STACK(OverlayTypeClass*, pOverlayType, STACK_OFFSET(0x24, -0x14));
+	REF_STACK(Point2D, pLocation, STACK_OFFSET(0x24, -0x10));
+
+	int wallOwnerIndex = pThis->WallOwnerIndex;
+	int colorSchemeIndex = HouseClass::CurrentPlayer->ColorSchemeIndex;
+
+	if (wallOwnerIndex >= 0)
+		colorSchemeIndex = HouseClass::Array->GetItem(wallOwnerIndex)->ColorSchemeIndex;
+
+	LightConvertClass* pConvert = nullptr;
+	auto const pTypeExt = OverlayTypeExt::ExtMap.Find(pOverlayType);
+
+	if (pTypeExt->Palette)
+		pConvert = pTypeExt->Palette->GetItem(colorSchemeIndex)->LightConvert;
+	else
+		pConvert = ColorScheme::Array->GetItem(colorSchemeIndex)->LightConvert;
+
+	DSurface::Temp->DrawSHP(pConvert, pShape, pThis->OverlayData, &pLocation, pBounds,
+		BlitterFlags(0x4E00), 0, -2 - zAdjust, ZGradient::Deg90, pThis->Intensity_Normal, 0, 0, 0, 0, 0);
+
+	return SkipGameCode;
+}

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -10,6 +10,7 @@
 #include <Ext/Bullet/Body.h>
 #include <Ext/BulletType/Body.h>
 #include <Ext/House/Body.h>
+#include <Ext/OverlayType/Body.h>
 #include <Ext/RadSite/Body.h>
 #include <Ext/Rules/Body.h>
 #include <Ext/Scenario/Body.h>
@@ -197,6 +198,7 @@ using PhobosTypeRegistry = TypeRegistry<
 	BulletExt,
 	BulletTypeExt,
 	HouseExt,
+	OverlayTypeExt,
 	RadSiteExt,
 	RulesExt,
 	ScenarioExt,


### PR DESCRIPTION
- Wall overlays are now drawn with the custom palette defined in `Palette` in `artmd.ini` if possible. This works identically to TechnoTypes regarding filenames and how lighting / color schemes get applied to it.