### PR TITLE
Fix Ares' InitialPayload for teams spawned by trigger actions

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -335,6 +335,7 @@ This page lists all the individual contributions to the project by their author.
    - Ares' Abductor weapon fix
    - Suppress Ares' swizzle warning when parsing tags and taskforces
    - Better fix for Ares academy not working on the initial payloads of vehicles built from a war factory
+   - Fix Ares' InitialPayload for teams spawned by trigger actions
    - Misc code refactor & maintenance, CN doc fixes, bugfixes
 - **FlyStar**
    - Campaign load screen PCX support

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -192,7 +192,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed Ares' Abductor weapon leaves permanent placement stats when abducting moving vehicles.
 - Suppressed Ares' swizzle warning when parsing `Tags` and `TaskForces` (typically begin with `[Developer fatal]Pointer 00000000 declared change to both`).
 - Fixed Academy *(Ares feature)* not working on the initial payloads *(Ares feature)* of vehicles built from a war factory.
-
+- Fixed Ares' InitialPayload not being created for vehicles spawned by trigger actions.
 ## Aircraft
 
 ### Carryall pickup voice

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -611,6 +611,7 @@ Fixes / interactions with other extensions:
 - Fixed Ares' Abductor weapon leaves permanent placement stats when abducting moving vehicles (by Trsdy)
 - Suppressed Ares' swizzle warning when parsing `Tags` and `TaskForces` (by Trsdy)
 - Fixed Academy *(Ares feature)* not working on the initial payloads *(Ares feature)* of vehicles built from a war factory (by Trsdy, supersedes Aephiex impl.)
+- Fixed Ares' InitialPayload not being created for vehicles spawned by trigger actions (by Trsdy)
 </details>
 
 ### 0.3.0.1

--- a/src/Ext/Team/Hooks.cpp
+++ b/src/Ext/Team/Hooks.cpp
@@ -4,20 +4,15 @@
 // Bugfix: TAction 7,80,107.
 DEFINE_HOOK(0x65DF67, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x6)
 {
+	if(!AresHelper::CanUseAres)
+		return 0; // Fuck you if not using Ares
+
 	GET(FootClass* const, pPayload, EAX);
 	GET(FootClass* const, pTransport, ESI);
 	GET(TeamClass* const, pTeam, EBP);
 	GET(TeamTypeClass const*, pThis, EBX);
 
-	
-	auto unmarkPayloadCreated = [](FootClass* pUnit)
-		{
-			if (AresHelper::CanUseAres)
-			{
-				if (auto& payloadCreated = reinterpret_cast<char*>(pUnit->align_154)[0x9E])
-					payloadCreated = false;
-			}
-		};
+	auto unmarkPayloadCreated = [](FootClass* sucker){reinterpret_cast<char*>(sucker->align_154)[0x9E] = false;};
 
 	if (!pTransport)
 	{

--- a/src/Ext/Team/Hooks.cpp
+++ b/src/Ext/Team/Hooks.cpp
@@ -4,15 +4,15 @@
 // Bugfix: TAction 7,80,107.
 DEFINE_HOOK(0x65DF67, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x6)
 {
-	if(!AresHelper::CanUseAres)
-		return 0; // Fuck you if not using Ares
+	if(!AresHelper::CanUseAres) // If you're not using Ares you don't deserve a fix
+		return 0;
 
 	GET(FootClass* const, pPayload, EAX);
 	GET(FootClass* const, pTransport, ESI);
 	GET(TeamClass* const, pTeam, EBP);
 	GET(TeamTypeClass const*, pThis, EBX);
 
-	auto unmarkPayloadCreated = [](FootClass* sucker){reinterpret_cast<char*>(sucker->align_154)[0x9E] = false;};
+	auto unmarkPayloadCreated = [](FootClass* member){reinterpret_cast<char*>(member->align_154)[0x9E] = false;};
 
 	if (!pTransport)
 	{

--- a/src/Ext/Team/Hooks.cpp
+++ b/src/Ext/Team/Hooks.cpp
@@ -1,5 +1,13 @@
 #include "Body.h"
 
+// Ares InitialPayload fix: Man, what can I say
+DEFINE_HOOK(0x65DE21, TeamTypeClass_CreateMembers_MutexOut, 0x6)
+{
+	GET(TeamClass*, pTeam, EBP);
+	GET(TechnoTypeClass*, pType, EDI);
+	R->ESI(pType->CreateObject(pTeam->Owner));
+	return 0x65DE53;
+}
 
 // Bugfix: TAction 7,80,107.
 DEFINE_HOOK(0x65DF81, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x7)


### PR DESCRIPTION
 [Ares](https://github.com/Ares-Developers/Ares/commit/1b8b66f4d3892509f565eabce7efd59a9f3dbed4) marked its initialpayload already created for units spawned by trigger actions because of the mutex.