### PR TITLE
Fixes issue #1107

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -6,6 +6,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 
 - Fixed the bug that GameModeOptions are not correctly saved. For example, `BuildOffAlly` is corrupted after load a save.
 - Fixed the bug that light tint created by buildings can never be removed (light tint persists even if the building is destroyed/sold) after loading a game
+- Fixed the subsequent bug that the game crashes if one returns to menu immediately after the game loads.
 - Fixed the bug when reading a map which puts `Preview(Pack)` after `Map` lead to the game fail to draw the preview
 - Fixed the bug when retinting map lighting with a map action corrupted light sources.
 - Fixed the bug when deploying mindcontrolled vehicle into a building permanently transferred the control to the house which mindcontrolled it.

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -340,9 +340,11 @@ void BuildingExt::ExtData::Serialize(T& Stm)
 		.Process(this->GrindingWeapon_LastFiredFrame)
 		.Process(this->CurrentAirFactory)
 		.Process(this->AccumulatedIncome)
-		.Process(this->OwnerObject()->LightSource)
 		.Process(this->CurrentLaserWeaponIndex)
 		;
+
+	if (this->OwnerObject()->LightSource)
+		Stm.Process(this->OwnerObject()->LightSource);
 }
 
 void BuildingExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)


### PR DESCRIPTION
Minor fix. The issue likely results from a null pointer exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed issues with saving game mode options.
	- Removed unintended light tint from buildings.
	- Prevented crashes when returning to the menu after loading a game.
	- Resolved problems with drawing map previews.
	- Corrected map lighting corruption.
	- Addressed control transfer issues with mind-controlled vehicles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->