### PR TITLE
Flashing Objects on selecting.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -308,6 +308,7 @@ This page lists all the individual contributions to the project by their author.
   - Customizable ElectricBolt Arcs
   - Sound entry on unit's creation
   - Auto-deploy/Deploy block on ammo change
+  - Flashing Technos on selecting
 - **ZivDero**
   - Allow giving ownership of buildings to players in Skirmish and MP using <Player @ A-H>
 - **Ares developers**

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1000,3 +1000,13 @@ In `rulesmd.ini`:
 [CrateRules]
 CrateOnlyOnLand=no  ; boolean
 ```
+
+## Flashing Technos on selecting
+
+Selecting technos, controlled by player, now may show a flash effect by setting `SelectFlashTimer` parameter. Set `SelectFlashTimer=0` to disable it.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+SelectFlashTimer=0  ; integer, number of frames
+```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1003,10 +1003,10 @@ CrateOnlyOnLand=no  ; boolean
 
 ## Flashing Technos on selecting
 
-Selecting technos, controlled by player, now may show a flash effect by setting `SelectFlashTimer` parameter. Set `SelectFlashTimer=0` to disable it.
+Selecting technos, controlled by player, now may show a flash effect by setting `SelectionFlashDuration` parameter. Set `SelectionFlashDuration=0` to disable it.
 
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
-SelectFlashTimer=0  ; integer, number of frames
+SelectionFlashDuration=0  ; integer, number of frames
 ```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -355,6 +355,7 @@ New:
 - Allow setting default singleplayer map loading screen and briefing offsets (by Starkku)
 - Allow toggling whether or not fire particle systems adjust target coordinates when firer rotates (by Starkku)
 - `AmbientDamage` warhead & main target ignore customization (by Starkku)
+- Flashing Technos on selecting (by Fryone)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -132,6 +132,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DisplayIncome_AllowAI.Read(exINI, GameStrings::AudioVisual, "DisplayIncome.AllowAI");
 
 	this->IsVoiceCreatedGlobal.Read(exINI, GameStrings::AudioVisual, "IsVoiceCreatedGlobal");
+	this->SelectFlashTimer.Read(exINI, GameStrings::AudioVisual, "SelectFlashTimer");
 
 	this->Buildings_DefaultDigitalDisplayTypes.Read(exINI, GameStrings::AudioVisual, "Buildings.DefaultDigitalDisplayTypes");
 	this->Infantry_DefaultDigitalDisplayTypes.Read(exINI, GameStrings::AudioVisual, "Infantry.DefaultDigitalDisplayTypes");
@@ -262,6 +263,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->RadialIndicatorVisibility)
 		.Process(this->DrawTurretShadow)
 		.Process(this->IsVoiceCreatedGlobal)
+		.Process(this->SelectFlashTimer)
 		.Process(this->AnimRemapDefaultColorScheme)
 		.Process(this->TimerBlinkColorScheme)
 		.Process(this->Buildings_DefaultDigitalDisplayTypes)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -132,7 +132,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DisplayIncome_AllowAI.Read(exINI, GameStrings::AudioVisual, "DisplayIncome.AllowAI");
 
 	this->IsVoiceCreatedGlobal.Read(exINI, GameStrings::AudioVisual, "IsVoiceCreatedGlobal");
-	this->SelectFlashTimer.Read(exINI, GameStrings::AudioVisual, "SelectFlashTimer");
+	this->SelectionFlashDuration.Read(exINI, GameStrings::AudioVisual, "SelectionFlashDuration");
 
 	this->Buildings_DefaultDigitalDisplayTypes.Read(exINI, GameStrings::AudioVisual, "Buildings.DefaultDigitalDisplayTypes");
 	this->Infantry_DefaultDigitalDisplayTypes.Read(exINI, GameStrings::AudioVisual, "Infantry.DefaultDigitalDisplayTypes");
@@ -263,7 +263,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->RadialIndicatorVisibility)
 		.Process(this->DrawTurretShadow)
 		.Process(this->IsVoiceCreatedGlobal)
-		.Process(this->SelectFlashTimer)
+		.Process(this->SelectionFlashDuration)
 		.Process(this->AnimRemapDefaultColorScheme)
 		.Process(this->TimerBlinkColorScheme)
 		.Process(this->Buildings_DefaultDigitalDisplayTypes)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -104,6 +104,7 @@ public:
 
 		Valueable<bool> ShowDesignatorRange;
 		Valueable<bool> IsVoiceCreatedGlobal;
+		Nullable<int> SelectFlashTimer;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -163,6 +164,7 @@ public:
 			, RadialIndicatorVisibility { AffectedHouse::Allies }
 			, DrawTurretShadow { false }
 			, IsVoiceCreatedGlobal { false }
+			, SelectFlashTimer { 0 }
 			, AnimRemapDefaultColorScheme { 0 }
 			, TimerBlinkColorScheme { 5 }
 			, Buildings_DefaultDigitalDisplayTypes {}

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -104,7 +104,7 @@ public:
 
 		Valueable<bool> ShowDesignatorRange;
 		Valueable<bool> IsVoiceCreatedGlobal;
-		Nullable<int> SelectFlashTimer;
+		Valueable<int> SelectFlashTimer;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -104,7 +104,7 @@ public:
 
 		Valueable<bool> ShowDesignatorRange;
 		Valueable<bool> IsVoiceCreatedGlobal;
-		Valueable<int> SelectFlashTimer;
+		Valueable<int> SelectionFlashDuration;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -164,7 +164,7 @@ public:
 			, RadialIndicatorVisibility { AffectedHouse::Allies }
 			, DrawTurretShadow { false }
 			, IsVoiceCreatedGlobal { false }
-			, SelectFlashTimer { 0 }
+			, SelectionFlashDuration { 0 }
 			, AnimRemapDefaultColorScheme { 0 }
 			, TimerBlinkColorScheme { 5 }
 			, Buildings_DefaultDigitalDisplayTypes {}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -464,8 +464,8 @@ DEFINE_HOOK(0x5F46AE, ObjectClass_Select, 0x7)
 
 	pThis->IsSelected = true;
 
-	if(RulesExt::Global()->SelectFlashTimer > 0 && pThis->GetOwningHouse()->IsControlledByCurrentPlayer())
-		pThis->Flash(RulesExt::Global()->SelectFlashTimer);
+	if(RulesExt::Global()->SelectionFlashDuration > 0 && pThis->GetOwningHouse()->IsControlledByCurrentPlayer())
+		pThis->Flash(RulesExt::Global()->SelectionFlashDuration);
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -456,3 +456,24 @@ DEFINE_HOOK(0x51BAFB, InfantryClass_ChronoSparkleDelay, 0x5)
 	R->ECX(RulesExt::Global()->ChronoSparkleDisplayDelay);
 	return 0x51BB00;
 }
+
+/*DEFINE_HOOK(0x708F95, Techno_ResponseSelect, 0x7)
+{
+	GET(TechnoClass*, pThis, ESI);
+	GET(unsigned int, v3, EDI);
+	GET(TypeList<int>*, v2, ECX);
+
+	pThis->QueueVoice(v2->GetItem(v3 % v2->Count));
+	return 0x708FAD;
+}*/
+
+DEFINE_HOOK_AGAIN(0x5F4718, ObjectClass_Select, 0x7)
+DEFINE_HOOK(0x5F46AE, ObjectClass_Select, 0x7)
+{
+	GET(ObjectClass*, pThis, ESI);
+	pThis->IsSelected = true;
+	if(RulesExt::Global()->SelectFlashTimer != 0)
+		if(pThis->GetOwningHouse()->IsControlledByCurrentPlayer())
+			pThis->Flash(RulesExt::Global()->SelectFlashTimer);
+	return 0;
+}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -457,16 +457,6 @@ DEFINE_HOOK(0x51BAFB, InfantryClass_ChronoSparkleDelay, 0x5)
 	return 0x51BB00;
 }
 
-/*DEFINE_HOOK(0x708F95, Techno_ResponseSelect, 0x7)
-{
-	GET(TechnoClass*, pThis, ESI);
-	GET(unsigned int, v3, EDI);
-	GET(TypeList<int>*, v2, ECX);
-
-	pThis->QueueVoice(v2->GetItem(v3 % v2->Count));
-	return 0x708FAD;
-}*/
-
 DEFINE_HOOK_AGAIN(0x5F4718, ObjectClass_Select, 0x7)
 DEFINE_HOOK(0x5F46AE, ObjectClass_Select, 0x7)
 {

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -461,9 +461,11 @@ DEFINE_HOOK_AGAIN(0x5F4718, ObjectClass_Select, 0x7)
 DEFINE_HOOK(0x5F46AE, ObjectClass_Select, 0x7)
 {
 	GET(ObjectClass*, pThis, ESI);
+
 	pThis->IsSelected = true;
-	if(RulesExt::Global()->SelectFlashTimer != 0)
-		if(pThis->GetOwningHouse()->IsControlledByCurrentPlayer())
-			pThis->Flash(RulesExt::Global()->SelectFlashTimer);
+
+	if(RulesExt::Global()->SelectFlashTimer > 0 && pThis->GetOwningHouse()->IsControlledByCurrentPlayer())
+		pThis->Flash(RulesExt::Global()->SelectFlashTimer);
+
 	return 0;
 }


### PR DESCRIPTION
[AudioVisual]
SelectFlashTimer= ;int frames

flashing only player-controlled objects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced visual feedback by introducing a flash effect on Techno selection.
    - Added the ability to enable/disable the flash effect via the `SelectionFlashDuration` parameter in `rulesmd.ini`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->