### PR TITLE
`DecreasingRadDamage` for radiation types to deal linear decreasing rad damage

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -146,6 +146,7 @@ AttachEffect.DurationOverrides=                ; integer - duration overrides (c
   - `RadSiteWarhead.Detonate` can be set to make `RadSiteWarhead` detonate on affected objects rather than only be used to dealt direct damage. This enables most Warhead effects, display of animations etc.
   - `RadHasOwner`, if set to true, makes damage dealt by the radiation count as having been dealt by the house that fired the projectile that created the radiation field. This means that Warhead controls such as `AffectsAllies` will be respected and any units killed will count towards that player's destroyed units count.
   - `RadHasInvoker`, if set to true, makes the damage dealt by the radiation count as having been dealt by the TechnoType (the 'invoker') that fired the projectile that created the radiation field. In addition to the effects of `RadHasOwner`, this will also grant experience from units killed by the radiation to the invoker. Note that if the invoker dies at any point during the radiation's lifetime it continues to behave as if not having an invoker.
+  - `DecreasingRadDamage`, if set to true, makes the damage dealt by the radiation decrease according to its remaining effective time.
 - By default `UseGlobalRadApplicationDelay` is set to true. This makes game always use `RadApplicationDelay` and `RadApplicationDelay.Building` from `[Radiation]` rather than specific radiation types. This is a performance-optimizing measure that should be disabled if a radiation type declares different application delay.
 
 In `rulesmd.ini`:
@@ -174,6 +175,7 @@ RadSiteWarhead=RadSite             ; WarheadType
 RadSiteWarhead.Detonate=false      ; boolean
 RadHasOwner=false                  ; boolean
 RadHasInvoker=false                ; boolean
+DecreasingRadDamage=false          ; boolean
 ```
 
 ### Laser Trails

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -408,7 +408,7 @@ New:
 - AttachEffect types with new features like custom tint and weapon range modifier (by Starkku)
 - Force shield effect sync on deploy & vs. organic targets effect customization to complement the Iron Curtain ones (by Starkku)
 - Map trigger action 41 (Play animation at waypoint) now uses additional parameter to determine if animation can play sound, deal damage etc. (by Starkku)
-- `DecreasingRadDamage` for radiation types to make radiation be able to dealt linear decreasing damage (by Hongze)
+- `DecreasingRadDamage` for radiation types to make radiation be able to deal linear decreasing damage (by Hongze)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -408,6 +408,7 @@ New:
 - AttachEffect types with new features like custom tint and weapon range modifier (by Starkku)
 - Force shield effect sync on deploy & vs. organic targets effect customization to complement the Iron Curtain ones (by Starkku)
 - Map trigger action 41 (Play animation at waypoint) now uses additional parameter to determine if animation can play sound, deal damage etc. (by Starkku)
+- `DecreasingRadDamage` for radiation types to make radiation be able to dealt linear decreasing damage (by Hongze)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/RadSite/Hooks.cpp
+++ b/src/Ext/RadSite/Hooks.cpp
@@ -157,7 +157,8 @@ DEFINE_HOOK(0x43FB23, BuildingClass_AI_Radiation, 0x5)
 			if (pRadExt->GetRadLevelAt(nCurrentCoord) <= 0.0 || !pType->GetWarhead())
 				continue;
 
-			auto damage = Game::F2I((pRadExt->GetRadLevelAt(nCurrentCoord) / 2) * pType->GetLevelFactor());
+			double damageFactor = pType->GetDecreasingRadDamage() ? pRadSite->GetEffectPercentage() : 1.0;
+			auto damage = Game::F2I((pRadExt->GetRadLevelAt(nCurrentCoord) / 2) * pType->GetLevelFactor() * damageFactor);
 
 			if (pBuilding->IsAlive) // simple fix for previous issues
 			{
@@ -213,7 +214,8 @@ DEFINE_HOOK(0x4DA59F, FootClass_AI_Radiation, 0x5)
 			if (nRadLevel <= 0.0 || !pType->GetWarhead())
 				continue;
 
-			int damage = Game::F2I(nRadLevel * pType->GetLevelFactor());
+			double damageFactor = pType->GetDecreasingRadDamage() ? pRadSite->GetEffectPercentage() : 1.0;
+			int damage = Game::F2I(nRadLevel * pType->GetLevelFactor() * damageFactor);
 
 			if (pFoot->IsAlive || !pFoot->IsSinking)
 			{

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -79,6 +79,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->RadWarhead_Detonate.Read(exINI, GameStrings::Radiation, "RadSiteWarhead.Detonate");
 	this->RadHasOwner.Read(exINI, GameStrings::Radiation, "RadHasOwner");
 	this->RadHasInvoker.Read(exINI, GameStrings::Radiation, "RadHasInvoker");
+	this->DecreasingRadDamage.Read(exINI, GameStrings::Radiation, "DecreasingRadDamage");
 	this->VeinholeWarhead.Read(exINI, GameStrings::CombatDamage, "VeinholeWarhead");
 	this->MissingCameo.Read(pINI, GameStrings::AudioVisual, "MissingCameo");
 
@@ -244,6 +245,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->RadWarhead_Detonate)
 		.Process(this->RadHasOwner)
 		.Process(this->RadHasInvoker)
+		.Process(this->DecreasingRadDamage)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->VeinholeWarhead)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -44,6 +44,7 @@ public:
 		Valueable<bool> RadWarhead_Detonate;
 		Valueable<bool> RadHasOwner;
 		Valueable<bool> RadHasInvoker;
+		Valueable<bool> DecreasingRadDamage;
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;
 
@@ -138,6 +139,7 @@ public:
 			, RadWarhead_Detonate { false }
 			, RadHasOwner { false }
 			, RadHasInvoker { false }
+			, DecreasingRadDamage { false }
 			, JumpjetCrash { 5.0 }
 			, JumpjetNoWobbles { false }
 			, VeinholeWarhead {}

--- a/src/New/Type/RadTypeClass.cpp
+++ b/src/New/Type/RadTypeClass.cpp
@@ -35,6 +35,7 @@ void RadTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->TintFactor.Read(exINI, section, "RadTintFactor");
 	this->RadHasOwner.Read(exINI, section, "RadHasOwner");
 	this->RadHasInvoker.Read(exINI, section, "RadHasInvoker");
+	this->DecreasingRadDamage.Read(exINI, section, "DecreasingRadDamage");
 }
 
 template <typename T>
@@ -55,6 +56,7 @@ void RadTypeClass::Serialize(T& Stm)
 		.Process(this->RadWarhead_Detonate)
 		.Process(this->RadHasOwner)
 		.Process(this->RadHasInvoker)
+		.Process(this->DecreasingRadDamage)
 		;
 };
 

--- a/src/New/Type/RadTypeClass.h
+++ b/src/New/Type/RadTypeClass.h
@@ -24,6 +24,7 @@ private:
 	Nullable<double> TintFactor;
 	Nullable<bool> RadHasOwner;
 	Nullable<bool> RadHasInvoker;
+	Nullable<bool> DecreasingRadDamage;
 
 public:
 
@@ -42,6 +43,7 @@ public:
 		, BuildingApplicationDelay { }
 		, RadHasOwner { }
 		, RadHasInvoker { }
+		, DecreasingRadDamage { }
 	{ }
 
 	virtual ~RadTypeClass() override = default;
@@ -116,6 +118,11 @@ public:
 	bool GetHasInvoker() const
 	{
 		return this->RadHasInvoker.Get(RulesExt::Global()->RadHasInvoker);
+	}
+
+	bool GetDecreasingRadDamage() const
+	{
+		return this->DecreasingRadDamage.Get(RulesExt::Global()->DecreasingRadDamage);
 	}
 
 	virtual void LoadFromINI(CCINIClass* pINI) override;


### PR DESCRIPTION
Add new option `DecreasingRadDamage` for radiation types.

If set to true, damage dealt by radiation will decrease over time within factor calculated by `RadTimeLeft / RadDuration`. In the most common case, turning the option on could make radiation damage more consistent with its visualization (say, while the rad color gets lighter, it deals lower damage as well).