### PR TITLE
Option to skip saving game on starting new campaign

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -294,6 +294,7 @@ This page lists all the individual contributions to the project by their author.
    - Skip units' turret rotation and jumpjets' wobbling under EMP
    - Droppod properties dehardcode
    - Waypoint entering building together with engineer/agent bug fix
+   - Skippable game save on scenario start
    - Misc code refactor & maintenance, CN doc fixes, bugfixes
 - **FlyStar**
    - Campaign load screen PCX support

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -494,3 +494,16 @@ In `RA2MD.ini`:
 [Phobos]
 ToolTipBlur=false  ; boolean, whether the blur effect of tooltips will be enabled.
 ```
+
+
+## Miscellanous
+
+### Skip saving game on starting a new campaign
+
+When starting a new campaign, the game automatically saves the game. Now you can decide whether you want that happen or not.
+
+In `RA2MD.ini`:
+```ini
+[Phobos]
+SaveGameOnScenarioStart = true ; boolean
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -359,6 +359,7 @@ New:
 - Projectile return weapon (by Starkku)
 - Allow customizing aircraft landing direction per aircraft or per dock (by Starkku)
 - Allow animations to play sounds detached from audio event handler (by Starkku)
+- Game save option when starting campaigns (by Trsdy)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Scenario/Hooks.Variables.cpp
+++ b/src/Ext/Scenario/Hooks.Variables.cpp
@@ -74,7 +74,9 @@ DEFINE_HOOK(0x6876C2, ReadScenarioINI_Inlined_ReadGlobalVariables, 0x6)
 	return 0x68773F;
 }
 
-DEFINE_HOOK(0x685670, DoWin_SaveVariables, 0x5)
+//IDK why but you can't do it at the beginning, just random place in the middle
+DEFINE_HOOK_AGAIN(0x6857EA, PhobosSaveVariables, 0x5)//Win
+DEFINE_HOOK(0x685EB1, PhobosSaveVariables, 0x5)//Lose
 {
 	if (Phobos::Config::SaveVariablesOnScenarioEnd)
 	{
@@ -85,13 +87,3 @@ DEFINE_HOOK(0x685670, DoWin_SaveVariables, 0x5)
 	return 0;
 }
 
-DEFINE_HOOK(0x685DC0, DoLose_SaveVariables, 0x5)
-{
-	if (Phobos::Config::SaveVariablesOnScenarioEnd)
-	{
-		ScenarioExt::ExtData::SaveVariablesToFile(false);
-		ScenarioExt::ExtData::SaveVariablesToFile(true);
-	}
-
-	return 0;
-}

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -42,6 +42,7 @@ int Phobos::Config::CampaignDefaultGameSpeed = 2;
 bool Phobos::Config::SkirmishUnlimitedColors = false;
 bool Phobos::Config::ShowDesignatorRange = false;
 bool Phobos::Config::SaveVariablesOnScenarioEnd = false;
+bool Phobos::Config::SaveGameOnScenarioStart = true;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -57,6 +58,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::RealTimeTimers = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers", false);
 	Phobos::Config::RealTimeTimers_Adaptive = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers.Adaptive", false);
 	Phobos::Config::DigitalDisplay_Enable = CCINIClass::INI_RA2MD->ReadBool("Phobos", "DigitalDisplay.Enable", false);
+	Phobos::Config::SaveGameOnScenarioStart = CCINIClass::INI_RA2MD->ReadBool("Phobos", "SaveGameOnScenarioStart", true);
 
 	CCINIClass* pINI_UIMD = CCINIClass::LoadINIFile(GameStrings::UIMD_INI);
 
@@ -205,4 +207,9 @@ DEFINE_HOOK(0x66E9DF, RulesClass_Process_Phobos, 0x8)
 #endif
 
 	return 0;
+}
+
+DEFINE_HOOK(0x55DBF5, MainLoop_SaveGame, 0xA)
+{
+	return Phobos::Config::SaveGameOnScenarioStart ? 0 : 0x55DC99;
 }

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -79,6 +79,7 @@ public:
 		static bool SkirmishUnlimitedColors;
 		static bool ShowDesignatorRange;
 		static bool SaveVariablesOnScenarioEnd;
+		static bool SaveGameOnScenarioStart;
 	};
 
 	class Misc


### PR DESCRIPTION
It takes time on old hard drives, maybe people don't want it.

In `RA2MD.ini`:
```ini
[Phobos]
SaveGameOnScenarioStart = true ; boolean
```

Also fixed the load game failure resulted from #1144 