### PR TITLE
Misc. singleplayer mission additions / improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -215,6 +215,7 @@ This page lists all the individual contributions to the project by their author.
   - Straight projectile trajectory additions
   - Airstrike & spy plane fixed spawn distance & height
   - Negative damage `Verses/PercentAtMax` toggle
+  - Misc. singleplayer mission improvements
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -39,6 +39,7 @@
     <ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
     <ClCompile Include="src\Ext\OverlayType\Body.cpp" />
     <ClCompile Include="src\Ext\OverlayType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Scenario\Hooks.cpp" />
     <ClCompile Include="src\Ext\Scenario\Hooks.Variables.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
     <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -12,9 +12,9 @@ This page describes all AI scripting and mapping related additions and changes i
 - Teams spawned by trigger action 7,80,107 can use IFV and opentopped logic normally. `InitialPayload` logic from Ares is not supported yet.
 - If a pre-placed building has a `NaturalParticleSystem`, it used to always be created when the game starts. This has been removed.
 
-## Maps
+## Singleplayer Misssion Maps
 
-### Base node repairing (singleplayer only)
+### Base node repairing
 
 - In singleplayer campaign missions you can now decide whether AI can repair the base nodes / buildings delivered by SW (Ares) by setting `RepairBaseNodes`.
 
@@ -24,7 +24,7 @@ In map file:
 RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy/ Normal/ Difficult game diffculty.
 ```
 
-### Default loading screen and briefing offsets (singleplayer only)
+### Default loading screen and briefing offsets
 
 - It is now possible to set defaults for singleplayer map loading screen briefing pixel offsets and the loading screen images and palette that are used if there are no values defined for the map itself.
 
@@ -40,7 +40,7 @@ DefaultLS800BkgdName     ; filename - including the .shp extension.
 DefaultLS800BkgdPal=     ; filename - including the .pal extension
 ```
 
-### MCV redeploying (singleplayer only)
+### MCV redeploying
 
 - You can now decide whether MCV can redeploy in singleplayer campaign missions by setting `MCVRedeploys`. Overrides `[MultiplayerDialogSettings]`->`MCVRedeploys` only in singleplayer campaign missions.
 
@@ -50,7 +50,7 @@ In map file:
 MCVRedeploys=false  ; boolean
 ```
 
-### Set par times and related string labels in missionmd.ini (singleplayer only)
+### Set par times and related string labels in missionmd.ini
 
 - By default the singleplayer mission par times and message strings are defined in `[Ranking]` section of the map file itself. These can now also be set in the map file's section in `missionmd.ini`, taking precedence over the map file's settings but defaulting to them if not set.
 
@@ -66,20 +66,29 @@ Ranking.OverParTitle=     ; CSF entry key
 Ranking.OverParMessage=   ; CSF entry key
 ```
 
-### Show briefing dialog on startup (singleplayer only)
+### Show briefing dialog on startup
 
 - You can now have the briefing dialog screen show up on singleplayer campaign mission startup by setting `ShowBriefing` to true in map file's `[Basic]` section, or in the map file's section in `missionmd.ini` (latter takes precedence over former if available).
+  - `BriefingTheme` (In order of precedence from highest to lowest: `missionmd.ini`, map file, side entry in `rulesmd.ini`) can be used to define a custom theme to play on this briefing screen. If not set, the loading screen theme will keep playing until the scenario starts properly.
 
 In `missionmd.ini`:
 ```ini
-[SOMEMISSION]  ; Filename of mission map
-ShowBriefing=  ; boolean
+[SOMEMISSION]   ; Filename of mission map
+ShowBriefing=   ; boolean
+BriefingTheme=  ; Theme name
 ```
 
 In map file:
 ```ini
 [Basic]
 ShowBriefing=false  ; boolean
+BriefingTheme=      ; Theme name
+```
+
+In `rulesmd.ini`
+```ini
+[SOMESIDE]      ; Side
+BriefingTheme=  ; Theme name
 ```
 
 ## Script Actions

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -34,6 +34,22 @@ In map file:
 MCVRedeploys=false  ; boolean
 ```
 
+### Set par times and related string labels in missionmd.ini (singleplayer only)
+
+- By default the singleplayer mission par times and message strings are defined in `[Ranking]` section of the map file itself. These can now also be set in the map file's section in `missionmd.ini`, taking precedence over the map file's settings but defaulting to them if not set.
+
+In `missionmd.ini`:
+```ini
+[SOMEMISSION]             ; Filename of mission map
+Ranking.ParTimeEasy=      ; time string (hh:mm:ss)
+Ranking.ParTimeMedium=    ; time string (hh:mm:ss)
+Ranking.ParTimeHard=      ; time string (hh:mm:ss)
+Ranking.UnderParTitle=    ; CSF entry key
+Ranking.UnderParMessage=  ; CSF entry key
+Ranking.OverParTitle=     ; CSF entry key
+Ranking.OverParMessage=   ; CSF entry key
+```
+
 ### Show briefing dialog on startup (singleplayer only)
 
 - You can now have the briefing dialog screen show up on singleplayer campaign mission startup by setting `ShowBriefing` to true in map file's `[Basic]` section, or in the map file's section in `missionmd.ini` (latter takes precedence over former if available).

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -24,6 +24,22 @@ In map file:
 RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy/ Normal/ Difficult game diffculty.
 ```
 
+### Default loading screen and briefing offsets (singleplayer only)
+
+- It is now possible to set defaults for singleplayer map loading screen briefing pixel offsets and the loading screen images and palette that are used if there are no values defined for the map itself.
+
+- In `missionmd.ini`:
+```ini
+[Defaults]
+DefaultLS640BriefLocX=0  ; integer
+DefaultLS640BriefLocY=0  ; integer 
+DefaultLS800BriefLocX=0  ; integer
+DefaultLS800BriefLocY=0  ; integer
+DefaultLS640BkgdName=    ; filename - including the .shp extension.
+DefaultLS800BkgdName     ; filename - including the .shp extension.
+DefaultLS800BkgdPal=     ; filename - including the .pal extension
+```
+
 ### MCV redeploying (singleplayer only)
 
 - You can now decide whether MCV can redeploy in singleplayer campaign missions by setting `MCVRedeploys`. Overrides `[MultiplayerDialogSettings]`->`MCVRedeploys` only in singleplayer campaign missions.

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -9,23 +9,46 @@ This page describes all AI scripting and mapping related additions and changes i
 - Map trigger action `125 Build At...` can now play buildup anim and becomes singleplayer-AI-repairable optionally (needs [following changes to `fadata.ini`](Whats-New.md#for-map-editor-final-alert-2).
 - Both Global Variables (`VariableNames` in `rulesmd.ini`) and Local Variables (`VariableNames` in map) are now unlimited.
 - Script action `Deploy` now has vehicles with `DeploysInto` searching for free space to deploy at if failing to do so at initial location, instead of simply getting stuck.
-- In **singleplayer campaigns**:
-  - You can now decide whether AI can repair the base nodes/buildings delivered by SW (Ares) by setting
+- Teams spawned by trigger action 7,80,107 can use IFV and opentopped logic normally. `InitialPayload` logic from Ares is not supported yet.
+- If a pre-placed building has a `NaturalParticleSystem`, it used to always be created when the game starts. This has been removed.
+
+## Maps
+
+### Base node repairing (singleplayer only)
+
+- In singleplayer campaign missions you can now decide whether AI can repair the base nodes / buildings delivered by SW (Ares) by setting `RepairBaseNodes`.
+
+In map file:
 ```ini
 [Country House]
-RepairBaseNodes=no,no,no ; 3 booleans indicating whether AI repair basenodes in Easy/ Normal/ Difficult game diffculty.
+RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy/ Normal/ Difficult game diffculty.
 ```
 
-  - You can now decide whether MCV can redeploy by setting
+### MCV redeploying (singleplayer only)
+
+- You can now decide whether MCV can redeploy in singleplayer campaign missions by setting `MCVRedeploys`. Overrides `[MultiplayerDialogSettings]`->`MCVRedeploys` only in singleplayer campaign missions.
+
+In map file:
 ```ini
 [Basic]
-MCVRedeploys=no  ; boolean, Overrides [MultiplayerDialogSettings]->MCVRedeploys only in campaigns
+MCVRedeploys=false  ; boolean
 ```
-  - **Note that these tags only work within the map file**
 
-- Teams spawned by trigger action 7,80,107 can use IFV and opentopped logic normally.
-  - `InitialPayload` logic from Ares is not supported yet.
-- If a pre-placed building has a `NaturalParticleSystem`, it used to always be created when the game starts. This has been removed.
+### Show briefing dialog on startup (singleplayer only)
+
+- You can now have the briefing dialog screen show up on singleplayer campaign mission startup by setting `ShowBriefing` to true in map file's `[Basic]` section, or in the map file's section in `missionmd.ini` (latter takes precedence over former if available).
+
+In `missionmd.ini`:
+```ini
+[SOMEMISSION]  ; Filename of mission map
+ShowBriefing=  ; boolean
+```
+
+In map file:
+```ini
+[Basic]
+ShowBriefing=false  ; boolean
+```
 
 ## Script Actions
 

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -21,12 +21,13 @@ This page describes all AI scripting and mapping related additions and changes i
 In map file:
 ```ini
 [Country House]
-RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy/ Normal/ Difficult game diffculty.
+RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy / Normal / Difficult game diffculty.
 ```
 
 ### Default loading screen and briefing offsets
 
 - It is now possible to set defaults for singleplayer map loading screen briefing pixel offsets and the loading screen images and palette that are used if there are no values defined for the map itself.
+  - Note that despite the key name being `DefaultLS800BkgdPal`, this applies to both shapes just like the original scenario-specific `LS800BkgdPal` does.
 
 - In `missionmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -351,6 +351,7 @@ New:
 - Allow enabling application of `Verses` and `PercentAtMax` for negative damage (by Starkku)
 - In addition to `PlacementGrid.Translucency`, allow to set the transparency of the grid when PlacementPreview is enabled, using the `PlacementGrid.TranslucencyWithPreview` tag (by Belonit).
 - Show briefing screen on singleplayer mission start (by Starkku)
+- Allow setting mission par times and related messages in `missionmd.ini` (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -350,6 +350,7 @@ New:
 - Airstrike & spy plane fixed spawn distance & height (by Starkku)
 - Allow enabling application of `Verses` and `PercentAtMax` for negative damage (by Starkku)
 - In addition to `PlacementGrid.Translucency`, allow to set the transparency of the grid when PlacementPreview is enabled, using the `PlacementGrid.TranslucencyWithPreview` tag (by Belonit).
+- Show briefing screen on singleplayer mission start (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -352,6 +352,7 @@ New:
 - In addition to `PlacementGrid.Translucency`, allow to set the transparency of the grid when PlacementPreview is enabled, using the `PlacementGrid.TranslucencyWithPreview` tag (by Belonit).
 - Show briefing screen on singleplayer mission start (by Starkku)
 - Allow setting mission par times and related messages in `missionmd.ini` (by Starkku)
+- Allow setting default singleplayer map loading screen and briefing offsets (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -107,8 +107,14 @@ void ScenarioExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		Nullable<bool> SP_MCVRedeploy;
 		SP_MCVRedeploy.Read(exINI, GameStrings::Basic, GameStrings::MCVRedeploys);
 		GameModeOptionsClass::Instance->MCVRedeploy = SP_MCVRedeploy.Get(false);
-	}
 
+		CCINIClass* pINI_MISSIONMD = CCINIClass::LoadINIFile(GameStrings::MISSIONMD_INI);
+		auto const scenarioName = this->OwnerObject()->FileName;
+
+		this->ShowBriefing = pINI_MISSIONMD->ReadBool(scenarioName, "ShowBriefing", pINI->ReadBool(GameStrings::Basic,"ShowBriefing", this->ShowBriefing));
+
+		CCINIClass::UnloadINIFile(pINI_MISSIONMD);
+	}
 }
 
 template <typename T>
@@ -119,6 +125,7 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->Variables[0])
 		.Process(this->Variables[1])
 		.Process(SessionClass::Instance->Config)
+		.Process(ShowBriefing)
 		;
 }
 

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -121,6 +121,7 @@ void ScenarioExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		pINI_MISSIONMD->ReadString(scenarioName, "Ranking.OverParMessage", pThis->OverParMessage, pThis->OverParMessage);
 
 		this->ShowBriefing = pINI_MISSIONMD->ReadBool(scenarioName, "ShowBriefing", pINI->ReadBool(GameStrings::Basic,"ShowBriefing", this->ShowBriefing));
+		this->BriefingTheme = pINI_MISSIONMD->ReadTheme(scenarioName, "BriefingTheme", pINI->ReadTheme(GameStrings::Basic, "BriefingTheme", this->BriefingTheme));
 
 		CCINIClass::UnloadINIFile(pINI_MISSIONMD);
 	}
@@ -135,6 +136,7 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->Variables[1])
 		.Process(SessionClass::Instance->Config)
 		.Process(ShowBriefing)
+		.Process(BriefingTheme)
 		;
 }
 

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -98,7 +98,7 @@ void ScenarioExt::LoadFromINIFile(ScenarioClass* pThis, CCINIClass* pINI)
 
 void ScenarioExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 {
-	// auto pThis = this->OwnerObject();
+	auto pThis = this->OwnerObject();
 
 	INI_EX exINI(pINI);
 
@@ -109,7 +109,16 @@ void ScenarioExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		GameModeOptionsClass::Instance->MCVRedeploy = SP_MCVRedeploy.Get(false);
 
 		CCINIClass* pINI_MISSIONMD = CCINIClass::LoadINIFile(GameStrings::MISSIONMD_INI);
-		auto const scenarioName = this->OwnerObject()->FileName;
+		auto const scenarioName = pThis->FileName;
+
+	    // Override rankings
+		pThis->ParTimeEasy = pINI_MISSIONMD->ReadTime(scenarioName, "Ranking.ParTimeEasy", pThis->ParTimeEasy);
+		pThis->ParTimeMedium = pINI_MISSIONMD->ReadTime(scenarioName, "Ranking.ParTimeMedium", pThis->ParTimeMedium);
+		pThis->ParTimeDifficult = pINI_MISSIONMD->ReadTime(scenarioName, "Ranking.ParTimeHard", pThis->ParTimeDifficult);
+		pINI_MISSIONMD->ReadString(scenarioName, "Ranking.UnderParTitle", pThis->UnderParTitle, pThis->UnderParTitle);
+		pINI_MISSIONMD->ReadString(scenarioName, "Ranking.UnderParMessage", pThis->UnderParMessage, pThis->UnderParMessage);
+		pINI_MISSIONMD->ReadString(scenarioName, "Ranking.OverParTitle", pThis->OverParTitle, pThis->OverParTitle);
+		pINI_MISSIONMD->ReadString(scenarioName, "Ranking.OverParMessage", pThis->OverParMessage, pThis->OverParMessage);
 
 		this->ShowBriefing = pINI_MISSIONMD->ReadBool(scenarioName, "ShowBriefing", pINI->ReadBool(GameStrings::Basic,"ShowBriefing", this->ShowBriefing));
 

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -135,8 +135,8 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->Variables[0])
 		.Process(this->Variables[1])
 		.Process(SessionClass::Instance->Config)
-		.Process(ShowBriefing)
-		.Process(BriefingTheme)
+		.Process(this->ShowBriefing)
+		.Process(this->BriefingTheme)
 		;
 }
 

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -24,10 +24,14 @@ public:
 	class ExtData final : public Extension<ScenarioClass>
 	{
 	public:
+
+		bool ShowBriefing;
+
 		std::map<int, CellStruct> Waypoints;
 		std::map<int, ExtendedVariable> Variables[2]; // 0 for local, 1 for global
 
 		ExtData(ScenarioClass* OwnerObject) : Extension<ScenarioClass>(OwnerObject)
+			, ShowBriefing { false }
 			, Waypoints { }
 			, Variables { }
 		{ }

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -26,12 +26,14 @@ public:
 	public:
 
 		bool ShowBriefing;
+		int BriefingTheme;
 
 		std::map<int, CellStruct> Waypoints;
 		std::map<int, ExtendedVariable> Variables[2]; // 0 for local, 1 for global
 
 		ExtData(ScenarioClass* OwnerObject) : Extension<ScenarioClass>(OwnerObject)
 			, ShowBriefing { false }
+			, BriefingTheme { -1 }
 			, Waypoints { }
 			, Variables { }
 		{ }

--- a/src/Ext/Scenario/Hooks.cpp
+++ b/src/Ext/Scenario/Hooks.cpp
@@ -1,8 +1,3 @@
-#include <HouseTypeClass.h>
-#include <SideClass.h>
-#include <SessionClass.h>
-#include <ThemeClass.h>
-
 #include <Ext/Scenario/Body.h>
 #include <Helpers/Macro.h>
 #include <Utilities/Debug.h>

--- a/src/Ext/Scenario/Hooks.cpp
+++ b/src/Ext/Scenario/Hooks.cpp
@@ -1,0 +1,32 @@
+#include <HouseTypeClass.h>
+#include <SideClass.h>
+#include <SessionClass.h>
+#include <ThemeClass.h>
+
+#include <Ext/Scenario/Body.h>
+#include <Helpers/Macro.h>
+#include <Utilities/Debug.h>
+
+DEFINE_HOOK(0x6870D7, ReadScenario_LoadingScreens, 0x5)
+{
+	enum { SkipGameCode = 0x6873AB };
+
+	LEA_STACK(CCINIClass*, pINI, STACK_OFFSET(0x174, -0x158));
+
+	auto const pScenario = ScenarioClass::Instance.get();
+	auto const scenarioName = pScenario->FileName;
+	auto const defaultsSection = "Defaults";
+
+	pScenario->LS640BriefLocX = pINI->ReadInteger(scenarioName, "LS640BriefLocX", pINI->ReadInteger(defaultsSection, "DefaultLS640BriefLocX", 0));
+	pScenario->LS640BriefLocY = pINI->ReadInteger(scenarioName, "LS640BriefLocY", pINI->ReadInteger(defaultsSection, "DefaultLS640BriefLocY", 0));
+	pScenario->LS800BriefLocX = pINI->ReadInteger(scenarioName, "LS800BriefLocX", pINI->ReadInteger(defaultsSection, "DefaultLS800BriefLocX", 0));
+	pScenario->LS800BriefLocY = pINI->ReadInteger(scenarioName, "LS800BriefLocY", pINI->ReadInteger(defaultsSection, "DefaultLS800BriefLocY", 0));
+	pINI->ReadString(defaultsSection, "DefaultLS640BkgdName", pScenario->LS640BkgdName, pScenario->LS640BkgdName, 64);
+	pINI->ReadString(scenarioName, "LS640BkgdName", pScenario->LS640BkgdName, pScenario->LS640BkgdName, 64);
+	pINI->ReadString(defaultsSection, "DefaultLS800BkgdName", pScenario->LS800BkgdName, pScenario->LS800BkgdName, 64);
+	pINI->ReadString(scenarioName, "LS800BkgdName", pScenario->LS800BkgdName, pScenario->LS800BkgdName, 64);
+	pINI->ReadString(defaultsSection, "DefaultLS800BkgdPal", pScenario->LS800BkgdPal, pScenario->LS800BkgdPal, 64);
+	pINI->ReadString(scenarioName, "LS800BkgdPal", pScenario->LS800BkgdPal, pScenario->LS800BkgdPal, 64);
+
+	return SkipGameCode;
+}

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -38,6 +38,7 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->ToolTip_Background_Color.Read(exINI, pSection, "ToolTip.Background.Color");
 	this->ToolTip_Background_Opacity.Read(exINI, pSection, "ToolTip.Background.Opacity");
 	this->ToolTip_Background_BlurSize.Read(exINI, pSection, "ToolTip.Background.BlurSize");
+	this->BriefingTheme = pINI->ReadTheme(pSection, "BriefingTheme", this->BriefingTheme);;
 }
 
 // =============================
@@ -64,6 +65,7 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->ToolTip_Background_BlurSize)
 		.Process(this->IngameScore_WinTheme)
 		.Process(this->IngameScore_LoseTheme)
+		.Process(this->BriefingTheme)
 		;
 }
 

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -33,6 +33,7 @@ public:
 		Nullable<ColorStruct> ToolTip_Background_Color;
 		Nullable<int> ToolTip_Background_Opacity;
 		Nullable<float> ToolTip_Background_BlurSize;
+		Valueable<int> BriefingTheme;
 
 		ExtData(SideClass* OwnerObject) : Extension<SideClass>(OwnerObject)
 			, ArrayIndex { -1 }
@@ -52,6 +53,7 @@ public:
 			, ToolTip_Background_Color { }
 			, ToolTip_Background_Opacity { }
 			, ToolTip_Background_BlurSize { }
+			, BriefingTheme { -1 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -3,10 +3,12 @@
 #include <Helpers/Macro.h>
 #include <PreviewClass.h>
 #include <Surface.h>
+#include <ThemeClass.h>
 
 #include <Ext/House/Body.h>
 #include <Ext/Side/Body.h>
 #include <Ext/Rules/Body.h>
+#include <Ext/Scenario/Body.h>
 #include <Ext/TechnoType/Body.h>
 #include <Ext/SWType/Body.h>
 #include <Misc/FlyingStrings.h>
@@ -219,4 +221,64 @@ DEFINE_HOOK(0x456776, BuildingClass_DrawRadialIndicator_Visibility, 0x6)
 		return ContinueDraw;
 
 	return DoNotDraw;
+}
+
+namespace BriefingTemp
+{
+	bool ShowBriefing = false;
+}
+
+// Check if briefing dialog should be played before starting scenario.
+DEFINE_HOOK(0x683E41, ScenarioClass_Start_ShowBriefing, 0x6)
+{
+	enum { SkipGameCode = 0x683E6B };
+
+	GET_STACK(bool, showBriefing, STACK_OFFSET(0xFC, -0xE9));
+
+	// Don't show briefing dialog for non-campaign games or on restarts etc.
+	if (!ScenarioExt::Global()->ShowBriefing || !showBriefing || !SessionClass::Instance->IsCampaign())
+		return 0;
+
+	BriefingTemp::ShowBriefing = true;
+
+	// Skip over playing scenario theme.
+	return SkipGameCode;
+}
+
+// Show the briefing dialog before entering game loop.
+DEFINE_HOOK(0x48CE85, MainGame_ShowBriefing, 0x5)
+{
+	enum { SkipGameCode = 0x48CE8A };
+
+	// Restore overridden instructions.
+	SessionClass::Instance->Resume();
+
+	if (BriefingTemp::ShowBriefing)
+	{
+		// Show briefing dialog.
+		Game::SpecialDialog = 9;
+		Game::ShowSpecialDialog();
+		BriefingTemp::ShowBriefing = false;
+
+		// Play scenario theme.
+		int theme = ScenarioClass::Instance->ThemeIndex;
+
+		if (theme == -1)
+			ThemeClass::Instance->Stop(true);
+		else
+			ThemeClass::Instance->Queue(theme);
+	}
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x683F66, PauseGame_ShowBriefing, 0x5)
+{
+	enum { SkipGameCode = 0x683FAA };
+
+	// Skip redrawing the screen if we're gonna show the briefing screen immediately after loading screen finishes
+	if (BriefingTemp::ShowBriefing)
+		return SkipGameCode;
+
+	return 0;
 }

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -241,6 +241,19 @@ DEFINE_HOOK(0x683E41, ScenarioClass_Start_ShowBriefing, 0x6)
 
 	BriefingTemp::ShowBriefing = true;
 
+	int theme = ScenarioExt::Global()->BriefingTheme;
+
+	if (theme == -1)
+	{
+		SideClass* pSide = SideClass::Array->GetItemOrDefault(ScenarioClass::Instance->PlayerSideIndex);
+
+		if (const auto pSideExt = SideExt::ExtMap.Find(pSide))
+			theme = pSideExt->BriefingTheme;
+	}
+
+	if (theme != -1)
+		ThemeClass::Instance->Queue(theme);
+
 	// Skip over playing scenario theme.
 	return SkipGameCode;
 }


### PR DESCRIPTION
- Toggle to show briefing screen on singleplayer mission start
- Allow setting mission par times and related messages in `missionmd.ini`
- Allow setting default singleplayer map loading screen and briefing offsets 

---------------------

# Default loading screen and briefing offsets

- It is now possible to set defaults for singleplayer map loading screen briefing pixel offsets and the loading screen images and palette that are used if there are no values defined for the map itself.

- In `missionmd.ini`:
```ini
[Defaults]
DefaultLS640BriefLocX=0  ; integer
DefaultLS640BriefLocY=0  ; integer 
DefaultLS800BriefLocX=0  ; integer
DefaultLS800BriefLocY=0  ; integer
DefaultLS640BkgdName=    ; filename - including the .shp extension.
DefaultLS800BkgdName     ; filename - including the .shp extension.
DefaultLS800BkgdPal=     ; filename - including the .pal extension
```

# Set par times and related string labels in missionmd.ini

- By default the singleplayer mission par times and message strings are defined in `[Ranking]` section of the map file itself. These can now also be set in the map file's section in `missionmd.ini`, taking precedence over the map file's settings but defaulting to them if not set.

In `missionmd.ini`:
```ini
[SOMEMISSION]             ; Filename of mission map
Ranking.ParTimeEasy=      ; time string (hh:mm:ss)
Ranking.ParTimeMedium=    ; time string (hh:mm:ss)
Ranking.ParTimeHard=      ; time string (hh:mm:ss)
Ranking.UnderParTitle=    ; CSF entry key
Ranking.UnderParMessage=  ; CSF entry key
Ranking.OverParTitle=     ; CSF entry key
Ranking.OverParMessage=   ; CSF entry key
```

# Show briefing dialog on startup

- You can now have the briefing dialog screen show up on singleplayer campaign mission startup by setting `ShowBriefing` to true in map file's `[Basic]` section, or in the map file's section in `missionmd.ini` (latter takes precedence over former if available).
  - `BriefingTheme` (In order of precedence from highest to lowest: `missionmd.ini`, map file, side entry in `rulesmd.ini`) can be used to define a custom theme to play on this briefing screen. If not set, the loading screen theme will keep playing until the scenario starts properly.

In `missionmd.ini`:
```ini
[SOMEMISSION]   ; Filename of mission map
ShowBriefing=   ; boolean
BriefingTheme=  ; Theme name
```

In map file:
```ini
[Basic]
ShowBriefing=false  ; boolean
BriefingTheme=      ; Theme name
```

In `rulesmd.ini`
```ini
[SOMESIDE]      ; Side
BriefingTheme=  ; Theme name
```
