### PR TITLE
New & restored TerrainType features

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -177,6 +177,7 @@ This page lists all the individual contributions to the project by their author.
   - Trailer animation owner inheritance
   - Warhead detonation on all objects on map
   - Animated TerrainTypes extension
+  - TerrainType damage & crumbling frames
   - Exploding unit passenger killing customization
   - Railgun particle target coordinate fix
   - Building target coordinate offset fix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -82,7 +82,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 ![Waving trees](_static/images/tree-shake.gif)
 *Animated trees used in [Ion Shock](https://www.moddb.com/mods/tiberian-war-ionshock)*
 
-- `IsAnimated`, `AnimationRate` and `AnimationProbability` now work on TerrainTypes without `SpawnsTiberium` set to true. Note that this might impact performance.
 - Fixed transports recursively put into each other not having a correct killer set after second transport when being killed by something.
 
 ![image](_static/images/translucency-fix.png)
@@ -877,6 +876,17 @@ ForbidParallelAIQueues.Building=no  ; boolean
 
 ## Terrains
 
+### Animated TerrainTypes
+
+- By default `IsAnimated`, `AnimationRate` and `AnimationProbability` only work on TerrainTypes with `SpawnsTiberium` set to true. This restriction has now been lifted.
+  - Length of the animation can now be customized by setting `AnimationLength` as well, defaulting to half (or quarter if [damaged frames](#damaged-frames-and-crumbling-animation) are enabled) the number of frames in TerrainType's image.
+
+In `rulesmd.ini`:
+```ini
+[SOMETERRAINTYPE]  ; TerrainType
+AnimationLength=   ; integer, number of frames
+```
+
 ### Customizable ore spawners
 
 ![image](_static/images/ore-01.png)
@@ -893,6 +903,27 @@ SpawnsTiberium.Type=0         ; tiberium/ore type index
 SpawnsTiberium.Range=1        ; integer, radius in cells
 SpawnsTiberium.GrowthStage=3  ; integer - single or comma-sep. range
 SpawnsTiberium.CellsPerAnim=1 ; integer - single or comma-sep. range
+```
+
+### Damaged frames and crumbling animation
+
+- By default game shows damage frame only for TerrainTypes alive at only 1 point of health left. Because none of the original game TerrainType assets were made with this in mind, the logic is now locked behind a new key `HasDamagedFrames`.
+  - Instead of showing at 1 point of HP left, TerrainTypes switch to damaged frames once their health reaches `[AudioVisual]` -> `ConditionYellow.Terrain` percentage of their maximum health. Defaults to `ConditionYellow` if not set.
+- In addition, TerrainTypes can now show 'crumbling' animation after their health has reached zero and before they are deleted from the map by setting `HasCrumblingFrames` to true.
+  - Crumbling frames start from first frame after both regular & damaged frames and ends at halfway point of the frames in TerrainType's image.
+    - Note that the number of regular & damage frames considered for this depends on value of `HasDamagedFrames` and for `IsAnimated` TerrainTypes, `AnimationLength` (see [Animated TerrainTypes](#animated-terraintypes). Exercise caution and ensure there are correct amount of frames to display.
+  - Sound event from `CrumblingSound` (if set) is played when crumbling animation starts playing.
+  - [Destroy animation & sound](New-or-Enhanced-Logics.md#destroy-animation-sound) only play after crumbling animation has finished.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+ConditionYellow.Terrain=  ; floating-point value
+
+[SOMETERRAINTYPE]         ; TerrainType
+HasDamagedFrames=false    ; boolean
+HasCrumblingFrames=false
+CrumblingSound=           ; Sound
 ```
 
 ### Minimap color customization

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -905,6 +905,17 @@ SpawnsTiberium.GrowthStage=3  ; integer - single or comma-sep. range
 SpawnsTiberium.CellsPerAnim=1 ; integer - single or comma-sep. range
 ```
 
+### Custom palette
+
+- You can now specify custom palette for TerrainTypes in similar manner as TechnoTypes can.
+  - Note that this palette behaves like an object palette and does not use tint etc. that have been applied to the tile the TerrainType resides on like a TerrainType using tile palette would.
+
+In `artmd.ini`:
+```ini
+[SOMETERRAINTYPE]  ; TerrainType
+Palette=           ; filename - excluding .pal extension and three-character theater-specific suffix
+```
+
 ### Damaged frames and crumbling animation
 
 - By default game shows damage frame only for TerrainTypes alive at only 1 point of health left. Because none of the original game TerrainType assets were made with this in mind, the logic is now locked behind a new key `HasDamagedFrames`.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -445,6 +445,7 @@ New:
 - Disabling `MultipleFactory` bonus from specific BuildingType (by Starkku)
 - Customizable ChronoSphere teleport delays for units (by Starkku)
 - Allowed and disallowed types for `FactoryPlant` (by Starkku)
+- Customizable damage & 'crumbling' (destruction) frames for TerrainTypes (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -446,6 +446,7 @@ New:
 - Customizable ChronoSphere teleport delays for units (by Starkku)
 - Allowed and disallowed types for `FactoryPlant` (by Starkku)
 - Customizable damage & 'crumbling' (destruction) frames for TerrainTypes (by Starkku)
+- Custom object palettes for TerrainTypes (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/OverlayType/Body.cpp
+++ b/src/Ext/OverlayType/Body.cpp
@@ -35,29 +35,17 @@ void OverlayTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->ZAdjust.Read(exArtINI, pArtSection, "ZAdjust");
 	this->PaletteFile.Read(pArtINI, pArtSection, "Palette");
-
-	BuildPalette();
+	this->Palette = GeneralUtils::BuildPalette(this->PaletteFile);
 
 	if (GeneralUtils::IsValidString(this->PaletteFile) && !this->Palette)
 		Debug::Log("[Developer warning] [%s] has Palette=%s set but no palette file was loaded (missing file or wrong filename). Missing palettes cause issues with lighting recalculations.\n", pArtSection, this->PaletteFile);
-}
-
-void OverlayTypeExt::ExtData::BuildPalette()
-{
-	if (GeneralUtils::IsValidString(this->PaletteFile))
-	{
-		char pFilename[0x20];
-		strcpy_s(pFilename, this->PaletteFile.data());
-
-		this->Palette = ColorScheme::GeneratePalette(pFilename);
-	}
 }
 
 void OverlayTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
 {
 	Extension<OverlayTypeClass>::LoadFromStream(Stm);
 	this->Serialize(Stm);
-	this->BuildPalette();
+	this->Palette = GeneralUtils::BuildPalette(this->PaletteFile);
 }
 
 void OverlayTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)

--- a/src/Ext/OverlayType/Body.h
+++ b/src/Ext/OverlayType/Body.h
@@ -39,7 +39,6 @@ public:
 	private:
 		template <typename T>
 		void Serialize(T& Stm);
-		void BuildPalette();
 	};
 
 	class ExtContainer final : public Container<OverlayTypeExt>

--- a/src/Ext/OverlayType/Hooks.cpp
+++ b/src/Ext/OverlayType/Hooks.cpp
@@ -31,15 +31,15 @@ DEFINE_HOOK(0x47F974, CellClass_DrawOverlay_Walls, 0x5)
 	int colorSchemeIndex = HouseClass::CurrentPlayer->ColorSchemeIndex;
 
 	if (wallOwnerIndex >= 0)
-		colorSchemeIndex = HouseClass::Array->GetItem(wallOwnerIndex)->ColorSchemeIndex;
+		colorSchemeIndex = HouseClass::Array->Items[wallOwnerIndex]->ColorSchemeIndex;
 
 	LightConvertClass* pConvert = nullptr;
 	auto const pTypeExt = OverlayTypeExt::ExtMap.Find(pOverlayType);
 
 	if (pTypeExt->Palette)
-		pConvert = pTypeExt->Palette->GetItem(colorSchemeIndex)->LightConvert;
+		pConvert = pTypeExt->Palette->Items[colorSchemeIndex]->LightConvert;
 	else
-		pConvert = ColorScheme::Array->GetItem(colorSchemeIndex)->LightConvert;
+		pConvert = ColorScheme::Array->Items[colorSchemeIndex]->LightConvert;
 
 	DSurface::Temp->DrawSHP(pConvert, pShape, pThis->OverlayData, &pLocation, pBounds,
 		BlitterFlags(0x4E00), 0, -2 - zAdjust, ZGradient::Deg90, pThis->Intensity_Normal, 0, 0, 0, 0, 0);

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -95,6 +95,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->PlacementPreview.Read(exINI, GameStrings::AudioVisual, "PlacementPreview");
 	this->PlacementPreview_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Translucency");
 
+	this->ConditionYellow_Terrain.Read(exINI, GameStrings::AudioVisual, "ConditionYellow.Terrain");
 	this->Shield_ConditionYellow.Read(exINI, GameStrings::AudioVisual, "Shield.ConditionYellow");
 	this->Shield_ConditionRed.Read(exINI, GameStrings::AudioVisual, "Shield.ConditionRed");
 	this->Pips_Shield.Read(exINI, GameStrings::AudioVisual, "Pips.Shield");
@@ -286,6 +287,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->PlacementGrid_TranslucencyWithPreview)
 		.Process(this->PlacementPreview)
 		.Process(this->PlacementPreview_Translucency)
+		.Process(this->ConditionYellow_Terrain)
 		.Process(this->Shield_ConditionYellow)
 		.Process(this->Shield_ConditionRed)
 		.Process(this->Pips_Shield)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -65,6 +65,7 @@ public:
 		Valueable<bool> PlacementPreview;
 		TranslucencyLevel PlacementPreview_Translucency;
 
+		Nullable<double> ConditionYellow_Terrain;
 		Nullable<double> Shield_ConditionYellow;
 		Nullable<double> Shield_ConditionRed;
 		Valueable<Vector3D<int>> Pips_Shield;

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -1,5 +1,6 @@
 #include "Body.h"
 
+#include <AnimClass.h>
 #include <TacticalClass.h>
 #include <TerrainClass.h>
 #include <TerrainTypeClass.h>
@@ -16,6 +17,14 @@ int TerrainTypeExt::ExtData::GetTiberiumGrowthStage()
 int TerrainTypeExt::ExtData::GetCellsPerAnim()
 {
 	return GeneralUtils::GetRangedRandomOrSingleValue(this->SpawnsTiberium_CellsPerAnim.Get());
+}
+
+void TerrainTypeExt::ExtData::PlayDestroyEffects(CoordStruct coords)
+{
+	VocClass::PlayIndexAtPos(this->DestroySound.Get(-1), coords);
+
+	if (auto const pAnimType = this->DestroyAnim)
+		GameCreate<AnimClass>(pAnimType, coords);
 }
 
 void TerrainTypeExt::Remove(TerrainClass* pTerrain)
@@ -46,6 +55,10 @@ void TerrainTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->MinimapColor)
 		.Process(this->IsPassable)
 		.Process(this->CanBeBuiltOn)
+		.Process(this->HasDamagedFrames)
+		.Process(this->HasCrumblingFrames)
+		.Process(this->CrumblingSound)
+		.Process(this->AnimationLength)
 		;
 }
 
@@ -70,6 +83,11 @@ void TerrainTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->IsPassable.Read(exINI, pSection, "IsPassable");
 	this->CanBeBuiltOn.Read(exINI, pSection, "CanBeBuiltOn");
+
+	this->HasDamagedFrames.Read(exINI, pSection, "HasDamagedFrames");
+	this->HasCrumblingFrames.Read(exINI, pSection, "HasCrumblingFrames");
+	this->CrumblingSound.Read(exINI, pSection, "CrumblingSound");
+	this->AnimationLength.Read(exINI, pSection, "AnimationLength");
 
 	//Strength is already part of ObjecTypeClass::ReadIni Duh!
 	//this->TerrainStrength.Read(exINI, pSection, "Strength");

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -19,7 +19,7 @@ int TerrainTypeExt::ExtData::GetCellsPerAnim()
 	return GeneralUtils::GetRangedRandomOrSingleValue(this->SpawnsTiberium_CellsPerAnim.Get());
 }
 
-void TerrainTypeExt::ExtData::PlayDestroyEffects(CoordStruct coords)
+void TerrainTypeExt::ExtData::PlayDestroyEffects(const CoordStruct& coords)
 {
 	VocClass::PlayIndexAtPos(this->DestroySound, coords);
 
@@ -98,6 +98,9 @@ void TerrainTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->PaletteFile.Read(pArtINI, pArtSection, "Palette");
 	this->Palette = GeneralUtils::BuildPalette(this->PaletteFile);
+
+	if (GeneralUtils::IsValidString(this->PaletteFile) && !this->Palette)
+		Debug::Log("[Developer warning] [%s] has Palette=%s set but no palette file was loaded (missing file or wrong filename). Missing palettes cause issues with lighting recalculations.\n", pArtSection, this->PaletteFile);
 }
 
 void TerrainTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -59,6 +59,7 @@ void TerrainTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->HasCrumblingFrames)
 		.Process(this->CrumblingSound)
 		.Process(this->AnimationLength)
+		.Process(this->PaletteFile)
 		;
 }
 
@@ -91,12 +92,19 @@ void TerrainTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	//Strength is already part of ObjecTypeClass::ReadIni Duh!
 	//this->TerrainStrength.Read(exINI, pSection, "Strength");
+
+	auto const pArtINI = &CCINIClass::INI_Art();
+	auto pArtSection = pThis->ImageFile;
+
+	this->PaletteFile.Read(pArtINI, pArtSection, "Palette");
+	this->Palette = GeneralUtils::BuildPalette(this->PaletteFile);
 }
 
 void TerrainTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
 {
 	Extension<TerrainTypeClass>::LoadFromStream(Stm);
 	this->Serialize(Stm);
+	this->Palette = GeneralUtils::BuildPalette(this->PaletteFile);
 }
 
 void TerrainTypeExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)

--- a/src/Ext/TerrainType/Body.cpp
+++ b/src/Ext/TerrainType/Body.cpp
@@ -21,7 +21,7 @@ int TerrainTypeExt::ExtData::GetCellsPerAnim()
 
 void TerrainTypeExt::ExtData::PlayDestroyEffects(CoordStruct coords)
 {
-	VocClass::PlayIndexAtPos(this->DestroySound.Get(-1), coords);
+	VocClass::PlayIndexAtPos(this->DestroySound, coords);
 
 	if (auto const pAnimType = this->DestroyAnim)
 		GameCreate<AnimClass>(pAnimType, coords);

--- a/src/Ext/TerrainType/Body.h
+++ b/src/Ext/TerrainType/Body.h
@@ -28,7 +28,7 @@ public:
 		Valueable<bool> CanBeBuiltOn;
 		Valueable<bool> HasDamagedFrames;
 		Valueable<bool> HasCrumblingFrames;
-		NullableIdx<VocClass> CrumblingSound;
+		ValueableIdx<VocClass> CrumblingSound;
 		Nullable<int> AnimationLength;
 
 		PhobosFixedString<32u> PaletteFile;
@@ -63,7 +63,7 @@ public:
 
 		int GetTiberiumGrowthStage();
 		int GetCellsPerAnim();
-		void PlayDestroyEffects(CoordStruct coords);
+		void PlayDestroyEffects(const CoordStruct& coords);
 
 	private:
 		template <typename T>

--- a/src/Ext/TerrainType/Body.h
+++ b/src/Ext/TerrainType/Body.h
@@ -31,6 +31,9 @@ public:
 		NullableIdx<VocClass> CrumblingSound;
 		Nullable<int> AnimationLength;
 
+		PhobosFixedString<32u> PaletteFile;
+		DynamicVectorClass<ColorScheme*>* Palette; // Intentionally not serialized - rebuilt from the palette file on load.
+
 		ExtData(TerrainTypeClass* OwnerObject) : Extension<TerrainTypeClass>(OwnerObject)
 			, SpawnsTiberium_Type { 0 }
 			, SpawnsTiberium_Range { 1 }
@@ -45,6 +48,8 @@ public:
 			, HasCrumblingFrames { false }
 			, CrumblingSound {}
 			, AnimationLength {}
+			, PaletteFile {}
+			, Palette {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TerrainType/Body.h
+++ b/src/Ext/TerrainType/Body.h
@@ -26,6 +26,10 @@ public:
 		Nullable<ColorStruct> MinimapColor;
 		Valueable<bool> IsPassable;
 		Valueable<bool> CanBeBuiltOn;
+		Valueable<bool> HasDamagedFrames;
+		Valueable<bool> HasCrumblingFrames;
+		NullableIdx<VocClass> CrumblingSound;
+		Nullable<int> AnimationLength;
 
 		ExtData(TerrainTypeClass* OwnerObject) : Extension<TerrainTypeClass>(OwnerObject)
 			, SpawnsTiberium_Type { 0 }
@@ -37,6 +41,10 @@ public:
 			, MinimapColor {}
 			, IsPassable { false }
 			, CanBeBuiltOn { false }
+			, HasDamagedFrames { false }
+			, HasCrumblingFrames { false }
+			, CrumblingSound {}
+			, AnimationLength {}
 		{ }
 
 		virtual ~ExtData() = default;
@@ -50,6 +58,7 @@ public:
 
 		int GetTiberiumGrowthStage();
 		int GetCellsPerAnim();
+		void PlayDestroyEffects(CoordStruct coords);
 
 	private:
 		template <typename T>

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -66,7 +66,7 @@ DEFINE_HOOK(0x71C812, TerrainClass_AI_Crumbling, 0x6)
 	if (pTypeExt->HasDamagedFrames && pThis->Health > 0)
 	{
 		if (!pThis->Type->IsAnimated && !pThis->Type->IsFlammable)
-			MapClass::Instance->Logics.get().Remove(pThis);
+			MapClass::Instance->Logics->Remove(pThis);
 
 		pThis->IsCrumbling = false;
 
@@ -126,13 +126,13 @@ DEFINE_HOOK(0x71C2BC, TerrainClass_Draw_Palette, 0x6)
 	int colorSchemeIndex = HouseClass::CurrentPlayer->ColorSchemeIndex;
 
 	if (wallOwnerIndex >= 0)
-		colorSchemeIndex = HouseClass::Array->GetItem(wallOwnerIndex)->ColorSchemeIndex;
+		colorSchemeIndex = HouseClass::Array->Items[wallOwnerIndex]->ColorSchemeIndex;
 
 	auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
 
 	if (pTypeExt->Palette)
 	{
-		R->EDX(pTypeExt->Palette->GetItem(colorSchemeIndex)->LightConvert);
+		R->EDX(pTypeExt->Palette->Items[colorSchemeIndex]->LightConvert);
 		R->EBP(pCell->Intensity_Normal);
 	}
 
@@ -221,7 +221,7 @@ DEFINE_HOOK(0x71C6EE, TerrainClass_FireOut_Crumbling, 0x6)
 	if (!pThis->IsCrumbling && pTypeExt->HasCrumblingFrames)
 	{
 		// Needs to be added to the logic layer for the anim to work.
-		MapClass::Instance->Logics.get().AddObject(pThis, false);
+		MapClass::Instance->Logics->AddObject(pThis, false);
 		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound.Get(-1), pThis->GetCoords());
 
 		return StartCrumbling;
@@ -249,7 +249,7 @@ DEFINE_HOOK(0x71B98B, TerrainClass_TakeDamage_RefreshDamageFrame, 0x7)
 	if (!pThis->Type->IsAnimated && pTypeExt->HasDamagedFrames && TerrainTypeTemp::PriorHealthRatio > condYellow && pThis->GetHealthPercentage() <= condYellow)
 	{
 		pThis->IsCrumbling = true; // Dirty hack to get game to redraw the art reliably.
-		MapClass::Instance->Logics.get().AddObject(pThis, false);
+		MapClass::Instance->Logics->AddObject(pThis, false);
 	}
 
 	return 0;
@@ -268,7 +268,7 @@ DEFINE_HOOK(0x71BB2C, TerrainClass_TakeDamage_NowDead_Add, 0x6)
 	if (pThis->IsCrumbling && pTypeExt->HasCrumblingFrames)
 	{
 		// Needs to be added to the logic layer for the anim to work.
-		MapClass::Instance->Logics.get().AddObject(pThis, false);
+		MapClass::Instance->Logics->AddObject(pThis, false);
 		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound.Get(-1), pThis->GetCoords());
 		pThis->Mark(MarkType::Change);
 		pThis->Disappear(true);

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -66,7 +66,7 @@ DEFINE_HOOK(0x71C812, TerrainClass_AI_Crumbling, 0x6)
 	if (pTypeExt->HasDamagedFrames && pThis->Health > 0)
 	{
 		if (!pThis->Type->IsAnimated && !pThis->Type->IsFlammable)
-			MapClass::Instance->Logics->Remove(pThis);
+			LogicClass::Instance->Remove(pThis);
 
 		pThis->IsCrumbling = false;
 
@@ -221,8 +221,8 @@ DEFINE_HOOK(0x71C6EE, TerrainClass_FireOut_Crumbling, 0x6)
 	if (!pThis->IsCrumbling && pTypeExt->HasCrumblingFrames)
 	{
 		// Needs to be added to the logic layer for the anim to work.
-		MapClass::Instance->Logics->AddObject(pThis, false);
-		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound.Get(-1), pThis->GetCoords());
+		LogicClass::Instance->AddObject(pThis, false);
+		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound, pThis->GetCoords());
 
 		return StartCrumbling;
 	}
@@ -249,7 +249,7 @@ DEFINE_HOOK(0x71B98B, TerrainClass_TakeDamage_RefreshDamageFrame, 0x7)
 	if (!pThis->Type->IsAnimated && pTypeExt->HasDamagedFrames && TerrainTypeTemp::PriorHealthRatio > condYellow && pThis->GetHealthPercentage() <= condYellow)
 	{
 		pThis->IsCrumbling = true; // Dirty hack to get game to redraw the art reliably.
-		MapClass::Instance->Logics->AddObject(pThis, false);
+		LogicClass::Instance->AddObject(pThis, false);
 	}
 
 	return 0;
@@ -268,8 +268,8 @@ DEFINE_HOOK(0x71BB2C, TerrainClass_TakeDamage_NowDead_Add, 0x6)
 	if (pThis->IsCrumbling && pTypeExt->HasCrumblingFrames)
 	{
 		// Needs to be added to the logic layer for the anim to work.
-		MapClass::Instance->Logics->AddObject(pThis, false);
-		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound.Get(-1), pThis->GetCoords());
+		LogicClass::Instance->AddObject(pThis, false);
+		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound, pThis->GetCoords());
 		pThis->Mark(MarkType::Change);
 		pThis->Disappear(true);
 

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -1,17 +1,19 @@
 #include "Body.h"
 
 #include <ScenarioClass.h>
+#include <SpecificStructures.h>
+#include <TacticalClass.h>
 #include <TiberiumClass.h>
 #include <TerrainClass.h>
-#include <SpecificStructures.h>
-#include <AnimClass.h>
 
+#include <Ext/Rules/Body.h>
 #include <Utilities/GeneralUtils.h>
 
 namespace TerrainTypeTemp
 {
 	TerrainTypeClass* pCurrentType = nullptr;
 	TerrainTypeExt::ExtData* pCurrentExt = nullptr;
+	double PriorHealthRatio = 0.0;
 }
 
 DEFINE_HOOK(0x71C84D, TerrainClass_AI_Animated, 0x6)
@@ -22,7 +24,9 @@ DEFINE_HOOK(0x71C84D, TerrainClass_AI_Animated, 0x6)
 
 	if (pThis->Type->IsAnimated)
 	{
-		if (pThis->Animation.Value == pThis->Type->GetImage()->Frames / 2)
+		auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
+
+		if (pThis->Animation.Value == pTypeExt->AnimationLength.Get(pThis->Type->GetImage()->Frames / (2 * (pTypeExt->HasDamagedFrames + 1))))
 		{
 			pThis->Animation.Value = 0;
 			pThis->Animation.Start(0);
@@ -30,7 +34,6 @@ DEFINE_HOOK(0x71C84D, TerrainClass_AI_Animated, 0x6)
 			// Spawn tiberium if enabled.
 			if (pThis->Type->SpawnsTiberium)
 			{
-				auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
 				auto pCell = pThis->GetCell();
 				int cellCount = pTypeExt->GetCellsPerAnim();
 
@@ -48,6 +51,68 @@ DEFINE_HOOK(0x71C84D, TerrainClass_AI_Animated, 0x6)
 		}
 	}
 
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x71C812, TerrainClass_AI_Crumbling, 0x6)
+{
+	enum { ReturnFromFunction = 0x71C839, SkipCheck = 0x71C7C2 };
+
+	GET(TerrainClass*, pThis, ESI);
+
+	auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
+
+	if (pTypeExt->HasDamagedFrames && pThis->Health > 0)
+	{
+		if (!pThis->Type->IsAnimated && !pThis->Type->IsFlammable)
+			MapClass::Instance->Logics.get().Remove(pThis);
+
+		pThis->IsCrumbling = false;
+
+		return SkipCheck;
+	}
+
+	int animationLength = pTypeExt->AnimationLength.Get(pThis->Type->GetImage()->Frames / (2 * (pTypeExt->HasDamagedFrames + 1)));
+	int currentStage = pThis->Animation.Value + (pThis->Type->IsAnimated ? animationLength * (pTypeExt->HasDamagedFrames + 1) : 0 + pTypeExt->HasDamagedFrames);
+
+	if (currentStage + 1 == pThis->Type->GetImage()->Frames / 2)
+	{
+		pTypeExt->PlayDestroyEffects(pThis->GetCoords());
+		TerrainTypeExt::Remove(pThis);
+	}
+
+	return ReturnFromFunction;
+}
+
+DEFINE_HOOK(0x71C1FE, TerrainClass_Draw_PickFrame, 0x6)
+{
+	enum { SkipGameCode = 0x71C234 };
+
+	GET(int, frame, EBX);
+
+	GET(TerrainClass*, pThis, ESI);
+
+	auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
+	bool isDamaged = pTypeExt->HasDamagedFrames && pThis->GetHealthPercentage() <= RulesExt::Global()->ConditionYellow_Terrain.Get(RulesClass::Instance->ConditionYellow);
+
+	if (pThis->Type->IsAnimated)
+	{
+		int animLength = pTypeExt->AnimationLength.Get(pThis->Type->GetImage()->Frames / (2 * (pTypeExt->HasDamagedFrames + 1)));
+
+		if (pTypeExt->HasCrumblingFrames && pThis->IsCrumbling)
+			frame = (animLength * (pTypeExt->HasDamagedFrames + 1)) + 1 + pThis->Animation.Value;
+		else
+			frame = pThis->Animation.Value + (isDamaged * animLength);
+	}
+	else
+	{
+		if (pTypeExt->HasCrumblingFrames && pThis->IsCrumbling)
+			frame = 1 + pThis->Animation.Value;
+		else if (isDamaged)
+			frame = 1;
+	}
+
+	R->EBX(frame);
 	return SkipGameCode;
 }
 
@@ -122,6 +187,51 @@ DEFINE_HOOK(0x48381D, CellClass_SpreadTiberium_CellSpread, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x71C6EE, TerrainClass_FireOut_Crumbling, 0x6)
+{
+	enum { StartCrumbling = 0x71C6F8, Skip = 0x71C72B };
+
+	GET(TerrainClass*, pThis, ESI);
+
+	auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
+
+	if (!pThis->IsCrumbling && pTypeExt->HasCrumblingFrames)
+	{
+		// Needs to be added to the logic layer for the anim to work.
+		MapClass::Instance->Logics.get().AddObject(pThis, false);
+		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound.Get(-1), pThis->GetCoords());
+
+		return StartCrumbling;
+	}
+
+	return Skip;
+}
+
+DEFINE_HOOK(0x71B965, TerrainClass_TakeDamage_SetContext, 0x8)
+{
+	GET(TerrainClass*, pThis, ESI);
+
+	TerrainTypeTemp::PriorHealthRatio = pThis->GetHealthPercentage();
+
+	return 0;
+}
+
+DEFINE_HOOK(0x71B98B, TerrainClass_TakeDamage_RefreshDamageFrame, 0x7)
+{
+	GET(TerrainClass*, pThis, ESI);
+
+	auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
+	double condYellow = RulesExt::Global()->ConditionYellow_Terrain.Get(RulesClass::Instance->ConditionYellow);
+
+	if (!pThis->Type->IsAnimated && pTypeExt->HasDamagedFrames && TerrainTypeTemp::PriorHealthRatio > condYellow && pThis->GetHealthPercentage() <= condYellow)
+	{
+		pThis->IsCrumbling = true; // Dirty hack to get game to redraw the art reliably.
+		MapClass::Instance->Logics.get().AddObject(pThis, false);
+	}
+
+	return 0;
+}
+
 //This one on Very end of it , let everything play first
 DEFINE_HOOK(0x71BB2C, TerrainClass_TakeDamage_NowDead_Add, 0x6)
 {
@@ -129,14 +239,21 @@ DEFINE_HOOK(0x71BB2C, TerrainClass_TakeDamage_NowDead_Add, 0x6)
 	//saved for later usage !
 	//REF_STACK(args_ReceiveDamage const, ReceiveDamageArgs, STACK_OFFSET(0x3C, 0x4));
 
-	if (auto const pTerrainExt = TerrainTypeExt::ExtMap.Find(pThis->Type))
-	{
-		auto const nCoords = pThis->GetCoords();
-		VocClass::PlayIndexAtPos(pTerrainExt->DestroySound, nCoords);
+	auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
 
-		if (pTerrainExt->DestroyAnim)
-			GameCreate<AnimClass>(pTerrainExt->DestroyAnim, nCoords);
+	// Skip over the removal of the tree as well as destroy sound/anim (for now) if the tree has crumble animation.
+	if (pThis->IsCrumbling && pTypeExt->HasCrumblingFrames)
+	{
+		// Needs to be added to the logic layer for the anim to work.
+		MapClass::Instance->Logics.get().AddObject(pThis, false);
+		VocClass::PlayIndexAtPos(pTypeExt->CrumblingSound.Get(-1), pThis->GetCoords());
+		pThis->Mark(MarkType::Change);
+		pThis->Disappear(true);
+
+		return 0x71BB79;
 	}
+
+	pTypeExt->PlayDestroyEffects(pThis->GetCoords());
 
 	return 0;
 }
@@ -195,3 +312,4 @@ DEFINE_HOOK(0x568432, MapClass_PlaceDown_0x0TerrainTypes, 0x8)
 
 	return 0;
 }
+

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -1,5 +1,6 @@
 #include "Body.h"
 
+#include <HouseClass.h>
 #include <ScenarioClass.h>
 #include <SpecificStructures.h>
 #include <TacticalClass.h>
@@ -114,6 +115,28 @@ DEFINE_HOOK(0x71C1FE, TerrainClass_Draw_PickFrame, 0x6)
 
 	R->EBX(frame);
 	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x71C2BC, TerrainClass_Draw_Palette, 0x6)
+{
+	GET(TerrainClass*, pThis, ESI);
+
+	auto const pCell = pThis->GetCell();
+	int wallOwnerIndex = pCell->WallOwnerIndex;
+	int colorSchemeIndex = HouseClass::CurrentPlayer->ColorSchemeIndex;
+
+	if (wallOwnerIndex >= 0)
+		colorSchemeIndex = HouseClass::Array->GetItem(wallOwnerIndex)->ColorSchemeIndex;
+
+	auto const pTypeExt = TerrainTypeExt::ExtMap.Find(pThis->Type);
+
+	if (pTypeExt->Palette)
+	{
+		R->EDX(pTypeExt->Palette->GetItem(colorSchemeIndex)->LightConvert);
+		R->EBP(pCell->Intensity_Normal);
+	}
+
+	return 0;
 }
 
 // Overrides Ares hook at 0x5F4FF9, required for animated terrain cause game & Ares check SpawnsTiberium instead of IsAnimated

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -6,6 +6,7 @@
 
 #include <Ext/Rules/Body.h>
 #include <Misc/FlyingStrings.h>
+#include <Utilities/Constructs.h>
 
 bool GeneralUtils::IsValidString(const char* str)
 {
@@ -215,6 +216,19 @@ void GeneralUtils::DisplayDamageNumberString(int damage, DamageDisplayType type,
 	FlyingStrings::Add(damageStr, coords, color, Point2D { offset - (width / 2), 0 });
 
 	offset = offset + width;
+}
+
+DynamicVectorClass<ColorScheme*>* GeneralUtils::BuildPalette(const char* paletteFileName)
+{
+	if (GeneralUtils::IsValidString(paletteFileName))
+	{
+		char pFilename[0x20];
+		strcpy_s(pFilename, paletteFileName);
+
+		return ColorScheme::GeneratePalette(pFilename);
+	}
+
+	return nullptr;
 }
 
 // Gets integer representation of color from ColorAdd corresponding to given index, or 0 if there's no color found.

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -37,6 +37,7 @@ public:
 	static CoordStruct CalculateCoordsFromDistance(CoordStruct currentCoords, CoordStruct targetCoords, int distance);
 	static void DisplayDamageNumberString(int damage, DamageDisplayType type, CoordStruct coords, int& offset);
 	static int GetColorFromColorAdd(int colorIndex);
+	static DynamicVectorClass<ColorScheme*>* BuildPalette(const char* paletteFileName);
 
 	template<typename T>
 	static constexpr T FastPow(T x, size_t n)


### PR DESCRIPTION
## Animated TerrainTypes

- Length of the animation can now be customized by setting `AnimationLength` as well, defaulting to half (or quarter if damaged frames are enabled) the number of frames in TerrainType's image.

In `rulesmd.ini`:
```ini
[SOMETERRAINTYPE]  ; TerrainType
AnimationLength=   ; integer, number of frames
```

## Damaged frames and crumbling animation

- By default game shows damage frame only for TerrainTypes alive at only 1 point of health left. Because none of the original game TerrainType assets were made with this in mind, the logic is now locked behind a new key `HasDamagedFrames`.
  - Instead of showing at 1 point of HP left, TerrainTypes switch to damaged frames once their health reaches `[AudioVisual]` -> `ConditionYellow.Terrain` percentage of their maximum health. Defaults to `ConditionYellow` if not set.
- In addition, TerrainTypes can now show 'crumbling' animation after their health has reached zero and before they are deleted from the map by setting `HasCrumblingFrames` to true.
  - Crumbling frames start from first frame after both regular & damaged frames and ends at halfway point of the frames in TerrainType's image.
    - Note that the number of regular & damage frames considered for this depends on value of `HasDamagedFrames` and for `IsAnimated` TerrainTypes, `AnimationLength`. Exercise caution and ensure there are correct amount of frames to display.
  - Sound event from `CrumblingSound` (if set) is played when crumbling animation starts playing.
  - Destroy animation & sound only play after crumbling animation has finished.

In `rulesmd.ini`:
```ini
[AudioVisual]
ConditionYellow.Terrain=  ; floating-point value

[SOMETERRAINTYPE]         ; TerrainType
HasDamagedFrames=false    ; boolean
HasCrumblingFrames=false
CrumblingSound=           ; Sound
```

## Custom palette

- You can now specify custom palette for TerrainTypes in similar manner as TechnoTypes can.
  - Note that this palette behaves like an object palette and does not use tint etc. that have been applied to the tile the TerrainType resides on like a TerrainType using tile palette would.

In `artmd.ini`:
```ini
[SOMETERRAINTYPE]  ; TerrainType
Palette=           ; filename - excluding .pal extension and three-character theater-specific suffix
```