### PR TITLE
Airburst/Splits reimplementation

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -243,6 +243,7 @@ This page lists all the individual contributions to the project by their author.
   - Forbidding parallel AI queues for specific TechnoTypes
   - Nonprovocative Warheads
   - Customizing effect of level lighting on air units
+  - Reimplemented `Airburst` & `Splits` logic with more customization options
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -171,6 +171,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Animations with `MakeInfantry` and `UseNormalLight=false` that are drawn in unit palette will now have cell lighting changes applied on them.
 - Removed 0 damage effect on jumpjet infantries from `InfDeath=9` warhead.
 - Fixed Nuke & Dominator Level lighting not applying to AircraftTypes.
+- Projectiles created from `AirburstWeapon` now remember the WeaponType and can apply radiation etc.
 
 ## Fixes / interactions with other extensions
 
@@ -416,6 +417,45 @@ Gas.MaxDriftSpeed=2    ; integer (TS default is 5)
 ```
 
 ## Projectiles
+
+### Airburst & Splits
+
+- `AirburstWeapon` logic has been reimplemented and thus there are several additions & changes to it.
+- `Splits` can be set to true to use projectile splitting logic from Firestorm, with the number of split projectiles defined by `Cluster`.
+  - `RetargetAccuracy` defines the probability that the splitted projectiles head to the same target as the original projectile.
+  - `RetargetSelf` determines if it is possible for the splitted projectiles to aim at the firer of the original projectile.
+    - `RetargetSelf.Probability` is the probability that if the original firer is chosen as a target, it is kept as the target instead of rerolled to another.
+  - `Splits.TargetingDistance` is the distance in cells that any potential target has to be within from the original target coordinates to be eligible for targeting by the splitted projectiles.
+  - `Splits.TargetCellRange` is the distance in whole cells from the original target cell from which the splitted projectiles can pick new target cells if not enough TechnoType targets were found nearby.
+  - `Splits.UseWeaponTargeting`, if set to true, enables weapon targeting filter for when checking targets for splitted projectiles. Target's `LegalTarget` setting, Warhead `Verses` against `Armor` as well as `AirburstWeapon` [weapon targeting filters](#weapon-targeting-filter) & [AttachEffect filters](#attached-effects) will be checked.
+    - Do note that this overrides checking Warhead for `AffectsAllies/Owner/Enemies` for targeting. You can use `CanTargetHouses` on `AirburstWeapon` to achieve similar behaviour, however.
+- Behaviour for if `Airburst` is set to true can also be customized.
+  - `AirburstSpread` is the distance in cells that the effect covers, with each cell in range being targeted by `AirburstWeapon` by default.
+  - `Airburst.UseCluster`, if set to true, makes it so that only number of cells in the affected area dictated by `Cluster` will be affected, instead of all of them.
+    - If `Airburst.RandomClusters` is set to true, the cells affected will be picked by random. Otherwise they will be evenly spaced (counting from center to edges of affected area).
+- `AroundTarget` controls whether or not targets for projectiles created by `Airburst` or `Splits` are checked for in area around the original projectile's intended target, or where the original projectile detonated. Defaults to value of `Splits`.
+- `AirburstWeapon.ApplyFirepowerMult` determines whether or not firepower modifiers from the firer of the original projectile are applied on the projectiles created from `AirburstWeapon`.
+
+In `rulesmd.ini`:
+```ini
+[SOMEPROJECTILE]                         ; Projectile
+Splits=                                  ; boolean
+RetargetAccuracy=0.0                     ; floating point value, percents or absolute (0.0-1.0)
+RetargetSelf=true                        ; boolean
+RetargetSelf.Probability=0.5             ; floating point value, percents or absolute (0.0-1.0)
+Splits.TargetingDistance=5.0             ; floating point value, distance in cells
+Splits.TargetCellRange=3                 ; integer, cell offset
+Splits.UseWeaponTargeting=false          ; boolean
+AirburstSpread=1.5                       ; floating point value, distance in cells
+Airburst.UseCluster=false                ; boolean
+Airburst.RandomClusters=false            ; boolean
+AroundTarget=                            ; boolean
+AirburstWeapon.ApplyFirepowerMult=false  ; boolean
+```
+
+```{note}
+`Splits`, `AirburstSpread`, `RetargetAccuracy`, `RetargetSelf` and `AroundTarget`, beyond the other additions, should function similarly to the equivalent features introduced by Ares and take precedence over them if Phobos is used together with Ares.
+```
 
 ### Cluster scatter distance customization
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -454,6 +454,7 @@ New:
 - `FireOnce` infantry sequence reset toggle (by Starkku)
 - Assign Super Weapon cameo to any sidebar tab (by NetsuNegi)
 - Customizing effect of level lighting on air units (by Starkku)
+- Reimplemented `Airburst` & `Splits` logic with more customization options (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
@@ -530,6 +531,7 @@ Vanilla fixes:
 - Animations with `MakeInfantry` and `UseNormalLight=false` that are drawn in unit palette will now have cell lighting changes applied on them (by Starkku)
 - Fixed Nuke & Dominator Level lighting not applying to AircraftTypes (by Starkku)
 - Removed the 0 damage effect from `InfDeath=9` warheads to in-air infantries (by Trsdy)
+- Projectiles created from `AirburstWeapon` now remember their WeaponType and can apply radiation etc. (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Bullet/Hooks.DetonateLogics.cpp
+++ b/src/Ext/Bullet/Hooks.DetonateLogics.cpp
@@ -364,3 +364,231 @@ DEFINE_HOOK(0x469AA4, BulletClass_Logics_Extras, 0x5)
 
 	return 0;
 }
+
+#pragma region Airburst
+
+static bool IsAllowedSplitsTarget(TechnoClass* pSource, HouseClass* pOwner, WeaponTypeClass* pWeapon, TechnoClass* pTarget, bool useWeaponTargeting)
+{
+	auto const pWH = pWeapon->Warhead;
+
+	if (useWeaponTargeting)
+	{
+		auto const pType = pTarget->GetTechnoType();
+
+		if (!pType->LegalTarget || GeneralUtils::GetWarheadVersusArmor(pWH, pType->Armor) == 0.0)
+			return false;
+
+		auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
+
+		if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pOwner, pTarget->Owner)
+			|| !EnumFunctions::IsCellEligible(pTarget->GetCell(), pWeaponExt->CanTarget, true, true)
+			|| !EnumFunctions::IsTechnoEligible(pTarget, pWeaponExt->CanTarget))
+		{
+			return false;
+		}
+
+		if (!pWeaponExt->HasRequiredAttachedEffects(pTarget, pSource))
+			return false;
+	}
+	else
+	{
+		if (!WarheadTypeExt::ExtMap.Find(pWH)->CanTargetHouse(pOwner, pTarget))
+			return false;
+	}
+
+	return true;
+}
+
+// Disable Ares' Airburst implementation.
+DEFINE_PATCH(0x469EBA, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90);
+
+DEFINE_HOOK(0x468EB3, BulletClass_Explodes_AirburstCheck1, 0x6)
+{
+	enum { Continue = 0x468EC7, Skip = 0x468FF4 };
+
+	GET(BulletClass*, pThis, ESI);
+
+	auto const pTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type);
+
+	R->EAX(pThis->Type);
+	return !(pThis->Type->Airburst || pTypeExt->Splits) ? Continue : Skip;
+}
+
+DEFINE_HOOK(0x468FF4, BulletClass_Explodes_AirburstCheck2, 0x6)
+{
+	enum { Continue = 0x46909A, Skip = 0x469008 };
+
+	GET(BulletClass*, pThis, ESI);
+
+	auto const pTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type);
+
+	R->EAX(pThis->Type);
+	return (pThis->Type->Airburst || pTypeExt->Splits) ? Continue : Skip;
+}
+
+DEFINE_HOOK(0x469EC0, BulletClass_Logics_AirburstWeapon, 0x6)
+{
+	enum { SkipGameCode = 0x46A290 };
+
+	GET(BulletClass*, pThis, ESI);
+
+	auto const pType = pThis->Type;
+	auto const pTypeExt = BulletTypeExt::ExtMap.Find(pType);
+	auto const pWeapon = pType->AirburstWeapon;
+
+	if ((pType->Airburst || pTypeExt->Splits) && pWeapon)
+	{
+		auto const pSource = pThis->Owner;
+		auto const pOwner = pSource ? pSource->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
+
+		auto& random = ScenarioClass::Instance->Random;
+		int clusterCount = pType->Cluster;
+
+		auto const coordsTarget = pTypeExt->AroundTarget.Get(pTypeExt->Splits) ? pThis->GetTargetCoords() : pThis->GetCoords();
+		auto const cellTarget = CellClass::Coord2Cell(coordsTarget);
+		DynamicVectorClass<AbstractClass*> targets;
+
+		if (!pTypeExt->Splits)
+		{
+			CellRangeIterator<CellClass>{}(cellTarget, pTypeExt->AirburstSpread, [&targets](CellClass* pCell) -> bool
+			{
+				targets.AddItem(pCell);
+				return true;
+			});
+
+			if (pTypeExt->Airburst_UseCluster)
+			{
+				DynamicVectorClass<AbstractClass*> newTargets;
+
+				if (pTypeExt->Airburst_RandomClusters)
+				{
+					// Do random cells for amount matching Cluster.
+					int count = 0;
+					int targetCount = targets.Count;
+
+					while (count < clusterCount)
+					{
+						int index = ScenarioClass::Instance->Random.RandomRanged(0, targetCount);
+						auto const pTarget = targets.GetItem(index);
+
+						if (count > targetCount || newTargets.FindItemIndex(pTarget) < 0)
+						{
+							newTargets.AddItem(pTarget);
+							count++;
+						}
+					}
+				}
+				else
+				{
+					// Do evenly selected cells for amount matching Cluster.
+					double stepSize = (targets.Count - 1.0) / (clusterCount - 1.0);
+
+					for (int i = 0; i < clusterCount; i++)
+					{
+						newTargets.AddItem(targets.GetItem(static_cast<int>(round(stepSize * i))));
+					}
+				}
+
+				targets = newTargets;
+			}
+			else
+			{
+				clusterCount = targets.Count;
+			}
+		}
+		else
+		{
+			for (auto const pTechno : *TechnoClass::Array)
+			{
+				if (pTechno->IsInPlayfield && pTechno->IsOnMap && pTechno->Health > 0 && (pTypeExt->RetargetSelf || pTechno != pThis->Owner))
+				{
+					auto const coords = pTechno->GetCoords();
+
+					if (coordsTarget.DistanceFrom(coords) < pTypeExt->Splits_TargetingDistance.Get()
+						&& (pType->AA || !pTechno->IsInAir())
+						&& IsAllowedSplitsTarget(pSource, pOwner, pWeapon, pTechno, pTypeExt->Splits_UseWeaponTargeting))
+					{
+						targets.AddItem(pTechno);
+					}
+				}
+			}
+
+			int range = pTypeExt->Splits_TargetCellRange;
+
+			while (targets.Count < clusterCount)
+			{
+				int x = random.RandomRanged(-range, range);
+				int y = random.RandomRanged(-range, range);
+
+				CellStruct cell = { static_cast<short>(cellTarget.X + x), static_cast<short>(cellTarget.Y + y) };
+				auto const pCell = MapClass::Instance->GetCellAt(cell);
+
+				targets.AddItem(pCell);
+			}
+		}
+
+		int projectileRange = WeaponTypeExt::ExtMap.Find(pWeapon)->ProjectileRange.Get();
+		auto const pTypeSplits = pWeapon->Projectile;
+		int damage = pWeapon->Damage;
+
+		if (pTypeExt->AirburstWeapon_ApplyFirepowerMult && pThis->Owner)
+			damage = static_cast<int>(damage * pThis->Owner->FirepowerMultiplier * TechnoExt::ExtMap.Find(pThis->Owner)->AE.FirepowerMultiplier);
+
+		for (int i = 0; i < clusterCount; ++i)
+		{
+			auto pTarget = pThis->Target;
+
+			if (!pTypeExt->Splits)
+			{
+				pTarget = targets.GetItem(i);
+			}
+			else if (!pTarget || pTypeExt->RetargetAccuracy < random.RandomDouble())
+			{
+				int index = random.RandomRanged(0, targets.Count - 1);
+				pTarget = targets.GetItem(index);
+
+				if (pTarget == pThis->Owner)
+				{
+					if (random.RandomDouble() > pTypeExt->RetargetSelf_Probability)
+					{
+						index = random.RandomRanged(0, targets.Count - 1);
+						pTarget = targets.GetItem(index);
+					}
+				}
+
+				targets.RemoveItem(index);
+			}
+
+			if (pTarget)
+			{
+
+				if (auto const pBullet = pTypeSplits->CreateBullet(pTarget, pThis->Owner, damage, pWeapon->Warhead, pWeapon->Speed, pWeapon->Bright))
+				{
+					BulletExt::ExtMap.Find(pBullet)->FirerHouse = pOwner;
+					pBullet->WeaponType = pWeapon;
+					pBullet->Range = projectileRange;
+
+					DirStruct dir;
+					dir.SetValue<5>(random.RandomRanged(0, 31));
+
+					auto const radians = dir.GetRadian<32>();
+					auto const sin_rad = Math::sin(radians);
+					auto const cos_rad = Math::cos(radians);
+					auto const cos_factor = -2.44921270764e-16; // cos(1.5 * Math::Pi * 1.00001)
+					auto const flatSpeed = cos_factor * pBullet->Speed;
+
+					BulletVelocity velocity;
+					velocity.X = cos_rad * flatSpeed;
+					velocity.Y = sin_rad * flatSpeed;
+					velocity.Z = -pBullet->Speed;
+
+					pBullet->MoveTo(pThis->Location, velocity);
+				}
+			}
+		}
+	}
+
+	return SkipGameCode;
+}
+
+#pragma endregion

--- a/src/Ext/BulletType/Body.cpp
+++ b/src/Ext/BulletType/Body.cpp
@@ -53,6 +53,19 @@ void BulletTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Arcing_AllowElevationInaccuracy.Read(exINI, pSection, "Arcing.AllowElevationInaccuracy");
 	this->ReturnWeapon.Read<true>(exINI, pSection, "ReturnWeapon");
 
+	this->Splits.Read(exINI, pSection, "Splits");
+	this->AirburstSpread.Read(exINI, pSection, "AirburstSpread");
+	this->RetargetAccuracy.Read(exINI, pSection, "RetargetAccuracy");
+	this->RetargetSelf.Read(exINI, pSection, "RetargetSelf");
+	this->RetargetSelf_Probability.Read(exINI, pSection, "RetargetSelf.Probability");
+	this->AroundTarget.Read(exINI, pSection, "AroundTarget");
+	this->Airburst_UseCluster.Read(exINI, pSection, "Airburst.UseCluster");
+	this->Airburst_RandomClusters.Read(exINI, pSection, "Airburst.RandomClusters");
+	this->Splits_TargetingDistance.Read(exINI, pSection, "Splits.TargetingDistance");
+	this->Splits_TargetCellRange.Read(exINI, pSection, "Splits.TargetCellRange");
+	this->Splits_UseWeaponTargeting.Read(exINI, pSection, "Splits.UseWeaponTargeting");
+	this->AirburstWeapon_ApplyFirepowerMult.Read(exINI, pSection, "AirburstWeapon.ApplyFirepowerMult");
+
 	// Ares 0.7
 	this->BallisticScatter_Min.Read(exINI, pSection, "BallisticScatter.Min");
 	this->BallisticScatter_Max.Read(exINI, pSection, "BallisticScatter.Max");
@@ -125,6 +138,18 @@ void BulletTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AAOnly)
 		.Process(this->Arcing_AllowElevationInaccuracy)
 		.Process(this->ReturnWeapon)
+		.Process(this->Splits)
+		.Process(this->AirburstSpread)
+		.Process(this->RetargetAccuracy)
+		.Process(this->RetargetSelf)
+		.Process(this->RetargetSelf_Probability)
+		.Process(this->AroundTarget)
+		.Process(this->Airburst_UseCluster)
+		.Process(this->Airburst_RandomClusters)
+		.Process(this->Splits_TargetingDistance)
+		.Process(this->Splits_TargetCellRange)
+		.Process(this->Splits_UseWeaponTargeting)
+		.Process(this->AirburstWeapon_ApplyFirepowerMult)
 
 
 		.Process(this->TrajectoryType) // just keep this shit at last

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -45,6 +45,19 @@ public:
 		Valueable<bool> Arcing_AllowElevationInaccuracy;
 		Valueable<WeaponTypeClass*> ReturnWeapon;
 
+		Valueable<bool> Splits;
+		Valueable<double> AirburstSpread;
+		Valueable<double> RetargetAccuracy;
+		Valueable<bool> RetargetSelf;
+		Valueable<double> RetargetSelf_Probability;
+		Nullable<bool> AroundTarget;
+		Valueable<bool> Airburst_UseCluster;
+		Valueable<bool> Airburst_RandomClusters;
+		Valueable<Leptons> Splits_TargetingDistance;
+		Valueable<int> Splits_TargetCellRange;
+		Valueable<bool> Splits_UseWeaponTargeting;
+		Valueable<bool> AirburstWeapon_ApplyFirepowerMult;
+
 		// Ares 0.7
 		Nullable<Leptons> BallisticScatter_Min;
 		Nullable<Leptons> BallisticScatter_Max;
@@ -71,6 +84,18 @@ public:
 			, AAOnly { false }
 			, Arcing_AllowElevationInaccuracy { true }
 			, ReturnWeapon {}
+			, Splits { false }
+			, AirburstSpread { 1.5 }
+			, RetargetAccuracy { 0.0 }
+			, RetargetSelf { true }
+			, RetargetSelf_Probability { 0.5 }
+			, AroundTarget {}
+			, Airburst_UseCluster { false }
+			, Airburst_RandomClusters { false }
+			, Splits_TargetingDistance{ Leptons(1280) }
+			, Splits_TargetCellRange { 3 }
+			, Splits_UseWeaponTargeting { false }
+			, AirburstWeapon_ApplyFirepowerMult { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -73,6 +73,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	INI_EX exINI(pINI);
 
 	this->DiskLaser_Radius.Read(exINI, pSection, "DiskLaser.Radius");
+	this->ProjectileRange.Read(exINI, pSection, "ProjectileRange");
 
 	this->Bolt_Disable1.Read(exINI, pSection, "Bolt.Disable1");
 	this->Bolt_Disable2.Read(exINI, pSection, "Bolt.Disable2");
@@ -120,6 +121,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->DiskLaser_Radius)
+		.Process(this->ProjectileRange)
 		.Process(this->Bolt_Disable1)
 		.Process(this->Bolt_Disable2)
 		.Process(this->Bolt_Disable3)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -22,6 +22,7 @@ public:
 	public:
 
 		Valueable<double> DiskLaser_Radius;
+		Valueable<Leptons> ProjectileRange;
 		Valueable<RadTypeClass*> RadType;
 		Valueable<bool> Bolt_Disable1;
 		Valueable<bool> Bolt_Disable2;
@@ -61,6 +62,7 @@ public:
 
 		ExtData(WeaponTypeClass* OwnerObject) : Extension<WeaponTypeClass>(OwnerObject)
 			, DiskLaser_Radius { DiskLaserClass::Radius }
+			, ProjectileRange { Leptons(100000) }
 			, RadType {}
 			, Bolt_Disable1 { false }
 			, Bolt_Disable2 { false }


### PR DESCRIPTION
TL;DR - Core differences here to Ares' implementation:
- Projectiles created from `AirburstWeapon` remember their WeaponType and thus can apply radiation.
- Previously hardcoded values are now customizable via `RetargetSelf.Probability`, `Splits.TargetingDistance` and `Splits.TargetCellRange`.
- More elaborate target filtering can be enabled for `Splits` via `Splits.UseWeaponTargeting`.
- `Airburst` can now respect `Cluster` by setting `Airburst.UseCluster`. `Airburst.RandomClusters` controls if they're spread randomly or evenly across the affected area.
- Firepower multipliers from the original firer of the weapon can be applied on `AirburstWeapon` by setting `AirburstWeapon.ApplyFirepowerMult`.

---------------------------------

### Airburst & Splits

- `AirburstWeapon` logic has been reimplemented and thus there are several additions & changes to it.
- `Splits` can be set to true to use projectile splitting logic from Firestorm, with the number of split projectiles defined by `Cluster`.
  - `RetargetAccuracy` defines the probability that the splitted projectiles head to the same target as the original projectile.
  - `RetargetSelf` determines if it is possible for the splitted projectiles to aim at the firer of the original projectile.
    - `RetargetSelf.Probability` is the probability that if the original firer is chosen as a target, it is kept as the target instead of rerolled to another.
  - `Splits.TargetingDistance` is the distance in cells that any potential target has to be within from the original target coordinates to be eligible for targeting by the splitted projectiles.
  - `Splits.TargetCellRange` is the distance in whole cells from the original target cell from which the splitted projectiles can pick new target cells if not enough TechnoType targets were found nearby.
  - `Splits.UseWeaponTargeting`, if set to true, enables weapon targeting filter for when checking targets for splitted projectiles. Target's `LegalTarget` setting, Warhead `Verses` against `Armor` as well as `AirburstWeapon` weapon targeting filters & AttachEffect filters will be checked.
    - Do note that this overrides checking Warhead for `AffectsAllies/Owner/Enemies` for targeting. You can use `CanTargetHouses` on `AirburstWeapon` to achieve similar behaviour, however.
- Behaviour for if `Airburst` is set to true can also be customized.
  - `AirburstSpread` is the distance in cells that the effect covers, with each cell in range being targeted by `AirburstWeapon` by default.
  - `Airburst.UseCluster`, if set to true, makes it so that only number of cells in the affected area dictated by `Cluster` will be affected, instead of all of them.
    - If `Airburst.RandomClusters` is set to true, the cells affected will be picked by random. Otherwise they will be evenly spaced (counting from center to edges of affected area).
- `AroundTarget` controls whether or not targets for projectiles created by `Airburst` or `Splits` are checked for in area around the original projectile's intended target, or where the original projectile detonated. Defaults to value of `Splits`.
- `AirburstWeapon.ApplyFirepowerMult` determines whether or not firepower modifiers from the firer of the original projectile are applied on the projectiles created from `AirburstWeapon`.

In `rulesmd.ini`:
```ini
[SOMEPROJECTILE]                         ; Projectile
Splits=                                  ; boolean
RetargetAccuracy=0.0                     ; floating point value, percents or absolute (0.0-1.0)
RetargetSelf=true                        ; boolean
RetargetSelf.Probability=0.5             ; floating point value, percents or absolute (0.0-1.0)
Splits.TargetingDistance=5.0             ; floating point value, distance in cells
Splits.TargetCellRange=3                 ; integer, cell offset
Splits.UseWeaponTargeting=false          ; boolean
AirburstSpread=1.5                       ; floating point value, distance in cells
Airburst.UseCluster=false                ; boolean
Airburst.RandomClusters=false            ; boolean
AroundTarget=                            ; boolean
AirburstWeapon.ApplyFirepowerMult=false  ; boolean
```

**Note:**
`Splits`, `AirburstSpread`, `RetargetAccuracy`, `RetargetSelf` and `AroundTarget`, beyond the other additions, should function similarly to the equivalent features introduced by Ares and take precedence over them if Phobos is used together with Ares.