### PR TITLE
[Minor][Needs testing] Attempt to fix the ReloadInTransport crash

### DIFF
--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -416,28 +416,6 @@ HouseClass* HouseExt::GetHouseKind(OwnerHouseKind const kind, bool const allowRa
 	}
 }
 
-void HouseExt::ExtData::UpdateAutoDeathObjectsInLimbo()
-{
-	for (auto const pExt : this->OwnedAutoDeathObjects)
-	{
-		auto const pTechno = pExt->OwnerObject();
-
-		if (!pTechno->IsInLogic && pTechno->IsAlive)
-			pExt->CheckDeathConditions(true);
-	}
-}
-
-void HouseExt::ExtData::UpdateTransportReloaders()
-{
-	for (auto const pExt : this->OwnedTransportReloaders)
-	{
-		auto const pTechno = pExt->OwnerObject();
-
-		if (pTechno->IsAlive && pTechno->Transporter && pTechno->Transporter->IsInLogic)
-			pTechno->Reload();
-	}
-}
-
 void HouseExt::ExtData::AddToLimboTracking(TechnoTypeClass* pTechnoType)
 {
 	if (pTechnoType)
@@ -542,8 +520,6 @@ void HouseExt::ExtData::Serialize(T& Stm)
 	Stm
 		.Process(this->PowerPlantEnhancers)
 		.Process(this->OwnedLimboDeliveredBuildings)
-		.Process(this->OwnedAutoDeathObjects)
-		.Process(this->OwnedTransportReloaders)
 		.Process(this->LimboAircraft)
 		.Process(this->LimboBuildings)
 		.Process(this->LimboInfantry)

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -23,8 +23,6 @@ public:
 	public:
 		std::map<BuildingTypeExt::ExtData*, int> PowerPlantEnhancers;
 		std::vector<BuildingClass*> OwnedLimboDeliveredBuildings;
-		std::vector<TechnoExt::ExtData*> OwnedAutoDeathObjects;
-		std::vector<TechnoExt::ExtData*> OwnedTransportReloaders; // Objects that can reload ammo in limbo
 
 		CounterClass LimboAircraft;  // Currently owned aircraft in limbo
 		CounterClass LimboBuildings; // Currently owned buildings in limbo
@@ -46,8 +44,6 @@ public:
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, PowerPlantEnhancers {}
 			, OwnedLimboDeliveredBuildings {}
-			, OwnedAutoDeathObjects {}
-			, OwnedTransportReloaders {}
 			, LimboAircraft {}
 			, LimboBuildings {}
 			, LimboInfantry {}
@@ -63,8 +59,6 @@ public:
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding);
-		void UpdateAutoDeathObjectsInLimbo();
-		void UpdateTransportReloaders();
 		void AddToLimboTracking(TechnoTypeClass* pTechnoType);
 		void RemoveFromLimboTracking(TechnoTypeClass* pTechnoType);
 		int CountOwnedPresentAndLimboed(TechnoTypeClass* pTechnoType);

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -1,21 +1,10 @@
 #include "Body.h"
 
 #include <Ext/Aircraft/Body.h>
+#include <Ext/Scenario/Body.h>
 #include "Ext/Techno/Body.h"
 #include "Ext/Building/Body.h"
 #include <unordered_map>
-
-DEFINE_HOOK(0x4F8440, HouseClass_Update_Beginning, 0x5)
-{
-	GET(HouseClass* const, pThis, ECX);
-
-	auto pExt = HouseExt::ExtMap.Find(pThis);
-
-	pExt->UpdateAutoDeathObjectsInLimbo();
-	pExt->UpdateTransportReloaders();
-
-	return 0;
-}
 
 DEFINE_HOOK(0x508C30, HouseClass_UpdatePower_UpdateCounter, 0x5)
 {
@@ -197,10 +186,7 @@ DEFINE_HOOK(0x6F6D85, TechnoClass_Unlimbo_RemoveTracking, 0x6)
 		pExt->HasBeenPlacedOnMap = true;
 
 		if (pExt->TypeExtData->AutoDeath_Behavior.isset())
-		{
-			auto const pOwnerExt = HouseExt::ExtMap.Find(pThis->Owner);
-			pOwnerExt->OwnedAutoDeathObjects.push_back(pExt);
-		}
+			ScenarioExt::Global()->AutoDeathObjects.push_back(pExt);
 	}
 
 	return 0;
@@ -220,21 +206,6 @@ DEFINE_HOOK(0x7015C9, TechnoClass_Captured_UpdateTracking, 0x6)
 	{
 		pOwnerExt->RemoveFromLimboTracking(pType);
 		pNewOwnerExt->AddToLimboTracking(pType);
-	}
-
-	if (pExt->TypeExtData->AutoDeath_Behavior.isset())
-	{
-		auto& vec = pOwnerExt->OwnedAutoDeathObjects;
-		vec.erase(std::remove(vec.begin(), vec.end(), pExt), vec.end());
-		pNewOwnerExt->OwnedAutoDeathObjects.push_back(pExt);
-	}
-
-	if (pThis->Transporter && pThis->WhatAmI() != AbstractType::Aircraft
-		&& pType->Ammo > 0 && pExt->TypeExtData->ReloadInTransport)
-	{
-		auto& vec = pOwnerExt->OwnedTransportReloaders;
-		vec.erase(std::remove(vec.begin(), vec.end(), pExt), vec.end());
-		pNewOwnerExt->OwnedTransportReloaders.push_back(pExt);
 	}
 
 	if (auto pMe = generic_cast<FootClass*>(pThis))

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -11,6 +11,7 @@
 #include "Ext/House/Body.h"
 #include "Ext/WarheadType/Body.h"
 #include "Ext/WeaponType/Body.h"
+#include <Ext/Scenario/Body.h>
 
 // ============= New SuperWeapon Effects================
 
@@ -110,7 +111,7 @@ inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 
 		if (pTechnoTypeExt->AutoDeath_Behavior.isset())
 		{
-			pOwnerExt->OwnedAutoDeathObjects.push_back(pTechnoExt);
+			ScenarioExt::Global()->AutoDeathObjects.push_back(pTechnoExt);
 
 			if (pTechnoTypeExt->AutoDeath_AfterDelay > 0)
 				pTechnoExt->AutoDeathTimer.Start(pTechnoTypeExt->AutoDeath_AfterDelay);

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -93,6 +93,28 @@ void ScenarioExt::LoadFromINIFile(ScenarioClass* pThis, CCINIClass* pINI)
 	Data->LoadFromINI(pINI);
 }
 
+void ScenarioExt::ExtData::UpdateAutoDeathObjectsInLimbo()
+{
+	for (auto const pExt : this->AutoDeathObjects)
+	{
+		auto const pTechno = pExt->OwnerObject();
+
+		if (!pTechno->IsInLogic && pTechno->IsAlive)
+			pExt->CheckDeathConditions(true);
+	}
+}
+
+void ScenarioExt::ExtData::UpdateTransportReloaders()
+{
+	for (auto const pExt : this->TransportReloaders)
+	{
+		auto const pTechno = pExt->OwnerObject();
+
+		if (pTechno->IsAlive && pTechno->Transporter && pTechno->Transporter->IsInLogic)
+			pTechno->Reload();
+	}
+}
+
 // =============================
 // load / save
 
@@ -136,6 +158,8 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->Variables[1])
 		.Process(this->ShowBriefing)
 		.Process(this->BriefingTheme)
+		.Process(this->AutoDeathObjects)
+		.Process(this->TransportReloaders)
 		;
 }
 
@@ -241,6 +265,9 @@ DEFINE_HOOK(0x68AD2F, ScenarioClass_LoadFromINI, 0x5)
 DEFINE_HOOK(0x55B4E1, LogicClass_Update_BeforeAll, 0x5)
 {
 	VeinholeMonsterClass::UpdateAllVeinholes();
+
+	ScenarioExt::Global()->UpdateAutoDeathObjectsInLimbo();
+	ScenarioExt::Global()->UpdateTransportReloaders();
 
 	return 0;
 }

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -6,6 +6,8 @@
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
 
+#include <Ext/Techno/Body.h>
+
 #include <map>
 
 struct ExtendedVariable
@@ -31,11 +33,16 @@ public:
 		std::map<int, CellStruct> Waypoints;
 		std::map<int, ExtendedVariable> Variables[2]; // 0 for local, 1 for global
 
+		std::vector<TechnoExt::ExtData*> AutoDeathObjects;
+		std::vector<TechnoExt::ExtData*> TransportReloaders; // Objects that can reload ammo in limbo
+
 		ExtData(ScenarioClass* OwnerObject) : Extension<ScenarioClass>(OwnerObject)
 			, ShowBriefing { false }
 			, BriefingTheme { -1 }
 			, Waypoints { }
 			, Variables { }
+			, AutoDeathObjects {}
+			, TransportReloaders {}
 		{ }
 
 		void SetVariableToByID(bool bIsGlobal, int nIndex, char bState);
@@ -51,6 +58,9 @@ public:
 
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+		void UpdateAutoDeathObjectsInLimbo();
+		void UpdateTransportReloaders();
 	private:
 		template <typename T>
 		void Serialize(T& Stm);

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -8,6 +8,7 @@
 #include <Ext/Bullet/Body.h>
 #include <Ext/House/Body.h>
 #include <Ext/WeaponType/Body.h>
+#include <Ext/Scenario/Body.h>
 #include <Utilities/EnumFunctions.h>
 #include <Utilities/AresFunctions.h>
 
@@ -438,17 +439,16 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 	// Remove from tracked AutoDeath objects if no longer has AutoDeath
 	if (pOldTypeExt->AutoDeath_Behavior.isset() && !this->TypeExtData->AutoDeath_Behavior.isset())
 	{
-		auto& vec = HouseExt::ExtMap.Find(pThis->Owner)->OwnedAutoDeathObjects;
+		auto& vec = ScenarioExt::Global()->AutoDeathObjects;
 		vec.erase(std::remove(vec.begin(), vec.end(), this), vec.end());
 	}
 
 	auto const rtti = pOldType->WhatAmI();
 
 	// Remove from limbo reloaders if no longer applicable
-	if (rtti != AbstractType::AircraftType && rtti != AbstractType::BuildingType
-		&& pOldType->Ammo > 0 && pOldTypeExt->ReloadInTransport && !this->TypeExtData->ReloadInTransport)
+	if (pOldType->Ammo > 0 && pOldTypeExt->ReloadInTransport && !this->TypeExtData->ReloadInTransport)
 	{
-		auto& vec = HouseExt::ExtMap.Find(pThis->Owner)->OwnedTransportReloaders;
+		auto& vec = ScenarioExt::Global()->TransportReloaders;
 		vec.erase(std::remove(vec.begin(), vec.end(), this), vec.end());
 	}
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -5,7 +5,7 @@
 #include <ScenarioClass.h>
 
 #include <Ext/Anim/Body.h>
-#include <Ext/House/Body.h>
+#include <Ext/Scenario/Body.h>
 
 #include <Utilities/AresFunctions.h>
 
@@ -19,16 +19,14 @@ TechnoExt::ExtData::~ExtData()
 
 	if (pTypeExt->AutoDeath_Behavior.isset())
 	{
-		auto const pOwnerExt = HouseExt::ExtMap.Find(pThis->Owner);
-		auto& vec = pOwnerExt->OwnedAutoDeathObjects;
+		auto& vec = ScenarioExt::Global()->AutoDeathObjects;
 		vec.erase(std::remove(vec.begin(), vec.end(), this), vec.end());
 	}
 
-	if (pThis->WhatAmI() != AbstractType::Aircraft && pThis->WhatAmI() != AbstractType::Building
+	if (pThis->Transporter && pThis->WhatAmI() != AbstractType::Aircraft && pThis->WhatAmI() != AbstractType::Building
 		&& pType->Ammo > 0 && pTypeExt->ReloadInTransport)
 	{
-		auto const pOwnerExt = HouseExt::ExtMap.Find(pThis->Owner);
-		auto& vec = pOwnerExt->OwnedTransportReloaders;
+		auto& vec = ScenarioExt::Global()->TransportReloaders;
 		vec.erase(std::remove(vec.begin(), vec.end(), this), vec.end());
 	}
 

--- a/src/Ext/Techno/Hooks.Transport.cpp
+++ b/src/Ext/Techno/Hooks.Transport.cpp
@@ -1,7 +1,6 @@
 #include "Body.h"
 
-#include <Ext/House/Body.h>
-
+#include <Ext/Scenario/Body.h>
 
 DEFINE_HOOK_AGAIN(0x6FA33C, TechnoClass_ThreatEvals_OpenToppedOwner, 0x6) // TechnoClass::AI
 DEFINE_HOOK_AGAIN(0x6F89F4, TechnoClass_ThreatEvals_OpenToppedOwner, 0x6) // TechnoClass::EvaluateCell
@@ -84,10 +83,10 @@ DEFINE_HOOK(0x71067B, TechnoClass_EnterTransport, 0x7)
 		if (pTransTypeExt->Passengers_SyncOwner && pTransTypeExt->Passengers_SyncOwner_RevertOnExit)
 			pExt->OriginalPassengerOwner = pPassenger->Owner;
 
-		if (pPassenger->WhatAmI() != AbstractType::Aircraft && pType->Ammo > 0 && pExt->TypeExtData->ReloadInTransport)
+		if (pPassenger->WhatAmI() != AbstractType::Aircraft && pPassenger->WhatAmI() != AbstractType::Building
+			&& pType->Ammo > 0 && pExt->TypeExtData->ReloadInTransport)
 		{
-			auto const pOwnerExt = HouseExt::ExtMap.Find(pThis->Owner);
-			pOwnerExt->OwnedTransportReloaders.push_back(pExt);
+			ScenarioExt::Global()->TransportReloaders.push_back(pExt);
 		}
 	}
 
@@ -105,17 +104,18 @@ DEFINE_HOOK(0x4DE722, FootClass_LeaveTransport, 0x6)
 		auto const pExt = TechnoExt::ExtMap.Find(pPassenger);
 		auto const pTransTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
 
+		// Remove from transport reloader list before switching house
+		if (pPassenger->WhatAmI() != AbstractType::Aircraft && pPassenger->WhatAmI() != AbstractType::Building
+			&& pType->Ammo > 0 && pExt->TypeExtData->ReloadInTransport)
+		{
+			auto& vec = ScenarioExt::Global()->TransportReloaders;
+			vec.erase(std::remove(vec.begin(), vec.end(), pExt), vec.end());
+		}
+
 		if (pTransTypeExt->Passengers_SyncOwner && pTransTypeExt->Passengers_SyncOwner_RevertOnExit &&
 			pExt->OriginalPassengerOwner)
 		{
 			pPassenger->SetOwningHouse(pExt->OriginalPassengerOwner, false);
-		}
-
-		if (pThis->WhatAmI() != AbstractType::Aircraft && pType->Ammo > 0 && pExt->TypeExtData->ReloadInTransport)
-		{
-			auto const pOwnerExt = HouseExt::ExtMap.Find(pThis->Owner);
-			auto& vec = pOwnerExt->OwnedTransportReloaders;
-			vec.erase(std::remove(vec.begin(), vec.end(), pExt), vec.end());
 		}
 	}
 


### PR DESCRIPTION
Techno with ReloadInTransport=yes suffered from a crash when the transporter's owner is changed (i.e. being mind controlled). This is because it'll move the techno from the original owner's OwnedTransportReloader list to the new owner's, which is actually wrong when the transporter doesn't have Passengers.SyncOwner=yes. Attempted to fix this issue and unified the conditions of ReloadInTransport