### PR TITLE
Voxel light source position/tilting fix

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -46,6 +46,7 @@ This page lists all the individual contributions to the project by their author.
   - Customizable ElectricBolt Arcs
   - Ability to disable shadow for debris & meteor animations
   - Voxel light source position customization
+  - Voxel light source position and tilting fix
 - **Uranusian (Thrifinesma)**:
   - Mind Control enhancement
   - Custom warhead splash list

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -773,18 +773,18 @@ ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
 
 ### Voxel light source customization
 
-![image](_static/images/VoxelLightSourceComparison.png)
-*New lighting with `VoxelLightSource=0.02,-0.69,0.36` vs default lighting, Prism Tank voxel by [CCS_qkl](https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index)*
-
 - Vanilla game applies some weird unnecessary math which resulted in the voxel light source being "nudged" up by a bit and light being applied incorrectly on tilted voxels. It is now possible to fix that.
 
 ```{note}
 Please note that enabling this will remove the vertical offset vanilla engine applies to the light source position. Assuming vanilla lighting this will make the light shine even more from below the ground than it was before, so it is recommended to turn the Z value up in value of `VoxelLightSource`.
 ```
 
+![image](_static/images/VoxelLightSourceComparison.png)
+*Applying `VoxelLightSource=0.02,-0.69,0.36` (assuming `UseFixedVoxelLighting=false`) vs default lighting, Prism Tank voxel by [CCS_qkl](https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index)*
+
 - It is now possible to change the position of the light relative to the voxels. This allows for better lighting to be set up.
   - Only the direction of the light is accounted, the distance to the voxel is not accounted.
-  - Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly at `0.201,-0.907,-0.362`.
+  - Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly at `VoxelLightSource=0.201,-0.907,-0.362`.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -775,7 +775,7 @@ ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
 ![image](_static/images/VoxelLightSourceComparison.png)
 *New lighting with `VoxelLightSource=0.02,-0.69,0.36` vs default lighting, Prism Tank voxel by [CCS_qkl](https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index)*
 
-- Vanilla game applies some weird unnecessary math which resulted in light being applied incorrectly on tilted voxels and the light source being "nudged" up by a bit. It is now possible to fix that.
+- Vanilla game applies some weird unnecessary math which resulted in the voxel light source being "nudged" up by a bit and light being applied incorrectly on tilted voxels. It is now possible to fix that.
 - It is now possible to change the position of the light relative to the voxels. This allows for better lighting to be set up.
   - Only the direction of the light is accounted, the distance to the voxel is not accounted.
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -776,8 +776,14 @@ ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
 *New lighting with `VoxelLightSource=0.02,-0.69,0.36` vs default lighting, Prism Tank voxel by [CCS_qkl](https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index)*
 
 - Vanilla game applies some weird unnecessary math which resulted in the voxel light source being "nudged" up by a bit and light being applied incorrectly on tilted voxels. It is now possible to fix that.
+
+```{note}
+Please note that enabling this will remove the vertical offset vanilla engine applies to the light source position. Assuming vanilla lighting this will make the light shine even more from below the ground than it was before, so it is recommended to turn the Z value up in value of `VoxelLightSource`.
+```
+
 - It is now possible to change the position of the light relative to the voxels. This allows for better lighting to be set up.
   - Only the direction of the light is accounted, the distance to the voxel is not accounted.
+  - Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly at `0.201,-0.907,-0.362`.
 
 In `rulesmd.ini`:
 ```ini
@@ -788,6 +794,8 @@ VoxelLightSource=           ; X,Y,Z - position of the light in the world relativ
 
 ```{hint}
 In order to easily preview the light source settings use the [VXL Viewer and VPL Generator tool by thomassneddon](https://github.com/ThomasSneddon/vxl-renderer/releases). To use the tool unpack it somewhere, then drag the main VXL file of a voxel that you will use to preview onto it (auxilliary VXL and HVA files must be in the same folder).
+
+Keep in mind that the tool doesn't account for `UseFixedVoxelLighting=true` as of yet, so the values shown in tool need to be offset when putting in the game with with fixed voxel lighting.
 ```
 
 ### Voxel shadow scaling in air

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -770,18 +770,20 @@ ShadowIndex.Frame=0   ; integer (HVA animation frame index)
 ShadowIndices.Frame=  ; list of integers (HVA animation frame indices)
 ```
 
-### Voxel light source position customization
+### Voxel light source customization
 
 ![image](_static/images/VoxelLightSourceComparison.png)
 *New lighting with `VoxelLightSource=0.02,-0.69,0.36` vs default lighting, Prism Tank voxel by [CCS_qkl](https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index)*
 
+- Vanilla game applies some weird unnecessary math which resulted in light being applied incorrectly on tilted voxels and the light source being "nudged" up by a bit. It is now possible to fix that.
 - It is now possible to change the position of the light relative to the voxels. This allows for better lighting to be set up.
   - Only the direction of the light is accounted, the distance to the voxel is not accounted.
 
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
-VoxelLightSource=  ; X,Y,Z - position of the light in the world relative to each voxel, floating point values
+UseFixedVoxelLighting=false ; boolean, whether to fix the lighting
+VoxelLightSource=           ; X,Y,Z - position of the light in the world relative to each voxel, floating point values
 ```
 
 ```{hint}

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -789,8 +789,8 @@ Please note that enabling this will remove the vertical offset vanilla engine ap
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
-UseFixedVoxelLighting=false ; boolean, whether to fix the lighting
-VoxelLightSource=           ; X,Y,Z - position of the light in the world relative to each voxel, floating point values
+UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting
+VoxelLightSource=            ; X,Y,Z - position of the light in the world relative to each voxel, floating point values
 ```
 
 ```{hint}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -437,6 +437,7 @@ New:
 - Option for Warhead damage to penetrate Iron Curtain or Force Shield (by Starkku)
 - Option for Warhead to remove all shield types at once (by Starkku)
 - Allow customizing voxel light source position (by Kerbiter, Morton, based on knowledge of thomassnedon)
+- Option to fix voxel light source being offset and incorrectly tilting on slopes (by Kerbiter)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -183,6 +183,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->ReplaceVoxelLightSources();
 
+	this->UseFixedVoxelLighting.Read(exINI, GameStrings::AudioVisual, "UseFixedVoxelLighting");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -347,6 +349,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->PodImage)
 		.Process(this->VoxelLightSource)
 		// .Process(this->VoxelShadowLightSource)
+		.Process(this->UseFixedVoxelLighting)
 		;
 }
 
@@ -371,7 +374,7 @@ void RulesExt::ExtData::ReplaceVoxelLightSources()
 	if (this->VoxelLightSource.isset())
 	{
 		needCacheFlush = true;
-		auto source = this->VoxelLightSource.Get().Normalized();
+		auto source = this->VoxelLightSource.Get();
 		Game::VoxelLightSource = Matrix3D::VoxelDefaultMatrix.get() * source;
 	}
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -374,7 +374,7 @@ void RulesExt::ExtData::ReplaceVoxelLightSources()
 	if (this->VoxelLightSource.isset())
 	{
 		needCacheFlush = true;
-		auto source = this->VoxelLightSource.Get();
+		auto source = this->VoxelLightSource.Get().Normalized();
 		Game::VoxelLightSource = Matrix3D::VoxelDefaultMatrix.get() * source;
 	}
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -142,6 +142,7 @@ public:
 
 		Nullable<Vector3D<float>> VoxelLightSource;
 		// Nullable<Vector3D<float>> VoxelShadowLightSource;
+		Valueable<bool> UseFixedVoxelLighting;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -243,6 +244,7 @@ public:
 			, PodImage { }
 			, VoxelLightSource { }
 			// , VoxelShadowLightSource { }
+			, UseFixedVoxelLighting { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -845,3 +845,16 @@ DEFINE_HOOK(0x412B40, AircraftTrackerClass_FillCurrentVector, 0x5)
 	R->EAX(0); // The original function returns some number, hell if I know what (it is 0 most of the time though and never actually used for anything).
 	return SkipGameCode;
 }
+
+// this fella was { 0, 0, 1 } before and somehow it also breaks both the light position a bit and how the lighting is applied when voxels rotate - Kerbiter
+DEFINE_HOOK(0x753D86, VoxelCalcNormals_NullAdditionalVector, 0x0)
+{
+	REF_STACK(Vector3D<float>, secondaryLightVector, STACK_OFFSET(0xD8, -0xC0))
+
+	if (RulesExt::Global()->UseFixedVoxelLighting)
+		secondaryLightVector = { 0, 0, 0 };
+	else
+		secondaryLightVector = { 0, 0, 1 };
+
+	return 0x753D9E;
+}


### PR DESCRIPTION
- Vanilla game applies some weird unnecessary math which resulted in light being applied incorrectly on tilted voxels and the light source being "nudged" up by a bit. It is now possible to fix that.

In `rulesmd.ini`:
```ini
[AudioVisual]
UseFixedVoxelLighting=false ; boolean, whether to fix the lighting
```