### PR TITLE
Scorch / Flamer fire animation spawning customization

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -249,6 +249,7 @@ This page lists all the individual contributions to the project by their author.
   - Light effect customizations
   - Building unit repair customizations
   - Build area customizations
+  - `Scorch` / `Flamer` fire animation customization
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -269,6 +269,41 @@ SplashAnims.PickRandom=false  ; boolean
 ExtraShadow=true              ; boolean
 ```
 
+### Fire animations spawned by Scorch & Flamer
+
+- Tiberian Sun allowed `Scorch=true` and `Flamer=true` animations to spawn fire animations from `[AudioVisual]` -> `SmallFire` & `LargeFire`. This behaviour has been reimplemented and is fully customizable.
+  - `ConstrainFireAnimsToCellSpots` controls whether or not spawned animations are locked to cell spots (e.g the subcell positions infantry are also constrained to).
+  - `FireAnimDisallowedLandTypes` controls which landtypes the fire animations are not allowed to spawn on. Defaults to `water,rock,beach,ice` for `Scorch=true`, `none` otherwise.
+  - `AttachFireAnimsToParent` controls if the spawned animations are attached to the owner of the parent animation if it is also attached. Defaults to true for `Scorch=true`, otherwise false.
+  - `SmallFireCount` determines number of small fire animations to spawn by both `Scorch=true` and `Flamer=true` animations. Defaults to 2 for `Flamer=true`, otherwise 1.
+     - `SmallFireAnims` can be used to set the animation types, defaults to `[AudioVisual]` -> `SmallFire` (single animation).
+     - `SmallFireChances` is a list of probabilities for the animations to spawn, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities. Defaults to `1.0,0.5` for `Flamer=true`, `1.0` otherwise.
+     - `SmallFireDistances` is a list of distances in cells for the animations to spawn at from the parent animation's coordinates, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities. Defaults to `0.25,0.625` for `Flamer=true`, `0.0` otherwise.
+  - `LargeFireCount` determines number of large fire animations to spawn by`Flamer=true` animations only.
+     - `LargeFireAnims` can be used to set the animation types, defaults to `[AudioVisual]` -> `LargeFire` (single animation).
+     - `LargeFireChances` is a list of probabilities for the animations to spawn, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities.
+     - `LargeFireDistances` is a list of distances in cells for the animations to spawn at from the parent animation's coordinates, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities.
+
+In `artmd.ini`:
+```ini
+[SOMEANIM]                          ; AnimationType
+ConstrainFireAnimsToCellSpots=true  ; boolean
+FireAnimDisallowedLandTypes=        ; List of LandTypes (none | clear | road | water | rock | wall | tiberium | beach | rough | ice | railroad | tunnel | weeds)
+AttachFireAnimsToParent=            ; boolean
+SmallFireCount=                     ; integer
+SmallFireAnims=                     ; list of animations
+SmallFireChances=                   ; list of floating point values (percent or absolute)
+SmallFireDistances=                 ; list of floating point values, distance in cells
+LargeFireCount=1                    ; integer
+LargeFireAnims=                     ; list of animations
+LargeFireChances=0.5                ; list of floating point values (percent or absolute)
+LargeFireDistances=0.4375           ; list of floating point values, distance in cells
+```
+
+```{note}
+Save for the change that `Flamer? does not spawn animations if the parent animation is in air, the default settings should provide identical results to similar feature from Ares.
+```
+
 ### Layer on animations attached to objects
 
 - You can now customize whether or not animations attached to objects follow the object's layer or respect their own `Layer` setting. If this is unset, attached animations use `ground` layer.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -462,6 +462,7 @@ New:
 - Building unit repair customizations (by Starkku)
 - Toggle to disallow buildings from providing build area during buildup (by Starkku)
 - Allow customizing which building types provide build area for a building (by Starkku)
+- `Scorch` / `Flamer` fire animation customization (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -239,6 +239,104 @@ void AnimExt::HandleDebrisImpact(AnimTypeClass* pExpireAnim, AnimTypeClass* pWak
 	}
 }
 
+void AnimExt::SpawnFireAnims(AnimClass* pThis)
+{
+	auto const pType = pThis->Type;
+	auto const pExt = AnimExt::ExtMap.Find(pThis);
+	auto const pTypeExt = AnimTypeExt::ExtMap.Find(pType);
+	auto const coords = pThis->GetCoords();
+
+	auto SpawnAnim = [&coords, pThis, pExt](AnimTypeClass* pType, int distance, bool constrainToCellSpots, bool attach)
+		{
+			if (!pType)
+				return;
+
+			CoordStruct newCoords = coords;
+
+			if (distance > 0)
+			{
+				newCoords = MapClass::GetRandomCoordsNear(coords, distance, false);
+
+				if (constrainToCellSpots)
+					newCoords = MapClass::PickInfantrySublocation(newCoords, true);
+			}
+
+			auto const loopCount = ScenarioClass::Instance->Random.RandomRanged(1, 2);
+			auto const pAnim = GameCreate<AnimClass>(pType, newCoords, 0, loopCount, 0x600u, 0, false);
+			pAnim->Owner = pThis->Owner;
+			auto const pExtNew = AnimExt::ExtMap.Find(pAnim);
+			pExtNew->Invoker = pExt->Invoker;
+			pExtNew->InvokerHouse = pExt->InvokerHouse;
+
+			if (attach && pThis->OwnerObject)
+				pAnim->SetOwnerObject(pThis->OwnerObject);
+		};
+
+	auto LoopAnims = [&coords, SpawnAnim](std::vector<AnimTypeClass*> const& anims, std::vector<double> const& chances, std::vector<double> const& distances,
+		int count, AnimTypeClass* defaultAnimType, double defaultChance0, double defaultChanceRest, int defaultDistance0, int defaultDistanceRest, bool constrainToCellSpots, bool attach)
+		{
+			double chance = 0.0;
+			int distance = 0;
+			AnimTypeClass* pAnimType = nullptr;
+
+			for (size_t i = 0; i < static_cast<unsigned int>(count); i++)
+			{
+				if (chances.size() > 0 && chances.size() > i)
+					chance = chances[i];
+				else if (chances.size() > 0)
+					chance = chances[chances.size() - 1];
+				else
+					chance = i == 0 ? defaultChance0 : defaultChanceRest;
+
+				if (chance < ScenarioClass::Instance->Random.RandomDouble())
+					continue;
+
+				if (anims.size() > 1)
+					pAnimType = anims[ScenarioClass::Instance->Random.RandomRanged(0, anims.size() - 1)];
+				else if (anims.size() > 0)
+					pAnimType = anims[0];
+				else
+					pAnimType = defaultAnimType;
+
+				if (distances.size() > 0 && distances.size() < i)
+					distance = static_cast<int>(distances[i] * Unsorted::LeptonsPerCell);
+				else if (distances.size() > 0)
+					distance = static_cast<int>(distances[distances.size() - 1] * Unsorted::LeptonsPerCell);
+				else
+					distance = i == 0 ? defaultDistance0 : defaultDistanceRest;
+
+				SpawnAnim(pAnimType, distance, constrainToCellSpots, attach);
+			}
+		};
+
+	auto const disallowedLandTypes = pTypeExt->FireAnimDisallowedLandTypes.Get(pType->Scorch ? LandTypeFlags::DefaultDisallowed : LandTypeFlags::None);
+
+	if (IsLandTypeInFlags(disallowedLandTypes, pThis->GetCell()->LandType))
+		return;
+
+	std::vector<AnimTypeClass*> anims = pTypeExt->SmallFireAnims;
+	std::vector<double> chances = pTypeExt->SmallFireChances;
+	std::vector<double> distances = pTypeExt->SmallFireDistances;
+	bool constrainToCellSpots = pTypeExt->ConstrainFireAnimsToCellSpots;
+	bool attach = pTypeExt->AttachFireAnimsToParent.Get(pType->Scorch);
+	int smallCount = pTypeExt->SmallFireCount.Get(1 + pType->Flamer);
+
+	if (pType->Flamer)
+	{
+		LoopAnims(anims, chances, distances, smallCount, RulesClass::Instance->SmallFire, 0.5, 1.0, 64, 160, constrainToCellSpots, attach);
+
+		anims = pTypeExt->LargeFireAnims;
+		chances = pTypeExt->LargeFireChances;
+		distances = pTypeExt->LargeFireDistances;
+
+		LoopAnims(anims, chances, distances, pTypeExt->LargeFireCount, RulesClass::Instance->LargeFire, 0.5, 0.5, 112, 112, constrainToCellSpots, attach);
+	}
+	else if (pType->Scorch)
+	{
+		LoopAnims(anims, chances, distances, smallCount, RulesClass::Instance->SmallFire, 1.0, 1.0, 0, 0, constrainToCellSpots, attach);
+	}
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -79,6 +79,8 @@ public:
 	static void HandleDebrisImpact(AnimTypeClass* pExpireAnim, AnimTypeClass* pWakeAnim, Iterator<AnimTypeClass*> splashAnims, HouseClass* pOwner, WarheadTypeClass* pWarhead, int nDamage,
 	CellClass* pCell, CoordStruct nLocation, bool heightFlag, bool isMeteor, bool warheadDetonate, bool explodeOnWater, bool splashAnimsPickRandom);
 
+	static void SpawnFireAnims(AnimClass* pThis);
+
 	static void InvalidateTechnoPointers(TechnoClass* pTechno);
 	static void InvalidateParticleSystemPointers(ParticleSystemClass* pParticleSystem);
 };

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -466,3 +466,25 @@ DEFINE_HOOK(0x425174, AnimClass_Detach_Cloak, 0x6)
 	return 0;
 }
 
+#pragma region ScorchFlamer
+
+// Disable Ares' implementation.
+DEFINE_PATCH(0x42511B, 0x5F, 0x5E, 0x5D, 0x5B, 0x83, 0xC4, 0x20);
+DEFINE_PATCH(0x4250C9, 0x5F, 0x5E, 0x5D, 0x5B, 0x83, 0xC4, 0x20);
+DEFINE_PATCH(0x42513F, 0x5F, 0x5E, 0x5D, 0x5B, 0x83, 0xC4, 0x20);
+
+DEFINE_HOOK(0x425060, AnimClass_Expire_ScorchFlamer, 0x6)
+{
+	GET(AnimClass*, pThis, ESI);
+
+	auto const pType = pThis->Type;
+
+	if (pType->Flamer || pType->Scorch)
+		AnimExt::SpawnFireAnims(pThis);
+
+	return 0;
+}
+
+#pragma endregion
+
+

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -120,6 +120,17 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->VisibleTo_ConsiderInvokerAsOwner.Read(exINI, pID, "VisibleTo.ConsiderInvokerAsOwner");
 	this->RestrictVisibilityIfCloaked.Read(exINI, pID, "RestrictVisibilityIfCloaked");
 	this->DetachOnCloak.Read(exINI, pID, "DetachOnCloak");
+	this->ConstrainFireAnimsToCellSpots.Read(exINI, pID, "ConstrainFireAnimsToCellSpots");
+	this->FireAnimDisallowedLandTypes.Read(exINI, pID, "FireAnimDisallowedLandTypes");
+	this->AttachFireAnimsToParent.Read(exINI, pID, "AttachFireAnimsToParent");
+	this->SmallFireCount.Read(exINI, pID, "SmallFireCount");
+	this->SmallFireAnims.Read(exINI, pID, "SmallFireAnims");
+	this->SmallFireChances.Read(exINI, pID, "SmallFireChances");
+	this->SmallFireDistances.Read(exINI, pID, "SmallFireDistances");
+	this->LargeFireCount.Read(exINI, pID, "LargeFireCount");
+	this->LargeFireAnims.Read(exINI, pID, "LargeFireAnims");
+	this->LargeFireChances.Read(exINI, pID, "LargeFireChances");
+	this->LargeFireDistances.Read(exINI, pID, "LargeFireDistances");
 }
 
 template <typename T>
@@ -163,6 +174,17 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->VisibleTo_ConsiderInvokerAsOwner)
 		.Process(this->RestrictVisibilityIfCloaked)
 		.Process(this->DetachOnCloak)
+		.Process(this->ConstrainFireAnimsToCellSpots)
+		.Process(this->FireAnimDisallowedLandTypes)
+		.Process(this->AttachFireAnimsToParent)
+		.Process(this->SmallFireCount)
+		.Process(this->SmallFireAnims)
+		.Process(this->SmallFireChances)
+		.Process(this->SmallFireDistances)
+		.Process(this->LargeFireCount)
+		.Process(this->LargeFireAnims)
+		.Process(this->LargeFireChances)
+		.Process(this->LargeFireDistances)
 		;
 }
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -54,6 +54,17 @@ public:
 		Valueable<bool> VisibleTo_ConsiderInvokerAsOwner;
 		Valueable<bool> RestrictVisibilityIfCloaked;
 		Valueable<bool> DetachOnCloak;
+		Valueable<bool> ConstrainFireAnimsToCellSpots;
+		Nullable<LandTypeFlags> FireAnimDisallowedLandTypes;
+		Nullable<bool> AttachFireAnimsToParent;
+		Nullable<int> SmallFireCount;
+		ValueableVector<AnimTypeClass*> SmallFireAnims;
+		ValueableVector<double> SmallFireChances;
+		ValueableVector<double> SmallFireDistances;
+		Valueable<int> LargeFireCount;
+		ValueableVector<AnimTypeClass*> LargeFireAnims;
+		ValueableVector<double> LargeFireChances;
+		ValueableVector<double> LargeFireDistances;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -92,6 +103,17 @@ public:
 			, VisibleTo_ConsiderInvokerAsOwner { false }
 			, RestrictVisibilityIfCloaked { false }
 			, DetachOnCloak { true }
+			, ConstrainFireAnimsToCellSpots { true }
+			, FireAnimDisallowedLandTypes {}
+			, AttachFireAnimsToParent { false }
+			, SmallFireCount {}
+			, SmallFireAnims {}
+			, SmallFireChances {}
+			, SmallFireDistances {}
+			, LargeFireCount { 1 }
+			, LargeFireAnims {}
+			, LargeFireChances {}
+			, LargeFireDistances {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -66,6 +66,33 @@ enum class SuperWeaponAITargetingMode
 	EnemyBase = 14
 };
 
+enum class LandTypeFlags : unsigned short
+{
+	None = 0,
+	Clear = 1 << (char)LandType::Clear,
+	Road = 1 << (char)LandType::Road,
+	Water = 1 << (char)LandType::Water,
+	Rock = 1 << (char)LandType::Rock,
+	Wall = 1 << (char)LandType::Wall,
+	Tiberium = 1 << (char)LandType::Tiberium,
+	Beach = 1 << (char)LandType::Beach,
+	Rough = 1 << (char)LandType::Rough,
+	Ice = 1 << (char)LandType::Ice,
+	Railroad = 1 << (char)LandType::Railroad,
+	Tunnel = 1 << (char)LandType::Tunnel,
+	Weeds = 1 << (char)LandType::Weeds,
+
+	All = 0xFFFF,
+	DefaultDisallowed = Water | Rock | Ice | Beach
+};
+
+MAKE_ENUM_FLAGS(LandTypeFlags);
+
+inline bool IsLandTypeInFlags(LandTypeFlags flags, LandType type)
+{
+	return (bool)((LandTypeFlags)(1 << (char)type) & flags);
+}
+
 enum class AffectedTarget : unsigned char
 {
 	None = 0x0,

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -634,6 +634,37 @@ namespace detail
 	}
 
 	template <>
+	inline bool read<LandTypeFlags>(LandTypeFlags& value, INI_EX& parser, const char* pSection, const char* pKey)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			auto parsed = LandTypeFlags::None;
+			auto str = parser.value();
+			char* context = nullptr;
+
+			for (auto cur = strtok_s(str, Phobos::readDelims, &context); cur; cur = strtok_s(nullptr, Phobos::readDelims, &context))
+			{
+				auto const landType = GroundType::GetLandTypeFromName(parser.value());
+
+				if (landType >= LandType::Clear && landType <= LandType::Weeds)
+				{
+					parsed |= (LandTypeFlags)(1 << (char)landType);
+				}
+				else
+				{
+					Debug::INIParseFailed(pSection, pKey, cur, "Expected a land type name");
+					return false;
+				}
+			}
+
+			value = parsed;
+			return true;
+		}
+
+		return false;
+	}
+
+	template <>
 	inline bool read<SuperWeaponAITargetingMode>(SuperWeaponAITargetingMode& value, INI_EX& parser, const char* pSection, const char* pKey)
 	{
 		if (parser.ReadString(pSection, pKey))


### PR DESCRIPTION
### Fire animations spawned by Scorch & Flamer

- Tiberian Sun allowed `Scorch=true` and `Flamer=true` animations to spawn fire animations from `[AudioVisual]` -> `SmallFire` & `LargeFire`. This behaviour has been reimplemented and is fully customizable.
  - `ConstrainFireAnimsToCellSpots` controls whether or not spawned animations are locked to cell spots (e.g the subcell positions infantry are also constrained to).
  - `FireAnimDisallowedLandTypes` controls which landtypes the fire animations are not allowed to spawn on. Defaults to `water,rock,beach,ice` for `Scorch=true`, `none` otherwise.
  - `AttachFireAnimsToParent` controls if the spawned animations are attached to the owner of the parent animation if it is also attached. Defaults to true for `Scorch=true`, otherwise false.
  - `SmallFireCount` determines number of small fire animations to spawn by both `Scorch=true` and `Flamer=true` animations. Defaults to 2 for `Flamer=true`, otherwise 1.
     - `SmallFireAnims` can be used to set the animation types, defaults to `[AudioVisual]` -> `SmallFire` (single animation).
     - `SmallFireChances` is a list of probabilities for the animations to spawn, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities. Defaults to `1.0,0.5` for `Flamer=true`, `1.0` otherwise.
     - `SmallFireDistances` is a list of distances in cells for the animations to spawn at from the parent animation's coordinates, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities. Defaults to `0.25,0.625` for `Flamer=true`, `0.0` otherwise.
  - `LargeFireCount` determines number of large fire animations to spawn by`Flamer=true` animations only.
     - `LargeFireAnims` can be used to set the animation types, defaults to `[AudioVisual]` -> `LargeFire` (single animation).
     - `LargeFireChances` is a list of probabilities for the animations to spawn, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities.
     - `LargeFireDistances` is a list of distances in cells for the animations to spawn at from the parent animation's coordinates, up to `SmallFireCount` amount of items are read. Last item listed is used if count exceeds the number of listed probabilities.

In `artmd.ini`:
```ini
[SOMEANIM]                          ; AnimationType
ConstrainFireAnimsToCellSpots=true  ; boolean
FireAnimDisallowedLandTypes=        ; List of LandTypes (none | clear | road | water | rock | wall | tiberium | beach | rough | ice | railroad | tunnel | weeds)
AttachFireAnimsToParent=            ; boolean
SmallFireCount=                     ; integer
SmallFireAnims=                     ; list of animations
SmallFireChances=                   ; list of floating point values (percent or absolute)
SmallFireDistances=                 ; list of floating point values, distance in cells
LargeFireCount=1                    ; integer
LargeFireAnims=                     ; list of animations
LargeFireChances=0.5                ; list of floating point values (percent or absolute)
LargeFireDistances=0.4375           ; list of floating point values, distance in cells
```

NOTE: Save for the change that `Flamer` does not spawn animations if the parent animation is in air, the default settings should provide identical results to similar feature from Ares.