### PR TITLE
recoil force

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -259,6 +259,7 @@ This page lists all the individual contributions to the project by their author.
       - Allow to tilt regardless of TiltCrashJumpjet
       - Forbid firing when crashing
    - OmniFire.TurnToTarget
+   - RecoilForce
    - Strafing aircraft weapon customization
    - Object Self-destruction logic
    - Misc vanilla suicidal behavior fix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -741,7 +741,7 @@ ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
 ### Voxel shadow scaling in air
 
 - It is now possible to adjust how voxel air units (`VehicleType` & `AircraftType`) shadows scale in air. By default the shadows scale by `AirShadowBaseScale` (defaults to 0.5) amount if unit is `ConsideredAircraft=true`.
-  - If `HeightShadowScaling=true`, the shadow is scaled by amount that is determined by following formula: `Max(AirShadowBaseScale ^ (currentHeight / ShadowSizeCharacteristicHeight), HeightShadowScaling.MinScale)`, where `currentHeight` is unit's current height in leptons, `ShadowSizeCharacteristicHeight` overrideable value that defaults to the maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and `HeightShadowScaling.MinScale` sets a floor for the scale.
+  - If `HeightShadowScaling=true`, the shadow is scaled by amount that is determined by following formula: $\mathtt{max}\left\{\exp\left(\ln(\mathtt{AirShadowBaseScale})  \dfrac{\mathrm{currentHeight}}{\mathtt{ShadowSizeCharacteristicHeight}}\right), \mathtt{HeightShadowScaling.MinScale}\right\}$, where `currentHeight` is unit's current height in leptons, `ShadowSizeCharacteristicHeight` overrideable value that defaults to the maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and `HeightShadowScaling.MinScale` sets a floor for the scale.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1538,6 +1538,17 @@ In `rulesmd.ini`:
 FeedbackWeapon=  ; WeaponType
 ```
 
+### Recoil force
+
+- You can now tilt a voxel unit after firing to simulate the recoil force.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWEAPON]  ; WeaponType
+RecoilForce=  ; floating point value, any value below 0.002 is considered 0
+```
+
+
 ### Radiation enhancements
 
 - In addition to allowing custom radiation types, several enhancements are also available to the default radiation type defined in `[Radiation]`, such as ability to set owner & invoker or deal damage against buildings. See [Custom Radiation Types](#custom-radiation-types) for more details.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -389,6 +389,7 @@ New:
 - Projectile return weapon (by Starkku)
 - Allow customizing aircraft landing direction per aircraft or per dock (by Starkku)
 - Allow animations to play sounds detached from audio event handler (by Starkku)
+- Voxel unit weapon recoil force (by Trsdy)
 - Game save option when starting campaigns (by Trsdy)
 - Carryall pickup voice (by Starkku)
 - Option to have `Grinding.Weapon` require accumulated credits from grinding (by Starkku)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Phobos'
-copyright = '2023, The Phobos Contributors'
+copyright = '2024, The Phobos Contributors'
 author = 'The Phobos Contributors'
 
 
@@ -28,7 +28,7 @@ author = 'The Phobos Contributors'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx_rtd_theme', 'myst_parser']
+extensions = ['sphinx_rtd_theme', 'myst_parser', 'sphinx.ext.mathjax']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -55,7 +55,10 @@ html_static_path = ['_static']
 
 myst_heading_anchors = 3
 
-myst_enable_extensions = []
+myst_enable_extensions = [
+    "amsmath",
+    "dollarmath",
+]
 
 html_theme_options = {
     'navigation_depth': 4,

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -93,6 +93,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ExtraWarheads_DetonationChances.Read(exINI, pSection, "ExtraWarheads.DetonationChances");
 	this->AmbientDamage_Warhead.Read<true>(exINI, pSection, "AmbientDamage.Warhead");
 	this->AmbientDamage_IgnoreTarget.Read(exINI, pSection, "AmbientDamage.IgnoreTarget");
+	this->RecoilForce.Read(exINI, pSection, "RecoilForce");
 	this->AttachEffect_RequiredTypes.Read(exINI, pSection, "AttachEffect.RequiredTypes");
 	this->AttachEffect_DisallowedTypes.Read(exINI, pSection, "AttachEffect.DisallowedTypes");
 	exINI.ParseStringList(this->AttachEffect_RequiredGroups, pSection, "AttachEffect.RequiredGroups");
@@ -133,6 +134,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ExtraWarheads_DetonationChances)
 		.Process(this->AmbientDamage_Warhead)
 		.Process(this->AmbientDamage_IgnoreTarget)
+		.Process(this->RecoilForce)
 		.Process(this->AttachEffect_RequiredTypes)
 		.Process(this->AttachEffect_DisallowedTypes)
 		.Process(this->AttachEffect_RequiredGroups)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -45,6 +45,7 @@ public:
 		ValueableVector<double> ExtraWarheads_DetonationChances;
 		Nullable<WarheadTypeClass*> AmbientDamage_Warhead;
 		Valueable<bool> AmbientDamage_IgnoreTarget;
+		Valueable<double> RecoilForce;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_RequiredTypes;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_DisallowedTypes;
 		std::vector<std::string> AttachEffect_RequiredGroups;
@@ -81,6 +82,7 @@ public:
 			, ExtraWarheads_DetonationChances {}
 			, AmbientDamage_Warhead {}
 			, AmbientDamage_IgnoreTarget { false }
+			, RecoilForce { 0 }
 			, AttachEffect_RequiredTypes {}
 			, AttachEffect_DisallowedTypes {}
 			, AttachEffect_RequiredGroups {}

--- a/src/Ext/WeaponType/Hooks.cpp
+++ b/src/Ext/WeaponType/Hooks.cpp
@@ -1,5 +1,5 @@
 #include "Body.h"
-
+#include <UnitClass.h>
 #include <Ext/BulletType/Body.h>
 
 DEFINE_HOOK(0x772A0A, WeaponTypeClass_SetSpeed_ApplyGravity, 0x6)
@@ -22,3 +22,25 @@ DEFINE_HOOK(0x773087, WeaponTypeClass_GetSpeed_ApplyGravity, 0x6)
 	return 0x7730A3;
 }
 
+
+// An example for quick jumpjet tilting test
+DEFINE_HOOK(0x7413DD, UnitClass_Fire_RecoilForce, 0x6)
+{
+	GET(UnitClass* const, pThis, ESI);
+	if (pThis->Transporter || !pThis->IsVoxel())
+		return 0;
+
+	GET(BulletClass* const, pBullet, EDI);
+
+	auto force = WeaponTypeExt::ExtMap.Find(pBullet->WeaponType)->RecoilForce.Get();
+
+	if (std::abs(force) < 0.002)
+		return 0;
+
+	const double theta = pThis->GetRealFacing().GetRadian<32>() - pThis->PrimaryFacing.Current().GetRadian<32>();
+
+	pThis->RockingForwardsPerFrame += (float)(-force * Math::cos(theta) * Math::cos(pThis->AngleRotatedForwards) / pThis->Type->Weight);
+	pThis->RockingSidewaysPerFrame += (float)(force * Math::sin(theta) * Math::cos(pThis->AngleRotatedSideways) / pThis->Type->Weight);
+
+	return 0;
+}


### PR DESCRIPTION
For the 6th time
@mevitar would you plz test if this works under all cases?

What's new:
- Reverted #1217 
- `TiltCrashJumpjet=no` units will correctly tilt in air. Since previously there's no chance for jumpjets to tilt in air so I added a small new feature to test it out:
### Recoil force

- You can now tilt a voxel unit after firing to simulate the recoil force.
- The body's pseudo "moment of inertia" is simplified to be linearly proportional to the body voxel's size ratio rather than quadratically.

In `rulesmd.ini`:
```ini
[SOMEWEAPON]  ; WeaponType
RecoilForce=  ; floating point value
```

