### PR TITLE
[Minor] Add separate tag for grid transparency when PlacementPreview is enabled

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -178,7 +178,7 @@ DisplayIncome.Offset=0,0  ; X,Y, pixels relative to default
 *Building placement preview using 50% translucency in [Rise of the East](https://www.moddb.com/mods/riseoftheeast)*
 
 - Building previews can now be enabled when placing a building for construction. This can be enabled on a global basis with `[AudioVisual]->PlacementPreview` and then further customized for each building with `[SOMEBUILDING]->PlacementPreview`.
-- The building placement grid (`place.shp`) translucency setting can be adjusted via `PlacementGrid.Translucency` if `PlacementPreview` is disabled and `PlacementPreview.Grid.Translucency` if enabled.
+- The building placement grid (`place.shp`) translucency setting can be adjusted via `PlacementGrid.Translucency` if `PlacementPreview` is disabled and `PlacementGrid.TranslucencyWithPreview` if enabled.
 - If using the building's appropriate `Buildup` is not desired, customizations allow for you to choose the exact SHP and frame you'd prefer to show as preview through `PlacementPreview.Shape`, `PlacementPreview.ShapeFrame` and `PlacementPreview.Palette`.
   - You can specify theater-specific palettes and shapes by putting three `~` marks to the theater specific part of the filename. `~~~` is replaced with the theater’s three-letter extension.
 - `PlacementPreview.ShapeFrame=` tag defaults to building's artmd.ini `Buildup` entry's last non-shadow frame. If there is no 'Buildup' specified it will instead attempt to default to the building's normal first frame (animation frames and bibs are not included in this preview).
@@ -186,11 +186,11 @@ DisplayIncome.Offset=0,0  ; X,Y, pixels relative to default
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
-PlacementGrid.Translucency=0         ; translucency level (0/25/50/75)
+PlacementGrid.Translucency=0            ; translucency level (0/25/50/75)
+PlacementGrid.TranslucencyWithPreview=  ; translucency level (0/25/50/75), defaults to [AudioVisual]->PlacementGrid.Translucency
 
 PlacementPreview=no                  ; boolean
 PlacementPreview.Translucency=75     ; translucency level (0/25/50/75)
-PlacementPreview.Grid.Translucency=  ; translucency level (0/25/50/75), defaults to [AudioVisual]->PlacementGrid.Translucency
 
 [SOMEBUILDING]
 PlacementPreview=yes                 ; boolean

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -178,7 +178,7 @@ DisplayIncome.Offset=0,0  ; X,Y, pixels relative to default
 *Building placement preview using 50% translucency in [Rise of the East](https://www.moddb.com/mods/riseoftheeast)*
 
 - Building previews can now be enabled when placing a building for construction. This can be enabled on a global basis with `[AudioVisual]->PlacementPreview` and then further customized for each building with `[SOMEBUILDING]->PlacementPreview`.
-- The building placement grid (`place.shp`) translucency setting can be adjusted via `PlacementGrid.Translucency`.
+- The building placement grid (`place.shp`) translucency setting can be adjusted via `PlacementGrid.Translucency` if `PlacementPreview` is disabled and `PlacementPreview.Grid.Translucency` if enabled.
 - If using the building's appropriate `Buildup` is not desired, customizations allow for you to choose the exact SHP and frame you'd prefer to show as preview through `PlacementPreview.Shape`, `PlacementPreview.ShapeFrame` and `PlacementPreview.Palette`.
   - You can specify theater-specific palettes and shapes by putting three `~` marks to the theater specific part of the filename. `~~~` is replaced with the theater’s three-letter extension.
 - `PlacementPreview.ShapeFrame=` tag defaults to building's artmd.ini `Buildup` entry's last non-shadow frame. If there is no 'Buildup' specified it will instead attempt to default to the building's normal first frame (animation frames and bibs are not included in this preview).
@@ -186,9 +186,11 @@ DisplayIncome.Offset=0,0  ; X,Y, pixels relative to default
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
+PlacementGrid.Translucency=0         ; translucency level (0/25/50/75)
+
 PlacementPreview=no                  ; boolean
 PlacementPreview.Translucency=75     ; translucency level (0/25/50/75)
-PlacementGrid.Translucency=0         ; translucency level (0/25/50/75)
+PlacementPreview.Grid.Translucency=  ; translucency level (0/25/50/75), defaults to [AudioVisual]->PlacementGrid.Translucency
 
 [SOMEBUILDING]
 PlacementPreview=yes                 ; boolean

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -349,7 +349,7 @@ New:
 - Customizable straight trajectory detonation & snap distance and pass-through option (by Starkku)
 - Airstrike & spy plane fixed spawn distance & height (by Starkku)
 - Allow enabling application of `Verses` and `PercentAtMax` for negative damage (by Starkku)
-- In addition to `PlacementGrid.Translucency`, allow to set the transparency of the grid when PlacementPreview is enabled, using the `PlacementPreview.Grid.Translucency` tag (by Belonit).
+- In addition to `PlacementGrid.Translucency`, allow to set the transparency of the grid when PlacementPreview is enabled, using the `PlacementGrid.TranslucencyWithPreview` tag (by Belonit).
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -349,6 +349,7 @@ New:
 - Customizable straight trajectory detonation & snap distance and pass-through option (by Starkku)
 - Airstrike & spy plane fixed spawn distance & height (by Starkku)
 - Allow enabling application of `Verses` and `PercentAtMax` for negative damage (by Starkku)
+- In addition to `PlacementGrid.Translucency`, allow to set the transparency of the grid when PlacementPreview is enabled, using the `PlacementPreview.Grid.Translucency` tag (by Belonit).
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -139,9 +139,17 @@ DEFINE_HOOK(0x6D528A, TacticalClass_DrawPlacement_PlacementPreview, 0x6)
 
 DEFINE_HOOK(0x47EFAE, CellClass_Draw_It_SetPlacementGridTranslucency, 0x6)
 {
-	LEA_STACK(BlitterFlags*, blitFlags, STACK_OFFSET(0x68, -0x58));
+	auto pRules = RulesExt::Global();
+	BlitterFlags translucency = (pRules->PlacementPreview && Phobos::Config::ShowPlacementPreview)
+		? pRules->PlacementPreview_Grid_Translucency.Get(pRules->PlacementGrid_Translucency)
+		: pRules->PlacementGrid_Translucency;
 
-	*blitFlags |= RulesExt::Global()->PlacementGrid_Translucency;
+	if (translucency != BlitterFlags::None)
+	{
+		LEA_STACK(BlitterFlags*, blitFlags, STACK_OFFSET(0x68, -0x58));
+		*blitFlags |= translucency;
+	}
+
 	return 0;
 }
 

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -141,7 +141,7 @@ DEFINE_HOOK(0x47EFAE, CellClass_Draw_It_SetPlacementGridTranslucency, 0x6)
 {
 	auto pRules = RulesExt::Global();
 	BlitterFlags translucency = (pRules->PlacementPreview && Phobos::Config::ShowPlacementPreview)
-		? pRules->PlacementPreview_Grid_Translucency.Get(pRules->PlacementGrid_Translucency)
+		? pRules->PlacementGrid_TranslucencyWithPreview.Get(pRules->PlacementGrid_Translucency)
 		: pRules->PlacementGrid_Translucency;
 
 	if (translucency != BlitterFlags::None)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -83,9 +83,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->MissingCameo.Read(pINI, GameStrings::AudioVisual, "MissingCameo");
 
 	this->PlacementGrid_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.Translucency");
+	this->PlacementGrid_TranslucencyWithPreview.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.TranslucencyWithPreview");
 	this->PlacementPreview.Read(exINI, GameStrings::AudioVisual, "PlacementPreview");
 	this->PlacementPreview_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Translucency");
-	this->PlacementPreview_Grid_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Grid.Translucency");
 
 	this->Pips_Shield.Read(exINI, GameStrings::AudioVisual, "Pips.Shield");
 	this->Pips_Shield_Background.Read(exINI, GameStrings::AudioVisual, "Pips.Shield.Background");
@@ -223,9 +223,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->MissingCameo)
 		.Process(this->PlacementGrid_Translucency)
+		.Process(this->PlacementGrid_TranslucencyWithPreview)
 		.Process(this->PlacementPreview)
 		.Process(this->PlacementPreview_Translucency)
-		.Process(this->PlacementPreview_Grid_Translucency)
 		.Process(this->Pips_Shield)
 		.Process(this->Pips_Shield_Background)
 		.Process(this->Pips_Shield_Building)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -82,9 +82,11 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->RadHasInvoker.Read(exINI, GameStrings::Radiation, "RadHasInvoker");
 	this->MissingCameo.Read(pINI, GameStrings::AudioVisual, "MissingCameo");
 
+	this->PlacementGrid_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.Translucency");
 	this->PlacementPreview.Read(exINI, GameStrings::AudioVisual, "PlacementPreview");
 	this->PlacementPreview_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Translucency");
-	this->PlacementGrid_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.Translucency");
+	this->PlacementPreview_Grid_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Grid.Translucency");
+
 	this->Pips_Shield.Read(exINI, GameStrings::AudioVisual, "Pips.Shield");
 	this->Pips_Shield_Background.Read(exINI, GameStrings::AudioVisual, "Pips.Shield.Background");
 	this->Pips_Shield_Building.Read(exINI, GameStrings::AudioVisual, "Pips.Shield.Building");
@@ -223,6 +225,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->PlacementGrid_Translucency)
 		.Process(this->PlacementPreview)
 		.Process(this->PlacementPreview_Translucency)
+		.Process(this->PlacementPreview_Grid_Translucency)
 		.Process(this->Pips_Shield)
 		.Process(this->Pips_Shield_Background)
 		.Process(this->Pips_Shield_Building)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -50,9 +50,9 @@ public:
 		PhobosFixedString<32u> MissingCameo;
 
 		TranslucencyLevel PlacementGrid_Translucency;
+		Nullable<TranslucencyLevel> PlacementGrid_TranslucencyWithPreview;
 		Valueable<bool> PlacementPreview;
 		TranslucencyLevel PlacementPreview_Translucency;
-		Nullable<TranslucencyLevel> PlacementPreview_Grid_Translucency;
 
 		Valueable<Vector3D<int>> Pips_Shield;
 		Nullable<SHPStruct*> Pips_Shield_Background;
@@ -124,9 +124,9 @@ public:
 			, MissingCameo { GameStrings::XXICON_SHP() }
 
 			, PlacementGrid_Translucency { 0 }
+			, PlacementGrid_TranslucencyWithPreview { }
 			, PlacementPreview { false }
 			, PlacementPreview_Translucency { 75 }
-			, PlacementPreview_Grid_Translucency { }
 
 			, Pips_Shield_Background { }
 			, Pips_Shield_Building { { -1,-1,-1 } }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -48,9 +48,12 @@ public:
 		Valueable<bool> JumpjetNoWobbles;
 
 		PhobosFixedString<32u> MissingCameo;
+
 		TranslucencyLevel PlacementGrid_Translucency;
 		Valueable<bool> PlacementPreview;
 		TranslucencyLevel PlacementPreview_Translucency;
+		Nullable<TranslucencyLevel> PlacementPreview_Grid_Translucency;
+
 		Valueable<Vector3D<int>> Pips_Shield;
 		Nullable<SHPStruct*> Pips_Shield_Background;
 		Valueable<Vector3D<int>> Pips_Shield_Building;
@@ -119,9 +122,12 @@ public:
 			, JumpjetCrash { 5.0 }
 			, JumpjetNoWobbles { false }
 			, MissingCameo { GameStrings::XXICON_SHP() }
+
 			, PlacementGrid_Translucency { 0 }
 			, PlacementPreview { false }
 			, PlacementPreview_Translucency { 75 }
+			, PlacementPreview_Grid_Translucency { }
+
 			, Pips_Shield_Background { }
 			, Pips_Shield_Building { { -1,-1,-1 } }
 			, Pips_Shield_Building_Empty { }


### PR DESCRIPTION
```ini
[AudioVisual]
PlacementGrid.TranslucencyWithPreview=  ; translucency level (0/25/50/75), defaults to [AudioVisual]->PlacementGrid.Translucency
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced building placement previews with customization options for the grid's appearance.
	- Added setting for adjusting grid translucency during building placement.

- **Documentation**
	- Updated user interface documentation with new placement preview features.
	- Added details on the latest features to the "What's New" documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->