### PR TITLE
MP houses are named and allowed to house TechnoTypes owned by them on the map

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -287,6 +287,8 @@ This page lists all the individual contributions to the project by their author.
   - Vehicle voxel turret shadows & body multi-section shadows
 - **Fryone**
   - Customizable ElectricBolt Arcs
+- **ZivDero**
+  - Allow giving ownership of buildings to players in Skirmish and MP using <Player @ A-H>
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares
   - unfinished RadTypes code

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -50,6 +50,7 @@
     <ClCompile Include="src\Ext\Trigger\Hooks.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Crushing.cpp" />
     <ClCompile Include="src\Locomotion\TestLocomotionClass.cpp" />
+    <ClCompile Include="src\Misc\Hooks.AssignHouses.cpp" />
     <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
     <ClCompile Include="src\Misc\Hooks.Ares.cpp" />
     <ClCompile Include="src\Misc\PhobosToolTip.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -134,6 +134,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy.
 - `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`.
 - `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity` setting.
+- You can now specify houses named `<Player @ A>` through `<Player @ H>` as the owner of TechnoTypes preplaced on the map in the editor, and they will be correctly given to players starting on points 1-8. Originally, it was only possible to use these house names in events, actions and teams.
+
 
 ## Fixes / interactions with other extensions
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1271,13 +1271,3 @@ In `rulesmd.ini`:
 CanTarget=all        ; list of Affected Target Enumeration (none|land|water|empty|infantry|units|buildings|all)
 CanTargetHouses=all  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 ```
-
-### Player houses' ownership of TechnoTypes in Skirmish and Multiplayer maps
-
-- You can now specify houses named <Player @ A> through <Player @ H> as the owner of TechnoTypes preplaced on the map in the editor, and they will be correctly given to players starting on points 1-8. Originally, it was only possible to use these house names in events, actions and teams.
-
-In maps:
-```ini
-[TechnoTypes]       ; Structures, Units, Infantry or Aircraft
-index=<Player @ A>,SOMETECHNO,…     ; Owning player's house
-```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1271,3 +1271,13 @@ In `rulesmd.ini`:
 CanTarget=all        ; list of Affected Target Enumeration (none|land|water|empty|infantry|units|buildings|all)
 CanTargetHouses=all  ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 ```
+
+### Player houses' ownership of TechnoTypes in Skirmish and Multiplayer maps
+
+- You can now specify houses named <Player @ A> through <Player @ H> as the owner of TechnoTypes preplaced on the map in the editor, and they will be correctly given to players starting on points 1-8. Originally, it was only possible to use these house names in events, actions and teams.
+
+In maps:
+```ini
+[TechnoTypes]       ; Structures, Units, Infantry or Aircraft
+index=<Player @ A>,SOMETECHNO,…     ; Owning player's house
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -329,6 +329,7 @@ New:
 - Unhardcoded timer blinking color scheme (by Starkku)
 - Customizing shield self-healing timer restart when shield is damaged (by Starkku)
 - Customizing minimum & maximum amount of damage shield can take from a single hit (by Starkku)
+- Players can now be given ownership of preplaced buildings in Skirmish and Multiplayer in maps using houses of the format <Player @ X> where X goes from A to H for spawn positions 1-8 (by ZivDero)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -331,6 +331,28 @@ CellClass* HouseExt::GetEnemyBaseGatherCell(HouseClass* pTargetHouse, HouseClass
 	return MapClass::Instance->TryGetCellAt(cellStruct);
 }
 
+// Gives player houses names based on their spawning spot
+void HouseExt::SetSkirmishHouseName(HouseClass* pHouse)
+{
+	int spawn_position = pHouse->GetSpawnPosition();
+
+	// Default behaviour if something went wrong
+	if (spawn_position < 0 || spawn_position > 7)
+	{
+		if (pHouse->IsHumanPlayer)
+			sprintf(pHouse->PlainName, "<human player>");
+		else
+			sprintf(pHouse->PlainName, "Computer");
+	}
+	else
+	{
+		const char letters[9] = "ABCDEFGH";
+		sprintf(pHouse->PlainName, "<Player @ %c>", letters[spawn_position]);
+	}
+
+	Debug::Log("%s, %ls, position %d\n", pHouse->PlainName, pHouse->UIName, spawn_position);
+}
+
 // Ares
 HouseClass* HouseExt::GetHouseKind(OwnerHouseKind const kind, bool const allowRandom, HouseClass* const pDefault, HouseClass* const pInvoker, HouseClass* const pVictim)
 {

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -102,6 +102,8 @@ public:
 	static HouseClass* GetHouseKind(OwnerHouseKind kind, bool allowRandom, HouseClass* pDefault, HouseClass* pInvoker = nullptr, HouseClass* pVictim = nullptr);
 	static CellClass* GetEnemyBaseGatherCell(HouseClass* pTargetHouse, HouseClass* pCurrentHouse, CoordStruct defaultCurrentCoords, SpeedType speedTypeZone, int extraDistance = 0);
 
+	static void SetSkirmishHouseName(HouseClass* pHouse);
+
 	static bool IsDisabledFromShell(
 	HouseClass const* pHouse, BuildingTypeClass const* pItem);
 

--- a/src/Misc/Hooks.AssignHouses.cpp
+++ b/src/Misc/Hooks.AssignHouses.cpp
@@ -1,0 +1,29 @@
+#include <Utilities/Macro.h>
+#include <Utilities/Debug.h>
+#include <HouseClass.h>
+#include <Ext/House/Body.h>
+
+DEFINE_HOOK(0x68804A, AssignHouses_PlayerHouses, 0x5)
+{
+	Debug::Log("Assinging player houses' names\n");
+
+	GET(HouseClass*, pPlayerHouse, EBP);
+
+	HouseExt::SetSkirmishHouseName(pPlayerHouse);
+
+	return 0x68808E;
+}
+
+DEFINE_HOOK(0x688210, AssignHouses_ComputerHouses, 0x5)
+{
+	Debug::Log("Assinging computer houses' names\n");
+
+	GET(HouseClass*, pAiHouse, EBP);
+
+	HouseExt::SetSkirmishHouseName(pAiHouse);
+
+	return 0x688252;
+}
+
+// Skips checking the gamemode or who the player is when assigning houses
+DEFINE_JUMP(LJMP, 0x44F8CB, 0x44F8E1)

--- a/src/Misc/Hooks.AssignHouses.cpp
+++ b/src/Misc/Hooks.AssignHouses.cpp
@@ -1,12 +1,9 @@
 #include <Utilities/Macro.h>
-#include <Utilities/Debug.h>
 #include <HouseClass.h>
 #include <Ext/House/Body.h>
 
 DEFINE_HOOK(0x68804A, AssignHouses_PlayerHouses, 0x5)
 {
-	Debug::Log("Assinging player houses' names\n");
-
 	GET(HouseClass*, pPlayerHouse, EBP);
 
 	HouseExt::SetSkirmishHouseName(pPlayerHouse);
@@ -16,8 +13,6 @@ DEFINE_HOOK(0x68804A, AssignHouses_PlayerHouses, 0x5)
 
 DEFINE_HOOK(0x688210, AssignHouses_ComputerHouses, 0x5)
 {
-	Debug::Log("Assinging computer houses' names\n");
-
 	GET(HouseClass*, pAiHouse, EBP);
 
 	HouseExt::SetSkirmishHouseName(pAiHouse);


### PR DESCRIPTION
This PR renames the houses spaned on position 0-7 in MP/Skirmish to <Player @ X> and allows them to own TechnoTypes on the map, allowing for pre-placed buildings/units/etc.