### PR TITLE
Customizing whether passengers are kicked out when an aircraft fires

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -317,7 +317,7 @@ This page lists all the individual contributions to the project by their author.
    - Iron Curtain effects customization on infantries and organic units
    - Use `CustomPalette` for animations with `Tiled=yes`
    - Unlimited `AlternateFLH` entries
-   - Customizing whether members are kicked out when an aircraft fires
+   - Customizing whether passengers are kicked out when an aircraft fires
 - **TwinkleStar**
   - Custom slaves free sound
   - Jumpjet crash rotation control

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -317,6 +317,7 @@ This page lists all the individual contributions to the project by their author.
    - Iron Curtain effects customization on infantries and organic units
    - Use `CustomPalette` for animations with `Tiled=yes`
    - Unlimited `AlternateFLH` entries
+   - Customizing whether members are kicked out when an aircraft fires
 - **TwinkleStar**
   - Custom slaves free sound
   - Jumpjet crash rotation control

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1116,9 +1116,7 @@ ROF.RandomDelay=0,2  ; integer - single or comma-sep. range (game frames)
 ROF.RandomDelay=     ; integer - single or comma-sep. range (game frames)
 ```
 
-## Weapons
-
-### Customizing whether members are kicked out when an aircraft fires
+### Customizing whether passengers are kicked out when an aircraft fires
 
 - In yuri's revenge, if aircraft has passengers, aircraft force kick out it's passengers when firing but not fire weapons.
 - Now you can decide aircraft kick out it's passengers or not when firing.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1116,6 +1116,17 @@ ROF.RandomDelay=0,2  ; integer - single or comma-sep. range (game frames)
 ROF.RandomDelay=     ; integer - single or comma-sep. range (game frames)
 ```
 
+### Customizing whether members are kicked out when an aircraft fires
+
+- In yuri's revenge, if aircraft has passengers, aircraft force kick out it's passengers when firing but not fire weapons.
+- Now you can decide aircraft kick out it's passengers or not when firing.
+
+In `rulesmd.ini`
+```ini
+[SOMEWEAPON]
+KickOutPassenger=true  ; boolean 
+```
+
 ### Single-color lasers
 
 ![image](_static/images/issinglecolor.gif)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1123,7 +1123,7 @@ ROF.RandomDelay=     ; integer - single or comma-sep. range (game frames)
 In `rulesmd.ini`
 ```ini
 [SOMEWEAPON]
-KickOutPassenger=true  ; boolean
+KickOutPassengers=true  ; boolean
 ```
 
 ### Single-color lasers

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1116,6 +1116,8 @@ ROF.RandomDelay=0,2  ; integer - single or comma-sep. range (game frames)
 ROF.RandomDelay=     ; integer - single or comma-sep. range (game frames)
 ```
 
+## Weapons
+
 ### Customizing whether members are kicked out when an aircraft fires
 
 - In yuri's revenge, if aircraft has passengers, aircraft force kick out it's passengers when firing but not fire weapons.
@@ -1124,7 +1126,7 @@ ROF.RandomDelay=     ; integer - single or comma-sep. range (game frames)
 In `rulesmd.ini`
 ```ini
 [SOMEWEAPON]
-KickOutPassenger=true  ; boolean 
+KickOutPassenger=true  ; boolean
 ```
 
 ### Single-color lasers

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1118,8 +1118,7 @@ ROF.RandomDelay=     ; integer - single or comma-sep. range (game frames)
 
 ### Customizing whether passengers are kicked out when an aircraft fires
 
-- In yuri's revenge, if aircraft has passengers, aircraft force kick out it's passengers when firing but not fire weapons.
-- Now you can decide aircraft kick out it's passengers or not when firing.
+- You can now customize whether aircraft will forcefully eject passengers (vanilla behavior) or fire its weapon when attempting to fire.
 
 In `rulesmd.ini`
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -530,7 +530,7 @@ Fixes / interactions with other extensions:
 
 New:
 - Additional sync logging in case of desync errors occuring (by Starkku)
-- Customizing whether members are kicked out when an aircraft fires (by ststl)
+- Customizing whether passengers are kicked out when an aircraft fires (by ststl)
 
 Phobos fixes:
 - `AutoDeath` support for objects in limbo (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -530,6 +530,7 @@ Fixes / interactions with other extensions:
 
 New:
 - Additional sync logging in case of desync errors occuring (by Starkku)
+- Customizing whether members are kicked out when an aircraft fires (by ststl)
 
 Phobos fixes:
 - `AutoDeath` support for objects in limbo (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -413,6 +413,7 @@ New:
 - Allow customizing Aircraft weapon strafing regardless of `ROT` and `Strafing.Shots` values beyond 5 (by Trsdy)
 - Allow strafing weapons to deduct ammo per shot instead of per strafing run (by Starkku)
 - Allow `CloakVisible=true` laser trails optinally be seen only if unit is detected (by Starkku)
+- Customizing whether passengers are kicked out when an aircraft fires (by ststl)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
@@ -530,7 +531,6 @@ Fixes / interactions with other extensions:
 
 New:
 - Additional sync logging in case of desync errors occuring (by Starkku)
-- Customizing whether passengers are kicked out when an aircraft fires (by ststl)
 
 Phobos fixes:
 - `AutoDeath` support for objects in limbo (by Trsdy)

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -310,26 +310,28 @@ DEFINE_HOOK(0x4CF68D, FlyLocomotionClass_DrawMatrix_OnAirport, 0x5)
 	return 0;
 }
 
-DEFINE_HOOK(0x415EEE, AircraftClass_Fire_KickOutPassenger, 0x6)
+DEFINE_HOOK(0x415EEE, AircraftClass_Fire_KickOutPassengers, 0x6)
 {
 	GET(AircraftClass*, pThis, EDI);
 	GET_STACK(int, weaponIdx, STACK_OFFSET(0x7C, 0x8));
 
-	enum { KickOutPassenger = 0x415EF8, Fire = 0x415F08 };
+	enum { KickOutPassengers = 0x415EF8, Fire = 0x415F08 };
 
-	if (pThis->Passengers.GetFirstPassenger() == nullptr)
+	if (!TechnoExt::IsActive(pThis))
+		return 0;
+
+	if (!pThis->Passengers.GetFirstPassenger())
 		return Fire;
 
-	if (TechnoExt::IsActive(pThis) && pThis->GetWeapon(weaponIdx) != nullptr)
-	{
-		const WeaponTypeClass* pWeapon = pThis->GetWeapon(weaponIdx)->WeaponType;
+	const WeaponStruct* pWeapon = pThis->GetWeapon(weaponIdx);
 
-		if (const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon))
-		{
-			if (!pWeaponExt->KickOutPassenger)
-				return Fire;
-		}
-	}
+	if (!pWeapon)
+		return KickOutPassengers;
 
-	return KickOutPassenger;
+	const auto pWeaponTypeExt = WeaponTypeExt::ExtMap.Find(pWeapon->WeaponType);
+
+	if (!pWeaponTypeExt)
+		return KickOutPassengers;
+
+	return pWeaponTypeExt->KickOutPassengers ? KickOutPassengers : Fire;
 }

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -4,6 +4,7 @@
 #include <Ext/Aircraft/Body.h>
 #include <Ext/Techno/Body.h>
 #include <Ext/Anim/Body.h>
+#include <Ext/Techno/Body.h>
 #include <Ext/WeaponType/Body.h>
 #include <Utilities/Macro.h>
 
@@ -307,4 +308,28 @@ DEFINE_HOOK(0x4CF68D, FlyLocomotionClass_DrawMatrix_OnAirport, 0x5)
 	}
 
 	return 0;
+}
+
+DEFINE_HOOK(0x415EEE, AircraftClass_Fire_KickOutPassenger, 0x6)
+{
+	GET(AircraftClass*, pThis, EDI);
+	GET_STACK(int, weaponIdx, STACK_OFFSET(0x7C, 0x8));
+
+	enum { KickOutPassenger = 0x415EF8, Fire = 0x415F08 };
+
+	if (pThis->Passengers.GetFirstPassenger() == nullptr)
+		return Fire;
+
+	if (TechnoExt::IsActive(pThis) && pThis->GetWeapon(weaponIdx) != nullptr)
+	{
+		const WeaponTypeClass* pWeapon = pThis->GetWeapon(weaponIdx)->WeaponType;
+
+		if (const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon))
+		{
+			if (!pWeaponExt->KickOutPassenger)
+				return Fire;
+		}
+	}
+
+	return KickOutPassenger;
 }

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -312,26 +312,20 @@ DEFINE_HOOK(0x4CF68D, FlyLocomotionClass_DrawMatrix_OnAirport, 0x5)
 
 DEFINE_HOOK(0x415EEE, AircraftClass_Fire_KickOutPassengers, 0x6)
 {
+	enum { SkipKickOutPassengers = 0x415F08 };
+
 	GET(AircraftClass*, pThis, EDI);
 	GET_BASE(int, weaponIdx, 0xC);
 
-	enum { KickOutPassengers = 0x415EF8, Fire = 0x415F08 };
-
-	if (!TechnoExt::IsActive(pThis))
-		return 0;
-
-	if (!pThis->Passengers.GetFirstPassenger())
-		return Fire;
-
-	const WeaponStruct* pWeapon = pThis->GetWeapon(weaponIdx);
+	auto const pWeapon = pThis->GetWeapon(weaponIdx)->WeaponType;
 
 	if (!pWeapon)
-		return KickOutPassengers;
+		return 0;
 
-	const auto pWeaponTypeExt = WeaponTypeExt::ExtMap.Find(pWeapon->WeaponType);
+	auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
 
-	if (!pWeaponTypeExt)
-		return KickOutPassengers;
+	if (pWeaponExt->KickOutPassengers)
+		return 0;
 
-	return pWeaponTypeExt->KickOutPassengers ? KickOutPassengers : Fire;
+	return SkipKickOutPassengers;
 }

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -313,7 +313,7 @@ DEFINE_HOOK(0x4CF68D, FlyLocomotionClass_DrawMatrix_OnAirport, 0x5)
 DEFINE_HOOK(0x415EEE, AircraftClass_Fire_KickOutPassengers, 0x6)
 {
 	GET(AircraftClass*, pThis, EDI);
-	GET_STACK(int, weaponIdx, STACK_OFFSET(0x7C, 0x8));
+	GET_BASE(int, weaponIdx, 0xC);
 
 	enum { KickOutPassengers = 0x415EF8, Fire = 0x415F08 };
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -37,14 +37,14 @@ TechnoExt::ExtData::~ExtData()
 
 bool TechnoExt::IsActive(TechnoClass* pThis)
 {
-	return
-		pThis &&
-		!pThis->TemporalTargetingMe &&
-		!pThis->BeingWarpedOut &&
-		!pThis->IsUnderEMP() &&
-		pThis->IsAlive &&
-		pThis->Health > 0 &&
-		!pThis->InLimbo;
+	return pThis
+		&& pThis->IsAlive
+		&& pThis->Health > 0
+		&& !pThis->InLimbo
+		&& !pThis->TemporalTargetingMe
+		&& !pThis->BeingWarpedOut
+		&& !pThis->IsUnderEMP()
+		;
 }
 
 bool TechnoExt::IsHarvesting(TechnoClass* pThis)

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -102,6 +102,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttachEffect_DisallowedMinCounts.Read(exINI, pSection, "AttachEffect.DisallowedMinCounts");
 	this->AttachEffect_DisallowedMaxCounts.Read(exINI, pSection, "AttachEffect.DisallowedMaxCounts");
 	this->AttachEffect_IgnoreFromSameSource.Read(exINI, pSection, "AttachEffect.IgnoreFromSameSource");
+	this->KickOutPassenger.Read(exINI, pSection, "KickOutPassenger");
 }
 
 template <typename T>

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -102,7 +102,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttachEffect_DisallowedMinCounts.Read(exINI, pSection, "AttachEffect.DisallowedMinCounts");
 	this->AttachEffect_DisallowedMaxCounts.Read(exINI, pSection, "AttachEffect.DisallowedMaxCounts");
 	this->AttachEffect_IgnoreFromSameSource.Read(exINI, pSection, "AttachEffect.IgnoreFromSameSource");
-	this->KickOutPassenger.Read(exINI, pSection, "KickOutPassenger");
+	this->KickOutPassengers.Read(exINI, pSection, "KickOutPassengers");
 }
 
 template <typename T>
@@ -142,6 +142,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttachEffect_DisallowedMinCounts)
 		.Process(this->AttachEffect_DisallowedMaxCounts)
 		.Process(this->AttachEffect_IgnoreFromSameSource)
+		.Process(this->KickOutPassengers)
 		;
 };
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -54,7 +54,7 @@ public:
 		ValueableVector<int> AttachEffect_DisallowedMinCounts;
 		ValueableVector<int> AttachEffect_DisallowedMaxCounts;
 		Valueable<bool> AttachEffect_IgnoreFromSameSource;
-		Valueable<bool> KickOutPassenger;
+		Valueable<bool> KickOutPassengers;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius { DiskLaserClass::Radius }
@@ -90,7 +90,7 @@ public:
 			, AttachEffect_DisallowedMinCounts {}
 			, AttachEffect_DisallowedMaxCounts {}
 			, AttachEffect_IgnoreFromSameSource { false }
-			, KickOutPassenger { true }
+			, KickOutPassengers { true }
 		{ }
 
 		int GetBurstDelay(int burstIndex) const;

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -54,6 +54,7 @@ public:
 		ValueableVector<int> AttachEffect_DisallowedMinCounts;
 		ValueableVector<int> AttachEffect_DisallowedMaxCounts;
 		Valueable<bool> AttachEffect_IgnoreFromSameSource;
+		Valueable<bool> KickOutPassenger;
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius { DiskLaserClass::Radius }
@@ -89,6 +90,7 @@ public:
 			, AttachEffect_DisallowedMinCounts {}
 			, AttachEffect_DisallowedMaxCounts {}
 			, AttachEffect_IgnoreFromSameSource { false }
+			, KickOutPassenger { true }
 		{ }
 
 		int GetBurstDelay(int burstIndex) const;


### PR DESCRIPTION
- In yuri's revenge, if aircraft has passengers, aircraft force kick out it's passengers when firing but not fire weapons.
- Now you can decide aircraft kick out it's passengers or not when firing.

In `rulesmd.ini`
```ini
[SOMEWEAPON]
KickOutPassenger=true  ; boolean 
```