### PR TITLE
Jumpjet: height change on type conversion & type conversion at flight

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -241,6 +241,9 @@ This page lists all the individual contributions to the project by their author.
   - Dump variables to file on scenario end / hotkey
   - "House owns TechnoType" and "House doesn't own TechnoType" trigger events
   - Help with docs
+- Multfinite
+  - Fixed Ares jumpjet height sync issue
+  - Added `AlwaysBeInAir` and `AlwaysBeInAir.StayGrounded` flags
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance
    - Interceptor logic prototype

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -241,7 +241,7 @@ This page lists all the individual contributions to the project by their author.
   - Dump variables to file on scenario end / hotkey
   - "House owns TechnoType" and "House doesn't own TechnoType" trigger events
   - Help with docs
-- Multfinite
+- **Multfinite**
   - Fixed Ares jumpjet height sync issue
   - Added `AlwaysBeInAir` and `AlwaysBeInAir.StayGrounded` flags
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -158,6 +158,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 
 - All forms of type conversion (including Ares') now correctly update `OpenTopped` state of passengers in transport that is converted.
 - Fixed an issue introduced by Ares that caused `Grinding=true` building `ActiveAnim` to be incorrectly restored while `SpecialAnim` was playing and the building was sold, erased or destroyed.
+- Fixed Ares jumpjet height sync issue during type conversion between types with different `JumpjetHeight` was not changed to unit instance.
 
 ## Aircraft
 
@@ -612,6 +613,17 @@ JumpjetRotateOnCrash=true  ; boolean
 
 ```{warning}
 This may subject to further changes.
+```
+### Jumpjet: convert unit type in air and force unit always be in air
+
+`AlwaysBeInAir` designed to use with Ares type conversion logic (`IsSimpleDeployer=true` and `Convert.Deploy=TECHNOTYPE`) and will convert unit in air instead of convert type during deploy on ground as`BalloonHover` does.
+
+`AlwaysBeInAir.StayGrounded` prevents `AlwaysBeInAir` tagged unit to being immediately ascended in case if initial unit type has `AlwaysBeInAir=false` and converted unit type hasn't.
+
+```ini
+[SOMETECHNO]    ; TechnoType
+AlwaysBeInAir=false  ; boolean
+AlwaysBeInAir.StayGrounded=false  ; boolean
 ```
 
 ### Kill spawns on low power

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -3,6 +3,7 @@
 
 #include <SpawnManagerClass.h>
 #include <ParticleSystemClass.h>
+#include <JumpjetLocomotionClass.h>
 
 #include <Ext/Anim/Body.h>
 #include <Ext/Bullet/Body.h>
@@ -40,6 +41,7 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 	this->ApplySpawnLimitRange();
 	this->UpdateLaserTrails();
 	this->DepletedAmmoActions();
+	this->UpdateLocomotor();
 }
 
 
@@ -757,5 +759,69 @@ void TechnoExt::UpdateSharedAmmo(TechnoClass* pThis)
 				}
 			}
 		}
+	}
+}
+
+void TechnoExt::ExtData::UpdateLocomotor()
+{
+	auto* pFoot = abstract_cast<FootClass*>(OwnerObject());
+	if (!pFoot)
+		return;
+	
+	auto* pFootType = pFoot->GetTechnoType();
+	auto* pFootTypeExt = this->TypeExtData;
+
+	/*
+		Put your locomotion handlers here
+	*/
+
+	if (auto* pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor))
+	{
+		// Ares type convert function does not apply new target JJ height.
+		// So we need coherate JJ locomotor instance height value with new type.
+		if (pJJLoco->Height == pFootType->JumpjetHeight)
+			return;
+
+		// Save new height
+		pJJLoco->Height = pFoot->GetTechnoType()->JumpjetHeight;
+
+		/*
+			Need to update a real unit height, not only desired.
+			if unit considered to be in air:
+				- and it is grounded:
+					- and not forced to stay grounded then it must flight up anyway
+					- and force to stay frounded then it must stay grounded
+				- and it is hovering:
+					- height > current height then it should ascend
+					- height < current height then it should descend
+			if unit NOT considered to be in air:
+				- in all cases height should reapply during movement and there are no extra actions to do
+		*/
+		auto location = pFoot->Location;
+		auto floorHeight = MapClass::Instance->GetCellFloorHeight(location);
+		auto unitHeight = pFoot->GetHeight();
+		auto heightDiff = pJJLoco->Height - pJJLoco->CurrentHeight;
+		auto pCell = MapClass::Instance->GetCellAt(location);
+		auto isBridge = pCell->ContainsBridge();
+		int bridgeZ = isBridge ? CellClass::BridgeHeight : 0;
+		location.Z = floorHeight + bridgeZ + pJJLoco->Height;
+
+		auto mustFlight = pFootTypeExt->AlwaysBeInAir || pFootType->BalloonHover;
+		auto onWater = pCell->Tile_Is_Water() || pCell->Tile_Is_Shore();
+		auto onGround = pFoot->IsOnFloor() || pJJLoco->State == JumpjetLocomotionClass::State::Grounded;
+
+		auto reHeight =
+			(onGround && mustFlight && !pFootTypeExt->AlwaysBeInAir_StayGrounded) ||
+			heightDiff != 0 ||
+			onWater
+			;
+
+		if (reHeight)
+		{
+			pJJLoco->State = JumpjetLocomotionClass::State::Hovering;
+			pJJLoco->IsMoving = true;
+			pJJLoco->DestinationCoords = location;
+		}
+		else pJJLoco->Move_To(location);
 	}
 }

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -41,7 +41,6 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 	this->ApplySpawnLimitRange();
 	this->UpdateLaserTrails();
 	this->DepletedAmmoActions();
-	this->UpdateLocomotor();
 }
 
 
@@ -484,6 +483,8 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 			pPassenger = abstract_cast<FootClass*>(pPassenger->NextObject);
 		}
 	}
+
+	CoherateLocomotor();	
 }
 
 void TechnoExt::ExtData::UpdateLaserTrails()
@@ -762,12 +763,9 @@ void TechnoExt::UpdateSharedAmmo(TechnoClass* pThis)
 	}
 }
 
-void TechnoExt::ExtData::UpdateLocomotor()
+void TechnoExt::ExtData::CoherateLocomotor()
 {
-	auto* pFoot = abstract_cast<FootClass*>(OwnerObject());
-	if (!pFoot)
-		return;
-	
+	auto* pFoot = abstract_cast<FootClass*>(OwnerObject()); if (!pFoot) return;
 	auto* pFootType = pFoot->GetTechnoType();
 	auto* pFootTypeExt = this->TypeExtData;
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -78,7 +78,7 @@ public:
 		void UpdateLaserTrails();
 		void InitializeLaserTrails();
 		void UpdateMindControlAnim();
-		void UpdateLocomotor();
+		void CoherateLocomotor();
 
 		virtual ~ExtData() override;
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -78,6 +78,7 @@ public:
 		void UpdateLaserTrails();
 		void InitializeLaserTrails();
 		void UpdateMindControlAnim();
+		void UpdateLocomotor();
 
 		virtual ~ExtData() override;
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -276,6 +276,9 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SpawnHeight.Read(exINI, pSection, "SpawnHeight");
 	this->LandingDir.Read(exINI, pSection, "LandingDir");
 
+	this->AlwaysBeInAir.Read(exINI, pSection, "AlwaysBeInAir");
+	this->AlwaysBeInAir_StayGrounded.Read(exINI, pSection, "AlwaysBeInAir.StayGrounded");
+
 	this->Convert_HumanToComputer.Read(exINI, pSection, "Convert.HumanToComputer");
 	this->Convert_ComputerToHuman.Read(exINI, pSection, "Convert.ComputerToHuman");
 
@@ -605,6 +608,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DroppodType)
 		.Process(this->Convert_HumanToComputer)
 		.Process(this->Convert_ComputerToHuman)
+
+		.Process(this->AlwaysBeInAir)
+		.Process(this->AlwaysBeInAir_StayGrounded)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -191,6 +191,9 @@ public:
 		Valueable<TechnoTypeClass*> Convert_HumanToComputer;
 		Valueable<TechnoTypeClass*> Convert_ComputerToHuman;
 
+		Valueable<bool> AlwaysBeInAir;
+		Valueable<bool> AlwaysBeInAir_StayGrounded;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -377,6 +380,7 @@ public:
 			, DroppodType {}
 			, Convert_HumanToComputer { }
 			, Convert_ComputerToHuman { }
+			, AlwaysBeInAir_StayGrounded { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -279,3 +279,48 @@ DEFINE_HOOK(0x729B5D, TunnelLocomotionClass_DrawMatrix_Tilt, 0x8)
 
 // DEFINE_JUMP(VTABLE, 0x7F5A4C, 0x5142A0);//TunnelLocomotionClass_Shadow_Matrix : just use hover's to save my time
 // Since I've already invalidated the key for tilted vxls when reimplementing the shadow drawing code, this is no longer necessary
+DEFINE_HOOK(0x54BED1, JumpjetLocomotionClass__State_Hovering_54BED1, 0x9)
+{
+	GET(JumpjetLocomotionClass*, pThis, ESI);	
+
+	auto* pObj = pThis->LinkedTo;
+	TechnoTypeClass* pObjType = pObj->GetTechnoType();
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pObjType);
+
+	if (pTypeExt->AlwaysBeInAir)
+	{
+		pThis->CurrentHeight = pThis->Height;
+		pThis->State = JumpjetLocomotionClass::State::Hovering;
+	}
+	else
+	{
+		pThis->CurrentHeight = 0;
+		pThis->State = JumpjetLocomotionClass::State::Descending;
+	}
+
+	R->ECX(pObj);
+	return 0x54BEDB;
+}
+
+DEFINE_HOOK(0x54C2DC, JumpjetLocomotionClass__State_Cruising_54C2DC, 0x13)
+{
+	GET(JumpjetLocomotionClass*, pThis, ESI);
+
+	auto* pObj = pThis->LinkedTo;
+	TechnoTypeClass* pObjType = pObj->GetTechnoType();
+	auto pTypeExt = TechnoTypeExt::ExtMap.Find(pObjType);
+
+	if (pTypeExt->AlwaysBeInAir)
+	{
+		pThis->CurrentHeight = pThis->Height;
+		pThis->State = JumpjetLocomotionClass::State::Hovering;
+	}
+	else
+	{
+		pThis->CurrentHeight = 0;
+		pThis->State = JumpjetLocomotionClass::State::Descending;
+	}
+
+	R->ECX(pObj);
+	return 0x54C2F0;
+}


### PR DESCRIPTION
1. Coherate JJ type height and JJ loco height
- It fixes Ares type conversion height state issue,
- sync JumpjetHeight and JJ Loco height if it differs and ascend/descend FootClass if it needed.
2. Add `AlwaysBeInAir` and `AlwaysBeInAir.StayGrounded` flags
- It allow deploy unit in air during type conversion.
- Also proivide flag to make ascensing delayed or instant.

**Need some testing**