### PR TITLE
Show designator & inhibitor range

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -407,6 +407,7 @@ This page lists all the individual contributions to the project by their author.
   - Ares detection and integration
   - TechnoType conversion warhead & superweapon
   - Unlimited skirmish colors
+  - Show designator & inhibitor range
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="src\Commands\NextIdleHarvester.cpp" />
     <ClCompile Include="src\Commands\ObjectInfo.cpp" />
     <ClCompile Include="src\Commands\QuickSave.cpp" />
+    <ClCompile Include="src\Commands\ToggleDesignatorRange.cpp" />
     <ClCompile Include="src\Commands\ToggleDigitalDisplay.cpp" />
     <ClCompile Include="src\Ext\Anim\Body.cpp" />
     <ClCompile Include="src\Ext\Anim\Hooks.cpp" />
@@ -170,6 +171,7 @@
     <ClInclude Include="src\Commands\Commands.h" />
     <ClInclude Include="src\Commands\DamageDisplay.h" />
     <ClInclude Include="src\Commands\QuickSave.h" />
+    <ClInclude Include="src\Commands\ToggleDesignatorRange.h" />
     <ClInclude Include="src\Commands\ToggleDigitalDisplay.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -98,7 +98,17 @@ An example shape file for digits can be found on [Phobos supplementaries repo](h
 
 * It is now possible to display range of designator and inhibitor units when in super weapon targeting mode. Each instance of player owned techno types listed in `[SuperWeapon]->SW.Designators` will display a circle with radius set in `[TechnoType]->DesignatorRange` or `Sight`.
   * In a similar manner, each instance of enemy owned techno types listed in `[SuperWeapon]->SW.Inhibitors` will display a circle with radius set in `[TechnoType]->InhibitorRange` or `Sight`.
-* This feature can be enabled with `ShowDesignatorRange=true` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.
+* This feature can be disabled globally with `[AudioVisual]->ShowDesignatorRange=false` or per SuperWeaponType with `[SuperWeapon]->ShowDesignatorRange=false`.
+* This feature can be toggled *by the player* (if enabled in the mod) with `ShowDesignatorRange` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+ShowDesignatorRange=true    ; boolean
+
+[SOMESW]                    ; SuperWeapon
+ShowDesignatorRange=true    ; boolean
+```
 
 In `Ra2MD.ini`:
 ```ini

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -96,10 +96,10 @@ An example shape file for digits can be found on [Phobos supplementaries repo](h
 
 ### Show designator & inhibitor range
 
-* It is now possible to display range of designator and inhibitor units when in super weapon targeting mode. Each instance of player owned techno types listed in `[SuperWeapon]->SW.Designators` will display a circle with radius set in `[TechnoType]->DesignatorRange` or `Sight`.
-  * In a similar manner, each instance of enemy owned techno types listed in `[SuperWeapon]->SW.Inhibitors` will display a circle with radius set in `[TechnoType]->InhibitorRange` or `Sight`.
-* This feature can be disabled globally with `[AudioVisual]->ShowDesignatorRange=false` or per SuperWeaponType with `[SuperWeapon]->ShowDesignatorRange=false`.
-* This feature can be toggled *by the player* (if enabled in the mod) with `ShowDesignatorRange` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.
+- It is now possible to display range of designator and inhibitor units when in super weapon targeting mode. Each instance of player owned techno types listed in `[SuperWeapon]->SW.Designators` will display a circle with radius set in `[TechnoType]->DesignatorRange` or `Sight`.
+  - In a similar manner, each instance of enemy owned techno types listed in `[SuperWeapon]->SW.Inhibitors` will display a circle with radius set in `[TechnoType]->InhibitorRange` or `Sight`.
+- This feature can be disabled globally with `[AudioVisual]->ShowDesignatorRange=false` or per SuperWeaponType with `[SuperWeapon]->ShowDesignatorRange=false`.
+- This feature can be toggled *by the player* (if enabled in the mod) with `ShowDesignatorRange` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.
 
 In `rulesmd.ini`:
 ```ini
@@ -241,23 +241,35 @@ ShowTimer.Priority=0  ; integer
 
 ## Hotkey Commands
 
+### `[ ]` Display Damage Numbers
+
+- Switches on/off floating numbers when dealing damage. See [this](Miscellanous.md#display-damage-numbers) for details.
+- For localization add `TXT_DISPLAY_DAMAGE` and `TXT_DISPLAY_DAMAGE_DESC` into your `.csf` file.
+
 ### `[ ]` Dump Object Info
 
 - Writes currently hovered or last selected object info in log and shows a message. See [this](Miscellanous.md#dump-object-info) for details.
-- If need localization, just add `TXT_DUMP_OBJECT_INFO` and `TXT_DUMP_OBJECT_INFO_DESC` into your `.csf` file.
+- For localization add `TXT_DUMP_OBJECT_INFO` and `TXT_DUMP_OBJECT_INFO_DESC` into your `.csf` file.
 
 ### `[ ]` Next Idle Harvester
 
 - Selects and centers the camera on the next TechnoType that is counted via the [harvester counter](#harvester-counter) and is currently idle.
-- If need localization, just add `TXT_NEXT_IDLE_HARVESTER` and `TXT_NEXT_IDLE_HARVESTER_DESC` into your `.csf` file.
+- For localization add `TXT_NEXT_IDLE_HARVESTER` and `TXT_NEXT_IDLE_HARVESTER_DESC` into your `.csf` file.
 
 ### `[ ]` Quicksave
 
 - Save the current singleplayer game.
-- If need localization, just add `TXT_QUICKSAVE`, `TXT_QUICKSAVE_DESC`, `TXT_QUICKSAVE_SUFFIX` and `MSG:NotAvailableInMultiplayer` into your `.csf` file.
+- For localization, add `TXT_QUICKSAVE`, `TXT_QUICKSAVE_DESC`, `TXT_QUICKSAVE_SUFFIX` and `MSG:NotAvailableInMultiplayer` into your `.csf` file.
     - These vanilla CSF entries will be used: `TXT_SAVING_GAME`, `TXT_GAME_WAS_SAVED` and `TXT_ERROR_SAVING_GAME`.
     - The save should be looks like `Allied Mission 25: Esther's Money - QuickSaved`
 
+### `[ ]` Toggle Designator Range
+- Switches on/off super weapon designator range indicator. See [this](#show-designator--inhibitor-range) for details.
+- For localization add `TXT_DESIGNATOR_RANGE` and `TXT_DESIGNATOR_RANGE_DESC` into your `.csf` file.
+
+### `[ ]` Toggle Digital Display
+- Switches on/off [digital gisplay types](#digital-display).
+- For localization add `TXT_DIGITAL_DISPLAY` and `TXT_DIGITAL_DISPLAY_DESC` into your `.csf` file.
 
 ## Loading screen
 

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -101,10 +101,6 @@ An example shape file for digits can be found on [Phobos supplementaries repo](h
 * This feature can be disabled globally with `[AudioVisual]->ShowDesignatorRange=false` or per SuperWeaponType with `[SuperWeapon]->ShowDesignatorRange=false`.
 * This feature can be toggled *by the player* (if enabled in the mod) with `ShowDesignatorRange` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.
 
-```{note}
-Due to technical reasons, this feature only works for super weapons with `Range` >= 1.
-```
-
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -94,6 +94,18 @@ DigitalDisplay.Enable=false             ; boolean
 An example shape file for digits can be found on [Phobos supplementaries repo](https://github.com/Phobos-developers/PhobosSupplementaries)).
 ```
 
+### Show designator & inhibitor range
+
+* It is now possible to display range of designator and inhibitor units when in super weapon targeting mode. Each instance of player owned techno types listed in `[SuperWeapon]->SW.Designators` will display a circle with radius set in `[TechnoType]->DesignatorRange` or `Sight`.
+  * In a similar manner, each instance of enemy owned techno types listed in `[SuperWeapon]->SW.Inhibitors` will display a circle with radius set in `[TechnoType]->InhibitorRange` or `Sight`.
+* This feature can be enabled with `ShowDesignatorRange=true` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.
+
+In `Ra2MD.ini`:
+```ini
+[Phobos]
+ShowDesignatorRange=false             ; boolean
+```
+
 ### Hide health bars
 
 ![image](_static/images/healthbar.hide-01.png)

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -101,6 +101,10 @@ An example shape file for digits can be found on [Phobos supplementaries repo](h
 * This feature can be disabled globally with `[AudioVisual]->ShowDesignatorRange=false` or per SuperWeaponType with `[SuperWeapon]->ShowDesignatorRange=false`.
 * This feature can be toggled *by the player* (if enabled in the mod) with `ShowDesignatorRange` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.
 
+```{note}
+Due to technical reasons, this feature only works for super weapons with `Range` >= 1.
+```
+
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -332,6 +332,7 @@ New:
 - Players can now be given ownership of preplaced buildings in Skirmish and Multiplayer in maps using houses of the format <Player @ X> where X goes from A to H for spawn positions 1-8 (by ZivDero)
 - `AutoDeath.Technos(Dont)Exist` can optionally track limboed (not physically on map, e.g transports etc) technos (by Starkku)
 - Wall overlay `Palette` support (by Starkku)
+- Show designator & inhibitor range (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Commands/Commands.cpp
+++ b/src/Commands/Commands.cpp
@@ -7,6 +7,7 @@
 #include "FrameByFrame.h"
 #include "FrameStep.h"
 #include "ToggleDigitalDisplay.h"
+#include "ToggleDesignatorRange.h"
 
 DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 {
@@ -17,6 +18,7 @@ DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 	MakeCommand<QuickSaveCommandClass>();
 	MakeCommand<DamageDisplayCommandClass>();
 	MakeCommand<ToggleDigitalDisplayCommandClass>();
+	MakeCommand<ToggleDesignatorRangeCommandClass>();
 
 	MakeCommand<FrameByFrameCommandClass>();
 	MakeCommand<FrameStepCommandClass<1>>(); // Single step in

--- a/src/Commands/ToggleDesignatorRange.cpp
+++ b/src/Commands/ToggleDesignatorRange.cpp
@@ -1,0 +1,29 @@
+#include "ToggleDesignatorRange.h"
+
+#include <MessageListClass.h>
+#include <Utilities/GeneralUtils.h>
+
+const char* ToggleDesignatorRangeCommandClass::GetName() const
+{
+	return "Toggle Designator Range";
+}
+
+const wchar_t* ToggleDesignatorRangeCommandClass::GetUIName() const
+{
+	return GeneralUtils::LoadStringUnlessMissing("TXT_DESIGNATOR_RANGE", L"Toggle Designator Range");
+}
+
+const wchar_t* ToggleDesignatorRangeCommandClass::GetUICategory() const
+{
+	return CATEGORY_INTERFACE;
+}
+
+const wchar_t* ToggleDesignatorRangeCommandClass::GetUIDescription() const
+{
+	return GeneralUtils::LoadStringUnlessMissing("TXT_DESIGNATOR_RANGE_DESC", L"Show/hide designator range when targeting superweapons.");
+}
+
+void ToggleDesignatorRangeCommandClass::Execute(WWKey eInput) const
+{
+	Phobos::Config::ShowDesignatorRange = !Phobos::Config::ShowDesignatorRange;
+}

--- a/src/Commands/ToggleDesignatorRange.h
+++ b/src/Commands/ToggleDesignatorRange.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Commands.h"
+
+// Display damage strings
+class ToggleDesignatorRangeCommandClass : public PhobosCommandClass
+{
+public:
+	virtual const char* GetName() const override;
+	virtual const wchar_t* GetUIName() const override;
+	virtual const wchar_t* GetUICategory() const override;
+	virtual const wchar_t* GetUIDescription() const override;
+	virtual void Execute(WWKey eInput) const override;
+};

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -105,6 +105,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DrawTurretShadow.Read(exINI, GameStrings::AudioVisual, "DrawTurretShadow");
 	this->AnimRemapDefaultColorScheme.Read(exINI, GameStrings::AudioVisual, "AnimRemapDefaultColorScheme");
 	this->TimerBlinkColorScheme.Read(exINI, GameStrings::AudioVisual, "TimerBlinkColorScheme");
+	this->ShowDesignatorRange.Read(exINI, GameStrings::AudioVisual, "ShowDesignatorRange");
 
 	this->AllowParallelAIQueues.Read(exINI, "GlobalControls", "AllowParallelAIQueues");
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
@@ -255,6 +256,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Infantry_DefaultDigitalDisplayTypes)
 		.Process(this->Vehicles_DefaultDigitalDisplayTypes)
 		.Process(this->Aircraft_DefaultDigitalDisplayTypes)
+		.Process(this->ShowDesignatorRange)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -96,6 +96,8 @@ public:
 		ValueableVector<DigitalDisplayTypeClass*> Vehicles_DefaultDigitalDisplayTypes;
 		ValueableVector<DigitalDisplayTypeClass*> Aircraft_DefaultDigitalDisplayTypes;
 
+		Valueable<bool> ShowDesignatorRange;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -153,6 +155,7 @@ public:
 			, Infantry_DefaultDigitalDisplayTypes {}
 			, Vehicles_DefaultDigitalDisplayTypes {}
 			, Aircraft_DefaultDigitalDisplayTypes {}
+			, ShowDesignatorRange { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -44,6 +44,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_Next_RollChances)
 		.Process(this->ShowTimer_Priority)
 		.Process(this->Convert_Pairs)
+		.Process(this->ShowDesignatorRange)
 		;
 }
 
@@ -175,6 +176,8 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		else
 			this->Convert_Pairs.push_back({ convertFrom, convertTo, convertAffectedHouses });
 	}
+
+	this->ShowDesignatorRange.Read(exINI, pSection, "ShowDesignatorRange");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -56,6 +56,7 @@ public:
 		Nullable<WeaponTypeClass*> Detonate_Weapon;
 		Nullable<int> Detonate_Damage;
 		Valueable<bool> Detonate_AtFirer;
+		Valueable<bool> ShowDesignatorRange;
 
 		std::vector<ValueableVector<int>> LimboDelivery_RandomWeightsData;
 		std::vector<ValueableVector<int>> SW_Next_RandomWeightsData;
@@ -96,6 +97,7 @@ public:
 			, SW_Next_RandomWeightsData {}
 			, ShowTimer_Priority { 0 }
 			, Convert_Pairs {}
+			, ShowDesignatorRange { true }
 		{ }
 
 		// Ares 0.A functions

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -35,7 +35,7 @@ DEFINE_HOOK(0x6CB5EB, SuperClass_Grant_ShowTimer, 0x5)
 	return 0x6CB63E;
 }
 
-DEFINE_HOOK(0x6DC2C5, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x5)
+DEFINE_HOOK(0x6DC2AC, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x6)
 {
 	GET(const SuperWeaponTypeClass*, pSuperType, EDI);
 
@@ -66,7 +66,8 @@ DEFINE_HOOK(0x6DC2C5, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x5)
 			(float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight)) :
 			(float)(pTechnoTypeExt->InhibitorRange.Get(pCurrentTechnoType->Sight));
 
-		const CoordStruct coords = pCurrentTechno->GetCenterCoords();
+		CoordStruct coords = pCurrentTechno->GetCenterCoords();
+		coords.Z = MapClass::Instance->GetCellFloorHeight(coords);
 		const auto color = pOwner->Color;
 		Game::DrawRadialIndicator(false, true, coords, color, radius, false, true);
 	}

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -34,3 +34,40 @@ DEFINE_HOOK(0x6CB5EB, SuperClass_Grant_ShowTimer, 0x5)
 
 	return 0x6CB63E;
 }
+
+DEFINE_HOOK(0x6DC2C5, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x5)
+{
+	GET(const SuperWeaponTypeClass*, pSuperType, EDI);
+
+	if (!Phobos::Config::ShowDesignatorRange)
+		return 0;
+
+	const auto pExt = SWTypeExt::ExtMap.Find(pSuperType);
+	if (!pExt)
+		return 0;
+
+	for (const auto pType : pExt->SW_Designators)
+	{
+		for (const auto pCurrentTechno : *TechnoClass::Array)
+		{
+			const auto pCurrentTechnoType = pCurrentTechno->GetTechnoType();
+			const auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pCurrentTechnoType);
+
+			if (!pTechnoTypeExt
+				|| !pCurrentTechno->IsAlive
+				|| pCurrentTechno->InLimbo
+				|| !pExt->SW_Designators.Contains(pCurrentTechnoType)
+				|| (pCurrentTechno->Owner != HouseClass::CurrentPlayer))
+			{
+				continue;
+			}
+
+			const CoordStruct coords = pCurrentTechno->GetCenterCoords();
+			const auto color = pCurrentTechno->Owner->Color;
+			const float radius = (float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight));
+			Game::DrawRadialIndicator(false, true, coords, color, radius, false, true);
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -35,25 +35,23 @@ DEFINE_HOOK(0x6CB5EB, SuperClass_Grant_ShowTimer, 0x5)
 	return 0x6CB63E;
 }
 
-DEFINE_HOOK(0x6DC2AC, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x6)
+DEFINE_HOOK(0x6DBE74, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x7)
 {
-	GET(const SuperWeaponTypeClass*, pSuperType, EDI);
-
-	if (!Phobos::Config::ShowDesignatorRange || !(RulesExt::Global()->ShowDesignatorRange))
+	if (!Phobos::Config::ShowDesignatorRange || !(RulesExt::Global()->ShowDesignatorRange) || Unsorted::CurrentSWType == -1)
 		return 0;
 
+	const auto pSuperType = SuperWeaponTypeClass::Array()->GetItem(Unsorted::CurrentSWType);
 	const auto pExt = SWTypeExt::ExtMap.Find(pSuperType);
-	if (!pExt || !pExt->ShowDesignatorRange)
+
+	if (!pExt->ShowDesignatorRange)
 		return 0;
 
 	for (const auto pCurrentTechno : *TechnoClass::Array)
 	{
 		const auto pCurrentTechnoType = pCurrentTechno->GetTechnoType();
-		const auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pCurrentTechnoType);
 		const auto pOwner = pCurrentTechno->Owner;
 
-		if (!pTechnoTypeExt
-			|| !pCurrentTechno->IsAlive
+		if (!pCurrentTechno->IsAlive
 			|| pCurrentTechno->InLimbo
 			|| !pExt->SW_Designators.Contains(pCurrentTechnoType)
 			|| !((pOwner == HouseClass::CurrentPlayer)
@@ -61,6 +59,8 @@ DEFINE_HOOK(0x6DC2AC, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x6)
 		{
 			continue;
 		}
+
+		const auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pCurrentTechnoType);
 
 		const float radius = pOwner == HouseClass::CurrentPlayer ?
 			(float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight)) :

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -39,11 +39,11 @@ DEFINE_HOOK(0x6DC2C5, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x5)
 {
 	GET(const SuperWeaponTypeClass*, pSuperType, EDI);
 
-	if (!Phobos::Config::ShowDesignatorRange)
+	if (!Phobos::Config::ShowDesignatorRange || !(RulesExt::Global()->ShowDesignatorRange))
 		return 0;
 
 	const auto pExt = SWTypeExt::ExtMap.Find(pSuperType);
-	if (!pExt)
+	if (!pExt || !pExt->ShowDesignatorRange)
 		return 0;
 
 	for (const auto pCurrentTechno : *TechnoClass::Array)

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -62,9 +62,9 @@ DEFINE_HOOK(0x6DBE74, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x7)
 
 		const auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pCurrentTechnoType);
 
-		const float radius = pOwner == HouseClass::CurrentPlayer ?
-			(float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight)) :
-			(float)(pTechnoTypeExt->InhibitorRange.Get(pCurrentTechnoType->Sight));
+		const float radius = pOwner == HouseClass::CurrentPlayer
+			? (float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight))
+			: (float)(pTechnoTypeExt->InhibitorRange.Get(pCurrentTechnoType->Sight));
 
 		CoordStruct coords = pCurrentTechno->GetCenterCoords();
 		coords.Z = MapClass::Instance->GetCellFloorHeight(coords);

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -50,19 +50,24 @@ DEFINE_HOOK(0x6DC2C5, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x5)
 	{
 		const auto pCurrentTechnoType = pCurrentTechno->GetTechnoType();
 		const auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pCurrentTechnoType);
+		const auto pOwner = pCurrentTechno->Owner;
 
 		if (!pTechnoTypeExt
 			|| !pCurrentTechno->IsAlive
 			|| pCurrentTechno->InLimbo
 			|| !pExt->SW_Designators.Contains(pCurrentTechnoType)
-			|| (pCurrentTechno->Owner != HouseClass::CurrentPlayer))
+			|| !((pOwner == HouseClass::CurrentPlayer)
+				|| EnumFunctions::CanTargetHouse(AffectedHouse::Enemies, HouseClass::CurrentPlayer, pOwner)))
 		{
 			continue;
 		}
 
+		const float radius = pOwner == HouseClass::CurrentPlayer ?
+			(float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight)) :
+			(float)(pTechnoTypeExt->InhibitorRange.Get(pCurrentTechnoType->Sight));
+
 		const CoordStruct coords = pCurrentTechno->GetCenterCoords();
-		const auto color = pCurrentTechno->Owner->Color;
-		const float radius = (float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight));
+		const auto color = pOwner->Color;
 		Game::DrawRadialIndicator(false, true, coords, color, radius, false, true);
 	}
 

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -46,27 +46,24 @@ DEFINE_HOOK(0x6DC2C5, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x5)
 	if (!pExt)
 		return 0;
 
-	for (const auto pType : pExt->SW_Designators)
+	for (const auto pCurrentTechno : *TechnoClass::Array)
 	{
-		for (const auto pCurrentTechno : *TechnoClass::Array)
+		const auto pCurrentTechnoType = pCurrentTechno->GetTechnoType();
+		const auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pCurrentTechnoType);
+
+		if (!pTechnoTypeExt
+			|| !pCurrentTechno->IsAlive
+			|| pCurrentTechno->InLimbo
+			|| !pExt->SW_Designators.Contains(pCurrentTechnoType)
+			|| (pCurrentTechno->Owner != HouseClass::CurrentPlayer))
 		{
-			const auto pCurrentTechnoType = pCurrentTechno->GetTechnoType();
-			const auto pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pCurrentTechnoType);
-
-			if (!pTechnoTypeExt
-				|| !pCurrentTechno->IsAlive
-				|| pCurrentTechno->InLimbo
-				|| !pExt->SW_Designators.Contains(pCurrentTechnoType)
-				|| (pCurrentTechno->Owner != HouseClass::CurrentPlayer))
-			{
-				continue;
-			}
-
-			const CoordStruct coords = pCurrentTechno->GetCenterCoords();
-			const auto color = pCurrentTechno->Owner->Color;
-			const float radius = (float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight));
-			Game::DrawRadialIndicator(false, true, coords, color, radius, false, true);
+			continue;
 		}
+
+		const CoordStruct coords = pCurrentTechno->GetCenterCoords();
+		const auto color = pCurrentTechno->Owner->Color;
+		const float radius = (float)(pTechnoTypeExt->DesignatorRange.Get(pCurrentTechnoType->Sight));
+		Game::DrawRadialIndicator(false, true, coords, color, radius, false, true);
 	}
 
 	return 0;

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -38,6 +38,7 @@ bool Phobos::Config::RealTimeTimers = false;
 bool Phobos::Config::RealTimeTimers_Adaptive = false;
 int Phobos::Config::CampaignDefaultGameSpeed = 2;
 bool Phobos::Config::SkirmishUnlimitedColors = false;
+bool Phobos::Config::ShowDesignatorRange = false;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -132,6 +133,8 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 		Patch::Apply_RAW(0x55D77A, { temp }); // We overwrite the instructions that force GameSpeed to 2 (GS4)
 		Patch::Apply_RAW(0x55D78D, { temp }); // when speed control is off. Doesn't need a hook.
 	}
+
+	Phobos::Config::ShowDesignatorRange = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowDesignatorRange", false);
 
 	Phobos::Misc::CustomGS = pINI_RULESMD->ReadBool(GameStrings::General, "CustomGS", false);
 

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -73,6 +73,7 @@ public:
 		static bool RealTimeTimers_Adaptive;
 		static int CampaignDefaultGameSpeed;
 		static bool SkirmishUnlimitedColors;
+		static bool ShowDesignatorRange;
 	};
 
 	class Misc


### PR DESCRIPTION
* It is now possible to display range of designator and inhibitor units when in super weapon targeting mode. Each instance of player owned techno types listed in `[SuperWeapon]->SW.Designators` will display a circle with radius set in `[TechnoType]->DesignatorRange` or `Sight`.
  * In a similar manner, each instance of enemy owned techno types listed in `[SuperWeapon]->SW.Inhibitors` will display a circle with radius set in `[TechnoType]->InhibitorRange` or `Sight`.
* This feature can be disabled globally with `[AudioVisual]->ShowDesignatorRange=false` or per SuperWeaponType with `[SuperWeapon]->ShowDesignatorRange=false`.
* This feature can be toggled *by the player* (if enabled in the mod) with `ShowDesignatorRange` in `Ra2MD.ini` or with "Toggle Designator Range" hotkey in "Interface" category.

```{note}
Due to technical reasons, this feature only works for super weapons with `Range` >= 1.
```

In `rulesmd.ini`:
```ini
[AudioVisual]
ShowDesignatorRange=true    ; boolean

[SOMESW]                    ; SuperWeapon
ShowDesignatorRange=true    ; boolean
```

In `Ra2MD.ini`:
```ini
[Phobos]
ShowDesignatorRange=false             ; boolean
```