### PR TITLE
Nonprovocative Warheads

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -241,6 +241,7 @@ This page lists all the individual contributions to the project by their author.
   - Customizable ChronoSphere teleport delays for units
   - Allowed and disallowed types for `FactoryPlant`
   - Forbidding parallel AI queues for specific TechnoTypes
+  - Nonprovocative Warheads
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1248,6 +1248,20 @@ In `rulesmd.ini`:
 DecloakDamagedTargets=true  ; boolean
 ```
 
+### Nonprovocative Warheads
+
+- You can now make Warheads behave in nonprovocative fashion. Warheads with `Nonprovocative=true` exhibit following behaviours:
+  - They will not generate any EVA announcements upon hitting targets, be it for attacking ore miners, base buildings or ally base buildings.
+  - They will not spring 'attacked' / 'attacked by' events. Note that if the Warhead deals actual damage, events that check for that can still be sprung. 
+  - They will not evoke defense response from AI players when used to attack base buildings, `ToProtect=true` TechnoTypes or members of TeamTypes with `Whiner=true`.
+  - They will not evoke retaliation from TechnoTypes hit by the Warhead.
+
+In `rulesmd.ini`:
+```ini
+[SOMEWARHEAD]         ; WarheadType
+Nonprovocative=false  ; boolean
+```
+
 ### Restricting screen shaking to current view
 
 - You can now specify whether or not the warhead can only shake screen (`ShakeX/Ylo/hi`) if it is detonated while visible on current screen view.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -448,6 +448,7 @@ New:
 - Customizable damage & 'crumbling' (destruction) frames for TerrainTypes (by Starkku)
 - Custom object palettes for TerrainTypes (by Starkku)
 - Forbidding parallel AI queues for specific TechnoTypes (by Starkku)
+- Nonprovocative Warheads (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -250,6 +250,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DetonateOnAllMapObjects_AffectTypes.Read(exINI, pSection, "DetonateOnAllMapObjects.AffectTypes");
 	this->DetonateOnAllMapObjects_IgnoreTypes.Read(exINI, pSection, "DetonateOnAllMapObjects.IgnoreTypes");
 
+	this->Nonprovocative.Read(exINI, pSection, "Nonprovocative");
+
 	this->AttachEffect_AttachTypes.Read(exINI, pSection, "AttachEffect.AttachTypes");
 	this->AttachEffect_RemoveTypes.Read(exINI, pSection, "AttachEffect.RemoveTypes");
 	exINI.ParseStringList(this->AttachEffect_RemoveGroups, pSection, "AttachEffect.RemoveGroups");
@@ -476,6 +478,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->InflictLocomotor)
 		.Process(this->RemoveInflictedLocomotor)
+
+		.Process(this->Nonprovocative)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -51,7 +51,6 @@ public:
 		Valueable<double> Rocker_AmplitudeMultiplier;
 		Nullable<int> Rocker_AmplitudeOverride;
 
-
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
 		Valueable<int> Crit_ExtraDamage;
@@ -133,6 +132,8 @@ public:
 
 		Valueable<bool> InflictLocomotor;
 		Valueable<bool> RemoveInflictedLocomotor;
+
+		Valueable<bool> Nonprovocative;
 
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_AttachTypes;
 		ValueableVector<AttachEffectTypeClass*> AttachEffect_RemoveTypes;
@@ -280,6 +281,8 @@ public:
 
 			, InflictLocomotor { false }
 			, RemoveInflictedLocomotor { false }
+
+			, Nonprovocative { false }
 
 			, AttachEffect_AttachTypes {}
 			, AttachEffect_RemoveTypes {}

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -246,3 +246,98 @@ DEFINE_HOOK(0x489B49, MapClass_DamageArea_Rocker, 0xA)
 
 	return 0x489B53;
 }
+
+#pragma region Nonprovocative
+
+// Do not retaliate against being hit by these Warheads.
+DEFINE_HOOK(0x708B0B, TechnoClass_AllowedToRetaliate_Nonprovocative, 0x5)
+{
+	enum {  SkipEvents = 0x708B17 };
+
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0x18, 0x8));
+
+	auto const pTypeExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+	return pTypeExt->Nonprovocative ? SkipEvents : 0;
+}
+
+// Do not spring 'attacked' trigger events by these Warheads.
+DEFINE_HOOK(0x5F57CF, ObjectClass_ReceiveDamage_Nonprovocative, 0x6)
+{
+	enum { SkipEvents = 0x5F580C };
+
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0x24, 0xC));
+
+	auto const pTypeExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+	return pTypeExt->Nonprovocative ? SkipEvents : 0;
+}
+
+// Do not consider ToProtect technos hit by weapon as having been attacked e.g provoking response from AI.
+DEFINE_HOOK(0x7027E6, TechnoClass_ReceiveDamage_Nonprovocative, 0x8)
+{
+	enum { SkipGameCode = 0x7027EE };
+
+	GET(TechnoClass*, pThis, ESI);
+	GET(TechnoClass*, pSource, EAX);
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0xC4, 0xC));
+
+	auto const pTypeExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+
+	if (!pTypeExt->Nonprovocative)
+	{
+		pThis->BaseIsAttacked(pSource);
+
+		return SkipGameCode;
+	}
+
+	return SkipGameCode;
+}
+
+// Do not consider Whiner=true team members hit by weapon as having been attacked e.g provoking response from AI.
+DEFINE_HOOK(0x4D7493, FootClass_ReceiveDamage_Nonprovocative, 0x5)
+{
+	enum { SkipChecks = 0x4D74CD, SkipEvents = 0x4D74A3 };
+
+	GET(TechnoClass*, pSource, EBX);
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0x1C, 0xC));
+
+	if (!pSource)
+		return SkipChecks;
+
+	auto const pTypeExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+	return pTypeExt->Nonprovocative ? SkipEvents : 0;
+}
+
+// Suppress harvester under attack notification - Also covered by Ares' Malicious.
+DEFINE_HOOK(0x7384BD, UnitClass_ReceiveDamage_Nonprovocative, 0x6)
+{
+	enum { SkipEvents = 0x738535 };
+
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0x44, 0xC));
+
+	auto const pTypeExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+	return pTypeExt->Nonprovocative ? SkipEvents : 0;
+}
+
+// Do not consider buildings hit by weapon as having been attacked e.g provoking response from AI.
+DEFINE_HOOK(0x442290, BuildingClass_ReceiveDamage_Nonprovocative1, 0x6)
+{
+	enum { SkipEvents = 0x4422C1 };
+
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0x9C, 0xC));
+
+	auto const pTypeExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+	return pTypeExt->Nonprovocative ? SkipEvents : 0;
+}
+
+// Suppress all events and alerts that come from attacking a building, unlike Ares' Malicious this includes all EVA notifications AND events
+DEFINE_HOOK(0x442956, BuildingClass_ReceiveDamage_Nonprovocative2, 0x6)
+{
+	enum { SkipEvents = 0x442980 };
+
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0x9C, 0xC));
+
+	auto const pTypeExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+	return pTypeExt->Nonprovocative ? SkipEvents : 0;
+}
+
+#pragma endregion


### PR DESCRIPTION
TL;DR: This is basically more comprehensive version of Ares' `Malicious=true/false`.

----------------------

### Nonprovocative Warheads
- You can now make Warheads behave in nonprovocative fashion. Warheads with `Nonprovocative=true` exhibit following behaviours:
  - They will not generate any EVA announcements upon hitting targets, be it for attacking ore miners, base buildings or ally base buildings.
  - They will not spring 'attacked' / 'attacked by' events. Note that if the Warhead deals actual damage, events that check for that can still be sprung. 
  - They will not evoke defense response from AI players when used to attack base buildings, `ToProtect=true` TechnoTypes or members of TeamTypes with `Whiner=true`.
  - They will not evoke retaliation from TechnoTypes hit by the Warhead.

In `rulesmd.ini`:
```ini
[SOMEWARHEAD]         ; WarheadType
Nonprovocative=false  ; boolean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced "Nonprovocative Warheads," allowing for warheads that do not provoke enemy responses upon impact. This includes changes to EVA announcements, defense mechanisms, and retaliatory actions.
	- Added enhancements such as `XDrawOffset` for improved animations, shield passthrough & absorption features, and the ability to limit screen shaking to the current view.
	- Implemented new game options like saving at the start of campaigns, carryall pickup voice notifications, and adjustments to credit accumulation requirements for `Grinding.Weapon`.

- **Documentation**
	- Updated documentation to reflect new features and enhancements, including detailed descriptions in "What's New," "Fixed or Improved Logics," and credits acknowledgment.

- **Refactor**
	- Updated subproject references to improve project consistency and integration of new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->