### PR TITLE
Animatable template & animation transparency customization settings

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -266,6 +266,7 @@ This page lists all the individual contributions to the project by their author.
   - Customizing effect of level lighting on air units
   - Reimplemented `Airburst` & `Splits` logic with more customization options
   - Buildings considered as destroyable pathfinding obstacles
+  - Animation transparency customization settings
   - Animation visibility customization settings
   - Light effect customizations
   - Building unit repair customizations

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -53,6 +53,7 @@ This page lists all the individual contributions to the project by their author.
   - Ported XNA CnCNet Client MP save handling
   - Retint fix toggle
   - Voxel drawing invisible sections skip
+  - Animatable template
 - **Uranusian (Thrifinesma)**:
   - Mind Control enhancement
   - Custom warhead splash list
@@ -297,6 +298,7 @@ This page lists all the individual contributions to the project by their author.
   - Armed building guard mission retry delay customization
   - Building turret idle/firing/low power animations
   - Animation theater/tile palette toggle
+  - Animatable template
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -391,6 +391,7 @@
     <ClInclude Include="src\Utilities\Anchor.h" />
     <ClInclude Include="src\Utilities\AresFunctions.h" />
     <ClInclude Include="src\Utilities\AresHelper.h" />
+    <ClInclude Include="src\Utilities\Interpolation.h" />
     <ClInclude Include="src\Utilities\Constructs.h" />
     <ClInclude Include="src\Utilities\Container.h" />
     <ClInclude Include="src\Utilities\Debug.h" />

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -187,6 +187,27 @@ function onInput() {
 
 ## INI
 
+### Keyframe animations
+
+- Some features use keyframe-based animation system to define animations in INI. Defined in INI it looks something like following.
+
+```ini
+[SOMESECTION]
+BASEKEY.KeyframeN.Value=        ; Key-dependant value type
+BASEKEY.KeyframeN.Percentage=   ; floating point value, percents or absolute
+BASEKEY.KeyframeN.Absolute=     ; integer, zero-based frame index
+BASEKEY.Interpolation=none      ; Interpolation mode (none|linear)
+```
+
+- `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index.
+  - `Value` is a key/feature-dependant value type associated with that keyframe.
+  - `Percentage` is is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value.
+  - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
+
+```{note}
+Keyframes are expected to be defined in ascending order with no duplicates by percentage or absolute value. Failure to do so will crash the game and output developer warnings about offending keys to the log.
+```
+
 ### Include files
 
 ```{note}

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -197,12 +197,14 @@ BASEKEY.KeyframeN.Value=        ; Key-dependant value type
 BASEKEY.KeyframeN.Percentage=   ; floating point value, percents or absolute
 BASEKEY.KeyframeN.Absolute=     ; integer, zero-based frame index
 BASEKEY.Interpolation=none      ; Interpolation mode (none|linear)
+BASEKEY.ResetData=false         ; boolean
 ```
 
 - `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index.
   - `Value` is a key/feature-dependant value type associated with that keyframe.
   - `Percentage` is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value.
   - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
+  - `ResetData` if set to true makes it so that all existing keyframe data is reset before parsing. Can be used to reset keyframes when redefining them in map files etc.
 
 ```{note}
 Keyframes are expected to be defined with no duplicates for Percentage or Absolute. Failure to do so will crash the game and output developer warnings about offending keys to the log.

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -201,7 +201,7 @@ BASEKEY.Interpolation=none      ; Interpolation mode (none|linear)
 
 - `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index.
   - `Value` is a key/feature-dependant value type associated with that keyframe.
-  - `Percentage` is is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value.
+  - `Percentage` is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value.
   - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
 
 ```{note}

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -193,18 +193,18 @@ function onInput() {
 
 ```ini
 [SOMESECTION]
-BASEKEY.KeyframeN.Value=       ; Key-dependant value type
-BASEKEY.KeyframeN.Percentage=  ; floating point value, percents or absolute
-BASEKEY.KeyframeN.Absolute=    ; integer, zero-based frame index
-BASEKEY.Interpolation=none     ; Interpolation mode (none|linear)
-BASEKEY.ResetValues=false      ; boolean
+BASEKEY.KeyframeN.Value=            ; Key-dependant value type
+BASEKEY.KeyframeN.Percentage=       ; floating point value, percents or absolute
+BASEKEY.KeyframeN.Absolute=         ; integer, zero-based frame index
+BASEKEY.Keyframe.ResetValues=false  ; boolean
+BASEKEY.Interpolation=none          ; Interpolation mode (none|linear)
 ```
 
 - `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index. If no keyframes are defined, a single value from `BASEKEY` is attempted to be parsed instead.
   - `Value` is a key/feature-dependant value type associated with that keyframe.
   - `Percentage` is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value. Has to be 0.0 or above, values below this are not valid.
-  - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
   - `ResetValues` if set to true makes it so that all existing keyframe data is reset before parsing. Can be used to reset keyframes when redefining them in map files etc.
+  - `Interpolation` controls interpolation of values between animation keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
 
 ```{note}
 Keyframes are expected to be defined with no duplicates for Percentage or Absolute. Failure to do so will crash the game and output developer warnings about offending keys to the log.

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -193,18 +193,18 @@ function onInput() {
 
 ```ini
 [SOMESECTION]
-BASEKEY.KeyframeN.Value=        ; Key-dependant value type
-BASEKEY.KeyframeN.Percentage=   ; floating point value, percents or absolute
-BASEKEY.KeyframeN.Absolute=     ; integer, zero-based frame index
-BASEKEY.Interpolation=none      ; Interpolation mode (none|linear)
-BASEKEY.ResetData=false         ; boolean
+BASEKEY.KeyframeN.Value=       ; Key-dependant value type
+BASEKEY.KeyframeN.Percentage=  ; floating point value, percents or absolute
+BASEKEY.KeyframeN.Absolute=    ; integer, zero-based frame index
+BASEKEY.Interpolation=none     ; Interpolation mode (none|linear)
+BASEKEY.ResetValues=false      ; boolean
 ```
 
 - `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index. If no keyframes are defined, a single value from `BASEKEY` is attempted to be parsed instead.
   - `Value` is a key/feature-dependant value type associated with that keyframe.
-  - `Percentage` is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value.
+  - `Percentage` is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value. Has to be 0.0 or above, values below this are not valid.
   - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
-  - `ResetData` if set to true makes it so that all existing keyframe data is reset before parsing. Can be used to reset keyframes when redefining them in map files etc.
+  - `ResetValues` if set to true makes it so that all existing keyframe data is reset before parsing. Can be used to reset keyframes when redefining them in map files etc.
 
 ```{note}
 Keyframes are expected to be defined with no duplicates for Percentage or Absolute. Failure to do so will crash the game and output developer warnings about offending keys to the log.

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -205,7 +205,7 @@ BASEKEY.Interpolation=none      ; Interpolation mode (none|linear)
   - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
 
 ```{note}
-Keyframes are expected to be defined in ascending order with no duplicates by percentage or absolute value. Failure to do so will crash the game and output developer warnings about offending keys to the log.
+Keyframes are expected to be defined with no duplicates for Percentage or Absolute. Failure to do so will crash the game and output developer warnings about offending keys to the log.
 ```
 
 ### Include files

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -200,7 +200,7 @@ BASEKEY.Interpolation=none      ; Interpolation mode (none|linear)
 BASEKEY.ResetData=false         ; boolean
 ```
 
-- `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index.
+- `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index. If no keyframes are defined, a single value from `BASEKEY` is attempted to be parsed instead.
   - `Value` is a key/feature-dependant value type associated with that keyframe.
   - `Percentage` is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value.
   - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -577,24 +577,19 @@ AttachedSystem=  ; ParticleSystemType
 ### Customizable animation transparency settings
 
 - `Translucency.Cloaked` can be used to override `Translucency` on animations attached to currently cloaked TechnoTypes.
-- Properties of the three transparency stages used by `Translucent=true`can now be customized per animation type.
-  - `Translucent.StageX.Percent` controls at what percentage through the animation's frames the applicable translucency stage becomes active.
-    - If `Translucent.StageX.Frame` is set, this explicit frame value is used instead.
-  - `Translucent.StageX.Translucency` controls the transparency level for the stage.
+- `Translucent=true` animated transparency is now fully controllable via new keyframe settings.
+  - Keyframes are defined via `Translucent.KeyframeN.*` settings where N is zero-based keyframe index.
+  - `Translucent.KeyframeN.Value` is keyframe's transparency value.
+  - `Translucent.KeyframeN.Percentage` is the percentage through the animation's frames where the keyframes becomes active. It is also possible to instead use zero-based frame index via `Translucent.KeyframeN.Absolute` which takes precedence over percentage.
+  - Keyframes should be listed in ascending order with no duplicate percentages / frames across different keyframes. Failure to do so can produce unpredictable results.
 
 In `artmd.ini`:
 ```ini
 [SOMEANIM]                          ; AnimationType
 Translucency.Cloaked=               ; integer - only accepted values are 75, 50, 25 and 0.
-Translucent.Stage1.Percent=0.2      ; floating point value, percents or absolute
-Translucent.Stage1.Frame=           ; integer, 0-based frame index
-Translucent.Stage1.Translucency=25  ; integer - only accepted values are 75, 50, 25 and 0.
-Translucent.Stage2.Percent=0.4      ; floating point value, percents or absolute
-Translucent.Stage2.Frame=           ; integer, 0-based frame index
-Translucent.Stage2.Translucency=50  ; integer - only accepted values are 75, 50, 25 and 0.
-Translucent.Stage3.Percent=0.6      ; floating point value, percents or absolute
-Translucent.Stage3.Frame=           ; integer, 0-based frame index
-Translucent.Stage3.Translucency=75  ; integer - only accepted values are 75, 50, 25 and 0.
+Translucent.KeyframeN.Value=        ; integer - only accepted values are 75, 50, 25 and 0.
+Translucent.KeyframeN.Percentage=   ; floating point value, percents or absolute
+Translucent.KeyframeN.Absolute=     ; integer, zero-based frame index
 ```
 
 ### Customizable animation visibility settings

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -581,7 +581,6 @@ AttachedSystem=  ; ParticleSystemType
   - Keyframes are defined via `Translucent.KeyframeN.*` settings where N is zero-based keyframe index.
   - `Translucent.KeyframeN.Value` is keyframe's transparency value.
   - `Translucent.KeyframeN.Percentage` is the percentage through the animation's frames where the keyframes becomes active. It is also possible to instead use zero-based frame index via `Translucent.KeyframeN.Absolute` which takes precedence over percentage.
-  - Keyframes should be listed in ascending order with no duplicate percentages / frames across different keyframes. Failure to do so can produce unpredictable results.
   - `Translucent.Interpolation` controls interpolation of values between keyframes. These values are still clamped to the allowed transparency values of 0,25,50 and 75.
 
 In `artmd.ini`:
@@ -592,6 +591,10 @@ Translucent.KeyframeN.Value=        ; integer - only accepted values are 75, 50,
 Translucent.KeyframeN.Percentage=   ; floating point value, percents or absolute
 Translucent.KeyframeN.Absolute=     ; integer, zero-based frame index
 Translucent.Interpolation=none      ; Interpolation mode (none|linear)
+```
+
+```{note}
+Keyframes are expected to be defined in ascending order with no duplicates. Failure to do so will crash the game and output developer warnings about offending keys to the log.
 ```
 
 ### Customizable animation visibility settings

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -574,6 +574,29 @@ In `artmd.ini`:
 AttachedSystem=  ; ParticleSystemType
 ```
 
+### Customizable animation transparency settings
+
+- `Translucency.Cloaked` can be used to override `Translucency` on animations attached to currently cloaked TechnoTypes.
+- Properties of the three transparency stages used by `Translucent=true`can now be customized per animation type.
+  - `Translucent.StageX.Percent` controls at what percentage through the animation's frames the applicable translucency stage becomes active.
+    - If `Translucent.StageX.Frame` is set, this explicit frame value is used instead.
+  - `Translucent.StageX.Translucency` controls the transparency level for the stage.
+
+In `artmd.ini`:
+```ini
+[SOMEANIM]                          ; AnimationType
+Translucency.Cloaked=               ; integer - only accepted values are 75, 50, 25 and 0.
+Translucent.Stage1.Percent=0.2      ; floating point value, percents or absolute
+Translucent.Stage1.Frame=           ; integer, 0-based frame index
+Translucent.Stage1.Translucency=25  ; integer - only accepted values are 75, 50, 25 and 0.
+Translucent.Stage2.Percent=0.4      ; floating point value, percents or absolute
+Translucent.Stage2.Frame=           ; integer, 0-based frame index
+Translucent.Stage2.Translucency=50  ; integer - only accepted values are 75, 50, 25 and 0.
+Translucent.Stage3.Percent=0.6      ; floating point value, percents or absolute
+Translucent.Stage3.Frame=           ; integer, 0-based frame index
+Translucent.Stage3.Translucency=75  ; integer - only accepted values are 75, 50, 25 and 0.
+```
+
 ### Customizable animation visibility settings
 
 - It is now possible to customize which players can see an animation using `VisibleTo`.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -582,6 +582,7 @@ AttachedSystem=  ; ParticleSystemType
   - `Translucent.KeyframeN.Value` is keyframe's transparency value.
   - `Translucent.KeyframeN.Percentage` is the percentage through the animation's frames where the keyframes becomes active. It is also possible to instead use zero-based frame index via `Translucent.KeyframeN.Absolute` which takes precedence over percentage.
   - Keyframes should be listed in ascending order with no duplicate percentages / frames across different keyframes. Failure to do so can produce unpredictable results.
+  - `Translucent.Interpolation` controls interpolation of values between keyframes. These values are still clamped to the allowed transparency values of 0,25,50 and 75.
 
 In `artmd.ini`:
 ```ini
@@ -590,6 +591,7 @@ Translucency.Cloaked=               ; integer - only accepted values are 75, 50,
 Translucent.KeyframeN.Value=        ; integer - only accepted values are 75, 50, 25 and 0.
 Translucent.KeyframeN.Percentage=   ; floating point value, percents or absolute
 Translucent.KeyframeN.Absolute=     ; integer, zero-based frame index
+Translucent.Interpolation=none      ; Interpolation mode (none|linear)
 ```
 
 ### Customizable animation visibility settings

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -577,11 +577,8 @@ AttachedSystem=  ; ParticleSystemType
 ### Customizable animation transparency settings
 
 - `Translucency.Cloaked` can be used to override `Translucency` on animations attached to currently cloaked TechnoTypes.
-- `Translucent=true` animated transparency is now fully controllable via new keyframe settings.
-  - Keyframes are defined via `Translucent.KeyframeN.*` settings where N is zero-based keyframe index.
-  - `Translucent.KeyframeN.Value` is keyframe's transparency value.
-  - `Translucent.KeyframeN.Percentage` is the percentage through the animation's frames where the keyframes becomes active. It is also possible to instead use zero-based frame index via `Translucent.KeyframeN.Absolute` which takes precedence over percentage.
-  - `Translucent.Interpolation` controls interpolation of values between keyframes. These values are still clamped to the allowed transparency values of 0,25,50 and 75.
+- `Translucent=true` animated transparency is now fully controllable via new keyframe settings. Read more about the keyframe system [here](Miscellanous.md#keyframe-animations).
+  - If interpolation is enabled, the keyframe values are clamped to valid transparency values (0,25,50 and 75), e.g a value of 1.5 would become 0 and 56.525 would become 50 and so on.
 
 In `artmd.ini`:
 ```ini
@@ -591,10 +588,6 @@ Translucent.KeyframeN.Value=        ; integer - only accepted values are 75, 50,
 Translucent.KeyframeN.Percentage=   ; floating point value, percents or absolute
 Translucent.KeyframeN.Absolute=     ; integer, zero-based frame index
 Translucent.Interpolation=none      ; Interpolation mode (none|linear)
-```
-
-```{note}
-Keyframes are expected to be defined in ascending order with no duplicates. Failure to do so will crash the game and output developer warnings about offending keys to the log.
 ```
 
 ### Customizable animation visibility settings

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -585,9 +585,6 @@ In `artmd.ini`:
 [SOMEANIM]                          ; AnimationType
 Translucency.Cloaked=               ; integer - only accepted values are 75, 50, 25 and 0.
 Translucent.KeyframeN.Value=        ; integer - only accepted values are 75, 50, 25 and 0.
-Translucent.KeyframeN.Percentage=   ; floating point value, percents or absolute
-Translucent.KeyframeN.Absolute=     ; integer, zero-based frame index
-Translucent.Interpolation=none      ; Interpolation mode (none|linear)
 ```
 
 ### Customizable animation visibility settings

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -577,14 +577,14 @@ AttachedSystem=  ; ParticleSystemType
 ### Customizable animation transparency settings
 
 - `Translucency.Cloaked` can be used to override `Translucency` on animations attached to currently cloaked TechnoTypes.
-- `Translucent=true` animated transparency is now fully controllable via new keyframe settings. Read more about the keyframe system [here](Miscellanous.md#keyframe-animations).
-  - If interpolation is enabled, the keyframe values are clamped to valid transparency values (0,25,50 and 75), e.g a value of 1.5 would become 0 and 56.525 would become 50 and so on.
+- Both `Translucency` and `Translucency.Cloaked` can use the new keyframe system to animate along with the animation. Read more about the keyframe system [here](Miscellanous.md#keyframe-animations).
+- If interpolation is enabled, the keyframe values are clamped to valid transparency values (0,25,50 and 75), e.g a value of 1.5 would become 0 and 56.525 would become 50 and so on.
 
 In `artmd.ini`:
 ```ini
-[SOMEANIM]                          ; AnimationType
-Translucency.Cloaked=               ; integer - only accepted values are 75, 50, 25 and 0.
-Translucent.KeyframeN.Value=        ; integer - only accepted values are 75, 50, 25 and 0.
+[SOMEANIM]             ; AnimationType
+Translucency=0         ; integer - only accepted values are 75, 50, 25 and 0.
+Translucency.Cloaked=  ; integer - only accepted values are 75, 50, 25 and 0.
 ```
 
 ### Customizable animation visibility settings

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -589,6 +589,7 @@ HideShakeEffects=false           ; boolean
 - [Dehardcode of parasites unlimboing after killing naval targets](Fixed-or-Improved-Logics.md#dehardcode-of-parasites-unlimboing-after-killing-naval-targets) (by Noble_Fish)
 - [Allow warhead to only affect invoker](New-or-Enhanced-Logics.md#allow-warhead-to-only-affect-invoker) (by Noble_Fish)
 - Allow customizing whether the creation of shrapnel weapon is controlled by the new target check on the warhead of the parent weapon (by Noble_Fish)
+- Animation transparency customization settings (by Starkku)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -589,7 +589,7 @@ HideShakeEffects=false           ; boolean
 - [Dehardcode of parasites unlimboing after killing naval targets](Fixed-or-Improved-Logics.md#dehardcode-of-parasites-unlimboing-after-killing-naval-targets) (by Noble_Fish)
 - [Allow warhead to only affect invoker](New-or-Enhanced-Logics.md#allow-warhead-to-only-affect-invoker) (by Noble_Fish)
 - Allow customizing whether the creation of shrapnel weapon is controlled by the new target check on the warhead of the parent weapon (by Noble_Fish)
-- Animation transparency customization settings (by Starkku)
+- [Animation transparency customization settings](New-or-Enhanced-Logics.md#customizable-animation-transparency-settings) (by Starkku)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -479,6 +479,7 @@ DEFINE_HOOK(0x423061, AnimClass_DrawIt_Visibility, 0x6)
 	return 0;
 }
 
+// Reverse-engineered from YR with exception of new additions.
 DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 {
 	enum { SkipGameCode = 0x4230FE, ReturnFromFunction = 0x4238A3 };
@@ -487,13 +488,14 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 	GET(BlitterFlags, flags, EBX);
 
 	auto const pType = pThis->Type;
-	int translucencyLevel = pThis->TranslucencyLevel; // Used by building animations when building needs to be drawn partially transparent.
+	int translucencyLevel = pThis->TranslucencyLevel; // Used by building animations when building needs to be drawn partially transparent. >= 15 means animation skips drawing.
 
 	if (!pType->Translucent)
 	{
 		auto translucency = pThis->Type->Translucency;
 		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pType);
 
+		// New addition: Different Translucency animation for attached animations on cloaked objects
 		if (pTypeExt->Translucency_Cloaked.isset())
 		{
 			if (auto const pTechno = abstract_cast<TechnoClass*>(pThis->OwnerObject))
@@ -505,6 +507,7 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 
 		if (translucency <= 0)
 		{
+			// Translucency <= 0, map translucencyLevel to transparency blitter flags
 			if (translucencyLevel)
 			{
 				if (translucencyLevel > 15)
@@ -519,6 +522,7 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 		}
 		else
 		{
+			// Translucency > 0, map Translucency to transparency blitter flags
 			if (translucencyLevel >= 15)
 				return ReturnFromFunction;
 			else if (translucency == 75)
@@ -538,12 +542,14 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 		int currentFrame = pThis->Animation.Value;
 		int frames = pType->End;
 
+		// New addition: Keyframeable Translucent stages.
 		if (pTypeExt->Translucent_Keyframes.KeyframeData.size() > 0)
 		{
 			flags |= pTypeExt->Translucent_Keyframes.Get(static_cast<double>(currentFrame) / frames);
 		}
 		else
 		{
+			// No keyframes -> default behaviour.
 			if (currentFrame > frames * 0.6)
 				flags |= BlitterFlags::TransLucent75;
 			else if (currentFrame > frames * 0.4)

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -539,17 +539,17 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 		int frames = pType->End;
 
 		if ((pTypeExt->Translucent_Stage3_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage3_Frame.Get())
-			|| currentFrame >= frames * pTypeExt->Translucent_Stage3_Percent)
+			|| (!pTypeExt->Translucent_Stage3_Frame.isset() && currentFrame >= frames * pTypeExt->Translucent_Stage3_Percent))
 		{
 			flags |= pTypeExt->Translucent_Stage3_Translucency.Get();
 		}
 		else if ((pTypeExt->Translucent_Stage2_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage2_Frame.Get())
-			|| currentFrame >= frames * pTypeExt->Translucent_Stage2_Percent)
+			|| (!pTypeExt->Translucent_Stage2_Frame.isset() && currentFrame >= frames * pTypeExt->Translucent_Stage2_Percent))
 		{
 			flags |= pTypeExt->Translucent_Stage2_Translucency.Get();
 		}
 		else if ((pTypeExt->Translucent_Stage1_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage1_Frame.Get())
-			|| currentFrame >= frames * pTypeExt->Translucent_Stage1_Percent)
+			|| (!pTypeExt->Translucent_Stage1_Frame.isset() && currentFrame >= frames * pTypeExt->Translucent_Stage1_Percent))
 		{
 			flags |= pTypeExt->Translucent_Stage1_Translucency.Get();
 		}

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -538,20 +538,18 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 		int currentFrame = pThis->Animation.Value;
 		int frames = pType->End;
 
-		if ((pTypeExt->Translucent_Stage3_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage3_Frame.Get())
-			|| (!pTypeExt->Translucent_Stage3_Frame.isset() && currentFrame >= frames * pTypeExt->Translucent_Stage3_Percent))
+		if (pTypeExt->Translucent_Keyframes.KeyframeData.size() > 0)
 		{
-			flags |= pTypeExt->Translucent_Stage3_Translucency.Get();
+			flags |= pTypeExt->Translucent_Keyframes.Get(static_cast<double>(currentFrame) / frames);
 		}
-		else if ((pTypeExt->Translucent_Stage2_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage2_Frame.Get())
-			|| (!pTypeExt->Translucent_Stage2_Frame.isset() && currentFrame >= frames * pTypeExt->Translucent_Stage2_Percent))
+		else
 		{
-			flags |= pTypeExt->Translucent_Stage2_Translucency.Get();
-		}
-		else if ((pTypeExt->Translucent_Stage1_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage1_Frame.Get())
-			|| (!pTypeExt->Translucent_Stage1_Frame.isset() && currentFrame >= frames * pTypeExt->Translucent_Stage1_Percent))
-		{
-			flags |= pTypeExt->Translucent_Stage1_Translucency.Get();
+			if (currentFrame > frames * 0.6)
+				flags |= BlitterFlags::TransLucent75;
+			else if (currentFrame > frames * 0.4)
+				flags |= BlitterFlags::TransLucent50;
+			else if (currentFrame > frames * 0.2)
+				flags |= BlitterFlags::TransLucent25;
 		}
 	}
 

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -543,7 +543,7 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 		int frames = pType->End;
 
 		// New addition: Keyframeable Translucent stages.
-		if (pTypeExt->Translucent_Keyframes.KeyframeData.size() > 0)
+		if (pTypeExt->Translucent_Keyframes.HasValues())
 		{
 			flags |= pTypeExt->Translucent_Keyframes.Get(static_cast<double>(currentFrame) / frames);
 		}

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -479,6 +479,86 @@ DEFINE_HOOK(0x423061, AnimClass_DrawIt_Visibility, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
+{
+	enum { SkipGameCode = 0x4230FE, ReturnFromFunction = 0x4238A3 };
+
+	GET(AnimClass*, pThis, ESI);
+	GET(BlitterFlags, flags, EBX);
+
+	auto const pType = pThis->Type;
+	int translucencyLevel = pThis->TranslucencyLevel; // Used by building animations when building needs to be drawn partially transparent.
+
+	if (!pType->Translucent)
+	{
+		auto translucency = pThis->Type->Translucency;
+		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pType);
+
+		if (pTypeExt->Translucency_Cloaked.isset())
+		{
+			if (auto const pTechno = abstract_cast<TechnoClass*>(pThis->OwnerObject))
+			{
+				if (pTechno->CloakState == CloakState::Cloaked || pTechno->CloakState == CloakState::Cloaking)
+					translucency = pTypeExt->Translucency_Cloaked.Get();
+			}
+		}
+
+		if (translucency <= 0)
+		{
+			if (translucencyLevel)
+			{
+				if (translucencyLevel > 15)
+					return ReturnFromFunction;
+				else if (translucencyLevel > 10)
+					flags |= BlitterFlags::TransLucent50;
+				else if (translucencyLevel > 5)
+					flags |= BlitterFlags::TransLucent50;
+				else
+					flags |= BlitterFlags::TransLucent25;
+			}
+		}
+		else
+		{
+			if (translucencyLevel >= 15)
+				return ReturnFromFunction;
+			else if (translucency == 75)
+				flags |= BlitterFlags::TransLucent75;
+			else if (translucency == 50)
+				flags |= BlitterFlags::TransLucent50;
+			else if (translucency == 25)
+				flags |= BlitterFlags::TransLucent25;
+		}
+	}
+	else
+	{
+		if (translucencyLevel >= 15)
+			return ReturnFromFunction;
+
+		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pType);
+		int currentFrame = pThis->Animation.Value;
+		int frames = pType->End;
+
+		if ((pTypeExt->Translucent_Stage3_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage3_Frame.Get())
+			|| currentFrame >= frames * pTypeExt->Translucent_Stage3_Percent)
+		{
+			flags |= pTypeExt->Translucent_Stage3_Translucency.Get();
+		}
+		else if ((pTypeExt->Translucent_Stage2_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage2_Frame.Get())
+			|| currentFrame >= frames * pTypeExt->Translucent_Stage2_Percent)
+		{
+			flags |= pTypeExt->Translucent_Stage2_Translucency.Get();
+		}
+		else if ((pTypeExt->Translucent_Stage1_Frame.isset() && currentFrame >= pTypeExt->Translucent_Stage1_Frame.Get())
+			|| currentFrame >= frames * pTypeExt->Translucent_Stage1_Percent)
+		{
+			flags |= pTypeExt->Translucent_Stage1_Translucency.Get();
+		}
+	}
+
+	R->EBX(flags);
+	return SkipGameCode;
+}
+
 #pragma region AltPalette
 
 // Fix AltPalette anims not using owner color scheme.

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -490,29 +490,43 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 	auto const pType = pThis->Type;
 	int translucencyLevel = pThis->TranslucencyLevel; // Used by building animations when building needs to be drawn partially transparent. >= 15 means animation skips drawing.
 
+	if (translucencyLevel >= 15)
+		return ReturnFromFunction;
+
+	int currentFrame = pThis->Animation.Value;
+	int frames = pType->End;
+	auto const pTypeExt = AnimTypeExt::ExtMap.Find(pType);
+
 	if (!pType->Translucent)
 	{
-		auto translucency = pThis->Type->Translucency;
-		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pType);
+		TranslucencyLevel level;
+		bool hasValue = false;
 
-		// New addition: Different Translucency animation for attached animations on cloaked objects
-		if (pTypeExt->Translucency_Cloaked.isset())
+		if (pTypeExt->Translucency_Cloaked.HasValues())
 		{
+			// New addition: Different Translucency animation for attached animations on cloaked objects. Also keyframeable.
 			if (auto const pTechno = abstract_cast<TechnoClass*>(pThis->OwnerObject))
 			{
 				if (pTechno->CloakState == CloakState::Cloaked || pTechno->CloakState == CloakState::Cloaking)
-					translucency = pTypeExt->Translucency_Cloaked.Get();
+				{
+					level = pTypeExt->Translucency_Cloaked.Get(static_cast<double>(currentFrame) / frames);
+					hasValue = true;
+				}
 			}
 		}
 
-		if (translucency <= 0)
+		if (!hasValue && pTypeExt->Translucency.HasValues())
+		{
+			// New addition: Keyframeable Translucency, replaces game Translucency setting.
+			level = pTypeExt->Translucency.Get(static_cast<double>(currentFrame) / frames);
+		}
+
+		if (level == BlitterFlags::None)
 		{
 			// Translucency <= 0, map translucencyLevel to transparency blitter flags
 			if (translucencyLevel)
 			{
-				if (translucencyLevel > 15)
-					return ReturnFromFunction;
-				else if (translucencyLevel > 10)
+				if (translucencyLevel > 10)
 					flags |= BlitterFlags::TransLucent50;
 				else if (translucencyLevel > 5)
 					flags |= BlitterFlags::TransLucent50;
@@ -522,41 +536,19 @@ DEFINE_HOOK(0x42308D, AnimClass_DrawIt_Transparency, 0x6)
 		}
 		else
 		{
-			// Translucency > 0, map Translucency to transparency blitter flags
-			if (translucencyLevel >= 15)
-				return ReturnFromFunction;
-			else if (translucency == 75)
-				flags |= BlitterFlags::TransLucent75;
-			else if (translucency == 50)
-				flags |= BlitterFlags::TransLucent50;
-			else if (translucency == 25)
-				flags |= BlitterFlags::TransLucent25;
+			// Translucency > 0, transparency level directly maps to blitter flags.
+			flags |= level;
 		}
 	}
 	else
 	{
-		if (translucencyLevel >= 15)
-			return ReturnFromFunction;
-
-		auto const pTypeExt = AnimTypeExt::ExtMap.Find(pType);
-		int currentFrame = pThis->Animation.Value;
-		int frames = pType->End;
-
-		// New addition: Keyframeable Translucent stages.
-		if (pTypeExt->Translucent_Keyframes.HasValues())
-		{
-			flags |= pTypeExt->Translucent_Keyframes.Get(static_cast<double>(currentFrame) / frames);
-		}
-		else
-		{
-			// No keyframes -> default behaviour.
-			if (currentFrame > frames * 0.6)
-				flags |= BlitterFlags::TransLucent75;
-			else if (currentFrame > frames * 0.4)
-				flags |= BlitterFlags::TransLucent50;
-			else if (currentFrame > frames * 0.2)
-				flags |= BlitterFlags::TransLucent25;
-		}
+		// Translucent=yes vanilla game logic.
+		if (currentFrame > frames * 0.6)
+			flags |= BlitterFlags::TransLucent75;
+		else if (currentFrame > frames * 0.4)
+			flags |= BlitterFlags::TransLucent50;
+		else if (currentFrame > frames * 0.2)
+			flags |= BlitterFlags::TransLucent25;
 	}
 
 	R->EBX(flags);

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -103,7 +103,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->RestrictVisibilityIfCloaked.Read(exINI, pID, "RestrictVisibilityIfCloaked");
 	this->DetachOnCloak.Read(exINI, pID, "DetachOnCloak");
 	this->Translucency.Read(exINI, pID, "Translucency", this->OwnerObject()->End);
-	this->Translucency_Cloaked.Read(exINI, pID, "Translucency.Cloaked", this->OwnerObject()->End, false);
+	this->Translucency_Cloaked.Read(exINI, pID, "Translucency.Cloaked", this->OwnerObject()->End, true);
 	this->ConstrainFireAnimsToCellSpots.Read(exINI, pID, "ConstrainFireAnimsToCellSpots");
 	this->FireAnimDisallowedLandTypes.Read<false, true>(exINI, pID, "FireAnimDisallowedLandTypes");
 	this->AttachFireAnimsToParent.Read(exINI, pID, "AttachFireAnimsToParent");

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -102,6 +102,16 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->VisibleTo_ConsiderInvokerAsOwner.Read(exINI, pID, "VisibleTo.ConsiderInvokerAsOwner");
 	this->RestrictVisibilityIfCloaked.Read(exINI, pID, "RestrictVisibilityIfCloaked");
 	this->DetachOnCloak.Read(exINI, pID, "DetachOnCloak");
+	this->Translucency_Cloaked.Read(exINI, pID, "Translucency.Cloaked");
+	this->Translucent_Stage1_Percent.Read(exINI, pID, "Translucent.Stage1.Percent");
+	this->Translucent_Stage1_Frame.Read(exINI, pID, "Translucent.Stage1.Frame");
+	this->Translucent_Stage1_Translucency.Read(exINI, pID, "Translucent.Stage1.Translucency");
+	this->Translucent_Stage2_Percent.Read(exINI, pID, "Translucent.Stage2.Percent");
+	this->Translucent_Stage2_Frame.Read(exINI, pID, "Translucent.Stage2.Frame");
+	this->Translucent_Stage2_Translucency.Read(exINI, pID, "Translucent.Stage2.Translucency");
+	this->Translucent_Stage3_Percent.Read(exINI, pID, "Translucent.Stage3.Percent");
+	this->Translucent_Stage3_Frame.Read(exINI, pID, "Translucent.Stage3.Frame");
+	this->Translucent_Stage3_Translucency.Read(exINI, pID, "Translucent.Stage3.Translucency");
 	this->ConstrainFireAnimsToCellSpots.Read(exINI, pID, "ConstrainFireAnimsToCellSpots");
 	this->FireAnimDisallowedLandTypes.Read<false, true>(exINI, pID, "FireAnimDisallowedLandTypes");
 	this->AttachFireAnimsToParent.Read(exINI, pID, "AttachFireAnimsToParent");
@@ -162,6 +172,16 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->VisibleTo_ConsiderInvokerAsOwner)
 		.Process(this->RestrictVisibilityIfCloaked)
 		.Process(this->DetachOnCloak)
+		.Process(this->Translucency_Cloaked)
+		.Process(this->Translucent_Stage1_Percent)
+		.Process(this->Translucent_Stage1_Frame)
+		.Process(this->Translucent_Stage1_Translucency)
+		.Process(this->Translucent_Stage2_Percent)
+		.Process(this->Translucent_Stage2_Frame)
+		.Process(this->Translucent_Stage2_Translucency)
+		.Process(this->Translucent_Stage3_Percent)
+		.Process(this->Translucent_Stage3_Frame)
+		.Process(this->Translucent_Stage3_Translucency)
 		.Process(this->ConstrainFireAnimsToCellSpots)
 		.Process(this->FireAnimDisallowedLandTypes)
 		.Process(this->AttachFireAnimsToParent)

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -103,15 +103,12 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->RestrictVisibilityIfCloaked.Read(exINI, pID, "RestrictVisibilityIfCloaked");
 	this->DetachOnCloak.Read(exINI, pID, "DetachOnCloak");
 	this->Translucency_Cloaked.Read(exINI, pID, "Translucency.Cloaked");
-	this->Translucent_Stage1_Percent.Read(exINI, pID, "Translucent.Stage1.Percent");
-	this->Translucent_Stage1_Frame.Read(exINI, pID, "Translucent.Stage1.Frame");
-	this->Translucent_Stage1_Translucency.Read(exINI, pID, "Translucent.Stage1.Translucency");
-	this->Translucent_Stage2_Percent.Read(exINI, pID, "Translucent.Stage2.Percent");
-	this->Translucent_Stage2_Frame.Read(exINI, pID, "Translucent.Stage2.Frame");
-	this->Translucent_Stage2_Translucency.Read(exINI, pID, "Translucent.Stage2.Translucency");
-	this->Translucent_Stage3_Percent.Read(exINI, pID, "Translucent.Stage3.Percent");
-	this->Translucent_Stage3_Frame.Read(exINI, pID, "Translucent.Stage3.Frame");
-	this->Translucent_Stage3_Translucency.Read(exINI, pID, "Translucent.Stage3.Translucency");
+
+	if (this->OwnerObject()->Translucent)
+	{
+		this->Translucent_Keyframes.Read(exINI, pID, "Translucent.%s", this->OwnerObject()->End);
+		this->Translucent_Keyframes.InterpolationMode = InterpolationMode::None;
+	}
 	this->ConstrainFireAnimsToCellSpots.Read(exINI, pID, "ConstrainFireAnimsToCellSpots");
 	this->FireAnimDisallowedLandTypes.Read<false, true>(exINI, pID, "FireAnimDisallowedLandTypes");
 	this->AttachFireAnimsToParent.Read(exINI, pID, "AttachFireAnimsToParent");
@@ -173,15 +170,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->RestrictVisibilityIfCloaked)
 		.Process(this->DetachOnCloak)
 		.Process(this->Translucency_Cloaked)
-		.Process(this->Translucent_Stage1_Percent)
-		.Process(this->Translucent_Stage1_Frame)
-		.Process(this->Translucent_Stage1_Translucency)
-		.Process(this->Translucent_Stage2_Percent)
-		.Process(this->Translucent_Stage2_Frame)
-		.Process(this->Translucent_Stage2_Translucency)
-		.Process(this->Translucent_Stage3_Percent)
-		.Process(this->Translucent_Stage3_Frame)
-		.Process(this->Translucent_Stage3_Translucency)
+		.Process(this->Translucent_Keyframes)
 		.Process(this->ConstrainFireAnimsToCellSpots)
 		.Process(this->FireAnimDisallowedLandTypes)
 		.Process(this->AttachFireAnimsToParent)

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -118,7 +118,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->TheaterPalette.Read(exINI, pID, "TheaterPalette");
 
 	if (this->OwnerObject()->Translucent)
-		this->Translucent_Keyframes.Read(exINI, pID, "Translucent.%s", this->OwnerObject()->End);
+		this->Translucent_Keyframes.Read(exINI, pID, "Translucent", this->OwnerObject()->End);
 
 	// Parasitic types
 	Nullable<TechnoTypeClass*> createUnit;

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -118,10 +118,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->TheaterPalette.Read(exINI, pID, "TheaterPalette");
 
 	if (this->OwnerObject()->Translucent)
-	{
 		this->Translucent_Keyframes.Read(exINI, pID, "Translucent.%s", this->OwnerObject()->End);
-		this->Translucent_Keyframes.InterpolationMode = InterpolationMode::None;
-	}
 
 	// Parasitic types
 	Nullable<TechnoTypeClass*> createUnit;

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -102,7 +102,8 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->VisibleTo_ConsiderInvokerAsOwner.Read(exINI, pID, "VisibleTo.ConsiderInvokerAsOwner");
 	this->RestrictVisibilityIfCloaked.Read(exINI, pID, "RestrictVisibilityIfCloaked");
 	this->DetachOnCloak.Read(exINI, pID, "DetachOnCloak");
-	this->Translucency_Cloaked.Read(exINI, pID, "Translucency.Cloaked");
+	this->Translucency.Read(exINI, pID, "Translucency", this->OwnerObject()->End);
+	this->Translucency_Cloaked.Read(exINI, pID, "Translucency.Cloaked", this->OwnerObject()->End, false);
 	this->ConstrainFireAnimsToCellSpots.Read(exINI, pID, "ConstrainFireAnimsToCellSpots");
 	this->FireAnimDisallowedLandTypes.Read<false, true>(exINI, pID, "FireAnimDisallowedLandTypes");
 	this->AttachFireAnimsToParent.Read(exINI, pID, "AttachFireAnimsToParent");
@@ -116,9 +117,6 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->LargeFireDistances.Read(exINI, pID, "LargeFireDistances");
 	this->Crater_DestroyTiberium.Read(exINI, pID, "Crater.DestroyTiberium");
 	this->TheaterPalette.Read(exINI, pID, "TheaterPalette");
-
-	if (this->OwnerObject()->Translucent)
-		this->Translucent_Keyframes.Read(exINI, pID, "Translucent", this->OwnerObject()->End);
 
 	// Parasitic types
 	Nullable<TechnoTypeClass*> createUnit;
@@ -166,8 +164,8 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->VisibleTo_ConsiderInvokerAsOwner)
 		.Process(this->RestrictVisibilityIfCloaked)
 		.Process(this->DetachOnCloak)
+		.Process(this->Translucency)
 		.Process(this->Translucency_Cloaked)
-		.Process(this->Translucent_Keyframes)
 		.Process(this->ConstrainFireAnimsToCellSpots)
 		.Process(this->FireAnimDisallowedLandTypes)
 		.Process(this->AttachFireAnimsToParent)

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -103,12 +103,6 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->RestrictVisibilityIfCloaked.Read(exINI, pID, "RestrictVisibilityIfCloaked");
 	this->DetachOnCloak.Read(exINI, pID, "DetachOnCloak");
 	this->Translucency_Cloaked.Read(exINI, pID, "Translucency.Cloaked");
-
-	if (this->OwnerObject()->Translucent)
-	{
-		this->Translucent_Keyframes.Read(exINI, pID, "Translucent.%s", this->OwnerObject()->End);
-		this->Translucent_Keyframes.InterpolationMode = InterpolationMode::None;
-	}
 	this->ConstrainFireAnimsToCellSpots.Read(exINI, pID, "ConstrainFireAnimsToCellSpots");
 	this->FireAnimDisallowedLandTypes.Read<false, true>(exINI, pID, "FireAnimDisallowedLandTypes");
 	this->AttachFireAnimsToParent.Read(exINI, pID, "AttachFireAnimsToParent");
@@ -122,6 +116,12 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->LargeFireDistances.Read(exINI, pID, "LargeFireDistances");
 	this->Crater_DestroyTiberium.Read(exINI, pID, "Crater.DestroyTiberium");
 	this->TheaterPalette.Read(exINI, pID, "TheaterPalette");
+
+	if (this->OwnerObject()->Translucent)
+	{
+		this->Translucent_Keyframes.Read(exINI, pID, "Translucent.%s", this->OwnerObject()->End);
+		this->Translucent_Keyframes.InterpolationMode = InterpolationMode::None;
+	}
 
 	// Parasitic types
 	Nullable<TechnoTypeClass*> createUnit;

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -93,7 +93,7 @@ public:
 			, RestrictVisibilityIfCloaked { false }
 			, DetachOnCloak { true }
 			, Translucency_Cloaked {}
-			, Translucent_Keyframes {}
+			, Translucent_Keyframes { TranslucencyLevel {} }
 			, ConstrainFireAnimsToCellSpots { true }
 			, FireAnimDisallowedLandTypes {}
 			, AttachFireAnimsToParent {}

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -50,8 +50,8 @@ public:
 		Valueable<bool> VisibleTo_ConsiderInvokerAsOwner;
 		Valueable<bool> RestrictVisibilityIfCloaked;
 		Valueable<bool> DetachOnCloak;
-		Nullable<int> Translucency_Cloaked;
-		Animatable<TranslucencyLevel> Translucent_Keyframes;
+		Animatable<TranslucencyLevel> Translucency;
+		Animatable<TranslucencyLevel> Translucency_Cloaked;
 		Valueable<bool> ConstrainFireAnimsToCellSpots;
 		Nullable<LandTypeFlags> FireAnimDisallowedLandTypes;
 		Nullable<bool> AttachFireAnimsToParent;
@@ -92,8 +92,8 @@ public:
 			, VisibleTo_ConsiderInvokerAsOwner { false }
 			, RestrictVisibilityIfCloaked { false }
 			, DetachOnCloak { true }
-			, Translucency_Cloaked {}
-			, Translucent_Keyframes { TranslucencyLevel {} }
+			, Translucency { TranslucencyLevel {} }
+			, Translucency_Cloaked { TranslucencyLevel {} }
 			, ConstrainFireAnimsToCellSpots { true }
 			, FireAnimDisallowedLandTypes {}
 			, AttachFireAnimsToParent {}

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -51,15 +51,7 @@ public:
 		Valueable<bool> RestrictVisibilityIfCloaked;
 		Valueable<bool> DetachOnCloak;
 		Nullable<int> Translucency_Cloaked;
-		Valueable<double> Translucent_Stage1_Percent;
-		Nullable<int> Translucent_Stage1_Frame;
-		Valueable<TranslucencyLevel> Translucent_Stage1_Translucency;
-		Valueable<double> Translucent_Stage2_Percent;
-		Nullable<int> Translucent_Stage2_Frame;
-		Valueable<TranslucencyLevel> Translucent_Stage2_Translucency;
-		Valueable<double> Translucent_Stage3_Percent;
-		Nullable<int> Translucent_Stage3_Frame;
-		Valueable<TranslucencyLevel> Translucent_Stage3_Translucency;
+		Animatable<TranslucencyLevel> Translucent_Keyframes;
 		Valueable<bool> ConstrainFireAnimsToCellSpots;
 		Nullable<LandTypeFlags> FireAnimDisallowedLandTypes;
 		Nullable<bool> AttachFireAnimsToParent;
@@ -101,15 +93,7 @@ public:
 			, RestrictVisibilityIfCloaked { false }
 			, DetachOnCloak { true }
 			, Translucency_Cloaked {}
-			, Translucent_Stage1_Percent { 0.2 }
-			, Translucent_Stage1_Frame {}
-			, Translucent_Stage1_Translucency { 25 }
-			, Translucent_Stage2_Percent { 0.4 }
-			, Translucent_Stage2_Frame {}
-			, Translucent_Stage2_Translucency { 50 }
-			, Translucent_Stage3_Percent { 0.6 }
-			, Translucent_Stage3_Frame {}
-			, Translucent_Stage3_Translucency { 75 }
+			, Translucent_Keyframes {}
 			, ConstrainFireAnimsToCellSpots { true }
 			, FireAnimDisallowedLandTypes {}
 			, AttachFireAnimsToParent {}

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -50,6 +50,16 @@ public:
 		Valueable<bool> VisibleTo_ConsiderInvokerAsOwner;
 		Valueable<bool> RestrictVisibilityIfCloaked;
 		Valueable<bool> DetachOnCloak;
+		Nullable<int> Translucency_Cloaked;
+		Valueable<double> Translucent_Stage1_Percent;
+		Nullable<int> Translucent_Stage1_Frame;
+		Valueable<TranslucencyLevel> Translucent_Stage1_Translucency;
+		Valueable<double> Translucent_Stage2_Percent;
+		Nullable<int> Translucent_Stage2_Frame;
+		Valueable<TranslucencyLevel> Translucent_Stage2_Translucency;
+		Valueable<double> Translucent_Stage3_Percent;
+		Nullable<int> Translucent_Stage3_Frame;
+		Valueable<TranslucencyLevel> Translucent_Stage3_Translucency;
 		Valueable<bool> ConstrainFireAnimsToCellSpots;
 		Nullable<LandTypeFlags> FireAnimDisallowedLandTypes;
 		Nullable<bool> AttachFireAnimsToParent;
@@ -90,6 +100,16 @@ public:
 			, VisibleTo_ConsiderInvokerAsOwner { false }
 			, RestrictVisibilityIfCloaked { false }
 			, DetachOnCloak { true }
+			, Translucency_Cloaked {}
+			, Translucent_Stage1_Percent { 0.2 }
+			, Translucent_Stage1_Frame {}
+			, Translucent_Stage1_Translucency { 25 }
+			, Translucent_Stage2_Percent { 0.4 }
+			, Translucent_Stage2_Frame {}
+			, Translucent_Stage2_Translucency { 50 }
+			, Translucent_Stage3_Percent { 0.6 }
+			, Translucent_Stage3_Frame {}
+			, Translucent_Stage3_Translucency { 75 }
 			, ConstrainFireAnimsToCellSpots { true }
 			, FireAnimDisallowedLandTypes {}
 			, AttachFireAnimsToParent {}

--- a/src/Utilities/Constructs.h
+++ b/src/Utilities/Constructs.h
@@ -488,14 +488,14 @@ public:
 		return *this;
 	}
 
-	operator BlitterFlags()
+	operator BlitterFlags() const
 	{
 		return this->value;
 	}
 
-	BlitterFlags GetBlitterFlags()
+	BlitterFlags GetBlitterFlags() const
 	{
-		return *this;
+		return this->value;
 	}
 
 	bool Read(INI_EX& parser, const char* pSection, const char* pKey);

--- a/src/Utilities/Constructs.h
+++ b/src/Utilities/Constructs.h
@@ -461,8 +461,20 @@ class TranslucencyLevel
 public:
 	constexpr TranslucencyLevel() noexcept = default;
 
-	TranslucencyLevel(int nInt)
+	TranslucencyLevel(int nInt, bool clamp = false)
 	{
+		if (clamp)
+		{
+			if (nInt >= 75)
+				nInt = 75;
+			else if (nInt >= 50)
+				nInt = 50;
+			else if (nInt >= 25)
+				nInt = 25;
+			else
+				nInt = 0;
+		}
+
 		*this = nInt;
 	}
 
@@ -496,6 +508,28 @@ public:
 	BlitterFlags GetBlitterFlags() const
 	{
 		return this->value;
+	}
+
+	int GetIntValue() const
+	{
+		int value = 0;
+
+		switch (this->value)
+		{
+		case BlitterFlags::TransLucent75:
+			value = 75;
+			break;
+		case BlitterFlags::TransLucent50:
+			value = 50;
+			break;
+		case BlitterFlags::TransLucent25:
+			value = 25;
+			break;
+		default:
+			break;
+		}
+
+		return value;
 	}
 
 	bool Read(INI_EX& parser, const char* pSection, const char* pKey);

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -405,3 +405,9 @@ public:
 		return false;
 	}
 };
+
+enum class InterpolationMode : BYTE
+{
+	None = 0,
+	Linear = 1
+};

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -275,7 +275,6 @@ enum class VerticalPosition : BYTE
 	Center = 1,
 	Bottom = 2
 };
-
 //hexagon
 enum class BuildingSelectBracketPosition :BYTE
 {

--- a/src/Utilities/Interpolation.h
+++ b/src/Utilities/Interpolation.h
@@ -1,26 +1,21 @@
 #pragma once
 
 #include <YRPPCore.h>
-
-enum class InterpolationMode : BYTE
-{
-	None = 0,
-	Linear = 1
-};
+#include "Enum.h"
 
 namespace detail
 {
 	#define FROM_DOUBLE(type, first, second, percentage, mode) \
-		 (type)(interpolate((double)first, (double)(second), percentage, mode));
+		 (type)(interpolate((double&)first, (double&)second, percentage, mode));
 
 	template <typename T>
-	inline T interpolate(T first, T second, double percentage, InterpolationMode mode)
+	inline T interpolate(T& first, T& second, double percentage, InterpolationMode mode)
 	{
 		return first;
 	}
 
 	template <>
-	inline double interpolate<double>(double first, double second, double percentage, InterpolationMode mode)
+	inline double interpolate<double>(double& first, double& second, double percentage, InterpolationMode mode)
 	{
 		double result = first;
 
@@ -37,17 +32,26 @@ namespace detail
 	}
 
 	template <>
-	inline int interpolate<int>(int first, int second, double percentage, InterpolationMode mode)
+	inline int interpolate<int>(int& first, int& second, double percentage, InterpolationMode mode)
 	{
 		return FROM_DOUBLE(int, first, second, percentage, mode);
 	}
 
 	template <>
-	inline ColorStruct interpolate<ColorStruct>(ColorStruct first, ColorStruct second, double percentage, InterpolationMode mode)
+	inline ColorStruct interpolate<ColorStruct>(ColorStruct& first, ColorStruct& second, double percentage, InterpolationMode mode)
 	{
 		BYTE r = FROM_DOUBLE(BYTE, first.R, second.R, percentage, mode);
 		BYTE g = FROM_DOUBLE(BYTE, first.G, second.G, percentage, mode);
 		BYTE b = FROM_DOUBLE(BYTE, first.B, second.B, percentage, mode);
 		return ColorStruct { r, g, b };
+	}
+
+	template <>
+	inline TranslucencyLevel interpolate<TranslucencyLevel>(TranslucencyLevel& first, TranslucencyLevel& second, double percentage, InterpolationMode mode)
+	{
+		int firstValue = first.GetIntValue();
+		int secondValue = second.GetIntValue();
+		int value = FROM_DOUBLE(int, firstValue, secondValue, percentage, mode);
+		return TranslucencyLevel(value, true);
 	}
 }

--- a/src/Utilities/Interpolation.h
+++ b/src/Utilities/Interpolation.h
@@ -10,6 +10,9 @@ enum class InterpolationMode : BYTE
 
 namespace detail
 {
+	#define FROM_DOUBLE(type, first, second, percentage, mode) \
+		 (type)(interpolate((double)first, (double)(second), percentage, mode));
+
 	template <typename T>
 	inline T interpolate(T first, T second, double percentage, InterpolationMode mode)
 	{
@@ -36,28 +39,15 @@ namespace detail
 	template <>
 	inline int interpolate<int>(int first, int second, double percentage, InterpolationMode mode)
 	{
-		return static_cast<int>(interpolate(static_cast<double>(first), static_cast<double>(second), percentage, mode));
+		return FROM_DOUBLE(int, first, second, percentage, mode);
 	}
 
 	template <>
 	inline ColorStruct interpolate<ColorStruct>(ColorStruct first, ColorStruct second, double percentage, InterpolationMode mode)
 	{
-		ColorStruct result = first;
-
-		switch (mode)
-		{
-		case InterpolationMode::Linear:
-		{
-			BYTE r = static_cast<BYTE>(first.R + ((second.R - first.R) * percentage));
-			BYTE g = static_cast<BYTE>(first.G + ((second.G - first.G) * percentage));
-			BYTE b = static_cast<BYTE>(first.B + ((second.B - first.B) * percentage));
-			result = ColorStruct { r, g, b };
-			break;
-		}
-		default:
-			break;
-		}
-
-		return result;
+		BYTE r = FROM_DOUBLE(BYTE, first.R, second.R, percentage, mode);
+		BYTE g = FROM_DOUBLE(BYTE, first.G, second.G, percentage, mode);
+		BYTE b = FROM_DOUBLE(BYTE, first.B, second.B, percentage, mode);
+		return ColorStruct { r, g, b };
 	}
 }

--- a/src/Utilities/Interpolation.h
+++ b/src/Utilities/Interpolation.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <YRPPCore.h>
+
+enum class InterpolationMode : BYTE
+{
+	None = 0,
+	Linear = 1
+};
+
+namespace detail
+{
+	template <typename T>
+	inline T interpolate(T first, T second, double percentage, InterpolationMode mode)
+	{
+		return first;
+	}
+
+	template <>
+	inline double interpolate<double>(double first, double second, double percentage, InterpolationMode mode)
+	{
+		double result = first;
+
+		switch (mode)
+		{
+		case InterpolationMode::Linear:
+			result = first + ((second - first) * percentage);
+			break;
+		default:
+			break;
+		}
+
+		return result;
+	}
+
+	template <>
+	inline int interpolate<int>(int first, int second, double percentage, InterpolationMode mode)
+	{
+		return static_cast<int>(interpolate(static_cast<double>(first), static_cast<double>(second), percentage, mode));
+	}
+
+	template <>
+	inline ColorStruct interpolate<ColorStruct>(ColorStruct first, ColorStruct second, double percentage, InterpolationMode mode)
+	{
+		ColorStruct result = first;
+
+		switch (mode)
+		{
+		case InterpolationMode::Linear:
+		{
+			BYTE r = static_cast<BYTE>(first.R + ((second.R - first.R) * percentage));
+			BYTE g = static_cast<BYTE>(first.G + ((second.G - first.G) * percentage));
+			BYTE b = static_cast<BYTE>(first.B + ((second.B - first.B) * percentage));
+			result = ColorStruct { r, g, b };
+			break;
+		}
+		default:
+			break;
+		}
+
+		return result;
+	}
+}

--- a/src/Utilities/Interpolation.h
+++ b/src/Utilities/Interpolation.h
@@ -5,9 +5,6 @@
 
 namespace detail
 {
-	#define FROM_DOUBLE(type, first, second, percentage, mode) \
-		 (type)(interpolate((double&)first, (double&)second, percentage, mode));
-
 	template <typename T>
 	inline T interpolate(T& first, T& second, double percentage, InterpolationMode mode)
 	{
@@ -34,24 +31,34 @@ namespace detail
 	template <>
 	inline int interpolate<int>(int& first, int& second, double percentage, InterpolationMode mode)
 	{
-		return FROM_DOUBLE(int, first, second, percentage, mode);
+		double firstValue = first;
+		double secondValue = second;
+		return (int)interpolate(firstValue, secondValue, percentage, mode);
+	}
+
+	template <>
+	inline BYTE interpolate<BYTE>(BYTE& first, BYTE& second, double percentage, InterpolationMode mode)
+	{
+		double firstValue = first;
+		double secondValue = second;
+		return (BYTE)interpolate(firstValue, secondValue, percentage, mode);
 	}
 
 	template <>
 	inline ColorStruct interpolate<ColorStruct>(ColorStruct& first, ColorStruct& second, double percentage, InterpolationMode mode)
 	{
-		BYTE r = FROM_DOUBLE(BYTE, first.R, second.R, percentage, mode);
-		BYTE g = FROM_DOUBLE(BYTE, first.G, second.G, percentage, mode);
-		BYTE b = FROM_DOUBLE(BYTE, first.B, second.B, percentage, mode);
+		BYTE r = interpolate(first.R, second.R, percentage, mode);
+		BYTE g = interpolate(first.G, second.G, percentage, mode);
+		BYTE b = interpolate(first.B, second.B, percentage, mode);
 		return ColorStruct { r, g, b };
 	}
 
 	template <>
 	inline TranslucencyLevel interpolate<TranslucencyLevel>(TranslucencyLevel& first, TranslucencyLevel& second, double percentage, InterpolationMode mode)
 	{
-		int firstValue = first.GetIntValue();
-		int secondValue = second.GetIntValue();
-		int value = FROM_DOUBLE(int, firstValue, secondValue, percentage, mode);
+		double firstValue = first.GetIntValue();
+		double secondValue = second.GetIntValue();
+		int value = (int)interpolate(firstValue, secondValue, percentage, mode);
 		return TranslucencyLevel(value, true);
 	}
 }

--- a/src/Utilities/Interpolation.h
+++ b/src/Utilities/Interpolation.h
@@ -8,6 +8,7 @@ namespace detail
 	template <typename T>
 	inline T interpolate(T& first, T& second, double percentage, InterpolationMode mode)
 	{
+		static_assert((sizeof(T) == 0), "interpolate<T> should not be instantiated, create and use a specialization.");
 		return first;
 	}
 

--- a/src/Utilities/Savegame.h
+++ b/src/Utilities/Savegame.h
@@ -8,6 +8,23 @@
 namespace Savegame
 {
 	template <typename T>
+	concept ImplementsUpperCaseSaveLoad = requires (PhobosStreamWriter& stmWriter, PhobosStreamReader& stmReader, T& value, bool registerForChange)
+	{
+		value.Save(stmWriter);
+		value.Load(stmReader, registerForChange);
+	};
+
+	template <typename T>
+	concept ImplementsLowerCaseSaveLoad = requires (PhobosStreamWriter & stmWriter, PhobosStreamReader & stmReader, T& value, bool registerForChange)
+	{
+		value.save(stmWriter);
+		value.load(stmReader, registerForChange);
+	};
+
+	template <typename T>
+	concept ImplementsSaveLoad = ImplementsUpperCaseSaveLoad<T> || ImplementsLowerCaseSaveLoad<T>;
+
+	template <typename T>
 	bool ReadPhobosStream(PhobosStreamReader& Stm, T& Value, bool RegisterForChange = true);
 
 	template <typename T>

--- a/src/Utilities/Savegame.h
+++ b/src/Utilities/Savegame.h
@@ -15,7 +15,7 @@ namespace Savegame
 	};
 
 	template <typename T>
-	concept ImplementsLowerCaseSaveLoad = requires (PhobosStreamWriter & stmWriter, PhobosStreamReader & stmReader, T& value, bool registerForChange)
+	concept ImplementsLowerCaseSaveLoad = requires (PhobosStreamWriter& stmWriter, PhobosStreamReader& stmReader, T& value, bool registerForChange)
 	{
 		value.save(stmWriter);
 		value.load(stmReader, registerForChange);

--- a/src/Utilities/SavegameDef.h
+++ b/src/Utilities/SavegameDef.h
@@ -22,20 +22,6 @@
 
 namespace Savegame
 {
-	template <typename T>
-	concept ImplementsUpperCaseSaveLoad = requires (PhobosStreamWriter & stmWriter, PhobosStreamReader & stmReader, T & value, bool registerForChange)
-	{
-		value.Save(stmWriter);
-		value.Load(stmReader, registerForChange);
-	};
-
-	template <typename T>
-	concept ImplementsLowerCaseSaveLoad = requires (PhobosStreamWriter & stmWriter, PhobosStreamReader & stmReader, T & value, bool registerForChange)
-	{
-		value.save(stmWriter);
-		value.load(stmReader, registerForChange);
-	};
-
 	#pragma warning(push)
 	#pragma warning(disable: 4702) // MSVC isn't smart enough and yells about unreachable code
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -38,7 +38,7 @@
 #include <FootClass.h>
 
 #include "Savegame.h"
-#include "Interpolation.h"
+#include "Enum.h"
 
 class INI_EX;
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -38,6 +38,7 @@
 #include <FootClass.h>
 
 #include "Savegame.h"
+#include "Interpolation.h"
 
 class INI_EX;
 
@@ -521,12 +522,6 @@ public:
 			ValueCount = 3;
 		}
 	}
-};
-
-enum class InterpolationMode : BYTE
-{
-	None = 0,
-	Linear = 1
 };
 
 // Designates that the type can read it's value from multiple flags.

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -522,3 +522,93 @@ public:
 		}
 	}
 };
+
+// Designates that the type can read it's value from multiple flags.
+template<typename T>
+concept MultiflagReadable = requires(T obj, INI_EX& const parser, const char* const pSection, const char* const pBaseFlag)
+{
+    { obj.Read(parser, pSection, pBaseFlag) } -> std::same_as<bool>;
+};
+
+template<MultiflagReadable T>
+class MultiflagValueableVector : public ValueableVector<T>
+{
+	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+};
+template<MultiflagReadable T>
+class MultiflagNullableVector : public NullableVector<T>
+{
+	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+};
+
+// Need multiple args or multiple return values? Use std::tuple - Kerbiter
+// template<typename TArg, typename TValue>
+// class Calculatable
+// {
+// public:
+
+// 	virtual TValue Get(TArg const arg) const noexcept = 0;
+
+// 	virtual void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag) = 0;
+
+// 	virtual bool Load(PhobosStreamReader& Stm, bool RegisterForChange) = 0;
+
+// 	virtual bool Save(PhobosStreamWriter& Stm) const = 0;
+// };
+
+// template<typename TArg>
+// class ArgBoundable
+// {
+// public:
+
+// 	virtual Vector2D<TArg> GetArgBounds() const noexcept = 0;
+// };
+
+// template<typename TValue>
+// class ValueBoundable
+// {
+// public:
+
+// 	virtual Vector2D<TValue> GetValueBounds() const noexcept = 0;
+// };
+
+
+template<typename TValue>
+class Animatable // : public Calculatable<double, TValue> //, public ArgBoundable<int>
+{
+public:
+	class KeyframeDataEntry
+	{
+	public:
+		Valueable<double> Percentage;
+		Nullable<int> Frame;
+
+		Valueable<TValue> Value;
+
+		inline bool Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+
+		inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
+
+		inline bool Save(PhobosStreamWriter& Stm) const;
+	};
+
+	MultiflagValueableVector<KeyframeDataEntry> KeyframeData;
+
+	// TODO ctors and stuff
+
+	inline TValue Get(double const percentage) const noexcept;
+
+	// inline TValue Get(int const frame) const noexcept;
+
+	// Vector2D<TArg> GetArgBounds() const noexcept override;
+
+	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+
+	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
+
+	inline bool Save(PhobosStreamWriter& Stm) const;
+};
+
+static_assert(Savegame::ImplementsSaveLoad<Animatable<std::monostate>::KeyframeDataEntry>);
+
+static_assert(Savegame::ImplementsSaveLoad<Animatable<std::monostate>>);

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -523,60 +523,36 @@ public:
 	}
 };
 
+enum class InterpolationMode : BYTE
+{
+	None = 0,
+	Linear = 1
+};
+
 // Designates that the type can read it's value from multiple flags.
 template<typename T, typename... TExtraArgs>
-concept MultiflagReadable = requires(T obj, INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs)
+concept MultiflagReadable = requires(T obj, INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs&... extraArgs)
 {
-    { obj.Read(parser, pSection, pBaseFlag, extraArgs...) } -> std::same_as<bool>;
+	{ obj.Read(parser, pSection, pBaseFlag, extraArgs...) } -> std::same_as<bool>;
 };
 
 template<typename T, typename... TExtraArgs>
 requires MultiflagReadable<T, TExtraArgs...>
 class MultiflagValueableVector : public ValueableVector<T>
 {
-	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs);
+public:
+	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs&... extraArgs);
 };
 template<typename T, typename... TExtraArgs>
 requires MultiflagReadable<T, TExtraArgs...>
 class MultiflagNullableVector : public NullableVector<T>
 {
-	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs);
+public:
+	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs&... extraArgs);
 };
 
-// Need multiple args or multiple return values? Use std::tuple - Kerbiter
-// template<typename TArg, typename TValue>
-// class Calculatable
-// {
-// public:
-
-// 	virtual TValue Get(TArg const arg) const noexcept = 0;
-
-// 	virtual void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag) = 0;
-
-// 	virtual bool Load(PhobosStreamReader& Stm, bool RegisterForChange) = 0;
-
-// 	virtual bool Save(PhobosStreamWriter& Stm) const = 0;
-// };
-
-// template<typename TArg>
-// class ArgBoundable
-// {
-// public:
-
-// 	virtual Vector2D<TArg> GetArgBounds() const noexcept = 0;
-// };
-
-// template<typename TValue>
-// class ValueBoundable
-// {
-// public:
-
-// 	virtual Vector2D<TValue> GetValueBounds() const noexcept = 0;
-// };
-
-
 template<typename TValue>
-class Animatable // : public Calculatable<double, TValue> //, public ArgBoundable<int>
+class Animatable
 {
 public:
 	using absolute_length_t = int;
@@ -584,27 +560,24 @@ public:
 	class KeyframeDataEntry
 	{
 	public:
-		Valueable<double> Percentage;
+		double Percentage;
 		Valueable<TValue> Value;
 
-		inline bool Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength = 0);
+		inline bool Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength = absolute_length_t(0));
 
 		inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 
 		inline bool Save(PhobosStreamWriter& Stm) const;
 	};
 
+	InterpolationMode InterpolationMode;
 	MultiflagValueableVector<KeyframeDataEntry, absolute_length_t> KeyframeData;
 
 	// TODO ctors and stuff
 
 	inline TValue Get(double const percentage) const noexcept;
 
-	// inline TValue Get(int const frame) const noexcept;
-
-	// Vector2D<TArg> GetArgBounds() const noexcept override;
-
-	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength = 0);
+	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength = absolute_length_t(0));
 
 	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -558,7 +558,7 @@ public:
 		double Percentage;
 		Valueable<TValue> Value;
 
-		inline bool Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength = absolute_length_t(0));
+		inline bool Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0));
 
 		inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 
@@ -572,7 +572,7 @@ public:
 
 	inline TValue Get(double const percentage) const noexcept;
 
-	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength = absolute_length_t(0));
+	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0));
 
 	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -568,7 +568,7 @@ public:
 	InterpolationMode InterpolationMode;
 	MultiflagValueableVector<KeyframeDataEntry, absolute_length_t> KeyframeData;
 
-	// TODO ctors and stuff
+	inline bool HasValues() const;
 
 	inline TValue Get(double const percentage) const noexcept;
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -39,6 +39,7 @@
 
 #include "Savegame.h"
 #include "Enum.h"
+#include <map>
 
 class INI_EX;
 
@@ -567,6 +568,7 @@ public:
 
 	InterpolationMode InterpolationMode;
 	MultiflagValueableVector<KeyframeDataEntry, absolute_length_t> KeyframeData;
+	mutable std::map<double, TValue> KeyframeValueCache;
 
 	inline bool HasValues() const;
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -566,6 +566,7 @@ public:
 		inline bool Save(PhobosStreamWriter& Stm) const;
 	};
 
+	TValue DefaultValue;
 	InterpolationMode InterpolationMode;
 	MultiflagValueableVector<KeyframeDataEntry, absolute_length_t> KeyframeData;
 	mutable std::map<double, TValue> KeyframeValueCache;
@@ -574,7 +575,7 @@ public:
 
 	inline TValue Get(double const percentage) const noexcept;
 
-	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0));
+	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0), bool useFallback = true);
 
 	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -524,21 +524,23 @@ public:
 };
 
 // Designates that the type can read it's value from multiple flags.
-template<typename T>
-concept MultiflagReadable = requires(T obj, INI_EX& const parser, const char* const pSection, const char* const pBaseFlag)
+template<typename T, typename... TExtraArgs>
+concept MultiflagReadable = requires(T obj, INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs)
 {
-    { obj.Read(parser, pSection, pBaseFlag) } -> std::same_as<bool>;
+    { obj.Read(parser, pSection, pBaseFlag, extraArgs...) } -> std::same_as<bool>;
 };
 
-template<MultiflagReadable T>
+template<typename T, typename... TExtraArgs>
+requires MultiflagReadable<T, TExtraArgs...>
 class MultiflagValueableVector : public ValueableVector<T>
 {
-	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs);
 };
-template<MultiflagReadable T>
+template<typename T, typename... TExtraArgs>
+requires MultiflagReadable<T, TExtraArgs...>
 class MultiflagNullableVector : public NullableVector<T>
 {
-	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs);
 };
 
 // Need multiple args or multiple return values? Use std::tuple - Kerbiter
@@ -577,22 +579,22 @@ template<typename TValue>
 class Animatable // : public Calculatable<double, TValue> //, public ArgBoundable<int>
 {
 public:
+	using absolute_length_t = int;
+
 	class KeyframeDataEntry
 	{
 	public:
 		Valueable<double> Percentage;
-		Nullable<int> Frame;
-
 		Valueable<TValue> Value;
 
-		inline bool Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+		inline bool Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength = 0);
 
 		inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 
 		inline bool Save(PhobosStreamWriter& Stm) const;
 	};
 
-	MultiflagValueableVector<KeyframeDataEntry> KeyframeData;
+	MultiflagValueableVector<KeyframeDataEntry, absolute_length_t> KeyframeData;
 
 	// TODO ctors and stuff
 
@@ -602,7 +604,7 @@ public:
 
 	// Vector2D<TArg> GetArgBounds() const noexcept override;
 
-	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag);
+	inline void Read(INI_EX& const parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength = 0);
 
 	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -576,7 +576,7 @@ public:
 
 	inline TValue Get(double const percentage) const;
 
-	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0), bool useFallback = true);
+	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0), bool requireParsedFallback = false);
 
 	inline bool Load(PhobosStreamReader& Stm, bool RegisterForChange);
 

--- a/src/Utilities/Template.h
+++ b/src/Utilities/Template.h
@@ -556,7 +556,7 @@ public:
 	class KeyframeDataEntry
 	{
 	public:
-		double Percentage;
+		double Percentage = -1.0;
 		Valueable<TValue> Value;
 
 		inline bool Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0));
@@ -569,11 +569,12 @@ public:
 	TValue DefaultValue;
 	InterpolationMode InterpolationMode;
 	MultiflagValueableVector<KeyframeDataEntry, absolute_length_t> KeyframeData;
+	std::vector<KeyframeDataEntry> SortedKeyFrames;
 	mutable std::map<double, TValue> KeyframeValueCache;
 
 	inline bool HasValues() const;
 
-	inline TValue Get(double const percentage) const noexcept;
+	inline TValue Get(double const percentage) const;
 
 	inline void Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength = absolute_length_t(0), bool useFallback = true);
 

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1246,6 +1246,30 @@ if(_strcmpi(parser.value(), #name) == 0){ value = __uuidof(name ## LocomotionCla
 	}
 
 	template <>
+	inline bool read<InterpolationMode>(InterpolationMode& value, INI_EX& parser, const char* pSection, const char* pKey)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			auto str = parser.value();
+			if (_strcmpi(str, "none") == 0)
+			{
+				value = InterpolationMode::None;
+			}
+			else if (_strcmpi(str, "linear") == 0)
+			{
+				value = InterpolationMode::Linear;
+			}
+			else
+			{
+				Debug::INIParseFailed(pSection, pKey, str, "Expected an interpolation mode");
+				return false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	template <>
 	inline bool read<HorizontalPosition>(HorizontalPosition& value, INI_EX& parser, const char* pSection, const char* pKey)
 	{
 		if (parser.ReadString(pSection, pKey))
@@ -1600,9 +1624,69 @@ if(_strcmpi(parser.value(), #name) == 0){ value = __uuidof(name ## LocomotionCla
 		}
 	}
 
-	// TODO detail::interpolate
-}
+	// Generic type interpolation, does not actually do interpolation.
+	template <typename T>
+	inline T interpolate(T& first, T& second, double percentage, InterpolationMode mode)
+	{
+		return first;
+	}
 
+	template <>
+	inline int interpolate<int>(int& first, int& second, double percentage, InterpolationMode mode)
+	{
+		int result = first;
+
+		switch (mode)
+		{
+			case InterpolationMode::Linear:
+				result = static_cast<int>(first + ((second - first) * percentage));
+				break;
+			default:
+				break;
+		}
+
+		return result;
+	}
+
+	template <>
+	inline double interpolate<double>(double& first, double& second, double percentage, InterpolationMode mode)
+	{
+		double result = first;
+
+		switch (mode)
+		{
+		case InterpolationMode::Linear:
+			result = first + ((second - first) * percentage);
+			break;
+		default:
+			break;
+		}
+
+		return result;
+	}
+
+	template <>
+	inline ColorStruct interpolate<ColorStruct>(ColorStruct& first, ColorStruct& second, double percentage, InterpolationMode mode)
+	{
+		ColorStruct result = first;
+
+		switch (mode)
+		{
+		case InterpolationMode::Linear:
+		{
+			BYTE r = static_cast<BYTE>(first.R + ((second.R - first.R) * percentage));
+			BYTE g = static_cast<BYTE>(first.G + ((second.G - first.G) * percentage));
+			BYTE b = static_cast<BYTE>(first.B + ((second.B - first.B) * percentage));
+			result = ColorStruct { r, g, b };
+			break;
+		}
+		default:
+			break;
+		}
+
+		return result;
+	}
+}
 
 // Valueable
 
@@ -1710,7 +1794,6 @@ void __declspec(noinline) NullableIdx<Lookuper>::Read(INI_EX& parser, const char
 		}
 	}
 }
-
 
 // Promotable
 
@@ -1940,7 +2023,6 @@ void __declspec(noinline) ValueableIdxVector<Lookuper>::Read(INI_EX& parser, con
 	}
 }
 
-
 // NullableIdxVector
 
 template <typename Lookuper>
@@ -2001,7 +2083,7 @@ bool Damageable<T>::Save(PhobosStreamWriter& Stm) const
 
 template<typename T, typename... TExtraArgs>
 requires MultiflagReadable<T, TExtraArgs...>
-void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs)
+void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs&... extraArgs)
 {
 	char flagName[0x40];
 	for (size_t i = 0; ; ++i)
@@ -2009,7 +2091,7 @@ void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_E
 		T dataEntry {};
 
 		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
-		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%%s");
+		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
 
 		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
 			break;
@@ -2022,7 +2104,7 @@ void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_E
 
 template<typename T, typename... TExtraArgs>
 requires MultiflagReadable<T, TExtraArgs...>
-void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs)
+void __declspec(noinline) MultiflagNullableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs&... extraArgs)
 {
 	char flagName[0x40];
 	for (size_t i = 0; ; ++i)
@@ -2030,7 +2112,7 @@ void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_E
 		T dataEntry {};
 
 		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
-		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%%s");
+		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
 
 		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
 			break;
@@ -2045,23 +2127,26 @@ void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_E
 // Animatable::KeyframeDataEntry
 
 template <typename TValue>
-bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength)
+bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength)
 {
 	char flagName[0x40];
 
+	Nullable<double> percentageTemp {};
 	Nullable<absolute_length_t> absoluteTemp {};
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Percentage");
-	this->Percentage.Read(parser, pSection, flagName);
+	percentageTemp.Read(parser, pSection, flagName);
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Absolute");
 	absoluteTemp.Read(parser, pSection, flagName);
 
-	if (!this->Frame.HasValue && !absoluteTemp.HasValue)
+	if (!percentageTemp.isset() && !absoluteTemp.isset())
 		return false;
 
-	if (absoluteTemp.HasValue)
-		this->Percentage.Value = (double)absoluteTemp.Value / absoluteLength;
+	if (absoluteTemp.isset())
+		this->Percentage = (double)absoluteTemp / absoluteLength;
+	else
+		this->Percentage = percentageTemp;
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Value");
 	this->Value.Read(parser, pSection, flagName);
@@ -2073,7 +2158,6 @@ template <typename TValue>
 bool Animatable<TValue>::KeyframeDataEntry::Load(PhobosStreamReader& Stm, bool RegisterForChange)
 {
 	return Savegame::ReadPhobosStream(Stm, this->Percentage, RegisterForChange)
-		&& Savegame::ReadPhobosStream(Stm, this->Frame, RegisterForChange)
 		&& Savegame::ReadPhobosStream(Stm, this->Value, RegisterForChange);
 }
 
@@ -2081,26 +2165,55 @@ template <typename TValue>
 bool Animatable<TValue>::KeyframeDataEntry::Save(PhobosStreamWriter& Stm) const
 {
 	return Savegame::WritePhobosStream(Stm, this->Percentage)
-		&& Savegame::WritePhobosStream(Stm, this->Frame)
 		&& Savegame::WritePhobosStream(Stm, this->Value);
 }
-
 
 template <typename TValue>
 TValue Animatable<TValue>::Get(double const percentage) const noexcept
 {
-	return detail::interpolate<TValue>(percentage);  // TODO
+	// This currently assumes the keyframes are ordered and there are no duplicates for same frame/percentage.
+	// Thing is still far from lightweight as searching for the correct items requires going through the vector.
+
+	TValue match {};
+	double startPercentage = 0.0;
+	size_t i = this->KeyframeData.size() - 1;
+
+	for (; i >= 0; i--)
+	{
+		auto const value = this->KeyframeData[i];
+
+		if (percentage >= value.Percentage)
+		{
+			startPercentage = value.Percentage;
+			match = value.Value;
+			break;
+		}
+	}
+
+	// Only interpolate if an interpolation mode is enabled and there's keyframes remaining.
+	if (this->InterpolationMode != InterpolationMode::None && i + 1 < this->KeyframeData.size())
+	{
+		auto const value = this->KeyframeData[i + 1];
+		TValue nextValue = value.Value;
+		double progressPercentage = (percentage - startPercentage) / (value.Percentage - startPercentage);
+		return detail::interpolate(match, nextValue, progressPercentage, this->InterpolationMode);
+	}
+
+	return match;
 }
 
 template <typename TValue>
-void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength)
+void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength)
 {
 	char flagName[0x40];
 
 	// we expect "BaseFlagName.%s" here
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%%d.%%s");
-
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%d.%s");
 	this->KeyframeData.Read(parser, pSection, flagName, absoluteLength);
+
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Interpolation");
+	detail::read(this->InterpolationMode, parser, pSection, flagName);
+	
 };
 
 template <typename TValue>

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2092,17 +2092,27 @@ bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& pa
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Percentage");
 	percentageTemp.Read(parser, pSection, flagName);
+	bool useNonAbs = true;
 
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Absolute");
-	absoluteTemp.Read(parser, pSection, flagName);
+	if (absoluteLength > absolute_length_t(0))
+	{
+		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Absolute");
+		absoluteTemp.Read(parser, pSection, flagName);
 
-	if (!percentageTemp.isset() && !absoluteTemp.isset())
-		return false;
+		if (absoluteTemp.isset())
+		{
+			this->Percentage = (double)absoluteTemp / absoluteLength;
+			useNonAbs = false;
+		}
+	}
 
-	if (absoluteTemp.isset())
-		this->Percentage = (double)absoluteTemp / absoluteLength;
-	else
-		this->Percentage = percentageTemp;
+	if (useNonAbs)
+	{
+		if (!percentageTemp.isset())
+			return false;
+		else
+			this->Percentage = percentageTemp;
+	}
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Value");
 	this->Value.Read(parser, pSection, flagName);

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1599,6 +1599,8 @@ if(_strcmpi(parser.value(), #name) == 0){ value = __uuidof(name ## LocomotionCla
 				Debug::INIParseFailed(pSection, pKey, pCur);
 		}
 	}
+
+	// TODO detail::interpolate
 }
 
 
@@ -1993,4 +1995,119 @@ bool Damageable<T>::Save(PhobosStreamWriter& Stm) const
 	return Savegame::WritePhobosStream(Stm, this->BaseValue)
 		&& Savegame::WritePhobosStream(Stm, this->ConditionYellow)
 		&& Savegame::WritePhobosStream(Stm, this->ConditionRed);
+}
+
+// MultiflagValueableVector
+
+template <MultiflagReadable T>
+void __declspec(noinline) MultiflagValueableVector<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+{
+	char flagName[0x40];
+	for (size_t i = 0; ; ++i)
+	{
+		T dataEntry {};
+
+		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
+		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%%s");
+
+		if (!dataEntry.Read(parser, pSection, flagName))
+			break;
+
+		this->push_back(dataEntry);
+	}
+}
+
+// MultiflagNullableVector
+
+template <MultiflagReadable T>
+void __declspec(noinline) MultiflagNullableVector<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+{
+	char flagName[0x40];
+	for (size_t i = 0; ; ++i)
+	{
+		T dataEntry {};
+
+		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
+		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%%s");
+
+		if (!dataEntry.Read(parser, pSection, flagName))
+			break;
+
+		this->push_back(dataEntry);
+		this->hasValue = true;
+	}
+}
+
+// Animatable
+
+// Animatable::KeyframeDataEntry
+
+template <typename TValue>
+bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+{
+	char flagName[0x40];
+
+	Nullable<double> percentageTemp {};
+
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Frame");
+	this->Frame.Read(parser, pSection, flagName);
+
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Percentage");
+	percentageTemp.Read(parser, pSection, flagName);
+
+	if (!this->Frame.HasValue && !percentageTemp.HasValue)
+		return false;
+
+	this->Percentage.Value = percentageTemp.Value;
+
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Value");
+	this->Value.Read(parser, pSection, flagName);
+
+	return true;
+};
+
+template <typename TValue>
+bool Animatable<TValue>::KeyframeDataEntry::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
+	return Savegame::ReadPhobosStream(Stm, this->Percentage, RegisterForChange)
+		&& Savegame::ReadPhobosStream(Stm, this->Frame, RegisterForChange)
+		&& Savegame::ReadPhobosStream(Stm, this->Value, RegisterForChange);
+}
+
+template <typename TValue>
+bool Animatable<TValue>::KeyframeDataEntry::Save(PhobosStreamWriter& Stm) const
+{
+	return Savegame::WritePhobosStream(Stm, this->Percentage)
+		&& Savegame::WritePhobosStream(Stm, this->Frame)
+		&& Savegame::WritePhobosStream(Stm, this->Value);
+}
+
+
+template <typename TValue>
+TValue Animatable<TValue>::Get(double const percentage) const noexcept
+{
+	return detail::interpolate<TValue>(percentage);  // TODO
+}
+
+template <typename TValue>
+void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+{
+	char flagName[0x40];
+
+	// we expect "BaseFlagName.%s" here
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%%d.%%s");
+
+	this->KeyframeData.Read(parser, pSection, flagName);
+};
+
+template <typename TValue>
+bool Animatable<TValue>::Load(PhobosStreamReader& Stm, bool RegisterForChange)
+{
+	return Savegame::ReadPhobosStream(Stm, this->KeyframeData, RegisterForChange);
+}
+
+template <typename TValue>
+bool Animatable<TValue>::Save(PhobosStreamWriter& Stm) const
+{
+	return Savegame::WritePhobosStream(Stm, this->KeyframeData);
 }

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2135,6 +2135,12 @@ bool Animatable<TValue>::KeyframeDataEntry::Save(PhobosStreamWriter& Stm) const
 }
 
 template <typename TValue>
+bool Animatable<TValue>::HasValues() const
+{
+	return this->KeyframeData.size() > 0;
+}
+
+template <typename TValue>
 TValue Animatable<TValue>::Get(double const percentage) const noexcept
 {
 	// This currently assumes the keyframes are ordered and there are no duplicates for same frame/percentage.
@@ -2142,7 +2148,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 
 	TValue match {};
 
-	if (!this->KeyframeData.size())
+	if (!this->HasValues())
 		return match;
 
 	double startPercentage = 0.0;

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2203,8 +2203,10 @@ TValue Animatable<TValue>::Get(double const percentage) const
 	return match;
 }
 
+// pBaseFlag - Expects clean INI key name without format strings.
+// requireParsedFallback - If set to true behaves like Nullable<> template and doesn't set default value as fallback if parsing from base INI key fails.
 template <typename TValue>
-void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength, bool useFallback)
+void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength, bool requireParsedFallback)
 {
 	// Set up buffers.
 	char flagName[0x40];
@@ -2223,11 +2225,12 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 
 	if (!this->HasValues())
 	{
-		if (useFallback)
+		TValue value { DefaultValue };
+		KeyframeDataEntry keyframe {};
+		bool parsed = detail::read(value, parser, pSection, pBaseFlag);
+
+		if (!requireParsedFallback || parsed)
 		{
-			TValue value { DefaultValue };
-			KeyframeDataEntry keyframe {};
-			detail::read(value, parser, pSection, pBaseFlag);
 			keyframe.Percentage = 0.0;
 			keyframe.Value = value;
 			this->KeyframeData.push_back(keyframe);

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2269,7 +2269,7 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 			foundError = true;
 		}
 
-		if (value.Percentage <= 0.0)
+		if (value.Percentage < 0.0)
 		{
 			Debug::Log("[Developer warning] [%s] %s has invalid keyframe percentage value %.3f.\n", pSection, flagName, value.Percentage);
 			foundError = true;

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2018,33 +2018,76 @@ bool Damageable<T>::Save(PhobosStreamWriter& Stm) const
 		&& Savegame::WritePhobosStream(Stm, this->ConditionRed);
 }
 
+namespace MultiflagVectorHelpers
+{
+	inline bool ShouldResetValues(INI_EX& parser, const char* pSection, const char* pBaseFlag)
+	{
+		char flagName[256];
+		const char* dot = strchr(pBaseFlag, '.');
+
+		if (dot)
+		{
+			size_t prefixLen = static_cast<size_t>(dot - pBaseFlag) + 1;
+
+			strncpy_s(flagName, sizeof(flagName), pBaseFlag, prefixLen);
+			flagName[prefixLen] = '\0';
+
+			strcat_s(flagName, sizeof(flagName), "ResetValues");
+		}
+		else
+		{
+			_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.ResetValues", pBaseFlag);
+		}
+
+		Valueable<bool> resetValues {};
+		resetValues.Read(parser, pSection, flagName);
+		return resetValues.Get();
+	}
+
+	template<typename Vec, typename T, typename... TExtraArgs>
+	void ReadVectorBase(Vec& vec, bool& hasValue, INI_EX& parser, const char* pSection, const char* pBaseFlag, TExtraArgs&... extraArgs)
+	{
+		char flagName[0x40];
+
+		for (size_t i = 0; ; ++i)
+		{
+			_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
+
+			if (i < vec.size())
+			{
+				T temp = vec[i];
+
+				if (!temp.Read(parser, pSection, flagName, extraArgs...))
+					continue;
+
+				vec[i] = std::move(temp);
+			}
+			else
+			{
+				T dataEntry {};
+
+				if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
+					break;
+
+				vec.push_back(std::move(dataEntry));
+			}
+
+			hasValue = true;
+		}
+	}
+}
+
 // MultiflagValueableVector
 
 template<typename T, typename... TExtraArgs>
 requires MultiflagReadable<T, TExtraArgs...>
 void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs&... extraArgs)
 {
-	char flagName[0x40];
-	for (size_t i = 0; ; ++i)
-	{
-		T dataEntry {};
+	if (MultiflagVectorHelpers::ShouldResetValues(parser, pSection, pBaseFlag))
+		this->clear();
 
-		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
-		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
-
-		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
-		{
-			if (i < this->size())
-				continue;
-			else
-				break;
-		}
-
-		if (this->size() > i)
-			this->at(i) = dataEntry;
-		else
-			this->push_back(dataEntry);
-	}
+	bool dummyHasValue = false;
+	MultiflagVectorHelpers::ReadVectorBase<decltype(*this), T>(*this, dummyHasValue, parser, pSection, pBaseFlag, extraArgs...);
 }
 
 // MultiflagNullableVector
@@ -2053,29 +2096,10 @@ template<typename T, typename... TExtraArgs>
 requires MultiflagReadable<T, TExtraArgs...>
 void __declspec(noinline) MultiflagNullableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs&... extraArgs)
 {
-	char flagName[0x40];
-	for (size_t i = 0; ; ++i)
-	{
-		T dataEntry {};
+	if (MultiflagVectorHelpers::ShouldResetValues(parser, pSection, pBaseFlag))
+		this->clear();
 
-		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
-		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
-
-		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
-		{
-			if (i < this->size())
-				continue;
-			else
-				break;
-		}
-
-		if (this->size() > i)
-			this->at(i) = dataEntry;
-		else
-			this->push_back(dataEntry);
-
-		this->hasValue = true;
-	}
+	MultiflagVectorHelpers::ReadVectorBase<decltype(*this), T>(*this, this->hasValue, parser, pSection, pBaseFlag, extraArgs...);
 }
 
 // Animatable
@@ -2086,13 +2110,14 @@ template <typename TValue>
 bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength)
 {
 	char flagName[0x40];
-
 	Nullable<double> percentageTemp {};
 	Nullable<absolute_length_t> absoluteTemp {};
-
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Percentage");
 	percentageTemp.Read(parser, pSection, flagName);
 	bool useNonAbs = true;
+
+	if (!percentageTemp.isset() && this->Percentage >= 0.0)
+		percentageTemp = this->Percentage;
 
 	if (absoluteLength > absolute_length_t(0))
 	{
@@ -2108,7 +2133,7 @@ bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& pa
 
 	if (useNonAbs)
 	{
-		if (!percentageTemp.isset())
+		if (!percentageTemp.isset() || percentageTemp < 0.0)
 			return false;
 		else
 			this->Percentage = percentageTemp;
@@ -2116,7 +2141,6 @@ bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& pa
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Value");
 	this->Value.Read(parser, pSection, flagName);
-
 	return true;
 };
 
@@ -2141,7 +2165,7 @@ bool Animatable<TValue>::HasValues() const
 }
 
 template <typename TValue>
-TValue Animatable<TValue>::Get(double const percentage) const noexcept
+TValue Animatable<TValue>::Get(double const percentage) const
 {
 	TValue match {};
 
@@ -2160,8 +2184,8 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 
 	// Binary search for a matching keyframe.
 	auto it = std::lower_bound(
-		this->KeyframeData.begin(),
-		this->KeyframeData.end(),
+		this->SortedKeyFrames.begin(),
+		this->SortedKeyFrames.end(),
 		percentage,
 		[](const KeyframeDataEntry& entry, double p)
 		{
@@ -2170,7 +2194,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	);
 
 	// We found a match.
-	if (it != this->KeyframeData.begin())
+	if (it != this->SortedKeyFrames.begin())
 	{
 		--it;
 		double startPercentage = it->Percentage;
@@ -2178,7 +2202,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 		auto it_next = std::next(it);
 
 		// Only interpolate if an interpolation mode is enabled and there's keyframes remaining.
-		if (this->InterpolationMode != InterpolationMode::None && it_next != this->KeyframeData.end())
+		if (this->InterpolationMode != InterpolationMode::None && it_next != this->SortedKeyFrames.end())
 		{
 			auto const& nextKeyFrame = *it_next;
 			TValue nextValue = nextKeyFrame.Value.Get();
@@ -2188,7 +2212,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	}
 
 	// Add value to cache.
-	this->KeyframeValueCache.emplace(percentage, match);
+	this->KeyframeValueCache.try_emplace(percentage, match);
 
 	return match;
 }
@@ -2201,15 +2225,11 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 	char flagName[0x40];
 	_snprintf_s(baseFlagName, sizeof(baseFlagName), "%s.%%s", pBaseFlag);
 
-	// Reset value cache.
+	// Clear value cache.
 	this->KeyframeValueCache.clear();
 
-	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "ResetData");
-	Valueable<bool> resetData {};
-	resetData.Read(parser, pSection, flagName);
-
-	if (resetData)
-		this->KeyframeData.clear();
+	// Clear sorted keyframes.
+	this->SortedKeyFrames.clear();
 
 	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "Keyframe%d.%s");
 	this->KeyframeData.Read(parser, pSection, flagName, absoluteLength);
@@ -2217,22 +2237,21 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "Interpolation");
 	detail::read(this->InterpolationMode, parser, pSection, flagName);
 
-	if (!this->HasValues() && useFallback)
+	if (!this->HasValues())
 	{
-		TValue value { DefaultValue };
-		KeyframeDataEntry keyframe {};
-		detail::read(value, parser, pSection, pBaseFlag);
-		keyframe.Value = value;
-		this->KeyframeData.push_back(keyframe);
+		if (useFallback)
+		{
+			TValue value { DefaultValue };
+			KeyframeDataEntry keyframe {};
+			detail::read(value, parser, pSection, pBaseFlag);
+			keyframe.Percentage = 0.0;
+			keyframe.Value = value;
+			this->KeyframeData.push_back(keyframe);
+			this->SortedKeyFrames.push_back(keyframe);
+		}
+
 		return;
 	}
-
-	// Sort the keyframe data based on percentages.
-	std::sort(KeyframeData.begin(), KeyframeData.end(),
-		  [](KeyframeDataEntry const& a, KeyframeDataEntry const& b)
-		  {
-			  return a.Percentage < b.Percentage;
-		  });
 
 	// Error handling
 	bool foundError = false;
@@ -2250,19 +2269,36 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 			foundError = true;
 		}
 
+		if (value.Percentage <= 0.0)
+		{
+			Debug::Log("[Developer warning] [%s] %s has invalid keyframe percentage value %.3f.\n", pSection, flagName, value.Percentage);
+			foundError = true;
+		}
+
 		percentages.insert(value.Percentage);
 	}
 
 	if (foundError)
-	{
-		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "%s");
-		int len = strlen(pBaseFlag);
+		Debug::FatalErrorAndExit("[%s] '%s' has invalid keyframe data defined. Check debug log for more details.\n", pSection, pBaseFlag);
 
-		if (len >= 4)
-			flagName[len - 3] = '\0';
+	// Copy keyframes over to sorted vector.
+	this->SortedKeyFrames.reserve(this->KeyframeData.size());
 
-		Debug::FatalErrorAndExit("[%s] %s has invalid keyframe data defined. Check debug log for more details.\n", pSection, flagName);
-	}
+	std::copy(
+		this->KeyframeData.begin(),
+		this->KeyframeData.end(),
+		std::back_inserter(this->SortedKeyFrames)
+	);
+
+	// Sort keyframes based on percentages.
+	std::sort(
+		this->SortedKeyFrames.begin(),
+		this->SortedKeyFrames.end(),
+		[](KeyframeDataEntry const& a, KeyframeDataEntry const& b)
+		{
+			return a.Percentage < b.Percentage;
+		}
+	);
 };
 
 template <typename TValue>

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1623,69 +1623,6 @@ if(_strcmpi(parser.value(), #name) == 0){ value = __uuidof(name ## LocomotionCla
 				Debug::INIParseFailed(pSection, pKey, pCur);
 		}
 	}
-
-	// Generic type interpolation, does not actually do interpolation.
-	template <typename T>
-	inline T interpolate(T& first, T& second, double percentage, InterpolationMode mode)
-	{
-		return first;
-	}
-
-	template <>
-	inline int interpolate<int>(int& first, int& second, double percentage, InterpolationMode mode)
-	{
-		int result = first;
-
-		switch (mode)
-		{
-			case InterpolationMode::Linear:
-				result = static_cast<int>(first + ((second - first) * percentage));
-				break;
-			default:
-				break;
-		}
-
-		return result;
-	}
-
-	template <>
-	inline double interpolate<double>(double& first, double& second, double percentage, InterpolationMode mode)
-	{
-		double result = first;
-
-		switch (mode)
-		{
-		case InterpolationMode::Linear:
-			result = first + ((second - first) * percentage);
-			break;
-		default:
-			break;
-		}
-
-		return result;
-	}
-
-	template <>
-	inline ColorStruct interpolate<ColorStruct>(ColorStruct& first, ColorStruct& second, double percentage, InterpolationMode mode)
-	{
-		ColorStruct result = first;
-
-		switch (mode)
-		{
-		case InterpolationMode::Linear:
-		{
-			BYTE r = static_cast<BYTE>(first.R + ((second.R - first.R) * percentage));
-			BYTE g = static_cast<BYTE>(first.G + ((second.G - first.G) * percentage));
-			BYTE b = static_cast<BYTE>(first.B + ((second.B - first.B) * percentage));
-			result = ColorStruct { r, g, b };
-			break;
-		}
-		default:
-			break;
-		}
-
-		return result;
-	}
 }
 
 // Valueable

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2143,37 +2143,48 @@ bool Animatable<TValue>::HasValues() const
 template <typename TValue>
 TValue Animatable<TValue>::Get(double const percentage) const noexcept
 {
-	// This currently assumes the keyframes are ordered and there are no duplicates for same frame/percentage.
-	// Thing is still far from lightweight as searching for the correct items requires going through the vector.
-
 	TValue match {};
 
 	if (!this->HasValues())
 		return match;
 
-	double startPercentage = 0.0;
-	int i = this->KeyframeData.size() - 1;
+	// Check if there is cached value for given percentage and return it if found.
+	auto it_cache = KeyframeValueCache.find(percentage);
+	
+	if (it_cache != KeyframeValueCache.end())
+		return it_cache->second;
 
-	for (; i >= 0; i--)
-	{
-		auto const& value = this->KeyframeData[i];
-
-		if (percentage >= value.Percentage)
+	// Binary search for a matching keyframe.
+	auto it = std::lower_bound(
+		KeyframeData.begin(),
+		KeyframeData.end(),
+		percentage,
+		[](const KeyframeDataEntry& entry, double p)
 		{
-			startPercentage = value.Percentage;
-			match = value.Value;
-			break;
+			return entry.Percentage < p;
+		}
+	);
+
+	// We found a match.
+	if (it != KeyframeData.begin())
+	{
+		--it;
+		double startPercentage = it->Percentage;
+		match = it->Value;
+		auto it_next = std::next(it);
+
+		// Only interpolate if an interpolation mode is enabled and there's keyframes remaining.
+		if (this->InterpolationMode != InterpolationMode::None && it_next != KeyframeData.end())
+		{
+			auto const& nextKeyFrame = *it_next;
+			TValue nextValue = nextKeyFrame.Value.Get();
+			double progressPercentage = (percentage - startPercentage) / (nextKeyFrame.Percentage - startPercentage);
+			match = detail::interpolate(match, nextValue, progressPercentage, this->InterpolationMode);
 		}
 	}
 
-	// Only interpolate if an interpolation mode is enabled and there's keyframes remaining.
-	if (this->InterpolationMode != InterpolationMode::None && i >= 0 && (size_t)(i + 1) < this->KeyframeData.size())
-	{
-		auto const& value = this->KeyframeData[i + 1];
-		TValue nextValue = value.Value;
-		double progressPercentage = (percentage - startPercentage) / (value.Percentage - startPercentage);
-		return detail::interpolate(match, nextValue, progressPercentage, this->InterpolationMode);
-	}
+	// Add value to cache.
+	this->KeyframeValueCache.emplace(percentage, match);
 
 	return match;
 }
@@ -2183,6 +2194,9 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 {
 	char flagName[0x40];
 
+	// Reset value cache.
+	this->KeyframeValueCache.clear();
+
 	// we expect "BaseFlagName.%s" here
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%d.%s");
 	this->KeyframeData.Read(parser, pSection, flagName, absoluteLength);
@@ -2190,9 +2204,15 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Interpolation");
 	detail::read(this->InterpolationMode, parser, pSection, flagName);
 
+	// Sort the keyframe data based on percentages.
+	std::sort(KeyframeData.begin(), KeyframeData.end(),
+		  [](KeyframeDataEntry const& a, KeyframeDataEntry const& b)
+		  {
+			  return a.Percentage < b.Percentage;
+		  });
+
 	// Error handling
 	bool foundError = false;
-	double lastPercentage = -DBL_MAX;
 	std::unordered_set<double> percentages;
 
 	for (size_t i = 0; i < this->KeyframeData.size(); i++)
@@ -2207,14 +2227,7 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 			foundError = true;
 		}
 
-		if (lastPercentage > value.Percentage)
-		{
-			Debug::Log("[Developer warning] [%s] %s has keyframe out of order (%.3f after previous keyframe of %.3f).\n", pSection, flagName, value.Percentage, lastPercentage);
-			foundError = true;
-		}
-
 		percentages.insert(value.Percentage);
-		lastPercentage = value.Percentage;
 	}
 
 	if (foundError)

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -61,6 +61,8 @@
 #include <LocomotionClass.h>
 #include <Locomotion/TestLocomotionClass.h>
 
+#include <unordered_set>
+
 namespace detail
 {
 	template <typename T, bool allocate = false>
@@ -2121,7 +2123,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 
 	for (; i >= 0; i--)
 	{
-		auto const value = this->KeyframeData[i];
+		auto const& value = this->KeyframeData[i];
 
 		if (percentage >= value.Percentage)
 		{
@@ -2134,7 +2136,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	// Only interpolate if an interpolation mode is enabled and there's keyframes remaining.
 	if (this->InterpolationMode != InterpolationMode::None && i >= 0 && (size_t)(i + 1) < this->KeyframeData.size())
 	{
-		auto const value = this->KeyframeData[i + 1];
+		auto const& value = this->KeyframeData[i + 1];
 		TValue nextValue = value.Value;
 		double progressPercentage = (percentage - startPercentage) / (value.Percentage - startPercentage);
 		return detail::interpolate(match, nextValue, progressPercentage, this->InterpolationMode);
@@ -2154,7 +2156,44 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Interpolation");
 	detail::read(this->InterpolationMode, parser, pSection, flagName);
-	
+
+	// Error handling
+	bool foundError = false;
+	double lastPercentage = -DBL_MAX;
+	std::unordered_set<double> percentages;
+
+	for (size_t i = 0; i < this->KeyframeData.size(); i++)
+	{
+		auto const& value = this->KeyframeData[i];
+		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%d");
+		_snprintf_s(flagName, sizeof(flagName), flagName, i);
+
+		if (percentages.contains(value.Percentage))
+		{
+			Debug::Log("[Developer warning] [%s] %s has duplicated keyframe %.3f.\n", pSection, flagName, value.Percentage);
+			foundError = true;
+		}
+
+		if (lastPercentage > value.Percentage)
+		{
+			Debug::Log("[Developer warning] [%s] %s has keyframe out of order (%.3f after previous value keyframe of %.3f).\n", pSection, flagName, value.Percentage, lastPercentage);
+			foundError = true;
+		}
+
+		percentages.insert(value.Percentage);
+		lastPercentage = value.Percentage;
+	}
+
+	if (foundError)
+	{
+		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "%s");
+		int len = strlen(pBaseFlag);
+
+		if (len >= 4)
+			flagName[len - 3] = '\0';
+
+		Debug::FatalErrorAndExit("[%s] %s has invalid keyframe data defined. Check debug log for more details.\n", pSection, flagName);
+	}
 };
 
 template <typename TValue>

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2033,9 +2033,17 @@ void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_E
 		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
 
 		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
-			break;
+		{
+			if (i < this->size())
+				continue;
+			else
+				break;
+		}
 
-		this->push_back(dataEntry);
+		if (this->size() > i)
+			this->at(i) = dataEntry;
+		else
+			this->push_back(dataEntry);
 	}
 }
 
@@ -2054,9 +2062,18 @@ void __declspec(noinline) MultiflagNullableVector<T, TExtraArgs...>::Read(INI_EX
 		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
 
 		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
-			break;
+		{
+			if (i < this->size())
+				continue;
+			else
+				break;
+		}
 
-		this->push_back(dataEntry);
+		if (this->size() > i)
+			this->at(i) = dataEntry;
+		else
+			this->push_back(dataEntry);
+
 		this->hasValue = true;
 	}
 }
@@ -2176,7 +2193,7 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 
 		if (lastPercentage > value.Percentage)
 		{
-			Debug::Log("[Developer warning] [%s] %s has keyframe out of order (%.3f after previous value keyframe of %.3f).\n", pSection, flagName, value.Percentage, lastPercentage);
+			Debug::Log("[Developer warning] [%s] %s has keyframe out of order (%.3f after previous keyframe of %.3f).\n", pSection, flagName, value.Percentage, lastPercentage);
 			foundError = true;
 		}
 

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2023,21 +2023,7 @@ namespace MultiflagVectorHelpers
 	inline bool ShouldResetValues(INI_EX& parser, const char* pSection, const char* pBaseFlag)
 	{
 		char flagName[256];
-		const char* dot = strchr(pBaseFlag, '.');
-
-		if (dot)
-		{
-			size_t prefixLen = static_cast<size_t>(dot - pBaseFlag) + 1;
-
-			strncpy_s(flagName, sizeof(flagName), pBaseFlag, prefixLen);
-			flagName[prefixLen] = '\0';
-
-			strcat_s(flagName, sizeof(flagName), "ResetValues");
-		}
-		else
-		{
-			_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.ResetValues", pBaseFlag);
-		}
+		_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.ResetValues", pBaseFlag);
 
 		Valueable<bool> resetValues {};
 		resetValues.Read(parser, pSection, flagName);
@@ -2051,7 +2037,7 @@ namespace MultiflagVectorHelpers
 
 		for (size_t i = 0; ; ++i)
 		{
-			_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%s");
+			_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s%zu", pBaseFlag, i);
 
 			if (i < vec.size())
 			{
@@ -2112,7 +2098,7 @@ bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& pa
 	char flagName[0x40];
 	Nullable<double> percentageTemp {};
 	Nullable<absolute_length_t> absoluteTemp {};
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Percentage");
+	_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.Percentage", pBaseFlag);
 	percentageTemp.Read(parser, pSection, flagName);
 	bool useNonAbs = true;
 
@@ -2121,7 +2107,7 @@ bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& pa
 
 	if (absoluteLength > absolute_length_t(0))
 	{
-		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Absolute");
+		_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.Absolute", pBaseFlag);
 		absoluteTemp.Read(parser, pSection, flagName);
 
 		if (absoluteTemp.isset())
@@ -2139,7 +2125,7 @@ bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& pa
 			this->Percentage = percentageTemp;
 	}
 
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Value");
+	_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.Value", pBaseFlag);
 	this->Value.Read(parser, pSection, flagName);
 	return true;
 };
@@ -2178,7 +2164,7 @@ TValue Animatable<TValue>::Get(double const percentage) const
 
 	// Check if there is cached value for given percentage and return it if found.
 	auto it_cache = KeyframeValueCache.find(percentage);
-	
+
 	if (it_cache != KeyframeValueCache.end())
 		return it_cache->second;
 
@@ -2221,9 +2207,7 @@ template <typename TValue>
 void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength, bool useFallback)
 {
 	// Set up buffers.
-	char baseFlagName[0x40];
 	char flagName[0x40];
-	_snprintf_s(baseFlagName, sizeof(baseFlagName), "%s.%%s", pBaseFlag);
 
 	// Clear value cache.
 	this->KeyframeValueCache.clear();
@@ -2231,10 +2215,10 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 	// Clear sorted keyframes.
 	this->SortedKeyFrames.clear();
 
-	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "Keyframe%d.%s");
+	_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.Keyframe", pBaseFlag);
 	this->KeyframeData.Read(parser, pSection, flagName, absoluteLength);
 
-	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "Interpolation");
+	_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.Interpolation", pBaseFlag);
 	detail::read(this->InterpolationMode, parser, pSection, flagName);
 
 	if (!this->HasValues())
@@ -2260,8 +2244,7 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 	for (size_t i = 0; i < this->KeyframeData.size(); i++)
 	{
 		auto const& value = this->KeyframeData[i];
-		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%d");
-		_snprintf_s(flagName, sizeof(flagName), flagName, i);
+		_snprintf_s(flagName, sizeof(flagName), _TRUNCATE, "%s.Keyframe%zu", pBaseFlag, i);
 
 		if (percentages.contains(value.Percentage))
 		{

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2148,6 +2148,10 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	if (!this->HasValues())
 		return match;
 
+	// Shortcut for fallback keyframe.
+	if (this->KeyframeData.size() == 1 && this->KeyframeData[0].Percentage == 0.0)
+		return this->KeyframeData[0].Value;
+
 	// Check if there is cached value for given percentage and return it if found.
 	auto it_cache = KeyframeValueCache.find(percentage);
 	
@@ -2156,8 +2160,8 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 
 	// Binary search for a matching keyframe.
 	auto it = std::lower_bound(
-		KeyframeData.begin(),
-		KeyframeData.end(),
+		this->KeyframeData.begin(),
+		this->KeyframeData.end(),
 		percentage,
 		[](const KeyframeDataEntry& entry, double p)
 		{
@@ -2166,7 +2170,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	);
 
 	// We found a match.
-	if (it != KeyframeData.begin())
+	if (it != this->KeyframeData.begin())
 	{
 		--it;
 		double startPercentage = it->Percentage;
@@ -2174,7 +2178,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 		auto it_next = std::next(it);
 
 		// Only interpolate if an interpolation mode is enabled and there's keyframes remaining.
-		if (this->InterpolationMode != InterpolationMode::None && it_next != KeyframeData.end())
+		if (this->InterpolationMode != InterpolationMode::None && it_next != this->KeyframeData.end())
 		{
 			auto const& nextKeyFrame = *it_next;
 			TValue nextValue = nextKeyFrame.Value.Get();
@@ -2189,27 +2193,39 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	return match;
 }
 
-// pBaseFlag is expected to be in format "BaseFlagName.%s".
 template <typename TValue>
-void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength)
+void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength, bool useFallback)
 {
+	// Set up buffers.
+	char baseFlagName[0x40];
 	char flagName[0x40];
+	_snprintf_s(baseFlagName, sizeof(baseFlagName), "%s.%%s", pBaseFlag);
 
 	// Reset value cache.
 	this->KeyframeValueCache.clear();
-	
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "ResetData");
+
+	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "ResetData");
 	Valueable<bool> resetData {};
 	resetData.Read(parser, pSection, flagName);
 
 	if (resetData)
 		this->KeyframeData.clear();
 
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%d.%s");
+	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "Keyframe%d.%s");
 	this->KeyframeData.Read(parser, pSection, flagName, absoluteLength);
 
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Interpolation");
+	_snprintf_s(flagName, sizeof(flagName), baseFlagName, "Interpolation");
 	detail::read(this->InterpolationMode, parser, pSection, flagName);
+
+	if (!this->HasValues() && useFallback)
+	{
+		TValue value { DefaultValue };
+		KeyframeDataEntry keyframe {};
+		detail::read(value, parser, pSection, pBaseFlag);
+		keyframe.Value = value;
+		this->KeyframeData.push_back(keyframe);
+		return;
+	}
 
 	// Sort the keyframe data based on percentages.
 	std::sort(KeyframeData.begin(), KeyframeData.end(),

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2064,7 +2064,7 @@ void __declspec(noinline) MultiflagNullableVector<T, TExtraArgs...>::Read(INI_EX
 // Animatable::KeyframeDataEntry
 
 template <typename TValue>
-bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength)
+bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength)
 {
 	char flagName[0x40];
 
@@ -2112,8 +2112,12 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	// Thing is still far from lightweight as searching for the correct items requires going through the vector.
 
 	TValue match {};
+
+	if (!this->KeyframeData.size())
+		return match;
+
 	double startPercentage = 0.0;
-	size_t i = this->KeyframeData.size() - 1;
+	int i = this->KeyframeData.size() - 1;
 
 	for (; i >= 0; i--)
 	{
@@ -2128,7 +2132,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	}
 
 	// Only interpolate if an interpolation mode is enabled and there's keyframes remaining.
-	if (this->InterpolationMode != InterpolationMode::None && i + 1 < this->KeyframeData.size())
+	if (this->InterpolationMode != InterpolationMode::None && i >= 0 && (size_t)(i + 1) < this->KeyframeData.size())
 	{
 		auto const value = this->KeyframeData[i + 1];
 		TValue nextValue = value.Value;
@@ -2140,7 +2144,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 }
 
 template <typename TValue>
-void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& absoluteLength)
+void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength)
 {
 	char flagName[0x40];
 

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -40,6 +40,7 @@
 #include "EnumFunctions.h"
 #include "SavegameDef.h"
 #include "Macro.h"
+#include "Interpolation.h"
 
 #include <InfantryTypeClass.h>
 #include <AircraftTypeClass.h>
@@ -1060,7 +1061,6 @@ namespace detail
 	{
 		return value.Read(parser, pSection, pKey);
 	}
-
 
 	template <>
 	inline bool read<IronCurtainEffect>(IronCurtainEffect& value, INI_EX& parser, const char* pSection, const char* pKey)

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2189,6 +2189,7 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 	return match;
 }
 
+// pBaseFlag is expected to be in format "BaseFlagName.%s".
 template <typename TValue>
 void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t absoluteLength)
 {
@@ -2196,8 +2197,14 @@ void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* c
 
 	// Reset value cache.
 	this->KeyframeValueCache.clear();
+	
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "ResetData");
+	Valueable<bool> resetData {};
+	resetData.Read(parser, pSection, flagName);
 
-	// we expect "BaseFlagName.%s" here
+	if (resetData)
+		this->KeyframeData.clear();
+
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%d.%s");
 	this->KeyframeData.Read(parser, pSection, flagName, absoluteLength);
 

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -1999,8 +1999,9 @@ bool Damageable<T>::Save(PhobosStreamWriter& Stm) const
 
 // MultiflagValueableVector
 
-template <MultiflagReadable T>
-void __declspec(noinline) MultiflagValueableVector<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+template<typename T, typename... TExtraArgs>
+requires MultiflagReadable<T, TExtraArgs...>
+void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs)
 {
 	char flagName[0x40];
 	for (size_t i = 0; ; ++i)
@@ -2010,7 +2011,7 @@ void __declspec(noinline) MultiflagValueableVector<T>::Read(INI_EX& parser, cons
 		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
 		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%%s");
 
-		if (!dataEntry.Read(parser, pSection, flagName))
+		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
 			break;
 
 		this->push_back(dataEntry);
@@ -2019,8 +2020,9 @@ void __declspec(noinline) MultiflagValueableVector<T>::Read(INI_EX& parser, cons
 
 // MultiflagNullableVector
 
-template <MultiflagReadable T>
-void __declspec(noinline) MultiflagNullableVector<T>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+template<typename T, typename... TExtraArgs>
+requires MultiflagReadable<T, TExtraArgs...>
+void __declspec(noinline) MultiflagValueableVector<T, TExtraArgs...>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, TExtraArgs& const... extraArgs)
 {
 	char flagName[0x40];
 	for (size_t i = 0; ; ++i)
@@ -2030,7 +2032,7 @@ void __declspec(noinline) MultiflagNullableVector<T>::Read(INI_EX& parser, const
 		// we expect %d for array number then %s for the subflag name, so we replace %s with itself (but escaped)
 		_snprintf_s(flagName, sizeof(flagName), pBaseFlag, i, "%%s");
 
-		if (!dataEntry.Read(parser, pSection, flagName))
+		if (!dataEntry.Read(parser, pSection, flagName, extraArgs...))
 			break;
 
 		this->push_back(dataEntry);
@@ -2043,22 +2045,23 @@ void __declspec(noinline) MultiflagNullableVector<T>::Read(INI_EX& parser, const
 // Animatable::KeyframeDataEntry
 
 template <typename TValue>
-bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+bool __declspec(noinline) Animatable<TValue>::KeyframeDataEntry::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength)
 {
 	char flagName[0x40];
 
-	Nullable<double> percentageTemp {};
-
-	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Frame");
-	this->Frame.Read(parser, pSection, flagName);
+	Nullable<absolute_length_t> absoluteTemp {};
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Percentage");
-	percentageTemp.Read(parser, pSection, flagName);
+	this->Percentage.Read(parser, pSection, flagName);
 
-	if (!this->Frame.HasValue && !percentageTemp.HasValue)
+	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Absolute");
+	absoluteTemp.Read(parser, pSection, flagName);
+
+	if (!this->Frame.HasValue && !absoluteTemp.HasValue)
 		return false;
 
-	this->Percentage.Value = percentageTemp.Value;
+	if (absoluteTemp.HasValue)
+		this->Percentage.Value = (double)absoluteTemp.Value / absoluteLength;
 
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Value");
 	this->Value.Read(parser, pSection, flagName);
@@ -2090,14 +2093,14 @@ TValue Animatable<TValue>::Get(double const percentage) const noexcept
 }
 
 template <typename TValue>
-void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag)
+void __declspec(noinline) Animatable<TValue>::Read(INI_EX& parser, const char* const pSection, const char* const pBaseFlag, absolute_length_t& const absoluteLength)
 {
 	char flagName[0x40];
 
 	// we expect "BaseFlagName.%s" here
 	_snprintf_s(flagName, sizeof(flagName), pBaseFlag, "Keyframe%%d.%%s");
 
-	this->KeyframeData.Read(parser, pSection, flagName);
+	this->KeyframeData.Read(parser, pSection, flagName, absoluteLength);
 };
 
 template <typename TValue>

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -2041,12 +2041,8 @@ namespace MultiflagVectorHelpers
 
 			if (i < vec.size())
 			{
-				T temp = vec[i];
-
-				if (!temp.Read(parser, pSection, flagName, extraArgs...))
+				if (!vec[i].Read(parser, pSection, flagName, extraArgs...))
 					continue;
-
-				vec[i] = std::move(temp);
 			}
 			else
 			{


### PR DESCRIPTION
Split from #1300 

-------------

### Customizable animation transparency settings

- `Translucency.Cloaked` can be used to override `Translucency` on animations attached to currently cloaked TechnoTypes.
- Both `Translucency` and `Translucency.Cloaked` can use the new keyframe system to animate along with the animation. Read more about the keyframe system below.
- If interpolation is enabled, the keyframe values are clamped to valid transparency values (0,25,50 and 75), e.g a value of 1.5 would become 0 and 56.525 would become 50 and so on.

In `artmd.ini`:
```ini
[SOMEANIM]             ; AnimationType
Translucency=0         ; integer - only accepted values are 75, 50, 25 and 0.
Translucency.Cloaked=  ; integer - only accepted values are 75, 50, 25 and 0.
```

----------------

### Keyframe animations (Animatable template)

- Some features use keyframe-based animation system to define animations in INI. Defined in INI it looks something like following.

```ini
[SOMESECTION]
BASEKEY.KeyframeN.Value=        ; Key-dependant value type
BASEKEY.KeyframeN.Percentage=   ; floating point value, percents or absolute
BASEKEY.KeyframeN.Absolute=     ; integer, zero-based frame index
BASEKEY.Interpolation=none      ; Interpolation mode (none|linear)
BASEKEY.ResetData=false         ; boolean
```

- `BASEKEY` is whatever base key name the feature in question may use. `N` is zero-based keyframe index. If no keyframes are defined, a single value from `BASEKEY` is attempted to be parsed instead.
  - `Value` is a key/feature-dependant value type associated with that keyframe.
  - `Percentage` is the percentage through the animation's frames where the keyframe becomes active. It is also possible to instead use zero-based frame index via `Absolute` which takes precedence over percentage, albeit it is internally converted to a percentage value.
  - `Interpolation` controls interpolation of values between keyframes. The behaviour here may depend on the value type in use, as not all value types may be interpolatable well or at all.
  - `ResetData` if set to true makes it so that all existing keyframe data is reset before parsing. Can be used to reset keyframes when redefining them in map files etc.

```{note}
Keyframes are expected to be defined with no duplicates for Percentage or Absolute. Failure to do so will crash the game and output developer warnings about offending keys to the log.
```