### PR TITLE
Part of a small fix on GlobalVariables

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -301,6 +301,7 @@ This page lists all the individual contributions to the project by their author.
 - **FlyStar**
    - Campaign load screen PCX support
    - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist
+   - GlobalVariable Passing fix, AltNextScenario fix
 - **NetsuNegi**
    - Forbidding parallel AI queues by type
    - Jumpjet crash speed fix when crashing onto building

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -26,6 +26,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed jumpjet units that are `Crashable` not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead.
 - Fixed jumpjet units being unable to turn to the target when firing from a different direction.
 - Fixed jumpjet units being able to continue firing at enemy target when crashing.
+- Fixed bug where AltNextScenario was not working properly.
 
 ![image](_static/images/jumpjet-turning.gif)
 *Jumpjet turning to target applied in [Robot Storm X](https://www.moddb.com/mods/cc-robot-storm-x)*

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -481,6 +481,7 @@ Phobos fixes:
 - Fixed heal / repair weapons being unable to remove parasites from shielded targets if they were unable to heal / repair the parent unit (by Starkku)
 - Fixed `Inviso=true` interceptor projectiles applying damage on interceptable, armor type-having projectiles twice (by Starkku)
 - Fixed `AutoDeath` causing crashes when used to kill a parasite unit inside an another unit (by Starkku)
+- GlobalVariables inherit their parameters in a different way (by FlyStar)
 
 Fixes / interactions with other extensions:
 - All forms of type conversion (including Ares') now correctly update `OpenTopped` state of passengers in transport that is converted (by Starkku)

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -57,6 +57,17 @@ void ScenarioExt::ExtData::ReadVariables(bool bIsGlobal, CCINIClass* pINI)
 				var.Value = 0;
 		}
 	}
+
+	if (bIsGlobal)
+	{
+		ScenarioExt::Global()->LoadVariablesToFile(true);
+
+		if (!Phobos::Config::SaveVariablesOnScenarioEnd)
+		{
+			// Is it better not to delete the file?
+			DeleteFileA("globals.ini");
+		}
+	}
 }
 
 void ScenarioExt::ExtData::SaveVariablesToFile(bool isGlobal)
@@ -86,9 +97,13 @@ void ScenarioExt::ExtData::SaveVariablesToFile(bool isGlobal)
 void ScenarioExt::ExtData::LoadVariablesToFile(bool isGlobal)
 {
 	const auto fileName = isGlobal ? "globals.ini" : "locals.ini";
-	auto pINI = CCINIClass::LoadINIFile(fileName);
-	if (pINI)
+	auto pINI = GameCreate<CCINIClass>();
+	auto pFile = GameCreate<CCFileClass>(fileName);
+
+	if (pFile->Exists())
 	{
+		pINI->ReadCCFile(pFile);
+
 		auto& variables = Global()->Variables[isGlobal];
 		for (auto& variable : variables)
 		{
@@ -99,7 +114,7 @@ void ScenarioExt::ExtData::LoadVariablesToFile(bool isGlobal)
 		}
 	}
 
-	CCINIClass::UnloadINIFile(pINI);
+	pFile->Close();
 }
 
 void ScenarioExt::Allocate(ScenarioClass* pThis)

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -61,12 +61,6 @@ void ScenarioExt::ExtData::ReadVariables(bool bIsGlobal, CCINIClass* pINI)
 	if (bIsGlobal)
 	{
 		ScenarioExt::Global()->LoadVariablesToFile(true);
-
-		if (!Phobos::Config::SaveVariablesOnScenarioEnd)
-		{
-			// Is it better not to delete the file?
-			DeleteFileA("globals.ini");
-		}
 	}
 }
 
@@ -96,6 +90,9 @@ void ScenarioExt::ExtData::SaveVariablesToFile(bool isGlobal)
 
 void ScenarioExt::ExtData::LoadVariablesToFile(bool isGlobal)
 {
+	if (!SessionClass::Instance->IsCampaign())
+		return;
+
 	const auto fileName = isGlobal ? "globals.ini" : "locals.ini";
 	auto pINI = GameCreate<CCINIClass>();
 	auto pFile = GameCreate<CCFileClass>(fileName);
@@ -115,6 +112,12 @@ void ScenarioExt::ExtData::LoadVariablesToFile(bool isGlobal)
 	}
 
 	pFile->Close();
+
+	if (!Phobos::Config::SaveVariablesOnScenarioEnd)
+	{
+		// Is it better not to delete the file?
+		DeleteFileA(fileName);
+	}
 }
 
 void ScenarioExt::Allocate(ScenarioClass* pThis)

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -72,10 +72,34 @@ void ScenarioExt::ExtData::SaveVariablesToFile(bool isGlobal)
 
 	const auto& variables = Global()->Variables[isGlobal];
 	for (const auto& variable : variables)
-		pINI->WriteInteger(ScenarioClass::Instance()->FileName, variable.second.Name, variable.second.Value, false);
+	{
+		// Using "GlobalVariables" is probably not a good idea.
+		pINI->WriteInteger(
+			isGlobal ? "GlobalVariables" : ScenarioClass::Instance()->FileName,
+			variable.second.Name, variable.second.Value, false);
+	}
 
 	pINI->WriteCCFile(pFile);
 	pFile->Close();
+}
+
+void ScenarioExt::ExtData::LoadVariablesToFile(bool isGlobal)
+{
+	const auto fileName = isGlobal ? "globals.ini" : "locals.ini";
+	auto pINI = CCINIClass::LoadINIFile(fileName);
+	if (pINI)
+	{
+		auto& variables = Global()->Variables[isGlobal];
+		for (auto& variable : variables)
+		{
+			// Does it really work for LocalVariables?
+			variable.second.Value = pINI->ReadInteger(
+				isGlobal ? "GlobalVariables" : ScenarioClass::Instance()->FileName,
+				variable.second.Name, 0);
+		}
+	}
+
+	CCINIClass::UnloadINIFile(pINI);
 }
 
 void ScenarioExt::Allocate(ScenarioClass* pThis)

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -42,6 +42,7 @@ public:
 		void GetVariableStateByID(bool bIsGlobal, int nIndex, char* pOut);
 		void ReadVariables(bool bIsGlobal, CCINIClass* pINI);
 		static void SaveVariablesToFile(bool isGlobal);
+		static void LoadVariablesToFile(bool isGlobal);
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/Scenario/Hooks.Variables.cpp
+++ b/src/Ext/Scenario/Hooks.Variables.cpp
@@ -94,15 +94,10 @@ DEFINE_HOOK(0x685EB1, PhobosSaveVariables, 0x5)//Lose
 // I'm not sure how it works, this seems to solve the problem for now.
 DEFINE_HOOK(0x4C6217, ScenarioClass_LoadVariables, 0x5)
 {
-	if (Phobos::Config::SaveVariablesOnScenarioEnd)
-	{
-		ScenarioExt::Global()->LoadVariablesToFile(false);
-		ScenarioExt::Global()->LoadVariablesToFile(true);
-	}
-	else
-	{
-		ScenarioExt::Global()->LoadVariablesToFile(true);
+	ScenarioExt::Global()->LoadVariablesToFile(true);
 
+	if (!Phobos::Config::SaveVariablesOnScenarioEnd)
+	{
 		// Is it better not to delete the file?
 		DeleteFileA("globals.ini");
 	}

--- a/src/Ext/Scenario/Hooks.Variables.cpp
+++ b/src/Ext/Scenario/Hooks.Variables.cpp
@@ -96,12 +96,6 @@ DEFINE_HOOK(0x4C6217, ScenarioClass_LoadVariables, 0x5)
 {
 	ScenarioExt::Global()->LoadVariablesToFile(true);
 
-	if (!Phobos::Config::SaveVariablesOnScenarioEnd)
-	{
-		// Is it better not to delete the file?
-		DeleteFileA("globals.ini");
-	}
-
 	return 0x4C622F;
 }
 


### PR DESCRIPTION
Previously while using phobos I noticed that the game was passing GlobalVariables with an error. due to a technical glitch I couldn't get to the root of the problem so I opted for an alternative method of exporting globals.ini and re-reading the parameters.

PS: There may be a better way, but that's not something I can do anymore.