### PR TITLE
Fix unarmed infantry executes capture mission and triggers EnteredBy event when waypointing with an engineer/agent into a building

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -293,6 +293,7 @@ This page lists all the individual contributions to the project by their author.
    - Teleport and Tunnel loco visual tilt fix
    - Skip units' turret rotation and jumpjets' wobbling under EMP
    - Droppod properties dehardcode
+   - Engineer/Agent waypoint bug fix
    - Misc code refactor & maintenance, CN doc fixes, bugfixes
 - **FlyStar**
    - Campaign load screen PCX support

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -293,7 +293,7 @@ This page lists all the individual contributions to the project by their author.
    - Teleport and Tunnel loco visual tilt fix
    - Skip units' turret rotation and jumpjets' wobbling under EMP
    - Droppod properties dehardcode
-   - Engineer/Agent waypoint bug fix
+   - Waypoint entering building together with engineer/agent bug fix
    - Misc code refactor & maintenance, CN doc fixes, bugfixes
 - **FlyStar**
    - Campaign load screen PCX support

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -149,7 +149,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed units with Teleport or Tunnel locomotor being unable to be visually flipped like other locomotors do.
 - Aircraft docking on buildings now respect `[AudioVisual]`->`PoseDir` as the default setting and do not always land facing north or in case of pre-placed buildings, the building's direction.
 - Spawned aircraft now align with the spawner's facing when landing.
-- Fixed the bug that waypointing unarmed infantries with agent/engineer to a spyable/capturable building triggers EnteredBy event.
+- Fixed the bug that waypointing unarmed infantries with agent/engineer/occupier to a spyable/capturable/occupiable building triggers EnteredBy event by executing capture mission.
 
 ## Fixes / interactions with other extensions
 
@@ -1028,16 +1028,6 @@ In `rulesmd.ini`:
 ```ini
 [CrateRules]
 CrateOnlyOnLand=no  ; boolean
-```
-
-## Flashing Technos on selecting
-
-Selecting technos, controlled by player, now may show a flash effect by setting `SelectionFlashDuration` parameter. Set `SelectionFlashDuration=0` to disable it.
-
-In `rulesmd.ini`:
-```ini
-[AudioVisual]
-SelectionFlashDuration=0  ; integer, number of frames
 ```
 
 ## DropPod

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -149,6 +149,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed units with Teleport or Tunnel locomotor being unable to be visually flipped like other locomotors do.
 - Aircraft docking on buildings now respect `[AudioVisual]`->`PoseDir` as the default setting and do not always land facing north or in case of pre-placed buildings, the building's direction.
 - Spawned aircraft now align with the spawner's facing when landing.
+- Fixed the bug that waypointing unarmed infantries with agent/engineer to a spyable/capturable building triggers EnteredBy event.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -241,6 +241,16 @@ ShowTimer=yes
 ShowTimer.Priority=0  ; integer
 ```
 
+### Flashing Technos on selecting
+
+Selecting technos, controlled by player, now may show a flash effect by setting `SelectionFlashDuration` parameter. Set `SelectionFlashDuration=0` to disable it.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+SelectionFlashDuration=0  ; integer, number of frames
+```
+
 ## Hotkey Commands
 
 ### `[ ]` Display Damage Numbers

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -416,6 +416,7 @@ Vanilla fixes:
 - Fixed teleport and drill units being unable to be visually flipped (by Trsdy)
 - Aircraft docking on buildings now respect `[AudioVisual]`->`PoseDir` as the default setting and do not always land facing north or in case of pre-placed buildings, the building's direction (by Starkku)
 - Spawned aircraft now align with the spawner's facing when landing (by Starkku)
+- Fixed non engineer/agent infantries try entering buildings by waypointing (by Trsdy)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -35,7 +35,6 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - `Grinding.DisplayRefund` is changed to `DisplayIncome`, `Grinding.DisplayRefund.Houses` is changed to `DisplayIncome.Houses`, `Grinding.DisplayRefund.Offset` is changed to `DisplayIncome.Offset`
 - `[JumpjetControls]`->`AllowLayerDeviation` and `JumpjetAllowLayerDeviation` have been deprecated as the animation layering issues have been properly fixed by default now.
 - `[JumpjetControls]->TurnToTarget` and `JumpjetTurnToTarget` are obsolete. Jumpjet units who fire `OmniFire=no` weapons **always** turn to targets as other units do.
-  - `OmniFire.TurnToTarget` is recommended for jumpjet units' omnifiring weapons for facing turning.
 - Buildings delivered by trigger action 125 will now **always** play buildup anim as long as it exists. `[ParamTypes]->53` is deprecated.
 - `Shadow` for debris & meteor animations is changed to `ExtraShadow`.
 
@@ -416,7 +415,7 @@ Vanilla fixes:
 - Fixed teleport and drill units being unable to be visually flipped (by Trsdy)
 - Aircraft docking on buildings now respect `[AudioVisual]`->`PoseDir` as the default setting and do not always land facing north or in case of pre-placed buildings, the building's direction (by Starkku)
 - Spawned aircraft now align with the spawner's facing when landing (by Starkku)
-- Fixed non engineer/agent infantries try entering buildings by waypointing (by Trsdy)
+- Fixed infantries attempted to entering buildings when waypointing together with engineer/agent/occupier/etc (by Trsdy)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Building/Hooks.Grinding.cpp
+++ b/src/Ext/Building/Hooks.Grinding.cpp
@@ -61,13 +61,13 @@ DEFINE_HOOK(0x4D4B43, FootClass_Mission_Capture_ForbidUnintended, 0x6)
 	enum { LosesDestination = 0x4D4BD1 };
 
 	auto pBld = specific_cast<BuildingClass*>(pThis->Destination);
-	if (!pThis || !pBld)
+	if (!pThis || !pBld || pThis->Target)//try less agressive first, only when no target, see if it doesn't fix something
 		return 0;
 
 	if (!(pBld->Type->Capturable && pThis->Type->Engineer)   // can't capture
 	&& !(pBld->Type->Spyable && pThis->Type->Infiltrate)     // can't infiltrate
 	&& !(pBld->Type->CanBeOccupied && (pThis->Type->Occupier || pThis->Type->Assaulter)) // can't occupy
-	//	&& !(pThis->Type->C4 || pThis->HasAbility(Ability::C4)) // can't C4, what else?
+	&& !(pThis->Type->C4 || pThis->HasAbility(Ability::C4)) // can't C4, what else?
 	)// If you can't do any of these why are you here?
 	{
 		pThis->SetDestination(nullptr, false);

--- a/src/Ext/Building/Hooks.Grinding.cpp
+++ b/src/Ext/Building/Hooks.Grinding.cpp
@@ -55,6 +55,28 @@ DEFINE_HOOK(0x4D4CD3, FootClass_Mission_Eaten_Grinding, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x4D4B43, FootClass_Mission_Capture_ForbidUnintended, 0x6)
+{
+	GET(InfantryClass*, pThis, EDI);
+	enum { LosesDestination = 0x4D4BD1 };
+
+	auto pBld = specific_cast<BuildingClass*>(pThis->Destination);
+	if (!pThis || !pBld)
+		return 0;
+
+	if (!(pBld->Type->Capturable && pThis->Type->Engineer)   // can't capture
+	&& !(pBld->Type->Spyable && pThis->Type->Infiltrate)     // can't infiltrate
+	&& !(pBld->Type->CanBeOccupied && (pThis->Type->Occupier || pThis->Type->Assaulter)) // can't occupy
+	//	&& !(pThis->Type->C4 || pThis->HasAbility(Ability::C4)) // can't C4, what else?
+	)// If you can't do any of these why are you here?
+	{
+		pThis->SetDestination(nullptr, false);
+		return LosesDestination;
+	}
+
+	return 0;
+}
+
 DEFINE_HOOK(0x51F0AF, InfantryClass_WhatAction_Grinding, 0x0)
 {
 	enum { Skip = 0x51F05E, ReturnValue = 0x51F17E };


### PR DESCRIPTION
Needs *Regression test*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where unarmed infantry with agent/engineer designation erroneously triggered an EnteredBy event when waypointed to a spyable/capturable building.
	- Fixed a bug preventing non-engineer/agent infantry units from mistakenly attempting to enter buildings, enhancing infantry behavior logic regarding building entry.
- **Documentation**
	- Updated CREDITS.md with recent fixes and maintenance activities.
	- Enhanced documentation in Fixed-or-Improved-Logics.md to reflect bug fixes and logic improvements.
- **Refactor**
	- Implemented a new control flow in infantry-building interaction logic to prevent unintended capturing or infiltrating of buildings by infantry units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->