### PR TITLE
[Garbage]This PR did not use a separate branch and has been recommit to # 1327

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
-# 由于本人GitHub账号认证问题，这个仓库在PR合并后会立即删除
-
----
-
-# Due to some issues with my GitHub account, this repository will be immediately deleted after the PR merge
-
----
-# .
-# .
-# .
-# .
-# .
----
 ![Phobos YR Engine Extension](logo.png)
 
 [![Github All Releases](https://img.shields.io/github/downloads/Phobos-developers/Phobos/total.svg)](https://github.com/Phobos-developers/Phobos/releases)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# 由于本人GitHub账号认证问题，这个仓库在PR合并后会立即删除
+
+---
+
+# Due to some issues with my GitHub account, this repository will be immediately deleted after the PR merge
+
+---
+# .
+# .
+# .
+# .
+# .
+---
 ![Phobos YR Engine Extension](logo.png)
 
 [![Github All Releases](https://img.shields.io/github/downloads/Phobos-developers/Phobos/total.svg)](https://github.com/Phobos-developers/Phobos/releases)

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -277,14 +277,25 @@ SelectionFlashDuration=0  ; integer, number of frames
     - These vanilla CSF entries will be used: `TXT_SAVING_GAME`, `TXT_GAME_WAS_SAVED` and `TXT_ERROR_SAVING_GAME`.
     - The save should be looks like `Allied Mission 25: Esther's Money - QuickSaved`
 
+### `[ ]` Save Variables
+
+- Save local & global variables to an INI file. See [this](Miscellanous.html#save-variables-to-file) for details.
+- For localization add `TXT_SAVE_VARIABLES` and `TXT_SAVE_VARIABLES_DESC` into your `.csf` file.
+
 ### `[ ]` Toggle Designator Range
 - Switches on/off super weapon designator range indicator. See [this](#show-designator--inhibitor-range) for details.
 - For localization add `TXT_DESIGNATOR_RANGE` and `TXT_DESIGNATOR_RANGE_DESC` into your `.csf` file.
 
 ### `[ ]` Toggle Digital Display
-- Switches on/off [digital gisplay types](#digital-display).
+- Switches on/off [digital display types](#digital-display).
 - For localization add `TXT_DIGITAL_DISPLAY` and `TXT_DIGITAL_DISPLAY_DESC` into your `.csf` file.
 
+### `[ ]` Toggle Frame By Frame Mode
+- Switches on/off [frame by frame mode](Miscellanous.html#frame-step-in).
+- For localization add `TXT_FRAME_BY_FRAME` and `TXT_FRAME_BY_FRAME_DESC` into your `.csf` file.
+```{warning}
+In versions up to and including build43, there was actually an erroneous reading of TXT_DISPLAY_DAMAGE_DESC which should not have been used here, as it was intended for Display Damage Numbers.
+```
 ## Loading screen
 
 - PCX files can now be used as loadscreen images.

--- a/src/Commands/FrameByFrame.cpp
+++ b/src/Commands/FrameByFrame.cpp
@@ -26,7 +26,7 @@ const wchar_t* FrameByFrameCommandClass::GetUICategory() const
 
 const wchar_t* FrameByFrameCommandClass::GetUIDescription() const
 {
-	return GeneralUtils::LoadStringUnlessMissing("TXT_DISPLAY_DAMAGE_DESC", L"Enter or exit frame by frame mode.");
+	return GeneralUtils::LoadStringUnlessMissing("TXT_FRAME_BY_FRAME_DESC", L"Enter or exit frame by frame mode.");
 }
 
 void FrameByFrameCommandClass::Execute(WWKey eInput) const


### PR DESCRIPTION
FrameByFrame mistakenly used the `TXT_DISPLAY_DAMAGE_DESC` originally intended for the Display Damage function.
It has affected my work, so I submitted this PR to make changes.
That's all