### PR TITLE
Voxel turret & multi-section shadow reimplementation

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -292,6 +292,7 @@ This page lists all the individual contributions to the project by their author.
    - EIP 00529A14 crash fix on Linux
    - Teleport timer reset after load game fix
    - Teleport, Tunnel and Fly loco visual tilt fix
+   - Turret/Barrel/NoSpawnAlt/Multi-section voxel shadow, dynamic voxel shadow
    - Skip units' turret rotation and jumpjets' wobbling under EMP
    - Droppod properties dehardcode
    - Waypoint entering building together with engineer/agent bug fix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -688,11 +688,30 @@ NoWobbles=false  ; boolean
 ### Voxel body multi-section shadows
 
 - It is also now possible for vehicles and aircraft to display shadows for multiple sections of the voxel body at once, instead of just one section specified by `ShadowIndex`, by specifying the section indices in `ShadowIndices` (which defaults to `ShadowIndex`) in unit's `artmd.ini` entry.
+  - `ShadowIndex.Frame` and `ShadowIndices.Frame` can be used to customize which frame of the HVA animation for the section from `ShadowIndex` and `ShadowIndices` is used to display the shadow, respectively. -1 is special value which means currently shown frame is used, and `ShadowIndices.Frame` defaults to this.
 
 In `artmd.ini`:
 ```ini
-[SOMETECHNO]    ; TechnoType
-ShadowIndices=  ; list of integers (voxel section indices)
+[SOMETECHNO]          ; TechnoType
+ShadowIndices=        ; list of integers (voxel section indices)
+ShadowIndex.Frame=0   ; integer (HVA animation frame index)
+ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
+```
+
+### Voxel shadow scaling in air
+
+- It is now possible to adjust how voxel air units (`VehicleType` & `AircraftType`) shadows scale in air. By default the shadows scale by `AirShadowBaseScale` (defaults to 0.5) amount if unit is `ConsideredAircraft=true`.
+  - If `HeightShadowScaling=true`, the shadow is scaled by amount that is determined by following formula: `Max(1.0 - AirShadowBaseScale * currentHeight / ShadowSizeCharacteristicHeight, HeightShadowScaling.MinScale)`, where `currentHeight` is unit's current height in leptons, `ShadowSizeCharacteristicHeight` overrideable value that defaults to the maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and `HeightShadowScaling.MinScale` sets a floor for the scale.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+AirShadowBaseScale=0.5            ; floating point value
+HeightShadowScaling=false         ; boolean
+HeightShadowScaling.MinScale=0.0  ; floating point value
+
+[SOMETECHNO]                      ; TechnoType
+ShadowSizeCharacteristicHeight=   ; integer, height in leptons
 ```
 
 ### Forbid parallel AI queues

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -701,7 +701,7 @@ ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
 ### Voxel shadow scaling in air
 
 - It is now possible to adjust how voxel air units (`VehicleType` & `AircraftType`) shadows scale in air. By default the shadows scale by `AirShadowBaseScale` (defaults to 0.5) amount if unit is `ConsideredAircraft=true`.
-  - If `HeightShadowScaling=true`, the shadow is scaled by amount that is determined by following formula: `Max(1.0 - AirShadowBaseScale * currentHeight / ShadowSizeCharacteristicHeight, HeightShadowScaling.MinScale)`, where `currentHeight` is unit's current height in leptons, `ShadowSizeCharacteristicHeight` overrideable value that defaults to the maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and `HeightShadowScaling.MinScale` sets a floor for the scale.
+  - If `HeightShadowScaling=true`, the shadow is scaled by amount that is determined by following formula: `Max(AirShadowBaseScale ^ (currentHeight / ShadowSizeCharacteristicHeight), HeightShadowScaling.MinScale)`, where `currentHeight` is unit's current height in leptons, `ShadowSizeCharacteristicHeight` overrideable value that defaults to the maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and `HeightShadowScaling.MinScale` sets a floor for the scale.
 
 In `rulesmd.ini`:
 ```ini
@@ -856,6 +856,8 @@ IronCurtain.KeptOnDeploy=    ; boolean, default to [CombatDamage]->IronCurtain.K
 ### Voxel turret shadow
 
 - Vehicle voxel turrets can now draw shadows if `[AudioVisual]` -> `DrawTurretShadow` is set to true. This can be overridden per VehicleType by setting `TurretShadow` in the vehicle's `artmd.ini` section.
+  - If you don't want to render the body's shadow at all, set `ShadowIndex` to an invalid number.
+
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -323,7 +323,7 @@ New:
 - TechnoType conversion on ownership change (by Trsdy)
 - Unlimited skirmish colors (by Morton)
 - Example custom locomotor that circles around the target (*NOTE: For developer use only*) (by Kerbiter, CCHyper, with help from Otamaa; based on earlier experiment by CnCVK)
-- Vehicle voxel turret shadows & body multi-section shadows (by TwinkleStar)
+- Vehicle voxel turret shadows & body multi-section shadows (by TwinkleStar & Trsdy)
 - Crushing tilt and slowdown customization (by Starkku)
 - Extra warhead detonations on weapon (by Starkku)
 - Chrono sparkle animation display customization and improvements (by Starkku)
@@ -368,6 +368,7 @@ New:
 - Allow to change the speed of gas particles (by ZivDero)
 - Allow upgrade animations to use `Powered` & `PoweredLight/Effect/Special` keys (by Starkku)
 - Toggle for `Explodes=true` BuildingTypes to not explode during buildup or being sold (by Starkku)
+- Toggleable height-based shadow scaling for voxel air units (by Trsdy & Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -117,7 +117,11 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AnimRemapDefaultColorScheme.Read(exINI, GameStrings::AudioVisual, "AnimRemapDefaultColorScheme");
 	this->TimerBlinkColorScheme.Read(exINI, GameStrings::AudioVisual, "TimerBlinkColorScheme");
 	this->ShowDesignatorRange.Read(exINI, GameStrings::AudioVisual, "ShowDesignatorRange");
-	this->AirShadowBaseScale.Read(exINI, GameStrings::AudioVisual, "AirShadowBaseScale");
+	Nullable<double>AirShadowBaseScale;
+	AirShadowBaseScale.Read(exINI, GameStrings::AudioVisual, "AirShadowBaseScale");
+	if (AirShadowBaseScale.isset() && AirShadowBaseScale.Get() > 0)
+		this->AirShadowBaseScale_log = -std::log(std::min(AirShadowBaseScale.Get(), 1.0));
+
 	this->HeightShadowScaling.Read(exINI, GameStrings::AudioVisual, "HeightShadowScaling");
 	this->HeightShadowScaling_MinScale.Read(exINI, GameStrings::AudioVisual, "HeightShadowScaling.MinScale");
 
@@ -263,7 +267,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_Tiberiums_DisplayOrder)
 		.Process(this->Pips_Tiberiums_WeedFrame)
 		.Process(this->Pips_Tiberiums_WeedEmptyFrame)
-		.Process(this->AirShadowBaseScale)
+		.Process(this->AirShadowBaseScale_log)
 		.Process(this->HeightShadowScaling)
 		.Process(this->HeightShadowScaling_MinScale)
 		.Process(this->AllowParallelAIQueues)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -117,6 +117,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AnimRemapDefaultColorScheme.Read(exINI, GameStrings::AudioVisual, "AnimRemapDefaultColorScheme");
 	this->TimerBlinkColorScheme.Read(exINI, GameStrings::AudioVisual, "TimerBlinkColorScheme");
 	this->ShowDesignatorRange.Read(exINI, GameStrings::AudioVisual, "ShowDesignatorRange");
+	this->AirShadowBaseScale.Read(exINI, GameStrings::AudioVisual, "AirShadowBaseScale");
+	this->HeightShadowScaling.Read(exINI, GameStrings::AudioVisual, "HeightShadowScaling");
+	this->HeightShadowScaling_MinScale.Read(exINI, GameStrings::AudioVisual, "HeightShadowScaling.MinScale");
 
 	this->AllowParallelAIQueues.Read(exINI, "GlobalControls", "AllowParallelAIQueues");
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Infantry");
@@ -260,6 +263,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Pips_Tiberiums_DisplayOrder)
 		.Process(this->Pips_Tiberiums_WeedFrame)
 		.Process(this->Pips_Tiberiums_WeedEmptyFrame)
+		.Process(this->AirShadowBaseScale)
+		.Process(this->HeightShadowScaling)
+		.Process(this->HeightShadowScaling_MinScale)
 		.Process(this->AllowParallelAIQueues)
 		.Process(this->ForbidParallelAIQueues_Aircraft)
 		.Process(this->ForbidParallelAIQueues_Building)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -78,9 +78,9 @@ public:
 		Valueable<int> Pips_Tiberiums_WeedFrame;
 		Valueable<int> Pips_Tiberiums_WeedEmptyFrame;
 
-		Valueable<double> AirShadowBaseScale;
 		Valueable<bool> HeightShadowScaling;
 		Valueable<double> HeightShadowScaling_MinScale;
+		double AirShadowBaseScale_log;
 
 		Valueable<bool> AllowParallelAIQueues;
 		Valueable<bool> ForbidParallelAIQueues_Aircraft;
@@ -164,9 +164,9 @@ public:
 			, Pips_Tiberiums_WeedFrame { 1 }
 			, Pips_Tiberiums_WeedEmptyFrame { 0 }
 
-			, AirShadowBaseScale { 0.5 }
 			, HeightShadowScaling { false }
 			, HeightShadowScaling_MinScale { 0.0 }
+			, AirShadowBaseScale_log { 0.693376137 }
 
 			, AllowParallelAIQueues { true }
 			, ForbidParallelAIQueues_Aircraft { false }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -78,6 +78,10 @@ public:
 		Valueable<int> Pips_Tiberiums_WeedFrame;
 		Valueable<int> Pips_Tiberiums_WeedEmptyFrame;
 
+		Valueable<double> AirShadowBaseScale;
+		Valueable<bool> HeightShadowScaling;
+		Valueable<double> HeightShadowScaling_MinScale;
+
 		Valueable<bool> AllowParallelAIQueues;
 		Valueable<bool> ForbidParallelAIQueues_Aircraft;
 		Valueable<bool> ForbidParallelAIQueues_Building;
@@ -159,6 +163,11 @@ public:
 			, Pips_Tiberiums_DisplayOrder {}
 			, Pips_Tiberiums_WeedFrame { 1 }
 			, Pips_Tiberiums_WeedEmptyFrame { 0 }
+
+			, AirShadowBaseScale { 0.5 }
+			, HeightShadowScaling { false }
+			, HeightShadowScaling_MinScale { 0.0 }
+
 			, AllowParallelAIQueues { true }
 			, ForbidParallelAIQueues_Aircraft { false }
 			, ForbidParallelAIQueues_Building { false }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -220,6 +220,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->NoSecondaryWeaponFallback_AllowAA.Read(exINI, pSection, "NoSecondaryWeaponFallback.AllowAA");
 
 	this->JumpjetRotateOnCrash.Read(exINI, pSection, "JumpjetRotateOnCrash");
+	this->ShadowSizeCharacteristicHeight.Read(exINI, pSection, "ShadowSizeCharacteristicHeight");
 
 	this->DeployingAnim_AllowAnyDirection.Read(exINI, pSection, "DeployingAnim.AllowAnyDirection");
 	this->DeployingAnim_KeepUnitVisible.Read(exINI, pSection, "DeployingAnim.KeepUnitVisible");
@@ -327,7 +328,21 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->TurretOffset.Read(exArtINI, pArtSection, "TurretOffset");
 	this->TurretShadow.Read(exArtINI, pArtSection, "TurretShadow");
-	this->ShadowIndices.Read(exArtINI, pArtSection, "ShadowIndices");
+	ValueableVector<int> shadow_indices;
+	shadow_indices.Read(exArtINI, pArtSection, "ShadowIndices");
+	ValueableVector<int> shadow_indices_frame;
+	shadow_indices_frame.Read(exArtINI, pArtSection, "ShadowIndices.Frame");
+	if (shadow_indices_frame.size() != shadow_indices.size())
+	{
+		if (!shadow_indices_frame.empty())
+			Debug::LogGame("[Developer warning] %s ShadowIndices.Frame size (%d) does not match ShadowIndices size (%d) \n"
+				, pSection, shadow_indices_frame.size(), shadow_indices.size());
+		shadow_indices_frame.resize(shadow_indices.size(), -1);
+	}
+	for (size_t i = 0; i < shadow_indices.size(); i++)
+		this->ShadowIndices[shadow_indices[i]] = shadow_indices_frame[i];
+
+	this->ShadowIndex_Frame.Read(exArtINI, pArtSection, "ShadowIndex.Frame");
 
 	this->LaserTrailData.clear();
 	for (size_t i = 0; ; ++i)
@@ -440,6 +455,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->TurretOffset)
 		.Process(this->TurretShadow)
 		.Process(this->ShadowIndices)
+		.Process(this->ShadowIndex_Frame)
 		.Process(this->Spawner_LimitRange)
 		.Process(this->Spawner_ExtraLimitRange)
 		.Process(this->Spawner_DelayFrames)
@@ -520,7 +536,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->NoAmmoWeapon)
 		.Process(this->NoAmmoAmount)
 		.Process(this->JumpjetRotateOnCrash)
-
+		.Process(this->ShadowSizeCharacteristicHeight)
 		.Process(this->DeployingAnim_AllowAnyDirection)
 		.Process(this->DeployingAnim_KeepUnitVisible)
 		.Process(this->DeployingAnim_ReverseForUndeploy)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -38,7 +38,8 @@ public:
 
 		Valueable<PartialVector3D<int>> TurretOffset;
 		Nullable<bool> TurretShadow;
-		ValueableVector<int> ShadowIndices;
+		Valueable<int> ShadowIndex_Frame;
+		std::map<int, int> ShadowIndices;
 		Valueable<bool> Spawner_LimitRange;
 		Valueable<int> Spawner_ExtraLimitRange;
 		Nullable<int> Spawner_DelayFrames;
@@ -127,6 +128,7 @@ public:
 		Valueable<int> NoAmmoAmount;
 
 		Valueable<bool> JumpjetRotateOnCrash;
+		Nullable<int> ShadowSizeCharacteristicHeight;
 
 		Valueable<bool> DeployingAnim_AllowAnyDirection;
 		Valueable<bool> DeployingAnim_KeepUnitVisible;
@@ -229,6 +231,7 @@ public:
 			, TurretOffset { { 0, 0, 0 } }
 			, TurretShadow { }
 			, ShadowIndices { }
+			, ShadowIndex_Frame { 0 }
 			, Spawner_LimitRange { false }
 			, Spawner_ExtraLimitRange { 0 }
 			, Spawner_DelayFrames {}
@@ -280,7 +283,7 @@ public:
 			, NoAmmoWeapon { -1 }
 			, NoAmmoAmount { 0 }
 			, JumpjetRotateOnCrash { true }
-
+			, ShadowSizeCharacteristicHeight { }
 			, DeployingAnim_AllowAnyDirection { false }
 			, DeployingAnim_KeepUnitVisible { false }
 			, DeployingAnim_ReverseForUndeploy { true }

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -16,6 +16,8 @@
 
 #include <Utilities/Macro.h>
 #include <Utilities/AresHelper.h>
+#include <JumpjetLocomotionClass.h>
+#include <FlyLocomotionClass.h>
 
 DEFINE_HOOK(0x6F64A9, TechnoClass_DrawHealthBar_Hide, 0x5)
 {
@@ -334,31 +336,136 @@ DEFINE_HOOK(0x6B0C2C, SlaveManagerClass_FreeSlaves_SlavesFreeSound, 0x5)
 	return 0x6B0C65;
 }
 
-DEFINE_HOOK(0x4DB157, FootClass_DrawVoxelShadow_TurretShadow, 0x8)
+DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 {
-	GET(FootClass*, pThis, ESI);
-	GET_STACK(Point2D, pos, STACK_OFFSET(0x18, 0x28));
-	GET_STACK(Surface*, pSurface, STACK_OFFSET(0x18, 0x24));
-	GET_STACK(bool, a9, STACK_OFFSET(0x18, 0x20));
-	GET_STACK(Matrix3D*, pMatrix, STACK_OFFSET(0x18, 0x1C));
-	GET_STACK(RectangleStruct*, bound, STACK_OFFSET(0x18, 0x14));
-	GET_STACK(Point2D, a3, STACK_OFFSET(0x18, -0x10));
-	GET_STACK(decltype(ObjectTypeClass::VoxelShadowCache)*, shadow_cache, STACK_OFFSET(0x18, 0x10));
-	GET_STACK(VoxelIndexKey, index_key, STACK_OFFSET(0x18, 0xC));
-	GET_STACK(int, shadow_index, STACK_OFFSET(0x18, 0x8));
-	GET_STACK(VoxelStruct*, main_vxl, STACK_OFFSET(0x18, 0x4));
+	GET(UnitClass*, pThis, EBP);
+	enum { SkipDrawing = 0x73C5C9 };
+	auto const loco = pThis->Locomotor.GetInterfacePtr();
+	if (!loco->Is_To_Have_Shadow())
+		return SkipDrawing;
 
-	auto pType = pThis->GetTechnoType();
-	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+	REF_STACK(Matrix3D, shadow_matrix, STACK_OFFSET(0x1C4, -0x130));
+	GET_STACK(VoxelIndexKey, vxl_index_key, STACK_OFFSET(0x1C4, -0x1B0));
+	LEA_STACK(RectangleStruct*, bounding, STACK_OFFSET(0x1C4, 0xC));
+	LEA_STACK(Point2D*, floor, STACK_OFFSET(0x1C4, -0x1A4));
+	GET_STACK(Surface* const, surface, STACK_OFFSET(0x1C4, -0x1A8));
 
+	GET(UnitTypeClass*, pType, EBX);
+	// This is not necessarily pThis->Type : UnloadingClass or WaterImage
+	// This is the very reason I need to do this here, there's no less hacky way to get this Type from those inner calls
+
+	const auto uTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+	// Byebye ConsideredAircraft
+	const auto jjloco = locomotion_cast<JumpjetLocomotionClass*>(loco);
+	const auto height = pThis->GetHeight();
+	if (height > 0)
+	{
+		if (jjloco)
+		{
+			const float ch = (float)uTypeExt->ShadowSizeCharacteristicHeight.Get(jjloco->Height);
+			if (ch > 0)
+			{
+				shadow_matrix.Scale(1.f - 0.5f * height / ch);
+				if (jjloco->State != JumpjetLocomotionClass::State::Hovering)
+					vxl_index_key = std::bit_cast<VoxelIndexKey>(-1);
+			}
+		}
+		else
+		{
+			const float ch = (float)uTypeExt->ShadowSizeCharacteristicHeight.Get(RulesClass::Instance->CruiseHeight);
+			if (ch > 0)
+			{
+				shadow_matrix.Scale(1.f - 0.5f * height / ch);
+				vxl_index_key = std::bit_cast<VoxelIndexKey>(-1);
+			}
+		}
+	}
 
 	// We need to handle Ares turrets/barrels
 	struct DummyExtHere
 	{
-		char before[0xA4];
+		char _[0xA4];
 		std::vector<VoxelStruct> ChargerTurrets;
 		std::vector<VoxelStruct> ChargerBarrels;
+		char __[0x120];
+		UnitTypeClass* WaterImage;
+		VoxelStruct NoSpawnAltVXL;
 	};
+
+	auto GetMainVoxel = [&]()
+	{
+		if (pType->NoSpawnAlt && pThis->SpawnManager && pThis->SpawnManager->CountDockedSpawns() == 0)
+		{
+			if (CAN_USE_ARES && AresHelper::CanUseAres)
+			{
+				vxl_index_key = std::bit_cast<VoxelIndexKey>(-1);// I'd just assume most of the time we have spawn
+				return &reinterpret_cast<DummyExtHere*>(pType->align_2FC)->NoSpawnAltVXL;
+			}
+			return &pType->TurretVoxel;
+		}
+		return &pType->MainVoxel;
+	};
+
+	auto const main_vxl = GetMainVoxel();
+
+	// TODO : adjust shadow point according to height
+	// There was a bit deviation that I cannot decipher, might need help with that
+	// But it turns out it has basically no visual difference
+
+	auto shadow_point = loco->Shadow_Point();
+	auto why = *floor + shadow_point;
+
+	float arf = pThis->AngleRotatedForwards;
+	float ars = pThis->AngleRotatedSideways;
+	// lazy, don't want to hook inside Shadow_Matrix
+	if (std::abs(ars) >= 0.005 || std::abs(arf) >= 0.005)
+	{
+		// index key is already invalid
+		shadow_matrix.TranslateX(float(Math::sgn(arf) * pType->VoxelScaleX * (1 - Math::cos(arf))));
+		shadow_matrix.TranslateY(float(Math::sgn(-ars) * pType->VoxelScaleY * (1 - Math::cos(ars))));
+		shadow_matrix.ScaleX((float)Math::cos(arf));
+		shadow_matrix.ScaleY((float)Math::cos(ars));
+	}
+
+	auto mtx = Matrix3D::VoxelDefaultMatrix() * shadow_matrix;
+
+	if (uTypeExt->ShadowIndices.empty())
+	{
+		if (pType->ShadowIndex >= 0 && pType->ShadowIndex < main_vxl->HVA->LayerCount)
+			pThis->DrawVoxelShadow(
+				   main_vxl,
+				   pType->ShadowIndex,
+				   vxl_index_key,
+				   &pType->VoxelShadowCache,
+				   bounding,
+				   &why,
+				   &mtx,
+				   true,
+				   surface,
+				   shadow_point
+			);
+	}
+	else
+	{
+		for (auto& [index, _] : uTypeExt->ShadowIndices)
+			pThis->DrawVoxelShadow(
+				   main_vxl,
+				   index,
+				   vxl_index_key,
+				   &pType->VoxelShadowCache,
+				   bounding,
+				   &why,
+				   &mtx,
+				   true,
+				   surface,
+				   shadow_point
+			);
+	}
+
+	if (!uTypeExt->TurretShadow.Get(RulesExt::Global()->DrawTurretShadow) || main_vxl == &pType->TurretVoxel)
+		return SkipDrawing;
+
 
 	auto GetTurretVoxel = [pType](int idx) ->VoxelStruct*
 	{
@@ -394,35 +501,197 @@ DEFINE_HOOK(0x4DB157, FootClass_DrawVoxelShadow_TurretShadow, 0x8)
 		return nullptr;
 	};
 
+	Matrix3D rot = Matrix3D::GetIdentity();
+	uTypeExt->ApplyTurretOffset(&rot, Pixel_Per_Lepton);
+	rot.RotateZ(static_cast<float>(pThis->SecondaryFacing.Current().GetRadian<32>() - pThis->PrimaryFacing.Current().GetRadian<32>()));
+	auto tur_mtx = mtx * rot; // unfortunately we won't have TurretVoxelScaleX/Y given the amount of work
+
 	auto tur = GetTurretVoxel(pThis->CurrentTurretNumber);
 
-	if (tur && pTypeExt->TurretShadow.Get(RulesExt::Global()->DrawTurretShadow) && tur->VXL && tur->HVA)
+	// sorry but you're fucked
+	if (tur && tur->VXL && tur->HVA)
+		pThis->DrawVoxelShadow(
+			tur,
+			0,
+			std::bit_cast<VoxelIndexKey>(-1), // no cache, no use for valid key
+			nullptr, // no cache atm
+			bounding,
+			&why,
+			&tur_mtx,
+			false,
+			surface,
+			shadow_point
+		);
+	
+	auto bar = GetBarrelVoxel(pThis->CurrentTurretNumber);
+
+	// and you are utterly fucked
+	if (bar && bar->VXL && bar->HVA)
+		pThis->DrawVoxelShadow(
+			bar,
+			0,
+			std::bit_cast<VoxelIndexKey>(-1), // no cache, no use
+			nullptr,//no cache atm
+			bounding,
+			&why,
+			&tur_mtx,
+			false,
+			surface,
+			shadow_point
+		);
+
+	// Add caches in Ext if necessary, remember not to serialize these shit
+	// IndexClass<ShadowVoxelIndexKey, VoxelCacheStruct*> VoxelTurretShadowCache {};
+	// IndexClass<ShadowVoxelIndexKey, VoxelCacheStruct*> VoxelBarrelShadowCache {};
+
+	return SkipDrawing;
+}
+
+DEFINE_HOOK(0x4147F9, AircraftClass_Draw_Shadow, 0x6)
+{
+	GET(AircraftClass*, pThis, EBP);
+	GET(const int, height, EBX);
+	REF_STACK(VoxelIndexKey, key, STACK_OFFSET(0xCC, -0xBC));
+	REF_STACK(Point2D, flor, STACK_OFFSET(0xCC, -0xAC));
+	GET_STACK(RectangleStruct*, bound, STACK_OFFSET(0xCC, 0x10));
+	enum { FinishDrawing = 0x4148A5 };
+
+	const auto loco = static_cast<FlyLocomotionClass*>(pThis->Locomotor.GetInterfacePtr());
+	if (!loco->Is_To_Have_Shadow() || pThis->IsSinking)
+		return FinishDrawing;
+
+	const auto aTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
+
+	auto shadow_mtx = loco->Shadow_Matrix(&key);
+
+	const float ch = (float)aTypeExt->ShadowSizeCharacteristicHeight.Get(loco->FlightLevel);
+	if (ch > 0)
 	{
-		auto mtx = Matrix3D::GetIdentity();
-		pTypeExt->ApplyTurretOffset(&mtx, Pixel_Per_Lepton);
-		mtx.TranslateZ(-tur->HVA->Matrixes[0].GetZVal());
-		mtx.RotateZ(static_cast<float>(pThis->SecondaryFacing.Current().GetRadian<32>() - pThis->PrimaryFacing.Current().GetRadian<32>()));
-		mtx = *pMatrix * mtx;
-
-		pThis->DrawVoxelShadow(tur, 0, index_key, nullptr, bound, &a3, &mtx, a9, pSurface, pos);
-
-		auto bar = GetBarrelVoxel(pThis->CurrentTurretNumber);
-
-		if (bar && bar->VXL && bar->HVA)
-			pThis->DrawVoxelShadow(bar, 0, index_key, nullptr, bound, &a3, &mtx, a9, pSurface, pos);
+		shadow_mtx.Scale(1.f - 0.5f * height / ch);
+		key = std::bit_cast<VoxelIndexKey>(-1); // I'm sorry
 	}
 
-	if (!pTypeExt->ShadowIndices.size())
+	if (pThis->IsCrashing)
 	{
-		pThis->DrawVoxelShadow(main_vxl, shadow_index, index_key, shadow_cache, bound, &a3, pMatrix, a9, pSurface, pos);
+		double arf = pThis->AngleRotatedForwards;
+		if (loco->CurrentSpeed > pThis->Type->PitchSpeed)
+			arf += pThis->Type->PitchAngle;
+		shadow_mtx.ScaleY((float)Math::cos(pThis->AngleRotatedSideways));
+		shadow_mtx.ScaleX((float)Math::cos(arf));
+	}
+
+	shadow_mtx = Matrix3D::VoxelDefaultMatrix() * shadow_mtx;
+	Point2D why = flor + loco->Shadow_Point();
+	auto const main_vxl = &pThis->Type->MainVoxel;
+
+	if (aTypeExt->ShadowIndices.empty())
+	{
+		auto const shadow_index = pThis->Type->ShadowIndex;
+		if (shadow_index >= 0 && shadow_index < main_vxl->HVA->LayerCount)
+			pThis->DrawVoxelShadow(main_vxl,
+				shadow_index,
+				key,
+				&pThis->Type->VoxelShadowCache,
+				bound,
+				&why,
+				&shadow_mtx,
+				true,
+				nullptr,
+				{ 0, 0 }
+		);
 	}
 	else
 	{
-		for (auto index : pTypeExt->ShadowIndices)
-		{
-			pThis->DrawVoxelShadow(main_vxl, index, index_key, shadow_cache, bound, &a3, pMatrix, a9, pSurface, pos);
-		}
+		for (auto& [index, _] : aTypeExt->ShadowIndices)
+			pThis->DrawVoxelShadow(main_vxl,
+				index,
+				key,
+				&pThis->Type->VoxelShadowCache,
+				bound,
+				&why,
+				&shadow_mtx,
+				true,
+				nullptr,
+				{ 0, 0 }
+		);
 	}
 
-	return 0x4DB195;
+	return FinishDrawing;
+}
+
+DEFINE_HOOK(0x7072A1, suka707280_ChooseTheGoddamnMatrix, 0x7)
+{
+	GET(FootClass*, pThis, EBX);//Maybe Techno later
+	GET(VoxelStruct*, pVXL, EBP);
+	GET_STACK(Matrix3D*, pMat, STACK_OFFSET(0xE8, 0xC));
+	GET_STACK(int, shadow_index_now, STACK_OFFSET(0xE8, 0x18));// it's used later, otherwise I could have chosen the frame index earlier
+
+	REF_STACK(Matrix3D, matRet, STACK_OFFSET(0xE8, -0x60));
+	auto pType = pThis->GetTechnoType();
+
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+	auto hva = pVXL->HVA;
+
+	auto ChooseFrame = [&]()->int //Don't want to use goto
+	{
+		// Turret or Barrel
+		if (pVXL != &pType->MainVoxel)
+		{
+			// verify just in case:
+			auto who_are_you = reinterpret_cast<uintptr_t*>(reinterpret_cast<DWORD>(pVXL) - (offsetof(TechnoTypeClass, MainVoxel)));
+			if (who_are_you[0] == UnitTypeClass::AbsVTable)
+				pType = reinterpret_cast<TechnoTypeClass*>(who_are_you);//you are someone else
+			else
+				return pThis->TurretAnimFrame % hva->FrameCount;
+			// you might also be SpawnAlt voxel, but I can't know
+			// otherwise what would you expect me to do, shift back to ares typeext base and check if ownerobject is technotype?
+		}
+
+		// Main body sections
+		auto& shadowIndices = pTypeExt->ShadowIndices;
+		if (shadowIndices.empty())
+		{
+			// Only ShadowIndex
+			if (pType->ShadowIndex == shadow_index_now)
+			{
+				int shadow_index_frame = pTypeExt->ShadowIndex_Frame;
+				if (shadow_index_frame > -1)
+					return shadow_index_frame % hva->FrameCount;
+			}
+			else
+			{
+				// WHO THE HELL ARE YOU???
+				return 0;
+			}
+		}
+		else
+		{
+			int idx_of_now = shadowIndices[shadow_index_now];
+			if (idx_of_now > -1)
+				return idx_of_now % hva->FrameCount;
+		}
+
+		return pThis->WalkedFramesSoFar % hva->FrameCount;
+	};
+
+
+	Matrix3D hvamat = hva->Matrixes[shadow_index_now + hva->LayerCount * ChooseFrame()];
+
+	// TO TEST : Check if this is the proper Z offset to shift the sections to the same level
+	hvamat.TranslateZ(
+		-hvamat.GetZVal()
+		- pVXL->VXL->TailerData->Bounds[0].Z
+	);
+
+	matRet = *pMat * hvamat;
+
+	// Recover vanilla instructions
+	if (pThis->GetTechnoType()->UseBuffer)
+		*reinterpret_cast<DWORD*>(0xB43180) = 1;
+
+	REF_STACK(Matrix3D, b, STACK_OFFSET(0xE8, -0x90));
+	b.MakeIdentity();// we don't do scaling here anymore
+
+	return 0x707331;
 }

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -38,7 +38,7 @@ public:
 	static void DisplayDamageNumberString(int damage, DamageDisplayType type, CoordStruct coords, int& offset);
 
 	template<typename T>
-	static T FastPow(T x, size_t n)
+	static constexpr T FastPow(T x, size_t n)
 	{
 		// Real fast pow calc x^n in O(log(n))
 		T result = 1;


### PR DESCRIPTION
Originally authored by @chaserli

- Attempt to fix the math of shadow projection (turrets being off kilter etc).
- Attempt to make multi-section shadows consider frame index.
- Fix shadow flickering with multi-section voxels using the HVA transform section swap method.
- Airborne voxel shadow scaling.

TODO:
- Regression tests with lots of voxels

---------------
Update from @chaserli 02/29:
* Considered Ares turrets/barrels, fixed wrong voxel selection especially in charging turret cases
* Added 2 new tags for the hva frame of each you want to render the shadow.
    * If you only want to render the ShadowIndex as usual but the VXL used the socalled hva section swap method, then naturally the hva matrix for the first frame is not null, so ShadowIndex.Frame is default to 0
        * If you set ShadowIndex to an invalid number the body's shadow will not be rendered, just for fail-safe, but you can exploit that since the turret will still do since the index for it is always 0
    * For multiple indices the default value is -1 since perhaps you want them to animate
* Mathematically speaking there's no solution for the projection, but it's been tested that it's possible to just adjust the vxl and get a visually appropriate shadow
 
---------------
Update from @chaserli 03/05:
* Add a simple method for calculating the shadow projection on the ground when being flipped
* Dynamic scaling is restored, provided you invalidate the cache, yeah
* Took NoSpawnAlt vxl from Ares into account, ehh
I'll hand over the rest to you @Starkku , bonne chance.
What I suggest:
* Make a compromise between caching and dynamic scaling for aircrafts
* Try if it's possible to cache the turret shadow, or prove it's not a potential perf issue
* Extensive regression tests, compare if the shadow even for the body locates differently than before, in air and on ground, since I didn't do the height check since IDK what's actually going on in there

----------------
Update from @chaserli 03/15
* Dynamic scaling for aircrafts too, screw up the caching

Update from @Starkku 03/30
* Dynamic shadow scaling is now opt-in, more customization options for it as well
* Added docs

## For testers:
- It is also now possible for vehicles and aircraft to display shadows for multiple sections of the voxel body at once, instead of just one section specified by `ShadowIndex`, by specifying the section indices in `ShadowIndices` (which defaults to `ShadowIndex`) in unit's `artmd.ini` entry.
  - `ShadowIndex.Frame` and `ShadowIndices.Frame` can be used to customize which frame of the HVA animation for the section from `ShadowIndex` and `ShadowIndices` is used to display the shadow, respectively. -1 is special value which means currently shown frame is used, and `ShadowIndices.Frame` defaults to this.

In `artmd.ini`:
```ini
[SOMETECHNO]          ; TechnoType
ShadowIndices=        ; list of integers (voxel section indices)
ShadowIndex.Frame=0   ; integer (HVA animation frame index)
ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
```

- It is now possible to adjust how voxel air units (`VehicleType` & `AircraftType`) shadows scale in air. By default the shadows scale by `AirShadowBaseScale` (defaults to 0.5) amount if unit is `ConsideredAircraft=true`.
  - If `HeightShadowScaling=true`, the shadow is scaled by amount that is determined by following formula: `Max(AirShadowBaseScale ^ (currentHeight / ShadowSizeCharacteristicHeight), HeightShadowScaling.MinScale)`, where `currentHeight` is unit's current height in leptons, `ShadowSizeCharacteristicHeight` overrideable value that defaults to the maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and `HeightShadowScaling.MinScale` sets a floor for the scale.

In `rulesmd.ini`:
```ini
[AudioVisual]
AirShadowBaseScale=0.5            ; floating point value
HeightShadowScaling=false         ; boolean
HeightShadowScaling.MinScale=0.0  ; floating point value

[SOMETECHNO]                      ; TechnoType
ShadowSizeCharacteristicHeight=   ; integer, height in leptons
```
