### PR TITLE
Light effect customizations

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -246,6 +246,7 @@ This page lists all the individual contributions to the project by their author.
   - Reimplemented `Airburst` & `Splits` logic with more customization options
   - Buildings considered as destroyable pathfinding obstacles
   - Animation visibility customization settings
+  - Light effect customizations
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -67,6 +67,7 @@
     <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
     <ClCompile Include="src\Misc\Hooks.Ares.cpp" />
     <ClCompile Include="src\Misc\Hooks.Crates.cpp" />
+    <ClCompile Include="src\Misc\Hooks.LightEffects.cpp" />
     <ClCompile Include="src\Misc\Hooks.VeinholeMonster.cpp" />
     <ClCompile Include="src\Misc\PhobosToolTip.cpp" />
     <ClCompile Include="src\Misc\TextInput.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1315,6 +1315,21 @@ In `rulesmd.ini`:
 AllowDamageOnSelf=false  ; boolean
 ```
 
+### Combat light customizations
+
+- You can now set minimum detail level at which combat light effects are shown by setting `[AudioVisual]` -> `CombatLightDetailLevel` or `CombatLightDetailLevel` on Warhead, latter defaults to former.
+- You can now set a percentage chance a combat light effect is shown on Warhead impact by setting `CombatLightChance`.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+CombatLightDetailLevel=0                     ; integer
+
+[SOMEWARHEAD]                                ; WarheadType
+CombatLightDetailLevel=                      ; integer
+CombatLightChance=1.0                        ; floating point value, percents or absolute (0.0-1.0)
+```
+
 ### Customizing decloak on damaging targets
 
 - You can now specify whether or not the warhead decloaks objects that are damaged by the warhead.
@@ -1338,6 +1353,7 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]         ; WarheadType
 Nonprovocative=false  ; boolean
 ```
+
 
 ```{note}
 Due to technical constraints, this does not suppress warnings from Ares' EMP effect.

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -131,6 +131,29 @@ In `rulesmd.ini`:
 HealthBar.Hide=false  ; boolean
 ```
 
+### Light flash effect toggling
+
+- It is possible to toggle certain light flash effects off. These light flash effects include:
+  - Combat light effects (`Bright=true`) and everything that uses same functionality e.g Iron Curtain / Force Field impact flashes.
+  - Alpha images attached to ParticleSystems or Particles that are generated through a Warhead's `Particle` if `[AudioVisual]` -> `WarheadParticleAlphaImageIsLightFlash` or on Warhead `Particle.AlphaImageIsLightFlash` is set to true, latter defaults to former.
+    - Additionally these alpha images are not created if `[AudioVisual]`->`LightFlashAlphaImageDetailLevel` is higher than current detail level, regardless of the `HideLightFlashEffects` setting.
+  
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+WarheadParticleAlphaImageIsLightFlash=false  ; boolean
+LightFlashAlphaImageDetailLevel=0            ; integer
+
+[SOMEWARHEAD]                                ; WarheadType
+Particle.AlphaImageIsLightFlash=             ; boolean
+```                                          
+
+In `RA2MD.ini`:
+```ini
+[Phobos]
+HideLightFlashEffects=false  ; boolean
+```
+
 ### Low priority for box selection
 
 ![smartvesters](_static/images/lowpriority-01.gif)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -89,6 +89,7 @@ ShowWeedsCounter=true            ; boolean
 ToolTipDescriptions=true         ; boolean
 ToolTipBlur=false                ; boolean
 SaveGameOnScenarioStart=true     ; boolean
+HideLightFlashEffects=false      ; boolean
 ```
 
 ### For Map Editor (Final Alert 2)
@@ -457,6 +458,7 @@ New:
 - Reimplemented `Airburst` & `Splits` logic with more customization options (by Starkku)
 - Buildings considered as destroyable pathfinding obstacles (by Starkku)
 - Animation visibility customization settings (by Starkku)
+- Light effect customizations (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -201,6 +201,10 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AIAllToHunt.Read(exINI, GameStrings::General, "AIAllToHunt");
 	this->RepairBaseNodes.Read(exINI, GameStrings::Basic, "RepairBaseNodes");
 
+	this->WarheadParticleAlphaImageIsLightFlash.Read(exINI, GameStrings::AudioVisual, "WarheadParticleAlphaImageIsLightFlash");
+	this->CombatLightDetailLevel.Read(exINI, GameStrings::AudioVisual, "CombatLightDetailLevel");
+	this->LightFlashAlphaImageDetailLevel.Read(exINI, GameStrings::AudioVisual, "LightFlashAlphaImageDetailLevel");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -379,6 +383,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AIFireSaleDelay)
 		.Process(this->AIAllToHunt)
 		.Process(this->RepairBaseNodes)
+		.Process(this->WarheadParticleAlphaImageIsLightFlash)
+		.Process(this->CombatLightDetailLevel)
+		.Process(this->LightFlashAlphaImageDetailLevel)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -160,6 +160,10 @@ public:
 		Valueable<bool> AIAllToHunt;
 		Valueable<bool> RepairBaseNodes;
 
+		Valueable<bool> WarheadParticleAlphaImageIsLightFlash;
+		Valueable<int> CombatLightDetailLevel;
+		Valueable<int> LightFlashAlphaImageDetailLevel;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -275,6 +279,9 @@ public:
 			, AIFireSaleDelay { 0 }
 			, AIAllToHunt { true }
 			, RepairBaseNodes { false }
+			, WarheadParticleAlphaImageIsLightFlash { false }
+			, CombatLightDetailLevel { 0 }
+			, LightFlashAlphaImageDetailLevel { 0 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -254,6 +254,10 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Nonprovocative.Read(exINI, pSection, "Nonprovocative");
 
+	this->CombatLightDetailLevel.Read(exINI, pSection, "CombatLightDetailLevel");
+	this->CombatLightChance.Read(exINI, pSection, "CombatLightChance");
+	this->Particle_AlphaImageIsLightFlash.Read(exINI, pSection, "Particle.AlphaImageIsLightFlash");
+
 	this->SuppressRevengeWeapons.Read(exINI, pSection, "SuppressRevengeWeapons");
 	this->SuppressRevengeWeapons_Types.Read(exINI, pSection, "SuppressRevengeWeapons.Types");
 	this->SuppressReflectDamage.Read(exINI, pSection, "SuppressReflectDamage");
@@ -474,6 +478,10 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->RemoveInflictedLocomotor)
 
 		.Process(this->Nonprovocative)
+
+		.Process(this->CombatLightDetailLevel)
+		.Process(this->CombatLightChance)
+		.Process(this->Particle_AlphaImageIsLightFlash)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -138,6 +138,10 @@ public:
 
 		Valueable<bool> Nonprovocative;
 
+		Nullable<int> CombatLightDetailLevel;
+		Valueable<double> CombatLightChance;
+		Nullable<bool> Particle_AlphaImageIsLightFlash;
+
 		Valueable<bool> SuppressRevengeWeapons;
 		ValueableVector<WeaponTypeClass*> SuppressRevengeWeapons_Types;
 		Valueable<bool> SuppressReflectDamage;
@@ -282,6 +286,10 @@ public:
 			, RemoveInflictedLocomotor { false }
 
 			, Nonprovocative { false }
+
+			, CombatLightDetailLevel {}
+			, CombatLightChance { 1.0 }
+			, Particle_AlphaImageIsLightFlash {}
 
 			, SuppressRevengeWeapons { false }
 			, SuppressRevengeWeapons_Types {}

--- a/src/Misc/Hooks.LightEffects.cpp
+++ b/src/Misc/Hooks.LightEffects.cpp
@@ -1,0 +1,75 @@
+#include <GameOptionsClass.h>
+
+#include <Ext/WarheadType/Body.h>
+#include <Helpers/Macro.h>
+
+namespace LightEffectsTemp
+{
+	bool AlphaIsLightFlash = false;
+}
+
+DEFINE_HOOK(0x48A444, AreaDamage_Particle_LightFlashSet, 0x5)
+{
+	GET(WarheadTypeClass*, pWH, EDI);
+
+	auto const pWHExt = WarheadTypeExt::ExtMap.Find(pWH);
+
+	if (pWHExt->Particle_AlphaImageIsLightFlash.Get(RulesExt::Global()->WarheadParticleAlphaImageIsLightFlash))
+		LightEffectsTemp::AlphaIsLightFlash = true;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x48A47E, AreaDamage_Particle_LightFlashUnset, 0x6)
+{
+	LightEffectsTemp::AlphaIsLightFlash = false;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x5F5053, ObjectClass_Unlimbo_AlphaImage, 0x6)
+{
+	enum { SkipAlphaImage = 0x5F514B };
+
+	int detailLevel = 0;
+
+	if (LightEffectsTemp::AlphaIsLightFlash)
+	{
+		if (Phobos::Config::HideLightFlashEffects)
+			return SkipAlphaImage;
+
+		detailLevel = RulesExt::Global()->LightFlashAlphaImageDetailLevel;
+	}
+
+	if (detailLevel > GameOptionsClass::Instance->DetailLevel)
+		return SkipAlphaImage;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x48A62E, DoFlash_CombatLightOptions, 0x6)
+{
+	enum { Continue = 0x48A64A, SkipFlash = 0x48A6FA };
+
+	if (Phobos::Config::HideLightFlashEffects)
+		return SkipFlash;
+
+	GET(int, currentDetailLevel, EAX);
+	GET(WarheadTypeClass*, pWH, EDI);
+
+	int detailLevel = RulesExt::Global()->CombatLightDetailLevel;
+
+	if (pWH)
+	{
+		auto const pWHExt = WarheadTypeExt::ExtMap.Find(pWH);
+		detailLevel = pWHExt->CombatLightDetailLevel.Get(detailLevel);
+
+		if (pWHExt->CombatLightChance < Randomizer::Global->RandomDouble())
+			return SkipFlash;
+	}
+
+	if (detailLevel <= currentDetailLevel)
+		return Continue;
+
+	return SkipFlash;
+}

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -53,6 +53,7 @@ bool Phobos::Config::ShowBriefing = true;
 bool Phobos::Config::ShowHarvesterCounter = false;
 bool Phobos::Config::ShowPowerDelta = true;
 bool Phobos::Config::ShowWeedsCounter = false;
+bool Phobos::Config::HideLightFlashEffects = true;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -73,6 +74,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::ShowPowerDelta = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowPowerDelta", true);
 	Phobos::Config::ShowHarvesterCounter = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowHarvesterCounter", true);
 	Phobos::Config::ShowWeedsCounter = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowWeedsCounter", true);
+	Phobos::Config::HideLightFlashEffects = CCINIClass::INI_RA2MD->ReadBool("Phobos", "HideLightFlashEffects", false);
 
 	// Custom game speeds, 6 - i so that GS6 is index 0, just like in the engine
 	Phobos::Config::CampaignDefaultGameSpeed = 6 - CCINIClass::INI_RA2MD->ReadInteger("Phobos", "CampaignDefaultGameSpeed", 4);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -91,6 +91,7 @@ public:
 		static bool ShowHarvesterCounter;
 		static bool ShowWeedsCounter;
 		static bool ShowPlanningPath;
+		static bool HideLightFlashEffects;
 	};
 
 	class Misc


### PR DESCRIPTION
### Combat light customizations

- You can now set minimum detail level at which combat light effects are shown by setting `[AudioVisual]` -> `CombatLightDetailLevel` or `CombatLightDetailLevel` on Warhead, latter defaults to former.
- You can now set a percentage chance a combat light effect is shown on Warhead impact by setting `CombatLightChance`.

In `rulesmd.ini`:
```ini
[AudioVisual]
CombatLightDetailLevel=0                     ; integer

[SOMEWARHEAD]                                ; WarheadType
CombatLightDetailLevel=                      ; integer
CombatLightChance=1.0                        ; floating point value, percents or absolute (0.0-1.0)
```

### Light flash effect toggling

- It is possible to toggle certain light flash effects off. These light flash effects include:
  - Combat light effects (`Bright=true`) and everything that uses same functionality e.g Iron Curtain / Force Field impact flashes.
  - Alpha images attached to ParticleSystems or Particles that are generated through a Warhead's `Particle` if `[AudioVisual]` -> `WarheadParticleAlphaImageIsLightFlash` or on Warhead `Particle.AlphaImageIsLightFlash` is set to true, latter defaults to former.
    - Additionally these alpha images are not created if `[AudioVisual]`->`LightFlashAlphaImageDetailLevel` is higher than current detail level, regardless of the `HideLightFlashEffects` setting.
  
In `rulesmd.ini`:
```ini
[AudioVisual]
WarheadParticleAlphaImageIsLightFlash=false  ; boolean
LightFlashAlphaImageDetailLevel=0            ; integer

[SOMEWARHEAD]                                ; WarheadType
Particle.AlphaImageIsLightFlash=             ; boolean
```                                          

In `RA2MD.ini`:
```ini
[Phobos]
HideLightFlashEffects=false  ; boolean
```