### PR TITLE
Couple of minor digital display improvements

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -44,7 +44,8 @@ IngameScore.LoseTheme= ; Soundtrack theme ID
     - Frames 0-9 will be used as digits when the owner's health bar is green, 10-19 when yellow, 20-29 when red. For `/` and `%` characters, frame numbers are 30-31, 32-33, 34-35, respectively.
   - Default `Offset.ShieldDelta` for `InfoType=Shield` is `0,-10`, `0,0` for others.
   - Default `Shape.Spacing` for buildings is `4,-2`, `4,0` for others.
-
+  - `ValueScaleDivisor` can be used to adjust scale of displayed values. Both the current & maximum value will be divided by the integer number given, if higher than 1.
+  
 In `rulesmd.ini`:
 ```ini
 [DigitalDisplayTypes]
@@ -69,6 +70,7 @@ Percentage=false                        ; boolean
 HideMaxValue=false                      ; boolean
 VisibleToHouses=owner                   ; Affected house enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 VisibleToHouses.Observer=true           ; boolean
+ValueScaleDivisor=1                     ; integer
 ; Text
 Text.Color=0,255,0                      ; integers - Red, Green, Blue
 Text.Color.ConditionYellow=255,255,0    ; integers - Red, Green, Blue

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -20,6 +20,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 #### From post-0.3 devbuilds
 
+- Digital display `Offset` and `Offset.ShieldDelta` Y-axis coordinates now work in inverted fashion (negative goes up, positive goes down) to be consistent with how pixel offsets work elsewhere in the game.
 - Phobos Warhead effects combined with `CellSpread` now correctly apply to buildings if any of the foundation cells are hit instead of only the top-left most cell (cell #0).
 - `ExtraWarheads.DamageOverrides` now falls back to last listed value if list is shorter than `ExtraWarheads` for all Warhead detonations exceeding the length.
 - Air and Top layer contents are no longer sorted, animations in these layers no longer respect `YSortAdjust`. Animations attached to flying units now get their layer updated immediately after parent unit, if they are on same layer they will draw above the parent unit.

--- a/src/Ext/Techno/Body.Visuals.cpp
+++ b/src/Ext/Techno/Body.Visuals.cpp
@@ -336,6 +336,12 @@ void TechnoExt::ProcessDigitalDisplays(TechnoClass* pThis)
 		if (value == -1 || maxValue == -1)
 			continue;
 
+		if (pDisplayType->ValueScaleDivisor > 1)
+		{
+			value = Math::max(value / pDisplayType->ValueScaleDivisor, value != 0 ? 1 : 0);
+			maxValue = Math::max(maxValue / pDisplayType->ValueScaleDivisor, maxValue != 0 ? 1 : 0);
+		}
+
 		const bool isBuilding = pThis->WhatAmI() == AbstractType::Building;
 		const bool isInfantry = pThis->WhatAmI() == AbstractType::Infantry;
 		const bool hasShield = pExt->Shield != nullptr && !pExt->Shield->IsBrokenAndNonRespawning();

--- a/src/New/Type/DigitalDisplayTypeClass.cpp
+++ b/src/New/Type/DigitalDisplayTypeClass.cpp
@@ -34,19 +34,20 @@ void DigitalDisplayTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->VisibleToHouses_Observer.Read(exINI, section, "VisibleToHouses.Observer");
 	this->VisibleToHouses.Read(exINI, section, "VisibleToHouses");
 	this->InfoType.Read(exINI, section, "InfoType");
+	this->ValueScaleDivisor.Read(exINI, section, "ValueScaleDivisor");
 }
 
 void DigitalDisplayTypeClass::Draw(Point2D position, int length, int value, int maxValue, bool isBuilding, bool isInfantry, bool hasShield)
 {
 	position.X += Offset.Get().X;
-	position.Y -= Offset.Get().Y;
+	position.Y += Offset.Get().Y;
 
 	if (hasShield)
 	{
 		if (Offset_ShieldDelta.isset())
 		{
 			position.X += Offset_ShieldDelta.Get().X;
-			position.Y -= Offset_ShieldDelta.Get().Y;
+			position.Y += Offset_ShieldDelta.Get().Y;
 		}
 		else if (InfoType == DisplayInfoType::Shield)
 		{
@@ -211,6 +212,7 @@ void DigitalDisplayTypeClass::Serialize(T& Stm)
 		.Process(this->VisibleToHouses_Observer)
 		.Process(this->VisibleToHouses)
 		.Process(this->InfoType)
+		.Process(this->ValueScaleDivisor)
 		;
 }
 

--- a/src/New/Type/DigitalDisplayTypeClass.h
+++ b/src/New/Type/DigitalDisplayTypeClass.h
@@ -23,6 +23,7 @@ public:
 	Valueable<bool> VisibleToHouses_Observer;
 	Valueable<AffectedHouse> VisibleToHouses;
 	Valueable<DisplayInfoType> InfoType;
+	Valueable<int> ValueScaleDivisor;
 
 	DigitalDisplayTypeClass(const char* pTitle = NONE_STR) : Enumerable<DigitalDisplayTypeClass>(pTitle)
 		, Text_Color({ 0, 255, 0 }, { 255,255,0 }, { 255,0,0 })
@@ -40,6 +41,7 @@ public:
 		, VisibleToHouses_Observer(true)
 		, VisibleToHouses(AffectedHouse::All)
 		, InfoType(DisplayInfoType::Health)
+		, ValueScaleDivisor { 1 }
 	{ }
 
 	virtual ~DigitalDisplayTypeClass() override = default;


### PR DESCRIPTION
- `Offset` and `Offset.ShieldDelta` Y-axis offset behaved inconsistently compared to everything else in the game, with negative values shifting down and positive up. It now works the other way around like `PixelSelectionBracketDelta`, `YDrawOffset` etc. do.
- Added `ValueScaleDivisor` (taking suggestions for name) that can be used to adjust the scale of displayed values. This is given as an integer to prevent rounding issues with floating point values and is used to divide the values.