### PR TITLE
Allow forbidding parallel AI queues for specific TechnoTypes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -240,6 +240,7 @@ This page lists all the individual contributions to the project by their author.
   - Disabling `MultipleFactory` bonus from specific BuildingType
   - Customizable ChronoSphere teleport delays for units
   - Allowed and disallowed types for `FactoryPlant`
+  - Forbidding parallel AI queues for specific TechnoTypes
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -862,6 +862,7 @@ ShadowSizeCharacteristicHeight=   ; integer, height in leptons
 
 - You can now set if specific types of factories do not have AI production cloning issue instead of Ares' indiscriminate behavior of `AllowParallelAIQueues=no`.
   - If `AllowParallelAIQueues=no` (*Ares feature*) is set, the tags have no effect.
+- You can also exclude specific TechnoTypes from being built in parallel by AI by setting `ForbidParallelAIQueues` to true on a TechnoType.
 
 In `rulesmd.ini`
 ```ini
@@ -872,6 +873,9 @@ ForbidParallelAIQueues.Vehicle=no   ; boolean
 ForbidParallelAIQueues.Navy=no      ; boolean
 ForbidParallelAIQueues.Aircraft=no  ; boolean
 ForbidParallelAIQueues.Building=no  ; boolean
+
+[SOMETECHNO]                        ; TechnoType
+ForbidParallelAIQueues=false        ; boolean
 ```
 
 ## Terrains

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -447,6 +447,7 @@ New:
 - Allowed and disallowed types for `FactoryPlant` (by Starkku)
 - Customizable damage & 'crumbling' (destruction) frames for TerrainTypes (by Starkku)
 - Custom object palettes for TerrainTypes (by Starkku)
+- Forbidding parallel AI queues for specific TechnoTypes (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -114,10 +114,12 @@ DEFINE_HOOK(0x4401BB, BuildingClass_AI_PickWithFreeDocks, 0x6)
 	GET(BuildingClass*, pBuilding, ESI);
 
 	auto pRulesExt = RulesExt::Global();
-	if (pRulesExt->AllowParallelAIQueues && !pRulesExt->ForbidParallelAIQueues_Aircraft)
-		return 0;
-
 	HouseClass* pOwner = pBuilding->Owner;
+	int index = pOwner->ProducingAircraftTypeIndex;
+	auto const pType = index >= 0 ? AircraftTypeClass::Array()->GetItem(index) : nullptr;
+
+	if (pRulesExt->AllowParallelAIQueues && !pRulesExt->ForbidParallelAIQueues_Aircraft && (!pType || !TechnoTypeExt::ExtMap.Find(pType)->ForbidParallelAIQueues))
+		return 0;
 
 	if (pOwner->Type->MultiplayPassive
 		|| pOwner->IsCurrentPlayer()
@@ -201,27 +203,56 @@ DEFINE_HOOK(0x4502F4, BuildingClass_Update_Factory_Phobos, 0x6)
 		{
 			enum { Skip = 0x4503CA };
 
+
+			TechnoTypeClass* pType = nullptr;
+			int index = -1;
+
 			switch (pThis->Type->Factory)
 			{
 			case AbstractType::BuildingType:
 				if (pRulesExt->ForbidParallelAIQueues_Building)
 					return Skip;
+
+				index = pOwner->ProducingBuildingTypeIndex;
+				pType = index >= 0 ? BuildingTypeClass::Array()->GetItem(index) : nullptr;
 				break;
 			case AbstractType::InfantryType:
 				if (pRulesExt->ForbidParallelAIQueues_Infantry)
 					return Skip;
+
+				index = pOwner->ProducingInfantryTypeIndex;
+				pType = index >= 0 ? InfantryTypeClass::Array()->GetItem(index) : nullptr;
 				break;
 			case AbstractType::AircraftType:
 				if (pRulesExt->ForbidParallelAIQueues_Aircraft)
 					return Skip;
+
+				index = pOwner->ProducingAircraftTypeIndex;
+				pType = index >= 0 ? AircraftTypeClass::Array()->GetItem(index) : nullptr;
 				break;
 			case AbstractType::UnitType:
 				if (pThis->Type->Naval ? pRulesExt->ForbidParallelAIQueues_Navy : pRulesExt->ForbidParallelAIQueues_Vehicle)
 					return Skip;
+
+				if (pThis->Type->Naval)
+				{
+					auto const pExt = HouseExt::ExtMap.Find(pOwner);
+					index = pExt->ProducingNavalUnitTypeIndex;
+				}
+				else
+				{
+					index = pOwner->ProducingUnitTypeIndex;
+				}
+
+				pType = index >= 0 ? UnitTypeClass::Array()->GetItem(index) : nullptr;
+
 				break;
 			default:
 				break;
 			}
+
+			if (pType && TechnoTypeExt::ExtMap.Find(pType)->ForbidParallelAIQueues)
+				return Skip;
 		}
 	}
 
@@ -248,31 +279,32 @@ DEFINE_HOOK(0x4CA07A, FactoryClass_AbandonProduction_Phobos, 0x8)
 		return 0;
 
 	auto const pOwnerExt = HouseExt::ExtMap.Find(pFactory->Owner);
+	bool forbid = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType())->ForbidParallelAIQueues;
 
 	switch (pTechno->WhatAmI())
 	{
 	case AbstractType::Building:
-		if (pRulesExt->ForbidParallelAIQueues_Building)
+		if (pRulesExt->ForbidParallelAIQueues_Building || forbid)
 			pOwnerExt->Factory_BuildingType = nullptr;
 		break;
 	case AbstractType::Unit:
 		if (!pTechno->GetTechnoType()->Naval)
 		{
-			if (pRulesExt->ForbidParallelAIQueues_Vehicle)
+			if (pRulesExt->ForbidParallelAIQueues_Vehicle || forbid)
 				pOwnerExt->Factory_VehicleType = nullptr;
 		}
 		else
 		{
-			if (pRulesExt->ForbidParallelAIQueues_Navy)
+			if (pRulesExt->ForbidParallelAIQueues_Navy || forbid)
 				pOwnerExt->Factory_NavyType = nullptr;
 		}
 		break;
 	case AbstractType::Infantry:
-		if (pRulesExt->ForbidParallelAIQueues_Infantry)
+		if (pRulesExt->ForbidParallelAIQueues_Infantry || forbid)
 			pOwnerExt->Factory_InfantryType = nullptr;
 		break;
 	case AbstractType::Aircraft:
-		if (pRulesExt->ForbidParallelAIQueues_Aircraft)
+		if (pRulesExt->ForbidParallelAIQueues_Aircraft || forbid)
 			pOwnerExt->Factory_AircraftType = nullptr;
 		break;
 	default:
@@ -287,11 +319,11 @@ DEFINE_HOOK(0x444119, BuildingClass_KickOutUnit_UnitType_Phobos, 0x6)
 	GET(UnitClass*, pUnit, EDI);
 	GET(BuildingClass*, pFactory, ESI);
 
-	auto pHouseExt = HouseExt::ExtMap.Find(pFactory->Owner);
+	auto const pHouseExt = HouseExt::ExtMap.Find(pFactory->Owner);
 
-	if (pUnit->Type->Naval)
+	if (pUnit->Type->Naval && pHouseExt->Factory_NavyType == pFactory)
 		pHouseExt->Factory_NavyType = nullptr;
-	else
+	else if (pHouseExt->Factory_VehicleType == pFactory)
 		pHouseExt->Factory_VehicleType = nullptr;
 
 	return 0;
@@ -299,27 +331,36 @@ DEFINE_HOOK(0x444119, BuildingClass_KickOutUnit_UnitType_Phobos, 0x6)
 
 DEFINE_HOOK(0x444131, BuildingClass_KickOutUnit_InfantryType_Phobos, 0x6)
 {
-	GET(HouseClass*, pHouse, EAX);
+	GET(BuildingClass*, pFactory, ESI);
 
-	HouseExt::ExtMap.Find(pHouse)->Factory_InfantryType = nullptr;
+	auto const pHouseExt = HouseExt::ExtMap.Find(pFactory->Owner);
+
+	if (pHouseExt->Factory_InfantryType == pFactory)
+		pHouseExt->Factory_InfantryType = nullptr;
 
 	return 0;
 }
 
 DEFINE_HOOK(0x44531F, BuildingClass_KickOutUnit_BuildingType_Phobos, 0xA)
 {
-	GET(HouseClass*, pHouse, EAX);
+	GET(BuildingClass*, pFactory, ESI);
 
-	HouseExt::ExtMap.Find(pHouse)->Factory_BuildingType = nullptr;
+	auto const pHouseExt = HouseExt::ExtMap.Find(pFactory->Owner);
+
+	if (pHouseExt->Factory_BuildingType == pFactory)
+		pHouseExt->Factory_BuildingType = nullptr;
 
 	return 0;
 }
 
 DEFINE_HOOK(0x443CCA, BuildingClass_KickOutUnit_AircraftType_Phobos, 0xA)
 {
-	GET(HouseClass*, pHouse, EDX);
+	GET(BuildingClass*, pFactory, ESI);
 
-	HouseExt::ExtMap.Find(pHouse)->Factory_AircraftType = nullptr;
+	auto const pHouseExt = HouseExt::ExtMap.Find(pFactory->Owner);
+
+	if (pHouseExt->Factory_AircraftType == pFactory)
+		pHouseExt->Factory_AircraftType = nullptr;
 
 	return 0;
 }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -153,6 +153,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		this->InitialStrength = Math::clamp(this->InitialStrength, 1, pThis->Strength);
 
 	this->ReloadInTransport.Read(exINI, pSection, "ReloadInTransport");
+	this->ForbidParallelAIQueues.Read(exINI, pSection, "ForbidParallelAIQueues");
 	this->ShieldType.Read<true>(exINI, pSection, "ShieldType");
 
 	this->Ammo_AddOnDeploy.Read(exINI, pSection, "Ammo.AddOnDeploy");
@@ -509,6 +510,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->NoManualMove)
 		.Process(this->InitialStrength)
 		.Process(this->ReloadInTransport)
+		.Process(this->ForbidParallelAIQueues)
 		.Process(this->ShieldType)
 		.Process(this->PassengerDeletionType)
 

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -54,6 +54,7 @@ public:
 		Valueable<bool> NoManualMove;
 		Nullable<int> InitialStrength;
 		Valueable<bool> ReloadInTransport;
+		Valueable<bool> ForbidParallelAIQueues;
 
 		Valueable<ShieldTypeClass*> ShieldType;
 		std::unique_ptr<PassengerDeletionTypeClass> PassengerDeletionType;
@@ -286,6 +287,7 @@ public:
 			, NoManualMove { false }
 			, InitialStrength {}
 			, ReloadInTransport { false }
+			, ForbidParallelAIQueues { false }
 			, ShieldType {}
 			, PassengerDeletionType { nullptr }
 


### PR DESCRIPTION
### Forbid parallel AI queues

- You can also exclude specific TechnoTypes from being built in parallel by AI by setting `ForbidParallelAIQueues` to true on a TechnoType.

In `rulesmd.ini`
```ini
[SOMETECHNO]                  ; TechnoType
ForbidParallelAIQueues=false  ; boolean
```

In addition, `ForbidParallelAIQueues` seemed to have some problems working, particularly with VehicleTypes. Resetting the current factory after unit is kicked out *seemed* to fix this but I am unsure if there are any unforeseen consequences. I have not noticed any so far myself.
