### PR TITLE
Universal deploy from any techno into any techno

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -130,6 +130,7 @@ This page lists all the individual contributions to the project by their author.
   - Shared ammo logic
   - Customizable FLH when infantry is prone or deployed
   - Initial strength for cloned infantry
+  - Universal deploy from any techno into any techno
 - **Starkku**:
   - Misc. minor bugfixes & improvements
   - AI script actions:

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -51,8 +51,10 @@
     <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
     <ClCompile Include="src\Ext\Team\Body.cpp" />
     <ClCompile Include="src\Ext\Team\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Techno\Body.UniversalDeploy.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Pips.cpp" />
     <ClCompile Include="src\Ext\Techno\Body.Visuals.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.UniversalDeploy.cpp" />
     <ClCompile Include="src\Ext\TEvent\Hooks.cpp" />
     <ClCompile Include="src\Ext\TEvent\Body.cpp" />
     <ClCompile Include="src\Ext\Trigger\Hooks.cpp" />

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -937,6 +937,47 @@ Spawner.ExtraLimitRange=0  ; integer, range in cells
 Spawner.DelayFrames=       ; integer, game frames
 ```
 
+### Universal deploy from any techno into any techno
+- Now is possible to convert any infantry/unit/structure into any infantry/unit/structure.
+- No direct support for aircrafts but they can be converted through warheads or super weapons (see below).
+- `Convert.UniversalDeploy` specifies the TechnoType which is the result of conversion.
+- `Convert.DeployingAnim` specifies the deployment animation. If no animation is declared then the conversion will be instantaneous.
+- `Convert.DeployToLand` forces the deployer to land before starting the deployment process.
+- `Convert.PreDeploy.AnimFX` specifies an animation at the same time the conversion starts.
+- `Convert.PostDeploy.AnimFX.FollowDeployer` attach the animation to the deployer.
+- `Convert.PostDeploy.AnimFX` specifies an animation at the end of the conversion.
+- `Convert.PostDeploy.AnimFX.FollowDeployer` attach the animation to the deployed TechnoType.
+- `Convert.PostDeploySound` specifies the sound that will be played when the deployemnt ends.
+- `Convert.DeployDir` determines the initial facing of created TechnoType.
+- `Convert.TransferPassengers` transfers passengers into the deployed TechnoType. If the new TechnoType has no enough space will kick out all the remaining passengers. 
+- `Convert.TransferPassengers.IgnoreInvalidOccupiers` if the deployed TechnoType is a structure all infantry passengers can be transfered ignoring the passenger's `Occupier` tag.
+- `Convert.ForceVeterancyTransfer` transfer the veterancy from the deployer to the deployed TechnoType ignoring the `Trainable` tag of the deployed TechnoType.
+- The use of `Convert.UseUniversalDeploy=true` in warheads or super weapons replaces the Ares techno deploy conversion logic by this logic. In this case it uses the `Convert.From` && `Convert.To` tags from the Ares logic.
+- `Convert.UseUniversalDeploy=true` skips lots of checks so in the case of deploying a structure into structure keep the same foundation size.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                                             ; TechnoType
+Convert.UniversalDeploy=                                 ; TechnoType
+Convert.DeployingAnim=                                   ; Animation
+Convert.DeployToLand=false                               ; WeaponType
+Convert.PreDeploy.AnimFX=                                ; Animation
+Convert.PreDeploy.AnimFX.FollowDeployer=false            ; Boolean
+Convert.PostDeploy.AnimFX=                               ; Animation
+Convert.PostDeploy.AnimFX.FollowDeployer=false           ; Boolean
+Convert.PostDeploySound=                                 ; Sound entry
+Convert.DeployDir=-1                                     ; Integer, facings in range of 0-7
+Convert.TransferPassengers=true                          ; Boolean
+Convert.TransferPassengers.IgnoreInvalidOccupiers=false  ; Boolean
+Convert.ForceVeterancyTransfer=false                     ; Boolean
+
+[SOMEWARHEAD]                     ; Warhead
+Convert.UseUniversalDeploy=false  ; Boolean
+
+[SOMESW]                          ; Superweapon
+Convert.UseUniversalDeploy=false  ; Boolean
+```
+
 ### Weapons fired on warping in / out
 
 - It is now possible to add weapons that are fired on a teleporting TechnoType when it warps in or out. They are at the same time as the appropriate animations (`WarpIn` / `WarpOut`) are displayed.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -357,6 +357,7 @@ New:
 - `AmbientDamage` warhead & main target ignore customization (by Starkku)
 - Flashing Technos on selecting (by Fryone)
 - Projectile return weapon (by Starkku)
+- Universal deploy from any techno into any techno (by FS-21)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -325,6 +325,38 @@ bool BuildingExt::HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfilt
 	return true;
 }
 
+void BuildingExt::HideBuildingAnimations(BuildingClass* pThis)
+{
+	if (!pThis)
+		return;
+
+	// Hide building animations
+	for (auto pAnim : pThis->Anims)
+	{
+		if (!pAnim)
+			continue;
+
+		pAnim->Invisible = true;
+		pAnim->NeedsRedraw = true;
+	}
+}
+
+void BuildingExt::UnhideBuildingAnimations(BuildingClass* pThis)
+{
+	if (!pThis)
+		return;
+
+	// Show building animations
+	for (auto pAnim : pThis->Anims)
+	{
+		if (!pAnim)
+			continue;
+
+		pAnim->Invisible = false;
+		pAnim->NeedsRedraw = true;
+	}
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -102,4 +102,6 @@ public:
 	static bool DoGrindingExtras(BuildingClass* pBuilding, TechnoClass* pTechno, int refund);
 	static bool HandleInfiltrate(BuildingClass* pBuilding, HouseClass* pInfiltratorHouse);
 	static bool CanUndeployOnSell(BuildingClass* pThis);
+	static void HideBuildingAnimations(BuildingClass* pThis = nullptr);
+	static void UnhideBuildingAnimations(BuildingClass* pThis = nullptr);
 };

--- a/src/Ext/Building/Hooks.Grinding.cpp
+++ b/src/Ext/Building/Hooks.Grinding.cpp
@@ -127,6 +127,17 @@ DEFINE_HOOK(0x740134, UnitClass_WhatAction_Grinding, 0x0)
 		}
 	}
 
+	// Show the deploy icon when the cursor is over one selected unit with this UniversalDeploy logic
+	auto const pTechno = abstract_cast<TechnoClass*>(pThis);
+	if (!pTechno || pTechno != pTarget)
+		return Continue;
+
+	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType());
+	if (!pTypeExt || !pTypeExt->Convert_UniversalDeploy.isset())
+		return Continue;
+
+	R->EBX(Action::Self_Deploy);
+
 	return Continue;
 }
 

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -45,6 +45,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ShowTimer_Priority)
 		.Process(this->Convert_Pairs)
 		.Process(this->ShowDesignatorRange)
+		.Process(this->Convert_UseUniversalDeploy)
 		;
 }
 
@@ -144,6 +145,8 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::Owner);
 
 	this->ShowDesignatorRange.Read(exINI, pSection, "ShowDesignatorRange");
+
+	this->Convert_UseUniversalDeploy.Read(exINI, pSection, "Convert.UseUniversalDeploy");
 }
 
 void SWTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -63,6 +63,8 @@ public:
 
 		std::vector<TypeConvertGroup> Convert_Pairs;
 
+		Valueable<bool> Convert_UseUniversalDeploy;
+
 		ExtData(SuperWeaponTypeClass* OwnerObject) : Extension<SuperWeaponTypeClass>(OwnerObject)
 			, Money_Amount { 0 }
 			, SW_Inhibitors {}
@@ -98,6 +100,7 @@ public:
 			, ShowTimer_Priority { 0 }
 			, Convert_Pairs {}
 			, ShowDesignatorRange { true }
+			, Convert_UseUniversalDeploy { false }
 		{ }
 
 		// Ares 0.A functions

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -311,6 +311,14 @@ void SWTypeExt::ExtData::ApplyTypeConversion(SuperClass* pSW)
 	if (this->Convert_Pairs.size() == 0)
 		return;
 
+	if (this->Convert_UseUniversalDeploy.Get())
+	{
+		for (const auto pTarget : *TechnoClass::Array)
+			TypeConvertGroup::UniversalConvert(pTarget, this->Convert_Pairs, pSW->Owner);
+
+		return;
+	}
+
 	for (const auto pTargetFoot : *FootClass::Array)
 		TypeConvertGroup::Convert(pTargetFoot, this->Convert_Pairs, pSW->Owner);
 }

--- a/src/Ext/Techno/Body.UniversalDeploy.cpp
+++ b/src/Ext/Techno/Body.UniversalDeploy.cpp
@@ -1,0 +1,1069 @@
+#include "Body.h"
+
+#include <Ext/Script/Body.h>
+
+void TechnoExt::CreateUniversalDeployAnimation(TechnoClass* pThis, AnimTypeClass* pAnimType)
+{
+	if (!pThis || !pAnimType)
+		return;
+
+	auto pExt = TechnoExt::ExtMap.Find(pThis);
+	if (!pExt)
+		return;
+
+	if (pExt->Convert_UniversalDeploy_DeployAnim)
+	{
+		pExt->Convert_UniversalDeploy_DeployAnim->UnInit();
+		pExt->Convert_UniversalDeploy_DeployAnim = nullptr;
+	}
+
+	if (auto pAnim = GameCreate<AnimClass>(pAnimType, pThis->Location))
+	{
+		pExt->Convert_UniversalDeploy_DeployAnim = pAnim;
+		pExt->Convert_UniversalDeploy_DeployAnim->SetOwnerObject(pThis);
+
+		// Use the unit palette in the animation
+		auto lcc = pThis->GetDrawer();
+		pExt->Convert_UniversalDeploy_DeployAnim->LightConvert = lcc;
+	}
+	else
+	{
+		Debug::Log("ERROR! [%s] Deploy animation %s can't be created.\n", pThis->GetTechnoType()->ID, pAnimType->ID);
+	}
+}
+
+void TechnoExt::UpdateUniversalDeploy(TechnoClass* pThis)
+{
+	if (!pThis)
+		return;
+
+	auto pThisExt = TechnoExt::ExtMap.Find(pThis);
+	if (!pThisExt || !pThisExt->Convert_UniversalDeploy_InProgress)
+		return;
+
+	// We have to know if the object that ran this method is the old deployer or the new object.
+	// If this method was executed by the new object then the stored object is the limboed original deployer and vice-versa.
+	// Is done in this way because limboed technos are ignored by the system and we want to continue the unfinished deployment logic like in the previous game frame.
+	bool isOriginalDeployer = pThisExt->Convert_UniversalDeploy_IsOriginalDeployer;
+	TechnoClass* pOld = !isOriginalDeployer ? pThisExt->Convert_UniversalDeploy_TemporalTechno : pThis;
+
+	auto pOldExt = TechnoExt::ExtMap.Find(pOld);
+	if (!pOldExt)
+		return;
+
+	auto pOldType = pOld->GetTechnoType();
+	if (!pOldType)
+		return;
+
+	auto pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOldType);
+	if (!pOldTypeExt)
+		return;
+
+	TechnoClass* pNew = !isOriginalDeployer ? pThis : nullptr;
+	auto const pNewType = !isOriginalDeployer ? pThis->GetTechnoType() : pOldTypeExt->Convert_UniversalDeploy.Get();
+	auto pNewExt = pNew ? TechnoExt::ExtMap.Find(pNew) : nullptr;
+
+	auto pNewTypeExt = TechnoTypeExt::ExtMap.Find(pNewType);
+	if (!pNewTypeExt)
+		return;
+
+	bool isOldBuilding = pOldType->WhatAmI() == AbstractType::BuildingType;
+	bool isOldInfantry = pOldType->WhatAmI() == AbstractType::InfantryType;
+	bool isOldAircraft = pOldType->WhatAmI() == AbstractType::AircraftType || pOldType->ConsideredAircraft;
+	bool isOldUnit = pOldType->WhatAmI() == AbstractType::UnitType;
+	bool oldTechnoIsUnit = isOldInfantry || isOldUnit || isOldAircraft;
+
+	bool isNewBuilding = pNewType->WhatAmI() == AbstractType::BuildingType;
+	bool isNewInfantry = pNewType->WhatAmI() == AbstractType::InfantryType;
+	bool isNewAircraft = pNewType->WhatAmI() == AbstractType::AircraftType || pNewType->ConsideredAircraft;
+	bool isNewUnit = pNewType->WhatAmI() == AbstractType::UnitType;
+	bool newTechnoIsUnit = isNewInfantry || isNewUnit || isNewAircraft;
+
+	auto const pOwner = pOld->Owner;
+	bool canDeployIntoStructure = false;
+	bool deployToLand = pOldTypeExt->Convert_DeployToLand;
+	auto pOldFoot = static_cast<FootClass*>(pOld);
+	BuildingClass* pBuildingOld = nullptr;
+	BuildingClass* pBuildingNew = nullptr;
+
+	AnimClass* pDeployAnim = pOldExt->Convert_UniversalDeploy_DeployAnim ? pOldExt->Convert_UniversalDeploy_DeployAnim : nullptr;
+	pDeployAnim = pNewExt && pNewExt->Convert_UniversalDeploy_DeployAnim ? pNewExt->Convert_UniversalDeploy_DeployAnim : pDeployAnim;
+
+	CoordStruct deployerLocation = pOld->GetCoords();
+	CoordStruct deploymentLocation = isOldInfantry && isNewInfantry ? deployerLocation : pOld->GetCell()->GetCenterCoords(); // Only infantry can use sub-cell locations
+	deploymentLocation = !deployToLand && pOld->GetHeight() > 0 && isNewAircraft ? pOld->Location : deploymentLocation;
+	DirType currentDir = pOld->PrimaryFacing.Current().GetDir(); // Returns current position in format [0 - 7] x 32
+
+	if (oldTechnoIsUnit && !pNew)
+	{
+		// Deployment to land check: Make sure the object will fall into ground (if some external factor changes it it restores the fall)
+		if (deployToLand)
+			pOld->IsFallingDown = true;
+
+		if (!pOld->IsFallingDown && pOldFoot->Locomotor->Is_Really_Moving_Now())
+			return;
+
+		// Deployment to land check: Update InAir information & let it fall into ground
+		if (deployToLand && pOld->GetHeight() <= 20)
+			pOld->SetHeight(0);
+
+		pOld->InAir = pOld->GetHeight() > 0; // Force the update
+
+		if (deployToLand)
+		{
+			if (pOld->InAir)
+				return;
+
+			pOldFoot->StopMoving();
+			pOldFoot->ParalysisTimer.Start(15);
+		}
+	}
+
+	// Unit direction check: Update the direction of the unit until it reaches the desired one, if specified
+	if (isOldUnit || isOldAircraft)
+	{
+		// Turn the unit to the right deploy facing
+		if (!pDeployAnim && pOldTypeExt->Convert_DeployDir >= 0)
+		{
+			DirType desiredDir = (static_cast<DirType>(pOldTypeExt->Convert_DeployDir * 32));
+			DirStruct desiredFacing;
+			desiredFacing.SetDir(desiredDir);
+
+			if (currentDir != desiredDir)
+			{
+				pOldFoot->Locomotor->Move_To(CoordStruct::Empty);
+				pOld->PrimaryFacing.SetDesired(desiredFacing);
+
+				return;
+			}
+		}
+	}
+
+	bool selected = false;
+	if (pOld->IsSelected)
+		selected = true;
+
+	// Here we go, the real conversions! There are 2 cases
+
+	// Case 1: "Unit into something" deploy, includes the case "Unit into Structure".
+	// Unit should loose the shape and get the structure shape for reserving the foundation space.
+	// This also prevents other units enter inside the structure foundation.
+	// This case should cover the "structure into structure".
+	if (oldTechnoIsUnit || isNewBuilding)
+	{
+		// Transfer enemies target (part 1/2)
+		DynamicVectorClass<TechnoClass*> enemiesTargetingMeList;
+		for (auto pEnemy : *TechnoClass::Array)
+		{
+			if (pEnemy->Target == pOld)
+				enemiesTargetingMeList.AddItem(pEnemy);
+		}
+
+		if (!pOld->InLimbo)
+			pOld->Limbo();
+
+		// Create & save it for later.
+		if (!pOldExt->Convert_UniversalDeploy_TemporalTechno)
+		{
+			pNew = static_cast<TechnoClass*>(pNewType->CreateObject(pOwner));
+
+			if (!pNew)
+			{
+				pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+				pOldExt->Convert_UniversalDeploy_TemporalTechno = nullptr;
+				pOldExt->Convert_UniversalDeploy_MakeInvisible = false;
+				pOldExt->Convert_UniversalDeploy_InProgress = false;
+				pOld->IsFallingDown = false;
+
+				++Unsorted::IKnowWhatImDoing;
+				pOld->Unlimbo(deployerLocation, currentDir);
+				--Unsorted::IKnowWhatImDoing;
+
+				if (selected)
+					pOld->Select();
+
+				return;
+			}
+
+			pOldExt->Convert_UniversalDeploy_TemporalTechno = pNew;
+			bool unlimboed = pNew->Unlimbo(deploymentLocation, currentDir);
+
+			// Failed deployment: restore the old object and abort operation
+			if (!unlimboed)
+			{
+				pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+				pOldExt->Convert_UniversalDeploy_TemporalTechno = nullptr;
+				pOldExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+				pOldExt->Convert_UniversalDeploy_MakeInvisible = false;
+				pOldExt->Convert_UniversalDeploy_InProgress = false;
+				pOld->IsFallingDown = false;
+
+				++Unsorted::IKnowWhatImDoing;
+				pOld->Unlimbo(deployerLocation, currentDir);
+				--Unsorted::IKnowWhatImDoing;
+
+				pOldFoot->ParalysisTimer.Stop();
+				pOld->ForceMission(Mission::Guard);
+
+				pNew->UnInit();
+
+				if (selected)
+					pOld->Select();
+
+				return;
+			}
+
+			// Transfer enemies target (part 2/2)
+			for (auto pEnemy : enemiesTargetingMeList)
+			{
+				//pEnemy->SetDestination(pNew, false);
+				pEnemy->SetTarget(pNew);
+			}
+
+			// Transfer Health stats from the old object to the new
+			double nHealthPercent = (double)(1.0 * pOld->Health / pOldType->Strength);
+			pNew->Health = (int)round(pNewType->Strength * nHealthPercent);
+			pNew->EstimatedHealth = pNew->Health;
+
+			// Because is too soon don't check the building stuff like energy, factory logic in the sidebar, etc
+			if (isNewBuilding)
+			{
+				pBuildingNew = static_cast<BuildingClass*>(pNew);
+				pBuildingNew->HasPower = false;
+
+				if (pBuildingNew->Factory)
+				{
+					pBuildingNew->IsPrimaryFactory = false;
+					pBuildingNew->Factory->IsSuspended = true;
+				}
+			}
+		}
+
+		// At this point the new object exists & is visible.
+		// If exists a deploy animation it must dissappear until the animation finished
+		pNew = !isOriginalDeployer ? pThis : pOldExt->Convert_UniversalDeploy_TemporalTechno;
+		pOldExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+		pOldExt->Convert_UniversalDeploy_MakeInvisible = true;
+
+		if (!pNewExt)
+			pNewExt = TechnoExt::ExtMap.Find(pNew);
+
+		pNewExt->Convert_UniversalDeploy_TemporalTechno = pOld;
+		pNewExt->Convert_UniversalDeploy_IsOriginalDeployer = false;
+		pNewExt->Convert_UniversalDeploy_InProgress = true;
+		pNewExt->Convert_UniversalDeploy_MakeInvisible = true;
+
+		if (isOldBuilding)
+		{
+			if (!pBuildingOld)
+				pBuildingOld = static_cast<BuildingClass*>(pOld);
+
+			BuildingExt::HideBuildingAnimations(pBuildingOld);
+			pBuildingOld->UpdateAnimations();
+		}
+
+		if (isNewBuilding)
+		{
+			if (!pBuildingNew)
+				pBuildingNew = static_cast<BuildingClass*>(pNew);
+
+			BuildingExt::HideBuildingAnimations(pBuildingNew);
+			pBuildingNew->UpdateAnimations();
+		}
+
+		// Play deploy sound, if set
+		if (pOldType->DeploySound >= 0 && !pDeployAnim)
+			VocClass::PlayAt(pOldType->DeploySound, deploymentLocation);
+
+		// Play pre-deploy FX animation
+		AnimTypeClass* pPreDeployAnimFXType = pOldTypeExt->Convert_PreDeploy_AnimFX.isset() ? pOldTypeExt->Convert_PreDeploy_AnimFX.Get() : nullptr;
+		bool preDeploy_AnimFX_FollowDeployer = pOldTypeExt->Convert_PreDeploy_AnimFX_FollowDeployer;
+
+		if (pPreDeployAnimFXType)
+		{
+			if (auto const pAnim = GameCreate<AnimClass>(pPreDeployAnimFXType, deploymentLocation))
+			{
+				if (preDeploy_AnimFX_FollowDeployer)
+					pAnim->SetOwnerObject(pNew);
+
+				pAnim->Owner = pNew->Owner;
+			}
+		}
+
+		if (selected)
+			pNew->Select();
+
+		// Setting the build up animation, if any.
+		AnimTypeClass* pDeployAnimType = pOldTypeExt->Convert_DeployingAnim.isset() ? pOldTypeExt->Convert_DeployingAnim.Get() : nullptr;
+
+		if (pDeployAnimType)
+		{
+			bool isDeployAnimPlaying = pDeployAnim ? true : false;
+			bool hasDeployAnimFinished = (isDeployAnimPlaying && (pDeployAnim->Animation.Value >= (pDeployAnimType->End + pDeployAnimType->Start - 1))) ? true : false;
+
+			// Hack for making the object invisible during a deploy
+			//pNewExt->Convert_UniversalDeploy_MakeInvisible = true;
+
+			// The conversion process won't start until the deploy animation ends
+			if (!isDeployAnimPlaying)
+			{
+				TechnoExt::CreateUniversalDeployAnimation(pNew, pDeployAnimType);
+				return;
+			}
+
+			if (!hasDeployAnimFinished)
+				return;
+
+			if (pNewExt->Convert_UniversalDeploy_DeployAnim->Type) // If this anim doesn't have a type pointer, just detach it
+			{
+				pNewExt->Convert_UniversalDeploy_DeployAnim->TimeToDie = true;
+				pNewExt->Convert_UniversalDeploy_DeployAnim->UnInit();
+			}
+
+			pNewExt->Convert_UniversalDeploy_DeployAnim = nullptr;
+		}
+
+		// The build up animation finished (if any).
+		// In this case we only have to transfer properties to the new object
+		pNewExt->Convert_UniversalDeploy_MakeInvisible = false;
+		//pNewExt->Convert_UniversalDeploy_IsOriginalDeployer = false;
+		pNewExt->Convert_UniversalDeploy_TemporalTechno = nullptr;
+		pNewExt->Convert_UniversalDeploy_InProgress = false;
+		pNew->MarkForRedraw();
+
+		if (isNewBuilding)
+		{
+			auto pBuildingNew = static_cast<BuildingClass*>(pNew);
+			BuildingExt::UnhideBuildingAnimations(pBuildingNew);
+			pBuildingNew->UpdateAnimations();
+			pBuildingNew->HasPower = true;
+
+			if (pBuildingNew->Factory)
+				pBuildingNew->Factory->IsSuspended = false;
+		}
+
+		// Transfer properties from the old object to the new one
+		TechnoExt::Techno2TechnoPropertiesTransfer(pOld, pNew);
+
+		// Play post-deploy sound
+		int convert_PostDeploySoundIndex = pOldTypeExt->Convert_PostDeploySound.isset() ? pOldTypeExt->Convert_PostDeploySound.Get() : -1;
+
+		if (convert_PostDeploySoundIndex >= 0)
+			VocClass::PlayAt(convert_PostDeploySoundIndex, deploymentLocation);
+
+		// Play post-deploy FX animation
+		AnimTypeClass* pPostDeployAnimFXType = pOldTypeExt->Convert_PostDeploy_AnimFX.isset() ? pOldTypeExt->Convert_PostDeploy_AnimFX.Get() : nullptr;
+		bool postDeploy_AnimFX_FollowDeployer = pOldTypeExt->Convert_PostDeploy_AnimFX_FollowDeployer;
+
+		if (pPostDeployAnimFXType)
+		{
+			if (auto const pAnim = GameCreate<AnimClass>(pPostDeployAnimFXType, deploymentLocation))
+			{
+				if (postDeploy_AnimFX_FollowDeployer)
+					pAnim->SetOwnerObject(pNew);
+
+				pAnim->Owner = pNew->Owner;
+			}
+		}
+
+		// The conversion process finished. Clean values
+		if (pOld->InLimbo)
+		{
+			pOwner->RegisterLoss(pOld, false);
+			pOwner->RemoveTracking(pOld);
+			pOld->UnInit();
+		}
+
+		// Register the new object
+		pOwner->AddTracking(pNew);
+		pOwner->RegisterGain(pNew, false);
+		pNew->Owner->RecheckTechTree = true;
+		pNew->Owner->RecheckPower = true;
+		pNew->Owner->RecheckRadar = true;
+
+		return;
+	}
+
+	// Case 2: "Building into something" deploy
+	// Structure foundation should remain until the deploy animation ends (if any).
+	// This also prevents other units enter inside the structure foundation.
+	if (isOldBuilding)
+	{
+		// Create & save it for later.
+		if (!pOldExt->Convert_UniversalDeploy_TemporalTechno)
+		{
+			pNew = static_cast<TechnoClass*>(pNewType->CreateObject(pOwner));
+
+			if (!pNew)
+			{
+				pOldExt->Convert_UniversalDeploy_TemporalTechno = nullptr;
+				pOldExt->Convert_UniversalDeploy_MakeInvisible = false;
+				pOldExt->Convert_UniversalDeploy_InProgress = false;
+				pOld->IsFallingDown = false;
+
+				++Unsorted::IKnowWhatImDoing;
+				pOld->Unlimbo(deployerLocation, currentDir);
+				--Unsorted::IKnowWhatImDoing;
+
+				if (selected)
+					pOld->Select();
+
+				return;
+			}
+
+			pNew->ForceMission(Mission::Guard);
+			pOldExt->Convert_UniversalDeploy_TemporalTechno = pNew;
+
+			if (isOldBuilding)
+			{
+				auto pBuildingOld = static_cast<BuildingClass*>(pOld);
+				pBuildingOld->HasPower = false;
+
+				if (pBuildingOld->Factory)
+				{
+					pBuildingOld->IsPrimaryFactory = false;
+					pBuildingOld->Factory->IsSuspended = true;
+				}
+			}
+		}
+
+		// At this point the new object exists & is visible.
+		// If exists a deploy animation it must dissappear until the animation finished
+		pOldExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+		pNew = !isOriginalDeployer ? pThis : pOldExt->Convert_UniversalDeploy_TemporalTechno;
+
+		if (!pNewExt)
+			pNewExt = TechnoExt::ExtMap.Find(pNew);
+
+		pNewExt->Convert_UniversalDeploy_TemporalTechno = pOld;
+		pNewExt->Convert_UniversalDeploy_IsOriginalDeployer = false;
+		pNewExt->Convert_UniversalDeploy_InProgress = true;
+
+		// Transfer Health stats from the old object to the new
+		double nHealthPercent = (double)(1.0 * pOld->Health / pOldType->Strength);
+		pNew->Health = (int)round(pNewType->Strength * nHealthPercent);
+		pNew->EstimatedHealth = pNew->Health;
+
+		// Play deploy sound, if set
+		if (pOldType->DeploySound >= 0 && !pDeployAnim)
+			VocClass::PlayAt(pOldType->DeploySound, deploymentLocation);
+
+		// Play pre-deploy FX animation
+		AnimTypeClass* pPreDeployAnimFXType = pOldTypeExt->Convert_PreDeploy_AnimFX.isset() ? pOldTypeExt->Convert_PreDeploy_AnimFX.Get() : nullptr;
+		bool preDeploy_AnimFX_FollowDeployer = pOldTypeExt->Convert_PreDeploy_AnimFX_FollowDeployer;
+
+		if (pPreDeployAnimFXType)
+		{
+			if (auto const pAnim = GameCreate<AnimClass>(pPreDeployAnimFXType, deploymentLocation))
+			{
+				if (preDeploy_AnimFX_FollowDeployer)
+					pAnim->SetOwnerObject(pNew);
+
+				pAnim->Owner = pNew->Owner;
+			}
+		}
+
+		// Setting the build up animation, if any.
+		AnimTypeClass* pDeployAnimType = pOldTypeExt->Convert_DeployingAnim.isset() ? pOldTypeExt->Convert_DeployingAnim.Get() : nullptr;
+
+		if (pDeployAnimType)
+		{
+			bool isDeployAnimPlaying = pDeployAnim ? true : false;
+			bool hasDeployAnimFinished = (isDeployAnimPlaying && (pDeployAnim->Animation.Value >= (pDeployAnimType->End + pDeployAnimType->Start - 1))) ? true : false;
+
+			// Hack for making the object invisible during a deploy
+			pOldExt->Convert_UniversalDeploy_MakeInvisible = true;
+			pOld->MarkForRedraw();
+
+			// The conversion process won't start until the deploy animation ends
+			if (!isDeployAnimPlaying)
+			{
+				TechnoExt::CreateUniversalDeployAnimation(pOld, pDeployAnimType);
+				return;
+			}
+
+			if (!hasDeployAnimFinished)
+				return;
+
+			if (pOldExt->Convert_UniversalDeploy_DeployAnim->Type) // If this anim doesn't have a type pointer, just detach it
+			{
+				pOldExt->Convert_UniversalDeploy_DeployAnim->TimeToDie = true;
+				pOldExt->Convert_UniversalDeploy_DeployAnim->UnInit();
+			}
+
+			pOldExt->Convert_UniversalDeploy_DeployAnim = nullptr;
+		}
+
+		// Transfer enemies target (part 1/2)
+		DynamicVectorClass<TechnoClass*> enemiesTargetingMeList;
+		for (auto pEnemy : *TechnoClass::Array)
+		{
+			if (pEnemy->Target == pOld)
+				enemiesTargetingMeList.AddItem(pEnemy);
+		}
+
+		// The build up animation finished (if any).
+		if (!pOld->InLimbo)
+			pOld->Limbo();
+
+		bool unlimboed = pNew->Unlimbo(deploymentLocation, currentDir);
+
+		// Failed deployment: restore the old object and abort operation
+		if (!unlimboed)
+		{
+			pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+			pOldExt->Convert_UniversalDeploy_TemporalTechno = nullptr;
+			pOldExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+			pOldExt->Convert_UniversalDeploy_MakeInvisible = false;
+			pOldExt->Convert_UniversalDeploy_InProgress = false;
+			pOld->IsFallingDown = false;
+
+			++Unsorted::IKnowWhatImDoing;
+			pOld->Unlimbo(deployerLocation, currentDir);
+			--Unsorted::IKnowWhatImDoing;
+
+			pOldFoot->ParalysisTimer.Stop();
+			pOld->ForceMission(Mission::Guard);
+
+			if (isOldBuilding)
+			{
+				auto pBuildingOld = static_cast<BuildingClass*>(pOld);
+				pBuildingOld->HasPower = true;
+
+				if (pBuildingOld->Factory)
+					pBuildingOld->Factory->IsSuspended = false;
+			}
+
+			pNew->UnInit();
+
+			if (selected)
+				pOld->Select();
+
+			return;
+		}
+
+		// Transfer enemies target (part 2/2)
+		for (auto pEnemy : enemiesTargetingMeList)
+		{
+			pEnemy->SetDestination(pNew, false);
+			pEnemy->SetTarget(pNew);
+		}
+
+		if (selected)
+			pNew->Select();
+
+		// Repaint the building graphics. Needed
+		if (isNewBuilding)
+		{
+			auto pBuildingNew = static_cast<BuildingClass*>(pNew);
+			pBuildingNew->BeginMode(BStateType::Active);
+			pNew->CurrentMission = Mission::Guard;
+			pBuildingNew->MarkForRedraw();
+		}
+
+		// Transfer properties from the old object to the new one
+		TechnoExt::Techno2TechnoPropertiesTransfer(pOld, pNew);
+
+		// Play post-deploy sound
+		int convert_PostDeploySoundIndex = pOldTypeExt->Convert_PostDeploySound.isset() ? pOldTypeExt->Convert_PostDeploySound.Get() : -1;
+
+		if (convert_PostDeploySoundIndex >= 0)
+			VocClass::PlayAt(convert_PostDeploySoundIndex, deploymentLocation);
+
+		// Play post-deploy FX animation
+		AnimTypeClass* pPostDeployAnimFXType = pOldTypeExt->Convert_PostDeploy_AnimFX.isset() ? pOldTypeExt->Convert_PostDeploy_AnimFX.Get() : nullptr;
+		bool postDeploy_AnimFX_FollowDeployer = pOldTypeExt->Convert_PostDeploy_AnimFX_FollowDeployer;
+
+		if (pPostDeployAnimFXType)
+		{
+			if (auto const pAnim = GameCreate<AnimClass>(pPostDeployAnimFXType, deploymentLocation))
+			{
+				if (postDeploy_AnimFX_FollowDeployer)
+					pAnim->SetOwnerObject(pNew);
+
+				pAnim->Owner = pNew->Owner;
+			}
+		}
+
+		// The conversion process finished. Clean values
+		if (pOld->InLimbo)
+		{
+			pNewExt->Convert_UniversalDeploy_TemporalTechno = nullptr;
+			pNewExt->Convert_UniversalDeploy_IsOriginalDeployer = false;
+			pNewExt->Convert_UniversalDeploy_InProgress = false;
+
+			pOwner->RegisterLoss(pOld, false);
+			pOwner->RemoveTracking(pOld);
+			pOld->UnInit();
+		}
+
+		if (newTechnoIsUnit)
+		{
+			auto pCell = pNew->GetCell();
+			bool cellIsOnWater = (pCell->LandType == LandType::Water || pCell->LandType == LandType::Beach);
+
+			// Jumpjet tricks: if they are in the ground make air units fly
+			if ((!pNew->InAir || cellIsOnWater) && (pNewType->JumpJet || pNewType->BalloonHover))
+			{
+				// Jumpjets should fly if
+				auto pFoot = static_cast<FootClass*>(pNew);
+				pFoot->Scatter(CoordStruct::Empty, true, false);
+				pNew->IsFallingDown = false; // Probably isn't necessary since the new object should not have this "true"
+			}
+			else
+			{
+				if (isNewAircraft && cellIsOnWater)
+				{
+					auto pFoot = static_cast<FootClass*>(pNew);
+					pFoot->Scatter(CoordStruct::Empty, true, false);
+					pNew->IsFallingDown = false; // Probably isn't necessary since the new object should not have this "true"
+				}
+			}
+		}
+
+		pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+		pNewExt->Convert_UniversalDeploy_InProgress = false;
+		pNewExt->Convert_UniversalDeploy_IsOriginalDeployer = false;
+		pNew->MarkForRedraw();
+
+		// Register the new object
+		pOwner->AddTracking(pNew);
+		pOwner->RegisterGain(pNew, false);
+		pNew->Owner->RecheckTechTree = true;
+		pNew->Owner->RecheckPower = true;
+		pNew->Owner->RecheckRadar = true;
+	}
+}
+
+// This simplified method transfer all settings from the old object to the new.
+// If a new object isn't defined then it will be picked from a list.
+TechnoClass* TechnoExt::UniversalDeployConversion(TechnoClass* pOld, TechnoTypeClass* pNewType)
+{
+	if (!pOld || !ScriptExt::IsUnitAvailable(pOld, false))
+		return nullptr;
+
+	auto pOldExt = TechnoExt::ExtMap.Find(pOld);
+	if (pOldExt->Convert_UniversalDeploy_InProgress)
+		return nullptr;
+
+	auto pOldType = pOld->GetTechnoType();
+	if (!pOldType)
+		return nullptr;
+
+	auto pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOldType);
+
+	// If the new object isn't defined then it will be picked from a list
+	if (!pNewType)
+	{
+		if (!pOldTypeExt->Convert_UniversalDeploy.isset())
+			return nullptr;
+
+		pNewType = pOldTypeExt->Convert_UniversalDeploy.Get();
+	}
+
+	bool isOldBuilding = pOldType->WhatAmI() == AbstractType::BuildingType;
+	bool isOldInfantry = pOldType->WhatAmI() == AbstractType::InfantryType;
+	bool isOldAircraft = pOldType->WhatAmI() == AbstractType::AircraftType || pOldType->ConsideredAircraft;
+	bool isOldUnit = pOldType->WhatAmI() == AbstractType::UnitType;
+	bool oldTechnoIsUnit = isOldInfantry || isOldUnit || isOldAircraft;
+
+	bool isNewBuilding = pNewType->WhatAmI() == AbstractType::BuildingType;
+	bool isNewInfantry = pNewType->WhatAmI() == AbstractType::InfantryType;
+	bool isNewAircraft = pNewType->WhatAmI() == AbstractType::AircraftType || pNewType->ConsideredAircraft;
+	bool isNewUnit = pNewType->WhatAmI() == AbstractType::UnitType;
+	bool newTechnoIsUnit = isNewInfantry || isNewUnit || isNewAircraft;
+
+	auto pNewTypeExt = TechnoTypeExt::ExtMap.Find(pNewType);
+	auto const pOwner = pOld->Owner;
+	pOld->InAir = (pOld->GetHeight() > 0); // Force the update
+	CoordStruct deployerLocation = pOld->GetCoords();
+	CoordStruct deploymentLocation = isOldInfantry && isNewInfantry ? deployerLocation : pOld->GetCell()->GetCenterCoords(); // infantry into infantry allows unlimbo into a sub-cell
+	DirType currentDir = pOld->PrimaryFacing.Current().GetDir(); // Returns current position in format [0 - 7] x 32
+	DirType currentTurretDir = pOld->SecondaryFacing.Current().GetDir(); // Returns current position in format [0 - 7] x 32
+
+	if (isNewBuilding && pOld->InAir)
+		return nullptr;
+
+	TechnoClass* pNew = static_cast<TechnoClass*>(pNewType->CreateObject(pOwner));
+	if (!pNew)
+		return nullptr;
+
+	pNew->ForceMission(Mission::Guard);
+
+	bool selected = false;
+	if (pOld->IsSelected)
+		pOld->Select();
+
+	// Transfer enemies target (part 1/2)
+	DynamicVectorClass<TechnoClass*> enemiesTargetingMeList;
+	for (auto pEnemy : *TechnoClass::Array)
+	{
+		if (pEnemy->Target == pOld)
+			enemiesTargetingMeList.AddItem(pEnemy);
+	}
+
+	++Unsorted::IKnowWhatImDoing;
+	pOld->Limbo();
+	bool unlimboed = pNew->Unlimbo(deploymentLocation, currentDir);
+	--Unsorted::IKnowWhatImDoing;
+
+	if (!unlimboed)
+	{
+		// I think here won't enter because I avoided checks
+		++Unsorted::IKnowWhatImDoing;
+		pNew->UnInit();
+		pOld->Unlimbo(deployerLocation, currentDir);
+		--Unsorted::IKnowWhatImDoing;
+	}
+
+	// Transfer enemies target (part 2/2)
+	for (auto pEnemy : enemiesTargetingMeList)
+	{
+		pEnemy->SetDestination(pNew, false);
+		pEnemy->SetTarget(pNew);
+	}
+
+	pNew->InAir = (pOld->GetHeight() > 0); // Force the update
+
+	if (pNew->InAir && !isNewAircraft) // Fall...
+		pNew->Scatter(CoordStruct::Empty, true, false);
+
+	if (newTechnoIsUnit)
+	{
+		auto pCell = pNew->GetCell();
+		bool cellIsOnWater = (pCell->LandType == LandType::Water || pCell->LandType == LandType::Beach);
+
+		// Jumpjet tricks: if they are in the ground make air units fly
+		if ((!pNew->InAir || cellIsOnWater) && (pNewType->JumpJet || pNewType->BalloonHover))
+		{
+			// Jumpjets should fly if
+			auto pFoot = static_cast<FootClass*>(pNew);
+			pFoot->Scatter(CoordStruct::Empty, true, false);
+			pNew->IsFallingDown = false; // Probably isn't necessary since the new object should not have this "true"
+		}
+		else
+		{
+			if (isNewAircraft && cellIsOnWater)
+			{
+				auto pFoot = static_cast<FootClass*>(pNew);
+				pFoot->Scatter(CoordStruct::Empty, true, false);
+				pNew->IsFallingDown = false; // Probably isn't necessary since the new object should not have this "true"
+			}
+		}
+	}
+
+	// Transfer all the important details
+	TechnoExt::Techno2TechnoPropertiesTransfer(pOld, pNew);
+
+	pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+	pOwner->RemoveTracking(pOld);
+	pOwner->RegisterLoss(pOld, false);
+	pOwner->AddTracking(pNew);
+	pOwner->RegisterGain(pNew, false);
+	pNew->MarkForRedraw();
+	pNew->Owner->RecheckTechTree = true;
+	pNew->Owner->RecheckPower = true;
+	pNew->Owner->RecheckRadar = true;
+
+	pOld->UnInit();
+
+	return pNew;
+}
+
+bool TechnoExt::Techno2TechnoPropertiesTransfer(TechnoClass* pOld, TechnoClass* pNew)
+{
+	if (!pOld || !pNew || !pNew->IsAlive || pNew->Health <= 0)
+		return false;
+
+	auto pOldExt = TechnoExt::ExtMap.Find(pOld);
+	auto pNewExt = TechnoExt::ExtMap.Find(pNew);
+
+	if (!pOldExt || !pNewExt)
+		return false;
+
+	auto const pOldType = pOld->GetTechnoType();
+	auto const pNewType = pNew->GetTechnoType();
+
+	if (!pOldType || !pNewType)
+		return false;
+
+	auto pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOldType);
+	auto pNewTypeExt = TechnoTypeExt::ExtMap.Find(pNewType);
+
+	if (!pOldTypeExt || !pNewTypeExt)
+		return false;
+
+	auto newLocation = pOld->Location;
+	auto pOwner = pOld->Owner;
+
+	bool isOldBuilding = pOld->WhatAmI() == AbstractType::Building;
+	bool isNewBuilding = pNew->WhatAmI() == AbstractType::Building;
+	bool isOldInfantry = pOld->WhatAmI() == AbstractType::Infantry;
+	bool isNewInfantry = pNew->WhatAmI() == AbstractType::Infantry;
+	bool isOldAircraft = pOld->WhatAmI() == AbstractType::Aircraft;
+	bool isNewAircraft = pNew->WhatAmI() == AbstractType::Aircraft;
+	bool isOldUnit = pOld->WhatAmI() == AbstractType::Unit;
+	bool isNewUnit = pNew->WhatAmI() == AbstractType::Unit;
+
+	++Unsorted::IKnowWhatImDoing;
+
+	// Transfer some stats from the old object to the new:
+	// Health update
+	double nHealthPercent = (double)(1.0 * pOld->Health / pOldType->Strength);
+	pNew->Health = (int)round(pNewType->Strength * nHealthPercent);
+	pNew->EstimatedHealth = pNew->Health;
+
+	// Shield update
+	if (auto pOldShieldData = pOldExt->Shield.get())
+	{
+		if (auto pNewShieldData = pNewExt->Shield.get())
+		{
+			if (pOldExt->CurrentShieldType
+				&& pOldShieldData
+				&& pNewExt->CurrentShieldType
+				&& pNewShieldData)
+			{
+				double nOldShieldHealthPercent = (double)(1.0 * pOldShieldData->GetHP() / pOldExt->CurrentShieldType->Strength);
+				pNewShieldData->SetHP((int)(nOldShieldHealthPercent * pNewExt->CurrentShieldType->Strength));
+			}
+		}
+	}
+
+	// Veterancy update
+
+	if (pNewType->Trainable || pOldTypeExt->Convert_ForceVeterancyTransfer)
+	{
+		VeterancyStruct nVeterancy = pOld->Veterancy;
+		pNew->Veterancy = nVeterancy;
+	}
+
+	// AI team update
+	if (pOld->BelongsToATeam())
+	{
+		auto pOldFoot = static_cast<FootClass*>(pOld);
+		auto pNewFoot = static_cast<FootClass*>(pNew);
+
+		if (pNewFoot)
+			pNewFoot->Team = pOldFoot->Team;
+	}
+
+	// Ammo update
+	pNew->Ammo = pNew->Ammo > pOld->Ammo ? pOld->Ammo : pNew->Ammo;
+
+	// Mind control update
+	if (pOld->IsMindControlled())
+		TechnoExt::TransferMindControlOnDeploy(pOld, pNew);
+
+	// Initial mission update (it can change if the deployer object has a target)
+	pNew->QueueMission(Mission::Guard, true);
+
+	// Cloak update
+	pNew->CloakState = pOld->CloakState;
+
+	// Facing update
+	pNew->PrimaryFacing.SetCurrent(pOld->PrimaryFacing.Current());
+	pNew->SecondaryFacing.SetCurrent(pOld->SecondaryFacing.Current());
+
+	if (pOldTypeExt->Convert_DeployDir >= 0)
+	{
+		DirStruct newDesiredFacing;
+		DirType newDesiredDir = (static_cast<DirType>(pOldTypeExt->Convert_DeployDir * 32));
+
+		newDesiredFacing.SetDir(newDesiredDir);
+		pNew->PrimaryFacing.SetCurrent(newDesiredFacing); // Body
+		pNew->SecondaryFacing.SetCurrent(newDesiredFacing); // Turret
+	}
+
+	// Jumpjet tricks: if they are in the ground make air units fly
+	auto pCell = pNew->GetCell();
+	bool cellIsOnWater = (pCell->LandType == LandType::Water || pCell->LandType == LandType::Beach);
+
+	// Jumpjet tricks: if they are in the ground make air units fly
+	if ((!pNew->InAir || cellIsOnWater) && (pNewType->JumpJet || pNewType->BalloonHover))
+	{
+		// Jumpjets should fly if
+		auto pFoot = static_cast<FootClass*>(pNew);
+		pFoot->Scatter(CoordStruct::Empty, true, false);
+		pNew->IsFallingDown = false; // Probably isn't necessary since the new object should not have this "true"
+	}
+	else
+	{
+		if (isNewAircraft && cellIsOnWater)
+		{
+			auto pNewFoot = static_cast<FootClass*>(pNew);
+			pNewFoot->Scatter(CoordStruct::Empty, true, false);
+			pNew->IsFallingDown = false; // Probably isn't necessary since the new object should not have this "true"
+		}
+	}
+
+	// Inherit other stuff
+	pNew->WarpingOut = pOld->WarpingOut;
+	pNew->unknown_280 = pOld->unknown_280; // Sth related to teleport
+	pNew->BeingWarpedOut = pOld->BeingWarpedOut;
+	pNew->Deactivated = pOld->Deactivated;
+	pNew->Flash(pOld->Flashing.DurationRemaining);
+	pNew->IdleActionTimer = pOld->IdleActionTimer;
+	pNew->ChronoLockRemaining = pOld->ChronoLockRemaining;
+	pNew->Berzerk = pOld->Berzerk;
+	pNew->BerzerkDurationLeft = pOld->BerzerkDurationLeft;
+	pNew->ChronoWarpedByHouse = pOld->ChronoWarpedByHouse;
+	pNew->EMPLockRemaining = pOld->EMPLockRemaining;
+	pNew->ShouldLoseTargetNow = pOld->ShouldLoseTargetNow;
+	pNew->SetOwningHouse(pOld->GetOwningHouse(), false);// Is really necessary? the object was created with the final owner by default... I have to try without this tag
+	pNew->AttachedTag = pOld->AttachedTag;
+	pNew->AttachedBomb = pOld->AttachedBomb;
+
+	// Detach CLEG targeting
+	auto tempUsing = pOld->TemporalImUsing;
+	if (tempUsing && tempUsing->Target)
+		tempUsing->Detach();
+
+	if (pOldExt->Convert_UniversalDeploy_RememberTarget)
+		pNew->SetTarget(pOldExt->Convert_UniversalDeploy_RememberTarget);
+
+	// Transfer Iron Courtain effect, if applied
+	TechnoExt::SyncIronCurtainStatus(pOld, pNew);
+
+	// Transfer passengers/garrisoned units from old object to the new, if possible
+	TechnoExt::PassengersTransfer(pOld, pNew);
+
+	// Transfer parasite, if possible
+	if (auto const pOldFoot = abstract_cast<FootClass*>(pOld))
+	{
+		if (auto const pParasite = pOldFoot->ParasiteEatingMe)
+		{
+			// Remove parasite
+			pParasite->ParasiteImUsing->SuppressionTimer.Start(50);
+			pParasite->ParasiteImUsing->ExitUnit();
+
+			if (auto const pNewFoot = abstract_cast<FootClass*>(pNew))
+			{
+				// Try to transfer parasite
+				pParasite->ParasiteImUsing->TryInfect(pNewFoot);
+			}
+		}
+	}
+
+	// Transfer AttachEffect (Reminder: add a new tag) - TO-DO: There is a Phobos PR that I should support once is merged into develop branch
+
+	--Unsorted::IKnowWhatImDoing;
+
+	// If the object was selected it should remain selected
+	if (pOld->IsSelected)
+		pNew->Select();
+
+	return true;
+}
+
+void TechnoExt::PassengersTransfer(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo = nullptr)
+{
+	if (!pTechnoFrom || (pTechnoFrom == pTechnoTo))
+		return;
+
+	// Without a target transport this method becomes an "eject passengers from transport"
+	auto pTechnoTypeTo = pTechnoTo ? pTechnoTo->GetTechnoType() : nullptr;
+	if (!pTechnoTypeTo && pTechnoTo)
+		return;
+
+	bool bTechnoToIsBuilding = (pTechnoTo && pTechnoTo->WhatAmI() == AbstractType::Building) ? true : false;
+	DynamicVectorClass<FootClass*> passengersList;
+
+	// From bunkered infantry
+	if (pTechnoFrom->WhatAmI() == AbstractType::Building)
+	{
+		auto pBuildingFrom = static_cast<BuildingClass*>(pTechnoFrom);
+
+		for (int i = 0; i < pBuildingFrom->Occupants.Count; i++)
+		{
+			InfantryClass* pPassenger = pBuildingFrom->Occupants.GetItem(i);
+			auto pFooter = static_cast<FootClass*>(pPassenger);
+			passengersList.AddItem(pFooter);
+		}
+	}
+
+	// We'll get the passengers list in a more easy data structure (to me)
+	while (pTechnoFrom->Passengers.NumPassengers > 0)
+	{
+		FootClass* pPassenger = pTechnoFrom->Passengers.RemoveFirstPassenger();
+
+		pPassenger->Transporter = nullptr;
+		pPassenger->ShouldEnterOccupiable = false;
+		pPassenger->ShouldGarrisonStructure = false;
+		pPassenger->InOpenToppedTransport = false;
+		pPassenger->QueueMission(Mission::Guard, false);
+		passengersList.AddItem(pPassenger);
+	}
+
+	if (passengersList.Count > 0)
+	{
+		double passengersSizeLimit = pTechnoTo ? pTechnoTypeTo->SizeLimit : 0;
+		int passengersLimit = pTechnoTo ? pTechnoTypeTo->Passengers : 0;
+		int numPassengers = pTechnoTo ? pTechnoTo->Passengers.NumPassengers : 0;
+		TechnoClass* transportReference = pTechnoTo ? pTechnoTo : pTechnoFrom;
+
+		while (passengersList.Count > 0)
+		{
+			bool forceEject = false;
+			FootClass* pPassenger = nullptr;
+
+			// The insertion order is different in buildings
+			int passengerIndex = bTechnoToIsBuilding ? 0 : passengersList.Count - 1;
+
+			pPassenger = passengersList.GetItem(passengerIndex);
+			passengersList.RemoveItem(passengerIndex);
+			auto pFromTypeExt = TechnoTypeExt::ExtMap.Find(pTechnoFrom->GetTechnoType());
+
+			if (!pTechnoTo || (pFromTypeExt && !pFromTypeExt->Convert_TransferPassengers))
+				forceEject = true;
+
+			// To bunkered infantry
+			if (pTechnoTo && pTechnoTo->WhatAmI() == AbstractType::Building)
+			{
+				auto pBuildingTo = static_cast<BuildingClass*>(pTechnoTo);
+				int nOccupants = pBuildingTo->Occupants.Count;
+				int maxNumberOccupants = pTechnoTo ? pBuildingTo->Type->MaxNumberOccupants : 0;
+
+				InfantryClass* infantry = static_cast<InfantryClass*>(pPassenger);
+				bool isOccupier = infantry && (infantry->Type->Occupier || pFromTypeExt->Convert_TransferPassengers_IgnoreInvalidOccupiers) ? true : false;
+
+				if (!forceEject && isOccupier && maxNumberOccupants > 0 && nOccupants < maxNumberOccupants)
+				{
+					pBuildingTo->Occupants.AddItem(infantry);
+				}
+				else
+				{
+					// Not enough space inside the new Bunker, eject the passenger
+					CoordStruct passengerLoc = PassengerKickOutLocation(transportReference, pPassenger);
+					CellClass* pCell = MapClass::Instance->TryGetCellAt(passengerLoc);
+					pPassenger->LastMapCoords = pCell->MapCoords;
+					pPassenger->Unlimbo(passengerLoc, DirType::North);
+				}
+			}
+			else
+			{
+				double passengerSize = pPassenger->GetTechnoType()->Size;
+				CoordStruct passengerLoc = PassengerKickOutLocation(transportReference, pPassenger);
+
+				if (!forceEject && passengerSize > 0 && (passengersLimit - numPassengers - passengerSize >= 0) && passengerSize <= passengersSizeLimit)
+				{
+					if (pTechnoTo->GetTechnoType()->OpenTopped)
+					{
+						pPassenger->SetLocation(pTechnoTo->Location);
+						pTechnoTo->EnteredOpenTopped(pPassenger);
+					}
+
+					pPassenger->Transporter = pTechnoTo;
+					pTechnoTo->AddPassenger(pPassenger);
+					numPassengers += (int)passengerSize;
+				}
+				else
+				{
+					// Not enough space inside the new transport, eject the passenger
+					CellClass* pCell = MapClass::Instance->TryGetCellAt(passengerLoc);
+					pPassenger->LastMapCoords = pCell->MapCoords;
+					pPassenger->Unlimbo(passengerLoc, DirType::North);
+				}
+			}
+		}
+	}
+}

--- a/src/Ext/Techno/Body.UniversalDeploy.cpp
+++ b/src/Ext/Techno/Body.UniversalDeploy.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
 
 #include <Ext/Script/Body.h>
+#include <Ext/Building/Body.h>
 
 void TechnoExt::CreateUniversalDeployAnimation(TechnoClass* pThis, AnimTypeClass* pAnimType)
 {

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -114,7 +114,7 @@ double TechnoExt::GetCurrentSpeedMultiplier(FootClass* pThis)
 		(pThis->HasAbility(Ability::Faster) ? RulesClass::Instance->VeteranSpeed : 1.0);
 }
 
-CoordStruct TechnoExt::PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger, int maxAttempts = 1)
+CoordStruct TechnoExt::PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger, int maxAttempts)
 {
 	if (!pThis || !pPassenger)
 		return CoordStruct::Empty;
@@ -346,6 +346,40 @@ bool TechnoExt::CanDeployIntoBuilding(UnitClass* pThis, bool noDeploysIntoDefaul
 	return canDeploy;
 }
 
+// Checks if a structure can deploy into another at its current location. If the building has problems forplacing the new one returns noDeploysIntoDefaultValue (def = false) instead.
+// If a building is specified then it will be used by default.
+bool TechnoExt::CanDeployIntoBuilding(BuildingClass* pThis, bool noDeploysIntoDefaultValue, BuildingTypeClass* pBuildingType)
+{
+	if (!pThis)
+		return false;
+
+	auto pDeployType = pBuildingType;
+
+	if (!pDeployType)
+	{
+		auto pBldTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+		if (!pBldTypeExt || !pBldTypeExt->Convert_UniversalDeploy.isset())
+			return noDeploysIntoDefaultValue;
+
+		pDeployType = static_cast<BuildingTypeClass*>(pBldTypeExt->Convert_UniversalDeploy.Get());
+	}
+
+	if (!pDeployType)
+		return noDeploysIntoDefaultValue;
+
+	bool canDeploy = true;
+	auto mapCoords = CellClass::Coord2Cell(pThis->GetCoords());
+
+	pThis->Mark(MarkType::Up);
+
+	if (!pDeployType->CanCreateHere(mapCoords, pThis->Owner))
+		canDeploy = false;
+
+	pThis->Mark(MarkType::Down);
+
+	return canDeploy;
+}
+
 bool TechnoExt::IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource)
 {
 	if (!pThis || !pSource)
@@ -384,6 +418,12 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->DeployFireTimer)
 		.Process(this->ForceFullRearmDelay)
 		.Process(this->WHAnimRemainingCreationInterval)
+		.Process(this->Convert_UniversalDeploy_DeployAnim)
+		.Process(this->Convert_UniversalDeploy_InProgress)
+		.Process(this->Convert_UniversalDeploy_MakeInvisible)
+		.Process(this->Convert_UniversalDeploy_TemporalTechno)
+		.Process(this->Convert_UniversalDeploy_IsOriginalDeployer)
+		.Process(this->Convert_UniversalDeploy_RememberTarget)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -8,6 +8,7 @@
 #include <Utilities/Macro.h>
 #include <New/Entity/ShieldClass.h>
 #include <New/Entity/LaserTrailClass.h>
+#include <Ext/Building/Body.h>
 
 class BulletClass;
 
@@ -43,6 +44,13 @@ public:
 		// as neither is guaranteed to point to the house the TechnoClass had prior to entering transport and cannot be safely overridden.
 		HouseClass* OriginalPassengerOwner;
 
+		AnimClass* Convert_UniversalDeploy_DeployAnim;
+		bool Convert_UniversalDeploy_InProgress;
+		bool Convert_UniversalDeploy_MakeInvisible;
+		TechnoClass* Convert_UniversalDeploy_TemporalTechno;
+		bool Convert_UniversalDeploy_IsOriginalDeployer;
+		AbstractClass* Convert_UniversalDeploy_RememberTarget;
+
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
 			, Shield {}
@@ -61,6 +69,12 @@ public:
 			, DeployFireTimer {}
 			, ForceFullRearmDelay { false }
 			, WHAnimRemainingCreationInterval { 0 }
+			, Convert_UniversalDeploy_DeployAnim { nullptr }
+			, Convert_UniversalDeploy_InProgress { false }
+			, Convert_UniversalDeploy_MakeInvisible { false }
+			, Convert_UniversalDeploy_TemporalTechno { nullptr }
+			, Convert_UniversalDeploy_IsOriginalDeployer { true }
+			, Convert_UniversalDeploy_RememberTarget { nullptr }
 		{ }
 
 		void ApplyInterceptor();
@@ -80,6 +94,9 @@ public:
 		virtual void InvalidatePointer(void* ptr, bool bRemoved) override
 		{
 			AnnounceInvalidPointer(OriginalPassengerOwner, ptr);
+			AnnounceInvalidPointer(Convert_UniversalDeploy_TemporalTechno, ptr);
+			AnnounceInvalidPointer(Convert_UniversalDeploy_DeployAnim, ptr);
+			AnnounceInvalidPointer(Convert_UniversalDeploy_RememberTarget, ptr);
 		}
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
@@ -137,11 +154,12 @@ public:
 	static void DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleStruct* pBounds);
 	static void ApplyGainedSelfHeal(TechnoClass* pThis);
 	static void SyncIronCurtainStatus(TechnoClass* pFrom, TechnoClass* pTo);
-	static CoordStruct PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger, int maxAttempts);
+	static CoordStruct PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger, int maxAttempts = 1);
 	static bool AllowedTargetByZone(TechnoClass* pThis, TechnoClass* pTarget, TargetZoneScanType zoneScanType, WeaponTypeClass* pWeapon = nullptr, bool useZone = false, int zone = -1);
 	static void UpdateAttachedAnimLayers(TechnoClass* pThis);
 	static bool ConvertToType(FootClass* pThis, TechnoTypeClass* toType);
 	static bool CanDeployIntoBuilding(UnitClass* pThis, bool noDeploysIntoDefaultValue = false);
+	static bool CanDeployIntoBuilding(BuildingClass* pThis, bool noDeploysIntoDefaultValue = false, BuildingTypeClass* pBuildingType = nullptr);
 	static bool IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource);
 
 	// WeaponHelpers.cpp
@@ -157,4 +175,10 @@ public:
 	static Point2D GetBuildingSelectBracketPosition(TechnoClass* pThis, BuildingSelectBracketPosition bracketPosition);
 	static void ProcessDigitalDisplays(TechnoClass* pThis);
 	static void GetValuesForDisplay(TechnoClass* pThis, DisplayInfoType infoType, int& value, int& maxValue);
+
+	static TechnoClass* UniversalDeployConversion(TechnoClass* pThis, TechnoTypeClass* pNewType = nullptr);
+	static void CreateUniversalDeployAnimation(TechnoClass* pThis, AnimTypeClass* pAnimType = nullptr);
+	static bool Techno2TechnoPropertiesTransfer(TechnoClass* pNew = nullptr, TechnoClass* pOld = nullptr);
+	static void UpdateUniversalDeploy(TechnoClass* pThis);
+	static void PassengersTransfer(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo);
 };

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -8,7 +8,6 @@
 #include <Utilities/Macro.h>
 #include <New/Entity/ShieldClass.h>
 #include <New/Entity/LaserTrailClass.h>
-#include <Ext/Building/Body.h>
 
 class BulletClass;
 

--- a/src/Ext/Techno/Hooks.UniversalDeploy.cpp
+++ b/src/Ext/Techno/Hooks.UniversalDeploy.cpp
@@ -1,0 +1,551 @@
+#include "Body.h"
+
+#include <Ext/Script/Body.h>
+
+DEFINE_HOOK(0x730B8F, DeployCommand_UniversalDeploy, 0x6)
+{
+	GET(int, index, EDI);
+
+	TechnoClass* pThis = static_cast<TechnoClass*>(ObjectClass::CurrentObjects->GetItem(index));
+
+	if (!pThis || !ScriptExt::IsUnitAvailable(pThis, false))
+		return 0;
+
+	auto pExt = TechnoExt::ExtMap.Find(pThis);
+	if (!pExt || pExt->Convert_UniversalDeploy_InProgress)
+		return 0;
+
+	// Infantry checks are done in another hook
+	if (pThis->WhatAmI() == AbstractType::Infantry)
+		return 0;
+
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+	if (!pTypeExt || !pTypeExt->Convert_UniversalDeploy.isset())
+		return 0;
+
+	// Building case, send the undeploy signal
+	if (pThis->WhatAmI() == AbstractType::Building)
+	{
+		// Is the building in the middle of a deployment?
+		auto const pBuilding = static_cast<BuildingClass*>(pThis);
+		if (pBuilding->BState == (int)BStateType::Construction)
+			return 0;
+
+		pExt->Convert_UniversalDeploy_InProgress = true;
+		pExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+
+		if (pThis->Target)
+			pExt->Convert_UniversalDeploy_RememberTarget = pThis->Target;
+
+		return 0x730C10;
+	}
+
+	// Unit case, send the undeploy signal only if this object meets the all the requisites
+	if (pThis->WhatAmI() == AbstractType::Unit)
+	{
+		// Is the unit in the middle of a deployment?
+		auto const pUnit = static_cast<UnitClass*>(pThis);
+		if (pUnit->Undeploying || pUnit->Deploying || pUnit->IsDeploying)
+			return 0;
+
+		auto const pIntoBuildingType = pTypeExt->Convert_UniversalDeploy.Get()->WhatAmI() == AbstractType::Building ? abstract_cast<BuildingTypeClass*>(pTypeExt->Convert_UniversalDeploy.Get()) : nullptr;
+		bool canDeployIntoStructure = pIntoBuildingType ? pIntoBuildingType->CanCreateHere(CellClass::Coord2Cell(pThis->GetCoords()), pThis->Owner) : false;
+		auto pCell = pThis->GetCell();
+		int nObjectsInCell = 0;
+
+		// Count objects located in the desired cell
+		for (auto pObject = pCell->FirstObject; pObject; pObject = pObject->NextObject)
+		{
+			auto const pItem = static_cast<TechnoClass*>(pObject);
+
+			if (pItem && pItem != pThis)
+				nObjectsInCell++;
+		}
+
+		// Abort if the cell is occupied with objects or can not be deployed into structure. And move the unit to a different nearby location.
+		if ((nObjectsInCell > 0 && !pIntoBuildingType) || pIntoBuildingType && !canDeployIntoStructure)
+		{
+			pExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+			pExt->Convert_UniversalDeploy_InProgress = false;
+			pThis->IsFallingDown = false;
+			pThis->Scatter(CoordStruct::Empty, true, false);
+
+			return 0;
+		}
+
+		auto const pFoot = static_cast<FootClass*>(pThis);
+
+		// Stop the deployable unit, can not be converted if the object is moving
+		if (!pThis->IsFallingDown && pThis->CurrentMission != Mission::Guard)
+		{
+			pExt->Convert_UniversalDeploy_RememberTarget = pThis->Target;
+
+			// Reset previous command
+			pFoot->SetTarget(nullptr);
+			pFoot->SetDestination(nullptr, false);
+			pFoot->ForceMission(Mission::Guard);
+		}
+
+		// If is set DeployToLand then is probably a flying unit that only can be deployed in ground
+		if (pTypeExt->Convert_DeployToLand)
+		{
+			bool isFlyingUnit = pThis->GetTechnoType()->MovementZone == MovementZone::Fly || pThis->GetTechnoType()->ConsideredAircraft;
+
+			// If the cell is occupied abort operation
+			if (isFlyingUnit && pThis->IsCellOccupied(pCell, FacingType::None, -1, nullptr, false) != Move::OK)
+			{
+				pExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+				pExt->Convert_UniversalDeploy_InProgress = false;
+				pThis->IsFallingDown = false;
+				pThis->Scatter(CoordStruct::Empty, true, false);
+
+				return 0;
+			}
+
+			// I don't know if is the right action to force air units to land, including units with BalloonHover=yes
+			pThis->IsFallingDown = true;
+		}
+
+		// Set the deployment signal, indicating the process hasn't finished
+		pExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+		pExt->Convert_UniversalDeploy_InProgress = true;
+
+		if (pThis->Target)
+			pExt->Convert_UniversalDeploy_RememberTarget = pThis->Target;
+
+		return 0x730C10;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x522510, InfantryClass_UniversalDeploy_DoingDeploy, 0x6)
+{
+	GET(InfantryClass*, pThis, ECX);
+
+	if (!pThis)
+		return 0;
+
+	auto pOld = static_cast<TechnoClass*>(pThis);
+	if (!pOld)
+		return 0;
+
+	auto const pOldExt = TechnoExt::ExtMap.Find(pOld);
+	if (!pOldExt || pOldExt->Convert_UniversalDeploy_InProgress)
+		return 0;
+
+	auto const pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOld->GetTechnoType());
+	if (!pOldTypeExt)
+		return 0;
+
+	// Is the infantry in the middle of a deployment?
+	if (pThis->IsDeploying)
+		return 0;
+
+	auto const pNewType = pOldTypeExt->Convert_UniversalDeploy.Get();
+	bool oldIsFlyingUnit = pThis->GetTechnoType()->MovementZone == MovementZone::Fly || pThis->GetTechnoType()->ConsideredAircraft;
+	auto pCell = pOld->GetCell();
+	bool cellIsOnWater = (pCell->LandType == LandType::Water || pCell->LandType == LandType::Beach);
+	bool isNewTechnoAmphibious = pNewType->MovementZone == MovementZone::Amphibious || pNewType->MovementZone == MovementZone::AmphibiousCrusher || pNewType->MovementZone == MovementZone::AmphibiousDestroyer;
+	bool isNewTechnoAircraft = pNewType->ConsideredAircraft || pNewType->MovementZone == MovementZone::Fly;
+
+	// If the deployer is over a water cell and the future deployed object doesn't support water cells abort the operation
+	if (cellIsOnWater && !(isNewTechnoAmphibious || pNewType->Naval || isNewTechnoAircraft))
+	{
+		pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+		pOldExt->Convert_UniversalDeploy_InProgress = false;
+		pOld->IsFallingDown = false;
+		pOld->Scatter(CoordStruct::Empty, true, false);
+
+		return 0;
+	}
+
+	// Preparing UniversalDeploy logic
+	bool inf2inf = pNewType->WhatAmI() == AbstractType::InfantryType;
+
+	int nObjectsInCell = 0;
+
+	for (auto pObject = pOld->GetCell()->FirstObject; pObject; pObject = pObject->NextObject)
+	{
+		auto const pItem = static_cast<TechnoClass*>(pObject);
+
+		if (pItem && pItem != pOld)
+			nObjectsInCell++;
+	}
+
+	// It the cell is occupied and isn't a infantry to infantry conversion the operation is aborted
+	if (nObjectsInCell > 0 && !inf2inf)
+	{
+		pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+		pOldExt->Convert_UniversalDeploy_InProgress = false;
+		pOld->IsFallingDown = false;
+		pOld->Scatter(CoordStruct::Empty, true, false);
+
+		return 0;
+	}
+
+	if (pOldTypeExt->Convert_DeployToLand)
+	{
+		auto newCell = MapClass::Instance->GetCellAt(pThis->Location);
+
+		// If the cell is occupied abort operation
+		if (oldIsFlyingUnit && pThis->IsCellOccupied(newCell, FacingType::None, -1, nullptr, false) != Move::OK)
+		{
+			pOldExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+			pOldExt->Convert_UniversalDeploy_InProgress = false;
+			pOld->IsFallingDown = false;
+			pOld->Scatter(CoordStruct::Empty, true, false);
+
+			return 0;
+		}
+
+		pThis->IsFallingDown = true;
+	}
+
+	pOldExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+	pOldExt->Convert_UniversalDeploy_InProgress = true;
+
+	if (pThis->Target)
+		pOldExt->Convert_UniversalDeploy_RememberTarget = pThis->Target;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x449C47, BuildingClass_MissionDeconstruction_UniversalDeploy, 0x6)
+{
+	enum { Skip = 0x449E00 };
+
+	GET(BuildingClass*, pBuilding, ECX);
+
+	if (!pBuilding)
+		return 0;
+
+	// Check if is the UniversalDeploy or a standard deploy
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pBuilding->GetTechnoType());
+	if (!pTypeExt || !pTypeExt->Convert_UniversalDeploy.isset())
+		return 0;
+
+	auto pExt = TechnoExt::ExtMap.Find(pBuilding);
+	if (!pExt)
+		return 0;
+
+	// Skip code for this UniversalDeploy logic
+	if (pExt->Convert_UniversalDeploy_InProgress)
+		return Skip;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x44725F, BuildingClass_WhatAction_UniversalDeploy_EnableDeployIcon, 0x5)
+{
+	GET(BuildingClass*, pThis, ESI);
+	GET_STACK(FootClass*, pFoot, 0x1C);
+
+	if (!pThis || !pFoot || pFoot->Location != pThis->Location)
+		return 0;
+
+	auto pFootTechno = static_cast<TechnoClass*>(pFoot);
+	if (!pFootTechno)
+		return 0;
+
+	auto pBldExt = TechnoExt::ExtMap.Find(pThis);
+	if (!pBldExt)
+		return 0;
+
+	if (pBldExt->Convert_UniversalDeploy_InProgress)
+	{
+		R->EAX(Action::NoDeploy);
+		return 0x447273;
+	}
+
+	auto pBldTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+	if (!pBldTypeExt || !pBldTypeExt->Convert_UniversalDeploy.isset())
+		return 0;
+
+	auto const pNewType = pBldTypeExt->Convert_UniversalDeploy.Get();
+
+	// If target deploy is a structure we can show the "No Deploy" icon if the foundation has obstacles
+	if (pNewType->WhatAmI() == AbstractType::BuildingType)
+	{
+		auto pNewBldType = static_cast<BuildingTypeClass*>(pNewType);
+		bool canDeployIntoStructure = TechnoExt::CanDeployIntoBuilding(pThis, false, pNewBldType);
+
+		if (!canDeployIntoStructure)
+		{
+			R->EAX(Action::NoDeploy);
+			return 0x447273;
+		}
+	}
+
+	R->EAX(Action::Self_Deploy);
+
+	return 0x447273;
+}
+
+// Probably obsolete since I added a new hook
+DEFINE_HOOK(0x457DE9, BuildingClass_EvictOccupiers_UniversalDeploy_DontEjectOccupiers, 0xC)
+{
+	GET(BuildingClass*, pBuilding, ECX);
+
+	if (!pBuilding)
+		return 0;
+
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pBuilding->Type);
+	if (!pTypeExt || !pTypeExt->Convert_UniversalDeploy.isset())
+		return 0;
+
+	// Don't eject the infantry if the UniversalDeploy is being used. UniversalDeploy Manages that operation
+	return 0x4581DB;
+}
+
+DEFINE_HOOK(0x4ABEE9, BuildingClass_MouseLeftRelease_UniversalDeploy_ExecuteDeploy, 0x7)
+{
+	GET(TechnoClass* const, pTechno, ESI);
+	GET(Action const, actionType, EBX);
+
+	if (actionType != Action::Self_Deploy || !pTechno || !pTechno->IsSelected || !ScriptExt::IsUnitAvailable(pTechno, false))
+		return 0;
+
+	auto pExt = TechnoExt::ExtMap.Find(pTechno);
+	if (!pExt || pExt->Convert_UniversalDeploy_InProgress)
+		return 0;
+
+	if (pTechno->WhatAmI() == AbstractType::Building)
+	{
+		// Is the building in the middle of a deployment?
+		auto const pBuilding = static_cast<BuildingClass*>(pTechno);
+		if (pBuilding->BState == (int)BStateType::Construction)
+			return 0;
+	}
+
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType());
+	if (!pTypeExt || !pTypeExt->Convert_UniversalDeploy.isset())
+		return 0;
+
+	auto const pNewTechnoType = pTypeExt->Convert_UniversalDeploy.Get();
+	bool oldIsFlyingUnit = pTechno->GetTechnoType()->MovementZone == MovementZone::Fly || pTechno->GetTechnoType()->ConsideredAircraft;
+	auto pCell = pTechno->GetCell();
+	bool cellIsOnWater = (pCell->LandType == LandType::Water || pCell->LandType == LandType::Beach);
+	bool isNewTechnoAmphibious = pNewTechnoType->MovementZone == MovementZone::Amphibious || pNewTechnoType->MovementZone == MovementZone::AmphibiousCrusher ||
+		pNewTechnoType->MovementZone == MovementZone::AmphibiousDestroyer;
+	bool isNewTechnoAircraft = pNewTechnoType->ConsideredAircraft || pNewTechnoType->MovementZone == MovementZone::Fly;
+
+	if (pTechno->WhatAmI() == AbstractType::Infantry)
+		return 0; // Checked in another hook. Or should I prevent the execution of that hook and put the code here?
+
+	// If the deployer is over a water cell and the future deployed object doesn't support water cells abort the operation
+	if (cellIsOnWater && !(isNewTechnoAmphibious || pNewTechnoType->Naval || isNewTechnoAircraft))
+	{
+		pExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+		pExt->Convert_UniversalDeploy_InProgress = false;
+		pTechno->IsFallingDown = false;
+		pTechno->Scatter(CoordStruct::Empty, true, false);
+
+		return 0;
+	}
+
+	// Building case, send the undeploy signal
+	if (pTechno->WhatAmI() == AbstractType::Building)
+	{
+		auto pBld = static_cast<BuildingClass*>(pTechno);
+		auto pBldType = static_cast<BuildingTypeClass*>(pNewTechnoType);
+		bool canDeployIntoStructure = TechnoExt::CanDeployIntoBuilding(pBld, false, pBldType);
+
+		if (!canDeployIntoStructure)
+		{
+			pExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+			pExt->Convert_UniversalDeploy_InProgress = false;
+			pTechno->IsFallingDown = false;
+			pTechno->Scatter(CoordStruct::Empty, true, false);
+
+			return 0;
+		}
+
+		R->EBX(Action::None);
+		pExt->Convert_UniversalDeploy_InProgress = true;
+		pExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+
+		if (pTechno->Target)
+			pExt->Convert_UniversalDeploy_RememberTarget = pTechno->Target;
+
+		return 0;
+	}
+
+	// vehicles case, send the undeploy signal only if meets the all the requisites
+	if (pTechno->WhatAmI() == AbstractType::Unit)
+	{
+		const auto pUnit = abstract_cast<UnitClass*>(pTechno);
+		const auto pIntoBuildingType = pTypeExt->Convert_UniversalDeploy.Get()->WhatAmI() == AbstractType::Building ? abstract_cast<BuildingTypeClass*>(pTypeExt->Convert_UniversalDeploy.Get()) : nullptr;
+		bool canDeployIntoStructure = pIntoBuildingType ? pIntoBuildingType->CanCreateHere(CellClass::Coord2Cell(pUnit->GetCoords()), pUnit->Owner) : false;
+		int nObjectsInCell = 0;
+
+		// Count objects located in the desired cell
+		for (auto pObject = pTechno->GetCell()->FirstObject; pObject; pObject = pObject->NextObject)
+		{
+			auto const pItem = static_cast<TechnoClass*>(pObject);
+
+			if (pItem && pItem != pTechno)
+				nObjectsInCell++;
+		}
+
+		// Abort if the cell is occupied with objects or can not be deployed into structure. And move the unit to a different nearby location.
+		if ((nObjectsInCell > 0 && !pIntoBuildingType) || pIntoBuildingType && !canDeployIntoStructure)
+		{
+			pExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+			pExt->Convert_UniversalDeploy_InProgress = false;
+			pTechno->IsFallingDown = false;
+			pTechno->Scatter(CoordStruct::Empty, true, false);
+
+			return 0;
+		}
+
+		auto pFoot = static_cast<FootClass*>(pTechno);
+
+		// Stop the deployable unit, can not be converted if the object is moving
+		if (!pTechno->IsFallingDown && pTechno->CurrentMission != Mission::Guard)
+		{
+			if (pTechno->Target)
+				pExt->Convert_UniversalDeploy_RememberTarget = pTechno->Target;
+
+			// Reset previous command
+			pExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+			pFoot->SetTarget(nullptr);
+			pFoot->SetDestination(nullptr, false);
+			pFoot->ForceMission(Mission::Guard);
+		}
+
+		if (pTypeExt->Convert_DeployToLand)
+		{
+			// If the cell is occupied abort operation
+			if (oldIsFlyingUnit && pTechno->IsCellOccupied(pCell, FacingType::None, -1, nullptr, false) != Move::OK)
+			{
+				pExt->Convert_UniversalDeploy_RememberTarget = nullptr;
+				pExt->Convert_UniversalDeploy_InProgress = false;
+				pTechno->IsFallingDown = false;
+				pTechno->Scatter(CoordStruct::Empty, true, false);
+
+				return 0;
+			}
+
+			// I don't know if is the right action to force air units to land, including units with BalloonHover=yes
+			pTechno->IsFallingDown = true;
+			//pFoot->ParalysisTimer.Start(15);
+		}
+
+		// Set the deployment signal, indicating the process hasn't finished
+		pExt->Convert_UniversalDeploy_IsOriginalDeployer = true;
+		pExt->Convert_UniversalDeploy_InProgress = true;
+
+		if (pTechno->Target)
+			pExt->Convert_UniversalDeploy_RememberTarget = pTechno->Target;
+	}
+
+	return 0;
+}
+
+// Avoid the sell cursor while the structure is being deployed with the UniversalDeploy
+DEFINE_HOOK(0x4494DC, BuildingClass_CanDemolish_UniversalDeploy, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	if (pExt && pExt->Convert_UniversalDeploy_InProgress)
+		return 0x449536;
+
+	return 0;
+}
+
+// Skip voxel turret drawing while the structure is being deployed with the UniversalDeploy
+DEFINE_HOOK(0x43DF6E, BuildingClass_Draw_UniversalDeploy, 0x6)
+{
+	GET(BuildingClass*, pThis, EBP);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	if (pExt && pExt->Convert_UniversalDeploy_InProgress)
+		return 0x43E795;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x73B4DA, UnitClass_DrawVoxel_UniversalDeploy_DontRenderObject, 0x6)
+{
+	enum { Skip = 0x73C5DC };
+
+	GET(UnitClass*, pThis, EBP);
+
+	if (!pThis)
+		return 0;
+
+	auto pTechno = static_cast<TechnoClass*>(pThis);
+	if (!pTechno)
+		return 0;
+
+	auto pExt = TechnoExt::ExtMap.Find(pTechno);
+	if (!pExt || !pExt->Convert_UniversalDeploy_MakeInvisible)
+		return 0;
+
+	// VXL units won't draw graphics when deploy
+	return Skip;
+}
+
+// Make object graphics invisible because they aren't rendered
+DEFINE_HOOK(0x73C602, TechnoClass_DrawObject_UniversalDeploy_DontRenderObject, 0x6)
+{
+	enum { Skip = 0x73CE00 };
+
+	GET(TechnoClass*, pThis, ECX);
+
+	if (!pThis)
+		return 0;
+
+	auto pExt = TechnoExt::ExtMap.Find(pThis);
+	if (!pExt || !pExt->Convert_UniversalDeploy_MakeInvisible)
+		return 0;
+
+	// SHP units won't draw graphics when deploy
+	return Skip;
+}
+
+// Make object graphics invisible because they aren't rendered
+DEFINE_HOOK(0x518FBC, InfantryClass_DrawIt_UniversalDeploy_DontRenderObject, 0x6)
+{
+	enum { Skip = 0x5192B5 };
+
+	GET(InfantryClass*, pThis, EBP);
+
+	if (!pThis)
+		return 0;
+
+	auto pTechno = static_cast<TechnoClass*>(pThis);
+	if (!pTechno)
+		return 0;
+
+	auto pExt = TechnoExt::ExtMap.Find(pTechno);
+	if (!pExt || !pExt->Convert_UniversalDeploy_MakeInvisible)
+		return 0;
+
+	// Here enters SHP units when deploy
+	return Skip;
+}
+
+// Make object graphics invisible because shouldn't be rendered in the middle of a deployment
+DEFINE_HOOK(0x43D29D, BuildingClass_DrawIt_UniversalDeploy_DontRenderObject, 0xD)
+{
+	enum { Skip = 0x43D688 };
+
+	GET(BuildingClass*, pThis, ESI);
+
+	if (!pThis)
+		return 0;
+
+	auto pTechno = static_cast<TechnoClass*>(pThis);
+	if (!pTechno)
+		return 0;
+
+	auto pExt = TechnoExt::ExtMap.Find(pTechno);
+	if (!pExt || !pExt->Convert_UniversalDeploy_MakeInvisible)
+		return 0;
+
+	// Here enters SHP objects, voxel turrets
+	return Skip;
+}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -33,6 +33,7 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 	pExt->DepletedAmmoActions();
 
 	TechnoExt::ApplyMindControlRangeLimit(pThis);
+	TechnoExt::UpdateUniversalDeploy(pThis);
 
 	return 0;
 }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -404,6 +404,29 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	{
 		this->InterceptorType.reset();
 	}
+
+	this->Convert_UniversalDeploy.Read(exINI, pSection, "Convert.UniversalDeploy");
+	this->Convert_DeployToLand.Read(exINI, pSection, "Convert.DeployToLand");
+	this->Convert_PreDeploy_AnimFX.Read(exINI, pSection, "Convert.PreDeploy.AnimFX");
+	this->Convert_PreDeploy_AnimFX_FollowDeployer.Read(exINI, pSection, "Convert.PreDeploy.AnimFX.FollowDeployer");
+	this->Convert_PostDeploy_AnimFX.Read(exINI, pSection, "Convert.PostDeploy.AnimFX");
+	this->Convert_PostDeploy_AnimFX_FollowDeployer.Read(exINI, pSection, "Convert.PostDeploy.AnimFX.FollowDeployer");
+	this->Convert_PostDeploySound.Read(exINI, pSection, "Convert.PostDeploySound");
+	this->Convert_DeployDir.Read(exINI, pSection, "Convert.DeployDir");
+	this->Convert_TransferPassengers.Read(exINI, pSection, "Convert.TransferPassengers");
+	this->Convert_TransferPassengers_IgnoreInvalidOccupiers.Read(exINI, pSection, "Convert.TransferPassengers.IgnoreInvalidOccupiers");
+	this->Convert_ForceVeterancyTransfer.Read(exINI, pSection, "Convert.ForceVeterancyTransfer");
+
+	// A structure deploy animation takes priority
+	pINI->ReadString(pSection, "Convert.DeployingAnim", "", Phobos::readBuffer);
+
+	if (strlen(Phobos::readBuffer))
+	{
+		auto const pDeployAnimType = AnimTypeClass::Find(Phobos::readBuffer);
+
+		if (pDeployAnimType)
+			this->Convert_DeployingAnim = pDeployAnimType;
+	}
 }
 
 template <typename T>
@@ -569,6 +592,19 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->SpawnDistanceFromTarget)
 		.Process(this->SpawnHeight)
+
+		.Process(this->Convert_UniversalDeploy)
+		.Process(this->Convert_DeployToLand)
+		.Process(this->Convert_PreDeploy_AnimFX)
+		.Process(this->Convert_PreDeploy_AnimFX_FollowDeployer)
+		.Process(this->Convert_PostDeploy_AnimFX)
+		.Process(this->Convert_PostDeploy_AnimFX_FollowDeployer)
+		.Process(this->Convert_DeployingAnim)
+		.Process(this->Convert_PostDeploySound)
+		.Process(this->Convert_DeployDir)
+		.Process(this->Convert_TransferPassengers)
+		.Process(this->Convert_TransferPassengers_IgnoreInvalidOccupiers)
+		.Process(this->Convert_ForceVeterancyTransfer)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -207,6 +207,19 @@ public:
 		std::vector<std::vector<CoordStruct>> DeployedWeaponBurstFLHs;
 		std::vector<std::vector<CoordStruct>> EliteDeployedWeaponBurstFLHs;
 
+		Nullable<TechnoTypeClass*> Convert_UniversalDeploy;
+		Valueable<bool> Convert_DeployToLand;
+		Nullable<AnimTypeClass*> Convert_PreDeploy_AnimFX;
+		Valueable<bool> Convert_PreDeploy_AnimFX_FollowDeployer;
+		Nullable<AnimTypeClass*> Convert_PostDeploy_AnimFX;
+		Valueable<bool> Convert_PostDeploy_AnimFX_FollowDeployer;
+		Nullable<AnimTypeClass*> Convert_DeployingAnim;
+		NullableIdx<VocClass> Convert_PostDeploySound;
+		Valueable<int> Convert_DeployDir;
+		Valueable<bool> Convert_TransferPassengers;
+		Valueable<bool> Convert_TransferPassengers_IgnoreInvalidOccupiers;
+		Valueable<bool> Convert_ForceVeterancyTransfer;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, UIDescription {}
@@ -359,6 +372,19 @@ public:
 
 			, SpawnDistanceFromTarget {}
 			, SpawnHeight {}
+
+			, Convert_UniversalDeploy {}
+			, Convert_DeployToLand { false }
+			, Convert_PreDeploy_AnimFX {}
+			, Convert_PreDeploy_AnimFX_FollowDeployer { false }
+			, Convert_PostDeploy_AnimFX {}
+			, Convert_PostDeploy_AnimFX_FollowDeployer { false }
+			, Convert_DeployingAnim {}
+			, Convert_PostDeploySound {}
+			, Convert_DeployDir { -1 }
+			, Convert_TransferPassengers { true }
+			, Convert_TransferPassengers_IgnoreInvalidOccupiers { false }
+			, Convert_ForceVeterancyTransfer { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -197,6 +197,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DetonateOnAllMapObjects_AffectTypes.Read(exINI, pSection, "DetonateOnAllMapObjects.AffectTypes");
 	this->DetonateOnAllMapObjects_IgnoreTypes.Read(exINI, pSection, "DetonateOnAllMapObjects.IgnoreTypes");
 
+	this->Convert_UseUniversalDeploy.Read(exINI, pSection, "Convert.UseUniversalDeploy");
+
 	// Convert.From & Convert.To
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::All);
 
@@ -348,6 +350,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->WasDetonatedOnAllMapObjects)
 		.Process(this->RemainingAnimCreationInterval)
 		.Process(this->PossibleCellSpreadDetonate)
+
+		.Process(this->Convert_UseUniversalDeploy)
 		;
 }
 

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -128,6 +128,8 @@ public:
 		int RemainingAnimCreationInterval;
 		bool PossibleCellSpreadDetonate;
 
+		Valueable<bool> Convert_UseUniversalDeploy;
+
 	private:
 		Valueable<double> Shield_Respawn_Rate_InMinutes;
 		Valueable<double> Shield_SelfHealing_Rate_InMinutes;
@@ -238,6 +240,8 @@ public:
 			, Splashed { false }
 			, RemainingAnimCreationInterval { 0 }
 			, PossibleCellSpreadDetonate {false}
+
+			, Convert_UseUniversalDeploy { false }
 		{ }
 
 	private:

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -346,6 +346,12 @@ void WarheadTypeExt::ExtData::ApplyConvert(HouseClass* pHouse, TechnoClass* pTar
 	if (!pTargetFoot || this->Convert_Pairs.size() == 0)
 		return;
 
+	if (this->Convert_UseUniversalDeploy.Get())
+	{
+		TypeConvertGroup::UniversalConvert(pTarget, this->Convert_Pairs, pHouse);
+		return;
+	}
+
 	TypeConvertGroup::Convert(pTargetFoot, this->Convert_Pairs, pHouse);
 }
 

--- a/src/New/Type/Affiliated/TypeConvertGroup.cpp
+++ b/src/New/Type/Affiliated/TypeConvertGroup.cpp
@@ -29,6 +29,40 @@ void TypeConvertGroup::Convert(FootClass* pTargetFoot, const std::vector<TypeCon
 	}
 }
 
+void TypeConvertGroup::UniversalConvert(TechnoClass* pTarget, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner)
+{
+	for (const auto& [fromTypes, toType, affectedHouses] : convertPairs)
+	{
+		if (!toType.isset() || !toType.Get()) continue;
+
+		if (!EnumFunctions::CanTargetHouse(affectedHouses, pOwner, pTarget->Owner))
+			continue;
+
+		if (fromTypes.size())
+		{
+			for (const auto& from : fromTypes)
+			{
+				// Check if the target matches upgrade-from TechnoType and it has something to upgrade to
+				if (from == pTarget->GetTechnoType())
+				{
+					if (pTarget->Target)
+					{
+						auto pTargetExt = TechnoExt::ExtMap.Find(pTarget);
+						pTargetExt->Convert_UniversalDeploy_RememberTarget = pTarget->Target;
+					}
+
+					bool converted = TechnoExt::UniversalDeployConversion(pTarget, toType) ? true : false;
+
+					break;
+				}
+			}
+		}
+		else
+		{
+			TechnoExt::UniversalDeployConversion(pTarget, toType);
+		}
+	}
+}
 
 bool TypeConvertGroup::Load(PhobosStreamReader& stm, bool registerForChange)
 {

--- a/src/New/Type/Affiliated/TypeConvertGroup.h
+++ b/src/New/Type/Affiliated/TypeConvertGroup.h
@@ -15,6 +15,7 @@ public:
 	static void Parse(std::vector<TypeConvertGroup>& list,INI_EX& exINI, const char* section,AffectedHouse defaultAffectHouse);
 
 	static void Convert(FootClass* pTargetFoot, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner);
+	static void UniversalConvert(TechnoClass* pTarget, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner);
 
 private:
 	template <typename T>


### PR DESCRIPTION
- Now is possible to convert any infantry/unit/structure into any infantry/unit/structure.
- No direct support for aircrafts but they can be converted through warheads or super weapons (see below).
- `Convert.UniversalDeploy` specifies the TechnoType which is the result of conversion.
- `Convert.DeployingAnim` specifies the deployment animation. If no animation is declared then the conversion will be instantaneous.
- `Convert.DeployToLand` forces the deployer to land before starting the deployment process.
- `Convert.PreDeploy.AnimFX` specifies an animation at the same time the conversion starts.
- `Convert.PostDeploy.AnimFX.FollowDeployer` attach the animation to the deployer.
- `Convert.PostDeploy.AnimFX` specifies an animation at the end of the conversion.
- `Convert.PostDeploy.AnimFX.FollowDeployer` attach the animation to the deployed TechnoType.
- `Convert.PostDeploySound` specifies the sound that will be played when the deployemnt ends.
- `Convert.DeployDir` determines the initial facing of created TechnoType.
- `Convert.TransferPassengers` transfers passengers into the deployed TechnoType. If the new TechnoType has no enough space will kick out all the remaining passengers. 
- `Convert.TransferPassengers.IgnoreInvalidOccupiers` if the deployed TechnoType is a structure all infantry passengers can be transfered ignoring the passenger's `Occupier` tag.
- `Convert.ForceVeterancyTransfer` transfer the veterancy from the deployer to the deployed TechnoType ignoring the `Trainable` tag of the deployed TechnoType.
- The use of `Convert.UseUniversalDeploy=true` in warheads or super weapons replaces the Ares techno deploy conversion logic by this logic. In this case it uses the `Convert.From` && `Convert.To` tags from the Ares logic.
- `Convert.UseUniversalDeploy=true` skips lots of checks so in the case of deploying a structure into structure keep the same foundation size.
- Don't combine with the undeploy "Structure into vehicle" logic (the Tiberian Sun deploy logic used here for MCV) or a desync will appear in online games.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                                             ; TechnoType
Convert.UniversalDeploy=                                 ; TechnoType
Convert.DeployingAnim=                                   ; Animation
Convert.DeployToLand=false                               ; WeaponType
Convert.PreDeploy.AnimFX=                                ; Animation
Convert.PreDeploy.AnimFX.FollowDeployer=false            ; Boolean
Convert.PostDeploy.AnimFX=                               ; Animation
Convert.PostDeploy.AnimFX.FollowDeployer=false           ; Boolean
Convert.PostDeploySound=                                 ; Sound entry
Convert.DeployDir=-1                                     ; Integer, facings in range of 0-7
Convert.TransferPassengers=true                          ; Boolean
Convert.TransferPassengers.IgnoreInvalidOccupiers=false  ; Boolean
Convert.ForceVeterancyTransfer=false                     ; Boolean

[SOMEWARHEAD]                     ; Warhead
Convert.UseUniversalDeploy=false  ; Boolean

[SOMESW]                          ; Superweapon
Convert.UseUniversalDeploy=false  ; Boolean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a universal deployment feature allowing any unit, infantry, or structure to transform into any other type, enhancing gameplay flexibility.
	- Added animations, sound effects, and passenger transfer capabilities for the new universal deployment feature.
	- Weapons can now be fired during the warp-in and warp-out phases of deployment.
	- Implemented a visual indicator for deployable units when the cursor hovers over them.

- **Enhancements**
	- Improved building animations with new hide and unhide functionalities.
	- Streamlined the serialization process for new deployment-related properties.

- **Documentation**
	- Updated documentation to include details on the new universal deployment feature and its impact on game mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->