### PR TITLE
Reset timer for Super Weapons

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -128,6 +128,7 @@ This page lists all the individual contributions to the project by their author.
   - Shared ammo logic
   - Customizable FLH when infantry is prone or deployed
   - Initial strength for cloned infantry
+  - Reset timer tags for SW
 - **Starkku**:
   - Misc. minor bugfixes & improvements
   - AI script actions:

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="src\Ext\SWType\FireSuperWeapon.cpp" />
     <ClCompile Include="src\Ext\SWType\SWHelpers.cpp" />
     <ClCompile Include="src\Ext\SWType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\SW\Body.cpp" />
     <ClCompile Include="src\Ext\TAction\Body.cpp" />
     <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
     <ClCompile Include="src\Ext\Team\Body.cpp" />
@@ -184,6 +185,7 @@
     <ClInclude Include="src\Ext\Sidebar\Body.h" />
     <ClInclude Include="src\Ext\Anim\Body.h" />
     <ClInclude Include="src\Ext\Surface\Body.h" />
+    <ClInclude Include="src\Ext\SW\Body.h" />
     <ClInclude Include="src\Ext\TAction\Body.h" />
     <ClInclude Include="src\Ext\Team\Body.h" />
     <ClInclude Include="src\Ext\TEvent\Body.h" />

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -648,19 +648,22 @@ Detonate.AtFirer=false  ; boolean
 - When this super weapon is clicked forces a countdown restart.
 - The cost of the super weapon can be substracted in the first click by setting `SW.FirstClickRestartsTimer.Cost` so `Money.Amount` isn't recommended here.
 - `SW.FirstClickRestartsTimer.AutoFire` launchs the super weapon at the end of the first counter restart. Don't use the tag `SW.AutoFire`.
-- `SW.FirstClickRestartsTimer.RefundIfAborted` refunds the paid cost if the SW is no longer available if the restarted countdown haven't finished.
+- `SW.FirstClickRestartsTimer.RefundIfAborted` refunds the restart cost if the SW is no longer available if the restarted countdown haven't finished.
 - Designed with upgrades (or research) in mind, simplifying the number of workarounds. Probably some Ares tags are still recommended for this job.
+- `EVA.RestartedTimer` is used to customize the EVA voice when is clicked the first time.
+- `Message.RestartedTimer` shows a text message when is clicked the first time.
+- `Message.InsufficientFunds=` shows a text message when is clicked the first time and the player doesn'thave the specified ammount in `SW.FirstClickRestartsTimer.Cost`.
 
 In `rulesmd.ini`:
 ```ini
-[SOMESW]                                        ; Super Weapon
-SW.FirstClickRestartsTimer=no                   ; boolean
-SW.FirstClickRestartsTimer.AutoFire=no          ; boolean
-SW.FirstClickRestartsTimer.Cost=0               ; integer, always substract money
-SW.FirstClickRestartsTimer.RefundIfAborted=no   ; boolean
-Message.InsufficientFunds=                      ; CSF entry key
-Message.RestartedTimer=                         ; CSF entry key
-EVA.RestartedTimer=                             ; EVA entry
+[SOMESW]                                          ; Super Weapon
+SW.FirstClickRestartsTimer=false                  ; boolean
+SW.FirstClickRestartsTimer.AutoFire=false         ; boolean
+SW.FirstClickRestartsTimer.Cost=0                 ; integer
+SW.FirstClickRestartsTimer.RefundIfAborted=false  ; boolean
+Message.InsufficientFunds=                        ; CSF entry key
+Message.RestartedTimer=                           ; CSF entry key
+EVA.RestartedTimer=                               ; EVA entry
 ```
 
 ## Technos

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -646,7 +646,6 @@ Detonate.AtFirer=false  ; boolean
 ### Reset timer for SW
 
 - When this super weapon is clicked forces a countdown restart.
-- To make `Warhead or Weapon detonation at target cell` tags work with this feature is needed to set `SW.FirstClickRestartsTimer.ForceDetonations=yes`.
 - The cost of the super weapon can be substracted in the first click by setting `SW.FirstClickRestartsTimer.Cost` so `Money.Amount` isn't recommended here.
 - `SW.FirstClickRestartsTimer.AutoFire` launchs the super weapon at the end of the first counter restart. Don't use the tag `SW.AutoFire`.
 - Designed with upgrades (or research) in mind, simplifiyng the number of workarounds. Probably some Ares tags are still recommended for this job.
@@ -656,7 +655,6 @@ In `rulesmd.ini`:
 [SOMESW]                                        ; Super Weapon
 SW.FirstClickRestartsTimer=no                   ; boolean
 SW.FirstClickRestartsTimer.AutoFire=no          ; boolean
-SW.FirstClickRestartsTimer.ForceDetonations=no  ; boolean
 SW.FirstClickRestartsTimer.Cost=0               ; integer, always substract money
 Message.InsufficientFunds=                      ; CSF entry key
 Message.RestartedTimer=                         ; CSF entry key

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -643,6 +643,26 @@ Detonate.Damage=        ; integer
 Detonate.AtFirer=false  ; boolean
 ```
 
+### Reset timer for SW
+
+- When this super weapon is clicked forces a countdown restart.
+- To make `Warhead or Weapon detonation at target cell` tags work with this feature is needed to set `SW.FirstClickRestartsTimer.AutoFire.ForceDetonations=yes`.
+- The cost of the super weapon can be substracted in the first click by setting `SW.FirstClickRestartsTimer.Cost` so `Money.Amount` isn't recommended here.
+- `SW.FirstClickRestartsTimer.AutoFire` launchs the super weapon at the end of the first counter restart. Don't use the tag `SW.AutoFire`.
+- Designed with upgrades (or research) in mind, simplifiyng the number of workarounds. Probably some Ares tags are still recommended for this job.
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]                                        ; Super Weapon
+SW.FirstClickRestartsTimer=no                   ; boolean
+SW.FirstClickRestartsTimer.AutoFire=no          ; boolean
+SW.FirstClickRestartsTimer.ForceDetonations=no  ; boolean
+SW.FirstClickRestartsTimer.Cost=0               ; integer, always substract money
+Message.InsufficientFunds=                      ; CSF entry key
+Message.RestartedTimer=                         ; CSF entry key
+EVA.RestartedTimer=                             ; EVA entry
+```
+
 ## Technos
 
 ### Automatic passenger deletion

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -648,6 +648,7 @@ Detonate.AtFirer=false  ; boolean
 - When this super weapon is clicked forces a countdown restart.
 - The cost of the super weapon can be substracted in the first click by setting `SW.FirstClickRestartsTimer.Cost` so `Money.Amount` isn't recommended here.
 - `SW.FirstClickRestartsTimer.AutoFire` launchs the super weapon at the end of the first counter restart. Don't use the tag `SW.AutoFire`.
+- `SW.FirstClickRestartsTimer.RefundIfAborted` refunds the paid cost if the SW is no longer available if the restarted countdown haven't finished.
 - Designed with upgrades (or research) in mind, simplifiyng the number of workarounds. Probably some Ares tags are still recommended for this job.
 
 In `rulesmd.ini`:
@@ -656,6 +657,7 @@ In `rulesmd.ini`:
 SW.FirstClickRestartsTimer=no                   ; boolean
 SW.FirstClickRestartsTimer.AutoFire=no          ; boolean
 SW.FirstClickRestartsTimer.Cost=0               ; integer, always substract money
+SW.FirstClickRestartsTimer.RefundIfAborted=no   ; boolean
 Message.InsufficientFunds=                      ; CSF entry key
 Message.RestartedTimer=                         ; CSF entry key
 EVA.RestartedTimer=                             ; EVA entry

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -646,7 +646,7 @@ Detonate.AtFirer=false  ; boolean
 ### Reset timer for SW
 
 - When this super weapon is clicked forces a countdown restart.
-- To make `Warhead or Weapon detonation at target cell` tags work with this feature is needed to set `SW.FirstClickRestartsTimer.AutoFire.ForceDetonations=yes`.
+- To make `Warhead or Weapon detonation at target cell` tags work with this feature is needed to set `SW.FirstClickRestartsTimer.ForceDetonations=yes`.
 - The cost of the super weapon can be substracted in the first click by setting `SW.FirstClickRestartsTimer.Cost` so `Money.Amount` isn't recommended here.
 - `SW.FirstClickRestartsTimer.AutoFire` launchs the super weapon at the end of the first counter restart. Don't use the tag `SW.AutoFire`.
 - Designed with upgrades (or research) in mind, simplifiyng the number of workarounds. Probably some Ares tags are still recommended for this job.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -649,7 +649,7 @@ Detonate.AtFirer=false  ; boolean
 - The cost of the super weapon can be substracted in the first click by setting `SW.FirstClickRestartsTimer.Cost` so `Money.Amount` isn't recommended here.
 - `SW.FirstClickRestartsTimer.AutoFire` launchs the super weapon at the end of the first counter restart. Don't use the tag `SW.AutoFire`.
 - `SW.FirstClickRestartsTimer.RefundIfAborted` refunds the paid cost if the SW is no longer available if the restarted countdown haven't finished.
-- Designed with upgrades (or research) in mind, simplifiyng the number of workarounds. Probably some Ares tags are still recommended for this job.
+- Designed with upgrades (or research) in mind, simplifying the number of workarounds. Probably some Ares tags are still recommended for this job.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -383,6 +383,7 @@ Vanilla fixes:
 - `EMPulseCannon=yes` building weapons now respect `Floater` and Phobos-added `Gravity` setting (by Starkku)
 - Fixed position and layer of info tip and reveal production cameo on selected building (by Belonit)
 - Fixed `TurretOffset` to be supported for SHP vehicles (by TwinkleStar)
+- Reset timer tags for SW (by FS-21)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/RadSite/Body.cpp
+++ b/src/Ext/RadSite/Body.cpp
@@ -141,12 +141,12 @@ double RadSiteExt::ExtData::GetRadLevelAt(CellStruct const& cell) const
 	const auto max = static_cast<double>(pThis->SpreadInLeptons);
 	const auto dist = coords.DistanceFrom(base);
 
-	//  will produce `-nan(ind)` result if both dist and max is zero 
+	//  will produce `-nan(ind)` result if both dist and max is zero
 	// and used on formula below this check
 	// ,.. -Otamaa
 	if(!dist && !max)
 		return pThis->RadLevel;
-	
+
 	return (dist > max) ? 0.0 : (max - dist) / max * pThis->RadLevel;
 }
 

--- a/src/Ext/SW/Body.cpp
+++ b/src/Ext/SW/Body.cpp
@@ -1,0 +1,86 @@
+#include "Body.h"
+
+SuperExt::ExtContainer SuperExt::ExtMap;
+
+// =============================
+// load / save
+
+template <typename T>
+void SuperExt::ExtData::Serialize(T& Stm)
+{
+	Stm
+		.Process(this->TimerRestarted)
+		;
+}
+
+void SuperExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
+{
+	Extension<SuperClass>::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void SuperExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
+{
+	Extension<SuperClass>::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+void SuperExt::ExtData::InvalidatePointer(void* ptr, bool bRemoved)
+{
+	//AnnounceInvalidPointer(SuperLeader, ptr);
+}
+
+// =============================
+// container
+
+SuperExt::ExtContainer::ExtContainer() : Container("SuperClass") { }
+SuperExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// container hooks
+
+//Everything InitEd beside the Vector below this address
+
+DEFINE_HOOK_AGAIN(0x6CAF32, SuperClass_CTOR, 0x6)
+DEFINE_HOOK(0x6CB00A, SuperClass_CTOR, 0x7)
+{
+	GET(SuperClass*, pThis, ESI);
+
+	SuperExt::ExtMap.TryAllocate(pThis);
+
+	return 0;
+}
+
+//before `test` i hope not crash the game ,..
+DEFINE_HOOK(0x6CB1AD, SuperClass_DTOR, 0x6)
+{
+	GET(SuperClass*, pThis, ESI);
+
+	SuperExt::ExtMap.Remove(pThis);
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x6CDEF0, SuperClass_SaveLoad_Prefix, 0x5)
+DEFINE_HOOK(0x6CDFD0, SuperClass_SaveLoad_Prefix, 0x8)
+{
+	GET_STACK(SuperClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	SuperExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6CDFC4, SuperClass_Load_Suffix, 0x7)
+{
+	SuperExt::ExtMap.LoadStatic();
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6CDFEA, SuperClass_Save_Suffix, 0x6)
+{
+	SuperExt::ExtMap.SaveStatic();
+	return 0;
+}

--- a/src/Ext/SW/Body.h
+++ b/src/Ext/SW/Body.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <SuperClass.h>
+
+#include <Helpers/Enumerators.h>
+#include <Helpers/Macro.h>
+#include <Utilities/Container.h>
+#include <Utilities/TemplateDef.h>
+#include <Phobos.h>
+
+class SuperExt
+{
+public:
+	using base_type = SuperClass;
+
+	static constexpr DWORD Canary = 0x37373735;
+	static constexpr size_t ExtPointerOffset = 0x18;
+
+	class ExtData final : public Extension<SuperClass>
+	{
+	public:
+		bool TimerRestarted;
+
+		ExtData(SuperClass* OwnerObject) : Extension<SuperClass>(OwnerObject)
+			, TimerRestarted { false }
+		{ }
+
+		virtual ~ExtData() = default;
+
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override;
+
+		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+	private:
+		template <typename T>
+		void Serialize(T& Stm);
+	};
+
+	class ExtContainer final : public Container<SuperExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+
+		/*virtual bool InvalidateExtDataIgnorable(void* const ptr) const override
+		{
+			auto const abs = static_cast<AbstractClass*>(ptr)->WhatAmI();
+
+			switch (abs)
+			{
+			case AbstractType::Infantry:
+			case AbstractType::Unit:
+			case AbstractType::Aircraft:
+				return false;
+			}
+
+			return true;
+		}*/
+	};
+
+	static ExtContainer ExtMap;
+
+};

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -48,6 +48,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_FirstClickRestartsTimer)
 		.Process(this->SW_FirstClickRestartsTimer_Cost)
 		.Process(this->SW_FirstClickRestartsTimer_AutoFire)
+		.Process(this->SW_FirstClickRestartsTimer_RefundIfAborted)
 		.Process(this->Message_InsufficientFunds)
 		.Process(this->Message_RestartedTimer)
 		.Process(this->EVA_RestartedTimer)
@@ -192,6 +193,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Message_RestartedTimer.Read(exINI, pSection, "Message.RestartedTimer");
 	this->EVA_RestartedTimer.Read(exINI, pSection, "EVA.RestartedTimer");
 	this->SW_FirstClickRestartsTimer_AutoFire.Read(exINI, pSection, "SW.FirstClickRestartsTimer.AutoFire");
+	this->SW_FirstClickRestartsTimer_RefundIfAborted.Read(exINI, pSection, "SW.FirstClickRestartsTimer.RefundIfAborted");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -45,6 +45,14 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ShowTimer_Priority)
 		.Process(this->Convert_Pairs)
 		.Process(this->ShowDesignatorRange)
+		.Process(this->SW_FirstClickRestartsTimer)
+		.Process(this->SW_FirstClickRestartsTimer_Cost)
+		.Process(this->SW_FirstClickRestartsTimer_AutoFire)
+		.Process(this->SW_FirstClickRestartsTimer_AutoFire_ForceDetonations)
+		.Process(this->Message_InsufficientFunds)
+		.Process(this->Message_RestartedTimer)
+		.Process(this->EVA_RestartedTimer)
+		.Process(this->TimerRestarted)
 		;
 }
 
@@ -178,6 +186,14 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	}
 
 	this->ShowDesignatorRange.Read(exINI, pSection, "ShowDesignatorRange");
+
+	this->SW_FirstClickRestartsTimer.Read(exINI, pSection, "SW.FirstClickRestartsTimer");
+	this->SW_FirstClickRestartsTimer_Cost.Read(exINI, pSection, "SW.FirstClickRestartsTimer.Cost");
+	this->Message_InsufficientFunds.Read(exINI, pSection, "Message.InsufficientFunds");
+	this->Message_RestartedTimer.Read(exINI, pSection, "Message.RestartedTimer");
+	this->EVA_RestartedTimer.Read(exINI, pSection, "EVA.RestartedTimer");
+	this->SW_FirstClickRestartsTimer_AutoFire.Read(exINI, pSection, "SW.FirstClickRestartsTimer.AutoFire");
+	this->SW_FirstClickRestartsTimer_AutoFire_ForceDetonations.Read(exINI, pSection, "SW.FirstClickRestartsTimer.AutoFire.ForceDetonations");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -48,7 +48,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_FirstClickRestartsTimer)
 		.Process(this->SW_FirstClickRestartsTimer_Cost)
 		.Process(this->SW_FirstClickRestartsTimer_AutoFire)
-		.Process(this->SW_FirstClickRestartsTimer_AutoFire_ForceDetonations)
+		.Process(this->SW_FirstClickRestartsTimer_ForceDetonations)
 		.Process(this->Message_InsufficientFunds)
 		.Process(this->Message_RestartedTimer)
 		.Process(this->EVA_RestartedTimer)
@@ -193,7 +193,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Message_RestartedTimer.Read(exINI, pSection, "Message.RestartedTimer");
 	this->EVA_RestartedTimer.Read(exINI, pSection, "EVA.RestartedTimer");
 	this->SW_FirstClickRestartsTimer_AutoFire.Read(exINI, pSection, "SW.FirstClickRestartsTimer.AutoFire");
-	this->SW_FirstClickRestartsTimer_AutoFire_ForceDetonations.Read(exINI, pSection, "SW.FirstClickRestartsTimer.AutoFire.ForceDetonations");
+	this->SW_FirstClickRestartsTimer_ForceDetonations.Read(exINI, pSection, "SW.FirstClickRestartsTimer.ForceDetonations");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -48,7 +48,6 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_FirstClickRestartsTimer)
 		.Process(this->SW_FirstClickRestartsTimer_Cost)
 		.Process(this->SW_FirstClickRestartsTimer_AutoFire)
-		.Process(this->SW_FirstClickRestartsTimer_ForceDetonations)
 		.Process(this->Message_InsufficientFunds)
 		.Process(this->Message_RestartedTimer)
 		.Process(this->EVA_RestartedTimer)
@@ -193,7 +192,6 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Message_RestartedTimer.Read(exINI, pSection, "Message.RestartedTimer");
 	this->EVA_RestartedTimer.Read(exINI, pSection, "EVA.RestartedTimer");
 	this->SW_FirstClickRestartsTimer_AutoFire.Read(exINI, pSection, "SW.FirstClickRestartsTimer.AutoFire");
-	this->SW_FirstClickRestartsTimer_ForceDetonations.Read(exINI, pSection, "SW.FirstClickRestartsTimer.ForceDetonations");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -67,7 +67,7 @@ public:
 		Valueable<bool> SW_FirstClickRestartsTimer;
 		Valueable<int> SW_FirstClickRestartsTimer_Cost;
 		Valueable<bool> SW_FirstClickRestartsTimer_AutoFire;
-		Valueable<bool> SW_FirstClickRestartsTimer_AutoFire_ForceDetonations;
+		Valueable<bool> SW_FirstClickRestartsTimer_ForceDetonations;
 		Valueable<CSFText> Message_InsufficientFunds;
 		Valueable<CSFText> Message_RestartedTimer;
 		NullableIdx<VoxClass> EVA_RestartedTimer;
@@ -110,7 +110,7 @@ public:
 			, SW_FirstClickRestartsTimer { false }
 			, SW_FirstClickRestartsTimer_Cost { 0 }
 			, SW_FirstClickRestartsTimer_AutoFire { false }
-			, SW_FirstClickRestartsTimer_AutoFire_ForceDetonations { false }
+			, SW_FirstClickRestartsTimer_ForceDetonations { false }
 			, Message_RestartedTimer {}
 			, Message_InsufficientFunds {}
 			, EVA_RestartedTimer {}

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -63,6 +63,15 @@ public:
 
 		std::vector<TypeConvertGroup> Convert_Pairs;
 
+		Valueable<bool> TimerRestarted;
+		Valueable<bool> SW_FirstClickRestartsTimer;
+		Valueable<int> SW_FirstClickRestartsTimer_Cost;
+		Valueable<bool> SW_FirstClickRestartsTimer_AutoFire;
+		Valueable<bool> SW_FirstClickRestartsTimer_AutoFire_ForceDetonations;
+		Valueable<CSFText> Message_InsufficientFunds;
+		Valueable<CSFText> Message_RestartedTimer;
+		NullableIdx<VoxClass> EVA_RestartedTimer;
+
 		ExtData(SuperWeaponTypeClass* OwnerObject) : Extension<SuperWeaponTypeClass>(OwnerObject)
 			, Money_Amount { 0 }
 			, SW_Inhibitors {}
@@ -98,6 +107,14 @@ public:
 			, ShowTimer_Priority { 0 }
 			, Convert_Pairs {}
 			, ShowDesignatorRange { true }
+			, SW_FirstClickRestartsTimer { false }
+			, SW_FirstClickRestartsTimer_Cost { 0 }
+			, SW_FirstClickRestartsTimer_AutoFire { false }
+			, SW_FirstClickRestartsTimer_AutoFire_ForceDetonations { false }
+			, Message_RestartedTimer {}
+			, Message_InsufficientFunds {}
+			, EVA_RestartedTimer {}
+			, TimerRestarted { false }
 		{ }
 
 		// Ares 0.A functions
@@ -114,7 +131,7 @@ public:
 
 		void ApplyLimboDelivery(HouseClass* pHouse);
 		void ApplyLimboKill(HouseClass* pHouse);
-		void ApplyDetonation(HouseClass* pHouse, const CellStruct& cell);
+		void ApplyDetonation(HouseClass* pHouse, const CellStruct& cell, bool forceDetonation = false);
 		void ApplySWNext(SuperClass* pSW, const CellStruct& cell);
 		void ApplyTypeConversion(SuperClass* pSW);
 

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -68,6 +68,7 @@ public:
 		Valueable<bool> SW_FirstClickRestartsTimer;
 		Valueable<int> SW_FirstClickRestartsTimer_Cost;
 		Valueable<bool> SW_FirstClickRestartsTimer_AutoFire;
+		Valueable<bool> SW_FirstClickRestartsTimer_RefundIfAborted;
 		Valueable<CSFText> Message_InsufficientFunds;
 		Valueable<CSFText> Message_RestartedTimer;
 		NullableIdx<VoxClass> EVA_RestartedTimer;
@@ -110,6 +111,7 @@ public:
 			, SW_FirstClickRestartsTimer { false }
 			, SW_FirstClickRestartsTimer_Cost { 0 }
 			, SW_FirstClickRestartsTimer_AutoFire { false }
+			, SW_FirstClickRestartsTimer_RefundIfAborted { false }
 			, Message_RestartedTimer {}
 			, Message_InsufficientFunds {}
 			, EVA_RestartedTimer {}

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -131,7 +131,7 @@ public:
 
 		void ApplyLimboDelivery(HouseClass* pHouse);
 		void ApplyLimboKill(HouseClass* pHouse);
-		void ApplyDetonation(HouseClass* pHouse, const CellStruct& cell, bool forceDetonation = false);
+		void ApplyDetonation(HouseClass* pHouse, const CellStruct& cell);
 		void ApplySWNext(SuperClass* pSW, const CellStruct& cell);
 		void ApplyTypeConversion(SuperClass* pSW);
 

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -7,6 +7,7 @@
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
 
+#include <Ext/SW/Body.h>
 #include <Ext/Building/Body.h>
 #include <Misc/TypeConvertHelper.h>
 
@@ -67,7 +68,6 @@ public:
 		Valueable<bool> SW_FirstClickRestartsTimer;
 		Valueable<int> SW_FirstClickRestartsTimer_Cost;
 		Valueable<bool> SW_FirstClickRestartsTimer_AutoFire;
-		Valueable<bool> SW_FirstClickRestartsTimer_ForceDetonations;
 		Valueable<CSFText> Message_InsufficientFunds;
 		Valueable<CSFText> Message_RestartedTimer;
 		NullableIdx<VoxClass> EVA_RestartedTimer;
@@ -110,7 +110,6 @@ public:
 			, SW_FirstClickRestartsTimer { false }
 			, SW_FirstClickRestartsTimer_Cost { 0 }
 			, SW_FirstClickRestartsTimer_AutoFire { false }
-			, SW_FirstClickRestartsTimer_ForceDetonations { false }
 			, Message_RestartedTimer {}
 			, Message_InsufficientFunds {}
 			, EVA_RestartedTimer {}

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -240,7 +240,7 @@ void SWTypeExt::ExtData::ApplyDetonation(HouseClass* pHouse, const CellStruct& c
 	const auto pWeapon = this->Detonate_Weapon.isset() ? this->Detonate_Weapon.Get() : nullptr;
 	auto const mapCoords = CellClass::Coord2Cell(coords);
 
-	if (!MapClass::Instance->CoordinatesLegal(mapCoords))
+	if (!MapClass::Instance->CoordinatesLegal(mapCoords) && !this->SW_FirstClickRestartsTimer_AutoFire_ForceDetonations)
 	{
 		auto const ID = pWeapon ? pWeapon->get_ID() : this->Detonate_Warhead.Get()->get_ID();
 		Debug::Log("ApplyDetonation: Superweapon [%s] failed to detonate [%s] - cell at %d, %d is invalid.\n", this->OwnerObject()->get_ID(), ID, mapCoords.X, mapCoords.Y);

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -240,7 +240,7 @@ void SWTypeExt::ExtData::ApplyDetonation(HouseClass* pHouse, const CellStruct& c
 	const auto pWeapon = this->Detonate_Weapon.isset() ? this->Detonate_Weapon.Get() : nullptr;
 	auto const mapCoords = CellClass::Coord2Cell(coords);
 
-	if (!MapClass::Instance->CoordinatesLegal(mapCoords) && !this->SW_FirstClickRestartsTimer_AutoFire_ForceDetonations)
+	if (!MapClass::Instance->CoordinatesLegal(mapCoords) && !this->SW_FirstClickRestartsTimer_ForceDetonations)
 	{
 		auto const ID = pWeapon ? pWeapon->get_ID() : this->Detonate_Warhead.Get()->get_ID();
 		Debug::Log("ApplyDetonation: Superweapon [%s] failed to detonate [%s] - cell at %d, %d is invalid.\n", this->OwnerObject()->get_ID(), ID, mapCoords.X, mapCoords.Y);

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -240,7 +240,7 @@ void SWTypeExt::ExtData::ApplyDetonation(HouseClass* pHouse, const CellStruct& c
 	const auto pWeapon = this->Detonate_Weapon.isset() ? this->Detonate_Weapon.Get() : nullptr;
 	auto const mapCoords = CellClass::Coord2Cell(coords);
 
-	if (!MapClass::Instance->CoordinatesLegal(mapCoords) && !this->SW_FirstClickRestartsTimer_ForceDetonations)
+	if (!MapClass::Instance->CoordinatesLegal(mapCoords))
 	{
 		auto const ID = pWeapon ? pWeapon->get_ID() : this->Detonate_Warhead.Get()->get_ID();
 		Debug::Log("ApplyDetonation: Superweapon [%s] failed to detonate [%s] - cell at %d, %d is invalid.\n", this->OwnerObject()->get_ID(), ID, mapCoords.X, mapCoords.Y);

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -1,6 +1,8 @@
 #include "Body.h"
 
 #include <SuperClass.h>
+#include <MessageListClass.h>
+#include <Utilities/AresFunctions.h>
 
 //Ares hooked at 0x6CC390 and jumped to 0x6CDE40
 // If a super is not handled by Ares however, we do it at the original entry point
@@ -70,6 +72,87 @@ DEFINE_HOOK(0x6DBE74, Tactical_SuperLinesCircles_ShowDesignatorRange, 0x7)
 		coords.Z = MapClass::Instance->GetCellFloorHeight(coords);
 		const auto color = pOwner->Color;
 		Game::DrawRadialIndicator(false, true, coords, color, radius, false, true);
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6AAEAC, SuperClass_Place_ResetTimer, 0x6)
+{
+	GET(int, idxSW, EDX);
+
+	SuperClass* pSuper = HouseClass::CurrentPlayer->Supers.GetItem(idxSW);
+	if (!pSuper)
+		return 0;
+
+	SWTypeExt::ExtData* pData = SWTypeExt::ExtMap.Find(pSuper->Type);
+	if (!pData)
+		return 0;
+
+	if (!pSuper->IsCharged)
+		return 0;
+
+	if (!pData->SW_FirstClickRestartsTimer)
+		return 0;
+
+	if (!pData->TimerRestarted)
+	{
+		// In case of require money prevent firing the SW if the player doesn't have sufficient funds
+		int cost = pData->SW_FirstClickRestartsTimer_Cost;
+		if (cost > 0)
+			cost *= -1;
+
+		if (cost != 0)
+		{
+			if (!HouseClass::CurrentPlayer->CanTransactMoney(cost))
+			{
+				VoxClass::Play(GameStrings::EVA_InsufficientFunds);
+				MessageListClass::Instance->PrintMessage(pData->Message_InsufficientFunds.Get(), RulesClass::Instance->MessageDelay, HouseClass::CurrentPlayer->ColorSchemeIndex, true);
+
+				return 0x6AB95A;
+			}
+
+			HouseClass::CurrentPlayer->TransactMoney(cost);
+		}
+
+		if (pData->EVA_RestartedTimer.isset())
+			VoxClass::PlayIndex(pData->EVA_RestartedTimer.Get());
+
+		MessageListClass::Instance->PrintMessage(pData->Message_RestartedTimer.Get(), RulesClass::Instance->MessageDelay, HouseClass::CurrentPlayer->ColorSchemeIndex, true);
+
+		pData->TimerRestarted = true;
+		pSuper->Reset();
+
+		return 0x6AB95A;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6CBD13, SuperClass_Place_ResetTimer_AutoFire, 0x6)
+{
+	GET(SuperClass*, pSuper, ESI);
+
+	SWTypeExt::ExtData* pData = SWTypeExt::ExtMap.Find(pSuper->Type);
+	if (!pData)
+		return 0;
+
+	if (!pSuper->IsCharged)
+		return 0;
+
+	if (!pData->SW_FirstClickRestartsTimer)
+		return 0;
+
+	if (!pData->TimerRestarted)
+		return 0;
+
+	if (pData->SW_FirstClickRestartsTimer_AutoFire)
+	{
+		pSuper->Launch(CellStruct::Empty, HouseClass::CurrentPlayer->IsCurrentPlayer());
+		pSuper->Reset();
+		SWTypeExt::FireSuperWeaponExt(pSuper, CellStruct::Empty);
+
+		return 0x6CBD2F;
 	}
 
 	return 0;

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -103,8 +103,6 @@ DEFINE_HOOK(0x6AAEAC, SuperClass_Place_ResetTimer, 0x6)
 	{
 		// In case of require money prevent firing the SW if the player doesn't have sufficient funds
 		int cost = pTypeData->SW_FirstClickRestartsTimer_Cost;
-		if (cost > 0)
-			cost *= -1;
 
 		if (cost != 0)
 		{
@@ -185,7 +183,12 @@ DEFINE_HOOK(0x6CBCD4, SuperClass_AI_ResetTimer_Update, 0x5)
 		pExt->TimerRestarted = false;
 
 		if (pTypeData->SW_FirstClickRestartsTimer_RefundIfAborted)
-			HouseClass::CurrentPlayer->TransactMoney(std::abs(pTypeData->SW_FirstClickRestartsTimer_Cost));
+		{
+			int cost = -1 * pTypeData->SW_FirstClickRestartsTimer_Cost;
+
+			if (HouseClass::CurrentPlayer->CanTransactMoney(cost))
+				HouseClass::CurrentPlayer->TransactMoney(cost);
+		}
 	}
 
 	return 0;

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -165,6 +165,19 @@ void PhobosToolTip::HelpText(SuperWeaponTypeClass* pType)
 		oss << Phobos::UI::CostLabel << nCost;
 		showCost = true;
 	}
+	else if (!pData->TimerRestarted)
+	{
+		if (nCost = std::abs(pData->SW_FirstClickRestartsTimer_Cost))
+		{
+			oss << L"\n";
+
+			if (pData->SW_FirstClickRestartsTimer_Cost > 0)
+				oss << '+';
+
+			oss << Phobos::UI::CostLabel << nCost;
+			showCost = true;
+		}
+	}
 
 	if (pType->RechargeTime > 0)
 	{


### PR DESCRIPTION
- When this super weapon is clicked forces a countdown restart.
- To make `Warhead or Weapon detonation at target cell` tags work with this feature is needed to set `SW.FirstClickRestartsTimer.ForceDetonations=yes`.
- The cost of the super weapon can be substracted in the first click by setting `SW.FirstClickRestartsTimer.Cost` so `Money.Amount` isn't recommended here.
- `SW.FirstClickRestartsTimer.AutoFire` launchs the super weapon at the end of the first counter restart. Don't use the tag `SW.AutoFire`.
- `SW.FirstClickRestartsTimer.RefundIfAborted` refunds the paid cost if the SW is no longer available if the restarted countdown haven't finished.
- Designed with upgrades (or research) in mind, simplifying the number of workarounds. Probably some Ares tags are still recommended for this job.

In `rulesmd.ini`:

[SOMESW]                                        ; Super Weapon
SW.FirstClickRestartsTimer=no                   ; boolean
SW.FirstClickRestartsTimer.AutoFire=no          ; boolean
SW.FirstClickRestartsTimer.Cost=0               ; integer, always substract money
SW.FirstClickRestartsTimer.RefundIfAborted=no  ; boolean
Message.InsufficientFunds=                      ; CSF entry key
Message.RestartedTimer=                         ; CSF entry key
EVA.RestartedTimer=                             ; EVA entry

