### PR TITLE
Experimental multithread mode for single player

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -236,6 +236,7 @@ This page lists all the individual contributions to the project by their author.
   - Show designator & inhibitor range
   - Dump variables to file on scenario end / hotkey
   - "House owns TechnoType" and "House doesn't own TechnoType" trigger events
+  - Multithreading for single player modes
   - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="src\Utilities\AresHelper.cpp" />
     <ClCompile Include="src\Utilities\AresAddressTable.cpp" />
     <ClCompile Include="src\Misc\SyncLogging.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Multithread.cpp" />
     <ClCompile Include="YRpp\StaticInits.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -163,6 +163,17 @@ function onInput() {
 }
 </script>
 
+### Single player multithreading
+
+- It is now possible to use **experimental** multithreading support for single player modes (campaign and skirmish) to improve game performance.
+- This feature must be enabled using with `MultiThreadSinglePlayer=true`.
+
+In `rulesmd.ini`:
+```ini
+[General]
+MultiThreadSinglePlayer=true    ; boolean
+```
+
 ## INI
 
 ### Include files

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -355,6 +355,7 @@ New:
 - Allow setting default singleplayer map loading screen and briefing offsets (by Starkku)
 - Allow toggling whether or not fire particle systems adjust target coordinates when firer rotates (by Starkku)
 - `AmbientDamage` warhead & main target ignore customization (by Starkku)
+- Multithreading for single player modes (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Misc/Hooks.Multithread.cpp
+++ b/src/Misc/Hooks.Multithread.cpp
@@ -177,7 +177,7 @@ DEFINE_HOOK(0x4F4480, GScreenClass_Render_Disable, 8)
 
 // We want to lock access to game resources when we're doing game logic potientially related to graphics.
 // The main thread should let the drawing thread run if it complains that it's too hungry and vice versa.
-// TODO: Try to hook later for shorter lock period.
+DEFINE_HOOK_AGAIN(0x55DBC3, MainLoop_StartLock_2, 5)
 DEFINE_HOOK(0x55D878, MainLoop_StartLock, 6)
 {
 	if (!Multithreading::IsMultithreadMode)
@@ -197,7 +197,7 @@ DEFINE_HOOK(0x55D878, MainLoop_StartLock, 6)
 }
 
 // See above.
-// TODO: Try to hook sooner for shorter lock period.
+DEFINE_HOOK_AGAIN(0x55D903, MainLoop_StopLock_2, 7)
 DEFINE_HOOK(0x55DDA0, MainLoop_StopLock, 5)
 {
 	if (!Multithreading::IsMultithreadMode)

--- a/src/Misc/Hooks.Multithread.cpp
+++ b/src/Misc/Hooks.Multithread.cpp
@@ -1,0 +1,167 @@
+#include <Helpers/Macro.h>
+
+#include <GScreenClass.h>
+#include <WWMouseClass.h>
+#include <TacticalClass.h>
+#include <GadgetClass.h>
+#include <MessageListClass.h>
+#include <CCToolTip.h>
+#include <MouseClass.h>
+
+#include <thread>
+
+namespace Multithreading
+{
+	static constexpr reference<bool, 0xB0B519u> const BlitMouse {};
+	static constexpr reference<bool, 0xA9FAB0u> const IonStormClass_ChronoScreenEffect_Status {};
+	static constexpr reference<GadgetClass*, 0xA8EF54u> const Buttons {};
+	static constexpr reference<bool, 0xA8ED6Bu> const DebugDebugDebug {};
+	static constexpr reference<bool, 0xA8B8B4u> const EnableMultiplayerDebug {};
+
+	std::thread DrawingThread;
+	bool SomethingWentWrong = false;
+	bool InGameLoop = false;
+	bool IsPaused = false;
+
+	void MultiplayerDebugPrint()
+		{ JMP_STD(0x55F1E0); }
+
+	void Render(GScreenClass* pThis)
+	{
+		auto pTempSurface = DSurface::Temp.get();
+		DSurface::Temp = DSurface::Composite;
+		WWMouseClass::Instance->func_40(DSurface::Composite, false);
+
+		bool shouldDraw = pThis->Bitfield != 0;
+		bool complete = pThis->Bitfield == 2;
+		pThis->Bitfield = 0;
+
+		if (!IonStormClass_ChronoScreenEffect_Status)
+		{
+			TacticalClass::Instance->Render(DSurface::Composite, shouldDraw, 0);
+			TacticalClass::Instance->Render(DSurface::Composite, shouldDraw, 1);
+			pThis->Draw(complete);
+			TacticalClass::Instance->Render(DSurface::Composite, shouldDraw, 2);
+		}
+
+		if (BlitMouse.get() && !DebugDebugDebug.get())
+		{
+			WWMouseClass::Instance->func_40(DSurface::Sidebar, true);
+			BlitMouse = false;
+		}
+
+		if (Buttons.get())
+			Buttons->DrawAll(false);
+
+		MessageListClass::Instance->Draw();
+
+		if (CCToolTip::Instance.get())
+			CCToolTip::Instance->Draw(false);
+
+		if (EnableMultiplayerDebug.get())
+			MultiplayerDebugPrint();
+
+		WWMouseClass::Instance->func_3C(DSurface::Composite, false);
+		pThis->vt_entry_44();
+
+		DSurface::Temp = pTempSurface;
+	}
+
+	void DrawingLoop()
+	{
+		while (InGameLoop)
+		{
+			// A failed attempt at smooth mouse handling outside of the mouse thread
+			/*
+			if ((WWMouseClass::Instance->XYOld.X != WWMouseClass::Instance->XY1.X)
+				|| (WWMouseClass::Instance->XYOld.Y != WWMouseClass::Instance->XY1.Y)
+				|| WWMouseClass::DoneSomething.get())
+			{
+				WWMouseClass::Instance->SomeBlit();
+				WWMouseClass::Instance->SomeDraw(WWMouseClass::Instance->Surface, 0, 0);
+			}
+			*/
+
+			// TODO: Exit when the main thread raises an exception (how can we know that?)
+			if (SomethingWentWrong)
+				return;
+
+			// NOTE: Busy wait is the worst, but let's leave performance for later :)
+			if (!IsPaused)
+				Render(MouseClass::Instance);
+		}
+	}
+}
+
+DEFINE_HOOK(0x48CE7E, MainGame_BeforeGameLoop, 7)
+{
+	Multithreading::InGameLoop = true;
+	Multithreading::DrawingThread = std::thread(Multithreading::DrawingLoop);
+	return 0;
+}
+
+DEFINE_HOOK(0x48CEAF, MainGame_AfterGameLoop, 5)
+{
+	Multithreading::InGameLoop = false;
+	Multithreading::DrawingThread.detach();
+	Multithreading::DrawingThread.~thread();
+	return 0;
+}
+
+DEFINE_HOOK(0x4F4480, GScreenClass_Render_Disable, 0)
+{
+	return 0x4F45A8;
+}
+
+DEFINE_HOOK(0x683EB6, PauseGame_SetPause, 6)
+{
+	Multithreading::IsPaused = true;
+	return 0;
+}
+
+DEFINE_HOOK(0x683FB2, ResmueGame_ResetPause, 5)
+{
+	Multithreading::IsPaused = false;
+	return 0;
+}
+
+// Main stuff
+/*
+DEFINE_HOOK(0x55D84F, MainLoop_SkipRender_1, 0)
+{
+	return 0x55D854;
+}
+
+DEFINE_HOOK(0x55D8F2, MainLoop_SkipRender_2, 0)
+{
+	return 0x55D8F7;
+}
+
+DEFINE_HOOK(0x55DBBE, MainLoop_SkipRender_3, 0)
+{
+	return 0x55DBC3;
+}
+
+DEFINE_HOOK(0x53B66B, MainLoop_SkipRender_3, 0)
+{
+	return 0x53B670;
+}
+
+DEFINE_HOOK(0x683F95, PauseGame_SkipRender, 0)
+{
+	return 0x683F9F;
+}
+*/
+
+// Mouse stuff
+/*
+DEFINE_HOOK(0x7BA204, ProcessMouse_SkipBlit_1, 0)
+{
+	return 0x7BA20B;
+}
+
+DEFINE_HOOK(0x7BA26C, ProcessMouse_SkipBlit_2, 0)
+{
+	return 0x7BA282;
+}
+*/

--- a/src/Misc/Hooks.Multithread.cpp
+++ b/src/Misc/Hooks.Multithread.cpp
@@ -212,7 +212,7 @@ DEFINE_HOOK(0x4F4480, GScreenClass_Render_Disable, 8)
 
 // We want to lock access to game resources when we're doing game logic potientially related to graphics.
 // The main thread should let the drawing thread run if it complains that it's too hungry and vice versa.
-DEFINE_HOOK_AGAIN(0x55DBC3, MainLoop_StartLock_2, 5)
+DEFINE_HOOK_AGAIN(0x55DBC3, MainLoop_StartLock, 5)
 DEFINE_HOOK(0x55D878, MainLoop_StartLock, 6)
 {
 	if (!Multithreading::IsInMultithreadMode)
@@ -232,7 +232,7 @@ DEFINE_HOOK(0x55D878, MainLoop_StartLock, 6)
 }
 
 // See above.
-DEFINE_HOOK_AGAIN(0x55D903, MainLoop_StopLock_2, 7)
+DEFINE_HOOK_AGAIN(0x55D903, MainLoop_StopLock, 7)
 DEFINE_HOOK(0x55DDA0, MainLoop_StopLock, 5)
 {
 	if (!Multithreading::IsInMultithreadMode)

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -40,6 +40,7 @@ int Phobos::Config::CampaignDefaultGameSpeed = 2;
 bool Phobos::Config::SkirmishUnlimitedColors = false;
 bool Phobos::Config::ShowDesignatorRange = false;
 bool Phobos::Config::SaveVariablesOnScenarioEnd = false;
+bool Phobos::Config::MultiThreadSinglePlayer = false;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -158,6 +159,8 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 		if (temp >= 1)
 			Phobos::Misc::CustomGS_ChangeInterval[i] = temp;
 	}
+
+	Phobos::Config::MultiThreadSinglePlayer = pINI_RULESMD->ReadBool(GameStrings::General, "MultiThreadSinglePlayer", false);
 
 	if (pINI_RULESMD->ReadBool(GameStrings::General, "FixTransparencyBlitters", true))
 		BlittersFix::Apply();

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -76,6 +76,7 @@ public:
 		static bool SkirmishUnlimitedColors;
 		static bool ShowDesignatorRange;
 		static bool SaveVariablesOnScenarioEnd;
+		static bool MultiThreadSinglePlayer;
 	};
 
 	class Misc


### PR DESCRIPTION
- It is now possible to use **experimental** multithreading support for single player modes (campaign and skirmish) to improve game performance.
- This feature must be enabled using with `MultiThreadSinglePlayer=true`.

In `rulesmd.ini`:
```ini
[General]
MultiThreadSinglePlayer=true    ; boolean
```

No multiplayer. Multiplayer never. I tried and I gave up and I tried again and I gave up twofold. I have robbed myself of hours for nothing. For some reason, all ztyping problems return in PvP, as if to mock me. Or is this a lesson? Punishment for hubris? Mockery of youthful ignorance, repetition of Icarian bravery. If "it" has agency, then it is against me. If "it" has form, then it is alien to my senses. When it first became apparent to me, idealism coming from dreams of progress gave way to pride and spite. Yet, anger only ever burns inside and the heavens do not believe in tears. And so I have arrived at the last act of grief, a timeless tragic play with one actor and no audience. I throw in the towel, wave the white flag, bend the knee, and kiss the pinky ring. There are men made for great things, but just because we walk among them doesn't make us equals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced multithreading support for single player modes to enhance game performance.
- **Documentation**
	- Updated documentation to include instructions on enabling experimental multithreading in single player modes.
- **Configuration**
	- Added a new setting to enable or disable multithreading in single player modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->