### PR TITLE
Fix unit get stuck in factory

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -343,6 +343,10 @@ This page lists all the individual contributions to the project by their author.
   - Re-enable the Veinhole Monster and Weeds from TS
   - Recreate the weed-charging of SWs like the TS Chemical Missile
   - Allow to change the speed of gas particles
+- **CrimRecya**
+  - Units will not always stuck in the factory
+- **TaranDahl**
+  - Units are now unable to kick out from a factory that is in construction process
 - **handama** - AI script action to jump back to previous script
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -162,6 +162,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - OverlayTypes now read and use `ZAdjust` if specified in their `artmd.ini` entry.
 - Setting `[AudioVisual]` -> `ColorAddUse8BitRGB` to true makes game treat values from `[ColorAdd]` as 8-bit RGB (0-255) instead of RGB565 (0-31 for red & blue, 0-63 for green). This works for `LaserTargetColor`, `IronCurtainColor`, `BerserkColor` and `ForceShieldColor`.
 - Weapons with `AA=true` Projectile can now correctly fire at air units when both firer and target are over a bridge.
+- Units are now unable to kick out from a factory that is in construction process, and will not always stuck in the factory. If the unit is not able to kick out from the factory, the unit will be removed and the cost will be given back to its house.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -505,6 +505,7 @@ Vanilla fixes:
 - Units with `Sensors=true` will no longer reveal ally buildings (by Starkku)
 - Air units are now reliably included by target scan with large range and Warhead detonation by large `CellSpread` (by Starkku)
 - Weapons with `AA=true` Projectile can now correctly fire at air units when both firer and target are over a bridge (by Starkku)
+- Units are now unable to kick out from a factory that is in construction process, and will not always stuck in the factory (by CrimRecya & TaranDahl)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -55,6 +55,7 @@ public:
 		bool HasSuperWeapon(int index, bool withUpgrades) const;
 		bool HandleInfiltrate(HouseClass* pInfiltratorHouse , int moneybefore);
 		void UpdatePrimaryFactoryAI();
+		void KickOutStuckUnits();
 		virtual ~ExtData() = default;
 
 		// virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -27,6 +27,7 @@ DEFINE_HOOK(0x43FE69, BuildingClass_AI, 0xA)
 
 	pExt->DisplayIncomeString();
 	pExt->ApplyPoweredKillSpawns();
+	pExt->KickOutStuckUnits();
 
 	return 0;
 }
@@ -322,6 +323,17 @@ DEFINE_HOOK(0x443CCA, BuildingClass_KickOutUnit_AircraftType_Phobos, 0xA)
 	HouseExt::ExtMap.Find(pHouse)->Factory_AircraftType = nullptr;
 
 	return 0;
+}
+
+DEFINE_HOOK(0x4444A0, BuildingClass_KickOutUnit_NoKickOutInConstruction, 0x7)
+{
+	enum { OfCourse = 0x444565, NoChance = 0x4444B3};
+
+	GET(BuildingClass* const, pThis, ESI);
+
+	const Mission mission = pThis->GetCurrentMission();
+
+	return (mission == Mission::Unload || mission == Mission::Construction) ? NoChance : OfCourse;
 }
 
 // Ares didn't have something like 0x7397E4 in its UnitDelivery code


### PR DESCRIPTION
- Units are now unable to kick out from a factory that is in construction process, and will not always stuck in the factory. If the unit is not able to kick out from the factory, the unit will be removed and the cost will be given back to its house.