### PR TITLE
Repale Shadow to ExtraShadow for debris & meteor animations

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -23,8 +23,8 @@ This page lists all the individual contributions to the project by their author.
   - Check for Changelog/Documentation/Credits in Pull Requests
   - Fix position and layer of info tip and reveal production cameo on selected building
   - Fix a glitch related to incorrect target setting for missiles
+  - Ability to disable shadow for debris & meteor animations
 - **Kerbiter (Metadorius)**:
-  - SHP debris respect `Shadow` fix
   - Building upgrades enhancement
   - Extended tooltips
   - Selection priority filtering
@@ -44,6 +44,7 @@ This page lists all the individual contributions to the project by their author.
   - VSCode configs
   - Code style
   - Customizable ElectricBolt Arcs
+  - Ability to disable shadow for debris & meteor animations
 - **Uranusian (Thrifinesma)**:
   - Mind Control enhancement
   - Custom warhead splash list

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -37,7 +37,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed Engineers being able to enter `Grinding` buildings even when they shouldn't (such as ally building at full HP).
 - Allowed usage of `AlternateFLH` of vehicles in `OpenTopped` transport.
 - Improved the statistic distribution of the spawned crates over the visible area of the map so that they will no longer have a higher chance to show up near the edges.
-- SHP debris shadows now respect the `Shadow` tag.
 - Allowed usage of TileSet of 255 and above without making NE-SW broken bridges unrepairable.
 - Added a "Load Game" button to the retry dialog on mission failure.
 
@@ -205,6 +204,7 @@ UseCenterCoordsIfAttached=false  ; boolean
 - `WakeAnim` contains a wake animation to play if `ExplodeOnWater` is not set and the animation impacts with water. Defaults to `[General]` -> `Wake` if `IsMeteor` is not set to true, otherwise no animation.
 - `SplashAnims` contains list of splash animations used if `ExplodeOnWater` is not set and the animation impacts with water. Defaults to `[CombatDamage]` -> `SplashList`.
   - If `SplashAnims.PickRandom` is set to true, picks a random animation from `SplashAnims` to use on each impact with water. Otherwise last listed animation from `SplashAnims` is used.
+- `ExtraShadow` can be set to false to disable the display of shadows on the ground.
 
 In `artmd.ini`:
 ```ini
@@ -214,6 +214,7 @@ Warhead.Detonate=false        ; boolean
 WakeAnim=                     ; Animation
 SplashAnims=                  ; list of animations
 SplashAnims.PickRandom=false  ; boolean
+ExtraShadow=true              ; boolean
 ```
 
 ### Layer on animations attached to objects

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -10,7 +10,6 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 ### From vanilla
 
-- SHP debris hardcoded shadows now respect `Shadow=no` tag value, and due to it being the default value they wouldn't have hardcoded shadows anymore by default. Override this by specifying `Shadow=yes` for SHP debris.
 - Translucent RLE SHPs will now be drawn using a more precise and performant algorithm that has no green tint and banding. Can be disabled with `rulesmd.ini->[General]->FixTransparencyBlitters=no`.
 - Iron Curtain status is now preserved by default when converting between TechnoTypes via `DeploysInto`/`UndeploysInto`. This behavior can be turned off per-TechnoType and global basis using `[SOMETECHNOTYPE]/[CombatDamage]->IronCurtain.KeptOnDeploy=no`.
 - The obsolete `[General] WarpIn` has been enabled for the default anim type when technos are warping in. If you want to restore the vanilla behavior, use the same anim type as `WarpOut`.
@@ -38,6 +37,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - `[JumpjetControls]->TurnToTarget` and `JumpjetTurnToTarget` are obsolete. Jumpjet units who fire `OmniFire=no` weapons **always** turn to targets as other units do.
   - `OmniFire.TurnToTarget` is recommended for jumpjet units' omnifiring weapons for facing turning.
 - Buildings delivered by trigger action 125 will now **always** play buildup anim as long as it exists. `[ParamTypes]->53` is deprecated.
+- `Shadow` for debris & meteor animations is changed to `ExtraShadow`.
 
 #### From pre-0.3 devbuilds
 

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -246,6 +246,23 @@ DEFINE_HOOK(0x4236F0, AnimClass_DrawIt_Tiled_Palette, 0x6)
 	return 0x4236F6;
 }
 
+DEFINE_HOOK(0x423365, AnimClass_DrawIt_ExtraShadow, 0x8)
+{
+	enum { DrawExtraShadow = 0x42336D, SkipExtraShadow = 0x4233EE };
+
+	GET(AnimClass*, pThis, ESI);
+
+	if (pThis->HasExtras)
+	{
+		const auto pTypeExt = AnimTypeExt::ExtMap.Find(pThis->Type);
+
+		if (!pTypeExt->ExtraShadow)
+			return SkipExtraShadow;
+	}
+
+	return SkipExtraShadow;
+}
+
 #pragma region AltPalette
 
 // Fix AltPalette anims not using owner color scheme.

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -111,6 +111,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->AttachedSystem.Read<true>(exINI, pID, "AttachedSystem");
 	this->AltPalette_ApplyLighting.Read(exINI, pID, "AltPalette.ApplyLighting");
 	this->MakeInfantryOwner.Read(exINI, pID, "MakeInfantryOwner");
+	this->ExtraShadow.Read(exINI, pID, "ExtraShadow");
 }
 
 template <typename T>
@@ -145,6 +146,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttachedSystem)
 		.Process(this->AltPalette_ApplyLighting)
 		.Process(this->MakeInfantryOwner)
+		.Process(this->ExtraShadow)
 		;
 }
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -45,6 +45,7 @@ public:
 		Valueable<ParticleSystemTypeClass*> AttachedSystem;
 		Valueable<bool> AltPalette_ApplyLighting;
 		Valueable<OwnerHouseKind> MakeInfantryOwner;
+		Valueable<bool> ExtraShadow;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -74,6 +75,7 @@ public:
 			, AttachedSystem {}
 			, AltPalette_ApplyLighting { false }
 			, MakeInfantryOwner { OwnerHouseKind::Victim }
+			, ExtraShadow { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -28,15 +28,6 @@
 #include <Utilities/Debug.h>
 #include <Utilities/TemplateDef.h>
 
-//Replace: checking of HasExtras = > checking of (HasExtras && Shadow)
-DEFINE_HOOK(0x423365, Phobos_BugFixes_SHPShadowCheck, 0x8)
-{
-	GET(AnimClass*, pAnim, ESI);
-	return (pAnim->Type->Shadow && pAnim->HasExtras) ?
-		0x42336D :
-		0x4233EE;
-}
-
 /*
 	Allow usage of TileSet of 255 and above without making NE-SW broken bridges unrepairable
 


### PR DESCRIPTION
Using `Shadow=yes` on debris & meteor animations caused unwanted side effects in the form of additional shadow frames being displayed.

Also having to set `Shadow=yes` for vanilla animations was a pain in the ass.

Frame showing the problem:
![image](https://github.com/Phobos-developers/Phobos/assets/54427022/ee6ea22f-557a-4936-8d7b-68d3dbb91190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to disable shadows for debris and meteor animations.
	- Added customizable ElectricBolt Arcs and enhancements to mind control and custom warhead splash lists.
- **Enhancements**
	- Building upgrades and extended tooltips.
	- Improved drawing of translucent RLE SHPs.
	- Iron Curtain status now preserved during TechnoType conversion with default behavior control.
	- Updated WarpIn behavior for technos warping in.
- **Bug Fixes**
	- Fixed the drawing of shadows on the ground respecting the new `ExtraShadow` tag.
- **Documentation**
	- Updated credits to acknowledge contributors' efforts.
	- Revised Fixed or Improved Logics and What's New documents to reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->