### PR TITLE
Fix potential desync caused by cursor on DeploysInto vehicles

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -222,6 +222,7 @@ This page lists all the individual contributions to the project by their author.
   - `AmbientDamage` warhead & main target ignore customization
   - Projectile return weapon
   - Aircraft landing / docking direction
+  - `DeploysInto` cursor desync fix
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -151,6 +151,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Spawned aircraft now align with the spawner's facing when landing.
 - Fixed the bug that waypointing unarmed infantries with agent/engineer/occupier to a spyable/capturable/occupiable building triggers EnteredBy event by executing capture mission.
 - `PowerUpN` building animations can now use `Powered` & `PoweredLight/Effect/Special` keys.
+- Fixed a desync potentially caused by displaying of cursor over selected `DeploysInto` units.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -448,6 +448,7 @@ Vanilla fixes:
 - Spawned aircraft now align with the spawner's facing when landing (by Starkku)
 - Fixed infantries attempted to entering buildings when waypointing together with engineer/agent/occupier/etc (by Trsdy)
 - Fixed jumpjet crash speed when crashing onto buildings (by NetsuNegi)
+- Fixed a desync potentially caused by displaying of cursor over selected `DeploysInto` units (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -384,6 +384,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->DeployFireTimer)
 		.Process(this->ForceFullRearmDelay)
 		.Process(this->WHAnimRemainingCreationInterval)
+		.Process(this->CanCurrentlyDeployIntoBuilding)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -38,6 +38,7 @@ public:
 		CDTimerClass DeployFireTimer;
 		bool ForceFullRearmDelay;
 		int WHAnimRemainingCreationInterval;
+		bool CanCurrentlyDeployIntoBuilding; // Only set on UnitClass technos with DeploysInto set in multiplayer games, recalculated once per frame.
 
 		// Used for Passengers.SyncOwner.RevertOnExit instead of TechnoClass::InitialOwner / OriginallyOwnedByHouse,
 		// as neither is guaranteed to point to the house the TechnoClass had prior to entering transport and cannot be safely overridden.
@@ -61,6 +62,7 @@ public:
 			, DeployFireTimer {}
 			, ForceFullRearmDelay { false }
 			, WHAnimRemainingCreationInterval { 0 }
+			, CanCurrentlyDeployIntoBuilding { false }
 		{ }
 
 		void OnEarlyUpdate();

--- a/src/Ext/Techno/Hooks.DeploysInto.cpp
+++ b/src/Ext/Techno/Hooks.DeploysInto.cpp
@@ -116,3 +116,42 @@ DEFINE_HOOK(0x7396AD, UnitClass_Deploy_CreateBuilding, 0x6)
 
 	return 0x7396B3;
 }
+
+// Game removes deploying vehicles from map temporarily to check if there's enough
+// space to deploy into a building when displaying allow/disallow deploy cursor.
+// This can cause desyncs if there are certain types of units around the deploying unit.
+// Only reasonable way to solve this is to perform the cell clear check on every client per frame
+// and use that result in cursor display which is client-specific. This is now implemented in multiplayer games only.
+#pragma region DeploysIntoDesyncFix
+
+DEFINE_HOOK(0x73635B, UnitClass_AI_DeploysIntoDesyncFix, 0x6)
+{
+	if (!SessionClass::Instance->IsMultiplayer())
+		return 0;
+
+	GET(UnitClass*, pThis, ESI);
+
+	if (pThis->Type->DeploysInto)
+		TechnoExt::ExtMap.Find(pThis)->CanCurrentlyDeployIntoBuilding = TechnoExt::CanDeployIntoBuilding(pThis);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x73FEC1, UnitClass_WhatAction_DeploysIntoDesyncFix, 0x6)
+{
+	if (!SessionClass::Instance->IsMultiplayer())
+		return 0;
+
+	enum { SkipGameCode = 0x73FFDF };
+
+	GET(UnitClass*, pThis, ESI);
+	LEA_STACK(Action*, pAction, STACK_OFFSET(0x20, 0x8));
+
+	if (!TechnoExt::ExtMap.Find(pThis)->CanCurrentlyDeployIntoBuilding)
+		*pAction = Action::NoDeploy;
+
+	return SkipGameCode;
+}
+
+#pragma endregion
+


### PR DESCRIPTION
Game removes deploying vehicles from map temporarily to check if there's enough space to deploy into a building when displaying allow/disallow deploy cursor. This can cause desyncs if there are certain types of units around the deploying unit.

Only reasonable way to solve this is to perform the cell clear check on every client per frame and use that result in cursor display which is client-specific. This is now implemented in multiplayer games only.