### PR TITLE
Two skirmish AI behavior dehardcoded and a minor improvement

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -344,6 +344,10 @@ This page lists all the individual contributions to the project by their author.
   - Recreate the weed-charging of SWs like the TS Chemical Missile
   - Allow to change the speed of gas particles
 - **handama** - AI script action to jump back to previous script
+- **航味麻酱**
+  - Skirmish AI "sell all and all in" behavior dehardcode
+  - Skirmish AI "regroup when mcv deploy" behavior dehardcode
+  - Global value of `RepairBaseNodes`
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares
   - unfinished RadTypes code

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -362,7 +362,7 @@ This page lists all the individual contributions to the project by their author.
   - Build limit group enhancement
   - Customizable rocker amplitude
 - **handama** - AI script action to jump back to previous script
-- **航味麻酱**
+- **TaranDahl (航味麻酱)**
   - Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode
   - Skirmish AI "gather when MCV deploy" behavior dehardcode
   - Global value of `RepairBaseNodes` and `MCVRedeploys`

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -352,7 +352,7 @@ This page lists all the individual contributions to the project by their author.
 - **航味麻酱**
   - Skirmish AI "sell all and all in" behavior dehardcode
   - Skirmish AI "regroup when mcv deploy" behavior dehardcode
-  - Global value of `RepairBaseNodes`
+  - Global value of `RepairBaseNodes` and `MCVRedeploys`
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares
   - unfinished RadTypes code

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -350,8 +350,8 @@ This page lists all the individual contributions to the project by their author.
   - Customizable rocker amplitude
 - **handama** - AI script action to jump back to previous script
 - **航味麻酱**
-  - Skirmish AI "sell all and all in" behavior dehardcode
-  - Skirmish AI "regroup when mcv deploy" behavior dehardcode
+  - Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode
+  - Skirmish AI "gather when mcv deploy" behavior dehardcode
   - Global value of `RepairBaseNodes` and `MCVRedeploys`
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -364,7 +364,7 @@ This page lists all the individual contributions to the project by their author.
 - **handama** - AI script action to jump back to previous script
 - **航味麻酱**
   - Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode
-  - Skirmish AI "gather when mcv deploy" behavior dehardcode
+  - Skirmish AI "gather when MCV deploy" behavior dehardcode
   - Global value of `RepairBaseNodes` and `MCVRedeploys`
 - **Ares developers**
   - YRpp and Syringe which are used, save/load, project foundation and generally useful code from Ares

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -52,12 +52,18 @@ DefaultLS800BkgdPal=     ; filename - including the .pal extension
 
 ### MCV redeploying
 
-- You can now decide whether MCV can redeploy in singleplayer campaign missions by setting `MCVRedeploys`. Overrides `[MultiplayerDialogSettings]`->`MCVRedeploys` only in singleplayer campaign missions.
+- You can now decide whether MCV can redeploy in singleplayer campaign missions by setting `[Basic]->MCVRedeploys` in map file. Overrides `[MultiplayerDialogSettings]`->`MCVRedeploys` only in singleplayer campaign missions. You can also define this globally by setting `[General]->MCVRedeploysInCampaign` in rulesmd.ini. The flag defined in map file has higher priority.
+
+In rulesmd.ini:
+```ini
+[General]
+MCVRedeploysInCampaign=false  ; boolean
+```
 
 In map file:
 ```ini
 [Basic]
-MCVRedeploys=false  ; boolean
+MCVRedeploys=                 ; boolean
 ```
 
 ### Set par times and related string labels in missionmd.ini

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -18,12 +18,19 @@ This page describes all AI scripting and mapping related additions and changes i
 
 ### Base node repairing
 
-- In singleplayer campaign missions you can now decide whether AI can repair the base nodes / buildings delivered by SW (Ares) by setting `RepairBaseNodes`.
+- In singleplayer campaign missions you can now decide whether AI can repair the base nodes / buildings delivered by SW (Ares).
+  - You can control it globally by setting `[General]->RepairBaseNodes` in rulesmd.ini, or locally by setting the flag with same name in `[Some House]` in certain map file. The global one will be overriden if the local one is set.
+
+In rulesmd.ini:
+```ini
+[General]
+RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy / Normal / Difficult game diffculty.
+```
 
 In map file:
 ```ini
 [Country House]
-RepairBaseNodes=false,false,false  ; list of 3 booleans indicating whether AI repair basenodes in Easy / Normal / Difficult game diffculty.
+RepairBaseNodes=                   ; list of 3 booleans indicating whether AI repair basenodes in Easy / Normal / Difficult game diffculty.
 ```
 
 ### Default loading screen and briefing offsets

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -744,19 +744,19 @@ NoWobbles=false  ; boolean
 ### Skirmish AI behavior dehardcode
 
 - In vanilla, there is a hardcoded behavior that when an skirmish AI player has no factory and has not taken damage for a while, it will sell its buildings and set its units to hunt. This can be customized now.
-  - `[General]->AISellAllOnLastLegs` and `[General]->AIAllInOnLastLegs` control whether the AI will act selling and hunting respectively.
-  - `[General]->AISellAllDelay` defines a timer, it will only work if `[General]->AISellAllOnLastLegs` is set to `true`. When the first time the AI reaches the trigger condition of vanilla behavior, the timer starts and prevents the selling behavior from happening until the timer is expired.
+  - `[General]->AIFireSale` and `[General]->AIAllToHunt` control whether the AI will act selling and hunting respectively.
+  - `[General]->AIFireSaleDelay` defines a timer, it will only work if `[General]->AIFireSale` is set to `true`. When the first time the AI reaches the trigger condition of vanilla behavior, the timer starts and prevents the selling behavior from happening until the timer is expired.
   - You can use these flags to make the AIs "all in" before they are defeated.
-- Another hardcoded behavior is that, when the AI deploys a MCV, it will regroup all of its forces to that place. This can be toggle off now.
-  - `[General]->RegroupWhenMCVDeploy` controls this behavior.
+- Another hardcoded behavior is that, when the AI deploys a MCV, it will gather all of its forces to that place. This can be toggle off now.
+  - `[General]->GatherWhenMCVDeploy` controls this behavior.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-AISellAllOnLastLegs=true   ; boolean
-AISellAllDelay=0           ; integer, number of frames
-AIAllInOnLastLegs=true     ; boolean
-RegroupWhenMCVDeploy=true  ; boolean
+AIFireSale=true           ; boolean
+AIFireSaleDelay=0         ; integer, number of frames
+AIAllToHunt=true          ; boolean
+GatherWhenMCVDeploy=true  ; boolean
 ```
 
 ### Subterranean unit travel height

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -740,6 +740,24 @@ NoWobbles=false  ; boolean
 `CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for `JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and `Acceleration` is for `JumpjetAccel`. All other corresponding keys just simply have no Jumpjet prefix.
 ```
 
+### Skirmish AI behavior dehardcode
+
+- In vanilla, there is a hardcoded behavior that when an skirmish AI player has no factory and has not taken damage for a while, it will sell its buildings and set its units to hunt. This can be customized now.
+  - `[General]->AISellAllOnLastLegs` and `[General]->AIAllInOnLastLegs` control whether the AI will act selling and hunting respectively.
+  - `[General]->AISellAllDelay` defines a timer, it will only work if `[General]->AISellAllOnLastLegs` is set to `true`. When the first time the AI reaches the trigger condition of vanilla behavior, the timer starts and prevents the selling behavior from happening until the timer is expired.
+  - You can use these flags to make the AIs "all in" before they are defeated.
+- Another hardcoded behavior is that, when the AI deploys a MCV, it will regroup all of its forces to that place. This can be toggle off now.
+  - `[General]->RegroupWhenMCVDeploy` controls this behavior.
+
+In `rulesmd.ini`:
+```ini
+[General]
+AISellAllOnLastLegs=true   ; boolean
+AISellAllDelay=0           ; integer, number of frames
+AIAllInOnLastLegs=true     ; boolean
+RegroupWhenMCVDeploy=true  ; boolean
+```
+
 ### Subterranean unit travel height
 
 - It is now possible to control the height at which units with subterranean (Tunnel) `Locomotor` travel, globally or per TechnoType.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -687,8 +687,8 @@ New:
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
 - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist (by FlyStar)
-- Skirmish AI "sell all and all in" behavior dehardcode (by 航味麻酱)
-- Skirmish AI "regroup when mcv deploy" behavior dehardcode (by 航味麻酱)
+- Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode (by 航味麻酱)
+- Skirmish AI "gather when mcv deploy" behavior dehardcode (by 航味麻酱)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -714,7 +714,7 @@ New:
 - Toggleable passenger killing for Explodes=true units (by Starkku)
 - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist (by FlyStar)
 - Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode (by 航味麻酱)
-- Skirmish AI "gather when mcv deploy" behavior dehardcode (by 航味麻酱)
+- Skirmish AI "gather when MCV deploy" behavior dehardcode (by 航味麻酱)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -713,8 +713,8 @@ New:
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
 - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist (by FlyStar)
-- Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode (by 航味麻酱)
-- Skirmish AI "gather when MCV deploy" behavior dehardcode (by 航味麻酱)
+- Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode (by TaranDahl/航味麻酱)
+- Skirmish AI "gather when MCV deploy" behavior dehardcode (by TaranDahl/航味麻酱)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -683,6 +683,8 @@ New:
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
 - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist (by FlyStar)
+- Skirmish AI "sell all and all in" behavior dehardcode (by 航味麻酱)
+- Skirmish AI "regroup when mcv deploy" behavior dehardcode (by 航味麻酱)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -507,14 +507,18 @@ void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	if ( nWrittenGlobal > 0)
 	{
 		for (size_t i = 0; i < 3; i++)
+		{
 			this->RepairBaseNodes[i] = RulesExt::Global()->RepairBaseNodes[i < nWrittenGlobal ? i : nWrittenGlobal - 1];
+		}
 	}
+
 	if (nWritten > 0)
 	{
 		for (size_t i = 0; i < 3; i++)
+		{
 			this->RepairBaseNodes[i] = readBaseNodeRepairInfo[i < nWritten ? i : nWritten - 1];
+		}
 	}
-
 }
 
 // =============================

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -542,7 +542,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 		.Process(this->RepairBaseNodes)
 		.Process(this->LastBuiltNavalVehicleType)
 		.Process(this->ProducingNavalUnitTypeIndex)
-		.Process(this->AISellAllDelayTimer)
+		.Process(this->AIFireSaleDelayTimer)
 		;
 }
 

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -503,6 +503,12 @@ void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	ValueableVector<bool> readBaseNodeRepairInfo;
 	readBaseNodeRepairInfo.Read(exINI, pSection, "RepairBaseNodes");
 	size_t nWritten = readBaseNodeRepairInfo.size();
+	size_t nWrittenGlobal = RulesExt::Global()->RepairBaseNodes.size();
+	if ( nWrittenGlobal > 0)
+	{
+		for (size_t i = 0; i < 3; i++)
+			this->RepairBaseNodes[i] = RulesExt::Global()->RepairBaseNodes[i < nWrittenGlobal ? i : nWrittenGlobal - 1];
+	}
 	if (nWritten > 0)
 	{
 		for (size_t i = 0; i < 3; i++)
@@ -532,6 +538,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 		.Process(this->RepairBaseNodes)
 		.Process(this->LastBuiltNavalVehicleType)
 		.Process(this->ProducingNavalUnitTypeIndex)
+		.Process(this->AISellAllDelayTimer)
 		;
 }
 

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -35,7 +35,7 @@ public:
 		BuildingClass* Factory_NavyType;
 		BuildingClass* Factory_AircraftType;
 
-		CDTimerClass AISellAllDelayTimer;
+		CDTimerClass AIFireSaleDelayTimer;
 
 		//Read from INI
 		bool RepairBaseNodes[3];
@@ -58,7 +58,7 @@ public:
 			, RepairBaseNodes { false,false,false }
 			, LastBuiltNavalVehicleType { -1 }
 			, ProducingNavalUnitTypeIndex { -1 }
-			, AISellAllDelayTimer {}
+			, AIFireSaleDelayTimer {}
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding);

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -35,6 +35,8 @@ public:
 		BuildingClass* Factory_NavyType;
 		BuildingClass* Factory_AircraftType;
 
+		CDTimerClass AISellAllDelayTimer;
+
 		//Read from INI
 		bool RepairBaseNodes[3];
 
@@ -56,6 +58,7 @@ public:
 			, RepairBaseNodes { false,false,false }
 			, LastBuiltNavalVehicleType { -1 }
 			, ProducingNavalUnitTypeIndex { -1 }
+			, AISellAllDelayTimer {}
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding);

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -271,3 +271,29 @@ DEFINE_HOOK(0x50B669, HouseClass_ShouldDisableCameo, 0x5)
 
 	return 0;
 }
+
+// Sell all and all in.
+DEFINE_HOOK(0x4FD8F7, HouseClass_UpdateAI_OnLastLegs, 0x10)
+{
+	enum { ret = 0x4FD907 };
+
+	GET(HouseClass*, pThis, EBX);
+
+	auto const pRules = RulesExt::Global();
+	auto const pExt = HouseExt::ExtMap.Find(pThis);
+	if (pRules->AISellAllOnLastLegs)
+	{
+		if (pRules->AISellAllDelay <= 0 || !pExt ||
+			pExt->AISellAllDelayTimer.Completed())
+		{
+			pThis->Fire_Sale();
+		}
+		else if (!pExt->AISellAllDelayTimer.HasStarted())
+		{
+			pExt->AISellAllDelayTimer.Start(pRules->AISellAllDelay);
+		}
+	}		
+	if (pRules->AIAllInOnLastLegs)
+		pThis->All_To_Hunt();
+	return ret;
+}

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -281,6 +281,7 @@ DEFINE_HOOK(0x4FD8F7, HouseClass_UpdateAI_OnLastLegs, 0x10)
 
 	auto const pRules = RulesExt::Global();
 	auto const pExt = HouseExt::ExtMap.Find(pThis);
+
 	if (pRules->AISellAllOnLastLegs)
 	{
 		if (pRules->AISellAllDelay <= 0 || !pExt ||
@@ -293,7 +294,11 @@ DEFINE_HOOK(0x4FD8F7, HouseClass_UpdateAI_OnLastLegs, 0x10)
 			pExt->AISellAllDelayTimer.Start(pRules->AISellAllDelay);
 		}
 	}		
+
 	if (pRules->AIAllInOnLastLegs)
+	{
 		pThis->All_To_Hunt();
+	}
+
 	return ret;
 }

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -282,20 +282,20 @@ DEFINE_HOOK(0x4FD8F7, HouseClass_UpdateAI_OnLastLegs, 0x10)
 	auto const pRules = RulesExt::Global();
 	auto const pExt = HouseExt::ExtMap.Find(pThis);
 
-	if (pRules->AISellAllOnLastLegs)
+	if (pRules->AIFireSale)
 	{
-		if (pRules->AISellAllDelay <= 0 || !pExt ||
-			pExt->AISellAllDelayTimer.Completed())
+		if (pRules->AIFireSaleDelay <= 0 || !pExt ||
+			pExt->AIFireSaleDelayTimer.Completed())
 		{
 			pThis->Fire_Sale();
 		}
-		else if (!pExt->AISellAllDelayTimer.HasStarted())
+		else if (!pExt->AIFireSaleDelayTimer.HasStarted())
 		{
-			pExt->AISellAllDelayTimer.Start(pRules->AISellAllDelay);
+			pExt->AIFireSaleDelayTimer.Start(pRules->AIFireSaleDelay);
 		}
 	}		
 
-	if (pRules->AIAllInOnLastLegs)
+	if (pRules->AIAllToHunt)
 	{
 		pThis->All_To_Hunt();
 	}

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -280,10 +280,11 @@ DEFINE_HOOK(0x4FD8F7, HouseClass_UpdateAI_OnLastLegs, 0x10)
 	GET(HouseClass*, pThis, EBX);
 
 	auto const pRules = RulesExt::Global();
-	auto const pExt = HouseExt::ExtMap.Find(pThis);
 
 	if (pRules->AIFireSale)
 	{
+		auto const pExt = HouseExt::ExtMap.Find(pThis);
+
 		if (pRules->AIFireSaleDelay <= 0 || !pExt ||
 			pExt->AIFireSaleDelayTimer.Completed())
 		{
@@ -293,7 +294,7 @@ DEFINE_HOOK(0x4FD8F7, HouseClass_UpdateAI_OnLastLegs, 0x10)
 		{
 			pExt->AIFireSaleDelayTimer.Start(pRules->AIFireSaleDelay);
 		}
-	}		
+	}
 
 	if (pRules->AIAllToHunt)
 	{

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -186,9 +186,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->UseFixedVoxelLighting.Read(exINI, GameStrings::AudioVisual, "UseFixedVoxelLighting");
 
 	this->RegroupWhenMCVDeploy.Read(exINI, GameStrings::General, "RegroupWhenMCVDeploy");
-	this->AISellAllOnLastLegs.Read(exINI, GameStrings::General, "AISellAllOnLastLegs");
-	this->AISellAllDelay.Read(exINI, GameStrings::General, "AISellAllDelay");
-	this->AIAllInOnLastLegs.Read(exINI, GameStrings::General, "AIAllInOnLastLegs");
+	this->AIFireSale.Read(exINI, GameStrings::General, "AIFireSale");
+	this->AIFireSaleDelay.Read(exINI, GameStrings::General, "AIFireSaleDelay");
+	this->AIAllToHunt.Read(exINI, GameStrings::General, "AIAllToHunt");
 	this->RepairBaseNodes.Read(exINI, GameStrings::General, "RepairBaseNodes");
 	this->MCVRedeploysInCampaign.Read(exINI, GameStrings::General, "MCVRedeploysInCampaign");
 
@@ -358,9 +358,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		// .Process(this->VoxelShadowLightSource)
 		.Process(this->UseFixedVoxelLighting)
 		.Process(this->RegroupWhenMCVDeploy)
-		.Process(this->AISellAllOnLastLegs)
-		.Process(this->AISellAllDelay)
-		.Process(this->AIAllInOnLastLegs)
+		.Process(this->AIFireSale)
+		.Process(this->AIFireSaleDelay)
+		.Process(this->AIAllToHunt)
 		.Process(this->RepairBaseNodes)
 		.Process(this->MCVRedeploysInCampaign)
 		;

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -182,6 +182,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	// this->VoxelShadowLightSource.Read(exINI, GameStrings::AudioVisual, "VoxelShadowLightSource");
 
 	this->ReplaceVoxelLightSources();
+	this->RegroupWhenMCVDeploy.Read(exINI, GameStrings::General, "RegroupWhenMCVDeploy");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -347,6 +348,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->PodImage)
 		.Process(this->VoxelLightSource)
 		// .Process(this->VoxelShadowLightSource)
+		.Process(this->RegroupWhenMCVDeploy)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -190,6 +190,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AISellAllDelay.Read(exINI, GameStrings::General, "AISellAllDelay");
 	this->AIAllInOnLastLegs.Read(exINI, GameStrings::General, "AIAllInOnLastLegs");
 	this->RepairBaseNodes.Read(exINI, GameStrings::General, "RepairBaseNodes");
+	this->MCVRedeploysInCampaign.Read(exINI, GameStrings::General, "MCVRedeploysInCampaign");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -361,6 +362,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AISellAllDelay)
 		.Process(this->AIAllInOnLastLegs)
 		.Process(this->RepairBaseNodes)
+		.Process(this->MCVRedeploysInCampaign)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -185,7 +185,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->UseFixedVoxelLighting.Read(exINI, GameStrings::AudioVisual, "UseFixedVoxelLighting");
 
-	this->RegroupWhenMCVDeploy.Read(exINI, GameStrings::General, "RegroupWhenMCVDeploy");
+	this->GatherWhenMCVDeploy.Read(exINI, GameStrings::General, "GatherWhenMCVDeploy");
 	this->AIFireSale.Read(exINI, GameStrings::General, "AIFireSale");
 	this->AIFireSaleDelay.Read(exINI, GameStrings::General, "AIFireSaleDelay");
 	this->AIAllToHunt.Read(exINI, GameStrings::General, "AIAllToHunt");
@@ -357,7 +357,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->VoxelLightSource)
 		// .Process(this->VoxelShadowLightSource)
 		.Process(this->UseFixedVoxelLighting)
-		.Process(this->RegroupWhenMCVDeploy)
+		.Process(this->GatherWhenMCVDeploy)
 		.Process(this->AIFireSale)
 		.Process(this->AIFireSaleDelay)
 		.Process(this->AIAllToHunt)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -182,7 +182,13 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	// this->VoxelShadowLightSource.Read(exINI, GameStrings::AudioVisual, "VoxelShadowLightSource");
 
 	this->ReplaceVoxelLightSources();
+
 	this->RegroupWhenMCVDeploy.Read(exINI, GameStrings::General, "RegroupWhenMCVDeploy");
+	this->AISellAllOnLastLegs.Read(exINI, GameStrings::General, "AISellAllOnLastLegs");
+	this->AISellAllDelay.Read(exINI, GameStrings::General, "AISellAllDelay");
+	this->AIAllInOnLastLegs.Read(exINI, GameStrings::General, "AIAllInOnLastLegs");
+
+	this->RepairBaseNodes.Read(exINI, GameStrings::General, "RepairBaseNodes");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -349,6 +355,10 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->VoxelLightSource)
 		// .Process(this->VoxelShadowLightSource)
 		.Process(this->RegroupWhenMCVDeploy)
+		.Process(this->AISellAllOnLastLegs)
+		.Process(this->AISellAllDelay)
+		.Process(this->AIAllInOnLastLegs)
+		.Process(this->RepairBaseNodes)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -149,6 +149,7 @@ public:
 		Valueable<int> AISellAllDelay;
 		Valueable<bool> AIAllInOnLastLegs;
 		ValueableVector<bool> RepairBaseNodes;
+		Valueable<bool> MCVRedeploysInCampaign;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -256,6 +257,7 @@ public:
 			, AISellAllDelay { 0 }
 			, AIAllInOnLastLegs { true }
 			, RepairBaseNodes {}
+			, MCVRedeploysInCampaign { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -144,7 +144,7 @@ public:
 		// Nullable<Vector3D<float>> VoxelShadowLightSource;
 		Valueable<bool> UseFixedVoxelLighting;
 
-		Valueable<bool> RegroupWhenMCVDeploy;
+		Valueable<bool> GatherWhenMCVDeploy;
 		Valueable<bool> AIFireSale;
 		Valueable<int> AIFireSaleDelay;
 		Valueable<bool> AIAllToHunt;
@@ -252,7 +252,7 @@ public:
 			, VoxelLightSource { }
 			// , VoxelShadowLightSource { }
 			, UseFixedVoxelLighting { false }
-			, RegroupWhenMCVDeploy { true }
+			, GatherWhenMCVDeploy { true }
 			, AIFireSale { true }
 			, AIFireSaleDelay { 0 }
 			, AIAllToHunt { true }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -144,6 +144,11 @@ public:
 		// Nullable<Vector3D<float>> VoxelShadowLightSource;
 
 		Valueable<bool> RegroupWhenMCVDeploy;
+		Valueable<bool> AISellAllOnLastLegs;
+		Valueable<int> AISellAllDelay;
+		Valueable<bool> AIAllInOnLastLegs;
+
+		ValueableVector<bool> RepairBaseNodes;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -246,6 +251,10 @@ public:
 			, VoxelLightSource { }
 			// , VoxelShadowLightSource { }
 			, RegroupWhenMCVDeploy { true }
+			, AISellAllOnLastLegs { true }
+			, AISellAllDelay { 0 }
+			, AIAllInOnLastLegs { true }
+			, RepairBaseNodes {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -143,6 +143,8 @@ public:
 		Nullable<Vector3D<float>> VoxelLightSource;
 		// Nullable<Vector3D<float>> VoxelShadowLightSource;
 
+		Valueable<bool> RegroupWhenMCVDeploy;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -243,6 +245,7 @@ public:
 			, PodImage { }
 			, VoxelLightSource { }
 			// , VoxelShadowLightSource { }
+			, RegroupWhenMCVDeploy { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -145,9 +145,9 @@ public:
 		Valueable<bool> UseFixedVoxelLighting;
 
 		Valueable<bool> RegroupWhenMCVDeploy;
-		Valueable<bool> AISellAllOnLastLegs;
-		Valueable<int> AISellAllDelay;
-		Valueable<bool> AIAllInOnLastLegs;
+		Valueable<bool> AIFireSale;
+		Valueable<int> AIFireSaleDelay;
+		Valueable<bool> AIAllToHunt;
 		ValueableVector<bool> RepairBaseNodes;
 		Valueable<bool> MCVRedeploysInCampaign;
 
@@ -253,9 +253,9 @@ public:
 			// , VoxelShadowLightSource { }
 			, UseFixedVoxelLighting { false }
 			, RegroupWhenMCVDeploy { true }
-			, AISellAllOnLastLegs { true }
-			, AISellAllDelay { 0 }
-			, AIAllInOnLastLegs { true }
+			, AIFireSale { true }
+			, AIFireSaleDelay { 0 }
+			, AIAllToHunt { true }
 			, RepairBaseNodes {}
 			, MCVRedeploysInCampaign { false }
 		{ }

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -128,7 +128,7 @@ void ScenarioExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	{
 		Nullable<bool> SP_MCVRedeploy;
 		SP_MCVRedeploy.Read(exINI, GameStrings::Basic, GameStrings::MCVRedeploys);
-		GameModeOptionsClass::Instance->MCVRedeploy = SP_MCVRedeploy.Get(false);
+		GameModeOptionsClass::Instance->MCVRedeploy = SP_MCVRedeploy.Get(RulesExt::Global()->MCVRedeploysInCampaign);
 
 		CCINIClass* pINI_MISSIONMD = CCINIClass::LoadINIFile(GameStrings::MISSIONMD_INI);
 		auto const scenarioName = pThis->FileName;

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -98,3 +98,16 @@ DEFINE_HOOK(0x6B7600, SpawnManagerClass_AI_InitDestination, 0x6)
 
 	return R->Origin() == 0x6B7600 ? SkipGameCode1 : SkipGameCode2;
 }
+
+// I must not regroup my forces.
+DEFINE_HOOK(0x739920, UnitClass_TryToDeploy_DisableRegroupAtNewConYard, 0x6)
+{
+	enum { SkipRegroup = 0x73992B, DoNotSkipRegroup = 0 };
+
+	auto const pRules = RulesExt::Global();
+	Debug::LogAndMessage("%d \n",pRules->RegroupWhenMCVDeploy);
+	if (!pRules->RegroupWhenMCVDeploy)
+		return SkipRegroup;
+	else
+		return DoNotSkipRegroup;
+}

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -105,6 +105,7 @@ DEFINE_HOOK(0x739920, UnitClass_TryToDeploy_DisableRegroupAtNewConYard, 0x6)
 	enum { SkipRegroup = 0x73992B, DoNotSkipRegroup = 0 };
 
 	auto const pRules = RulesExt::Global();
+
 	if (!pRules->GatherWhenMCVDeploy)
 		return SkipRegroup;
 	else

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -105,7 +105,6 @@ DEFINE_HOOK(0x739920, UnitClass_TryToDeploy_DisableRegroupAtNewConYard, 0x6)
 	enum { SkipRegroup = 0x73992B, DoNotSkipRegroup = 0 };
 
 	auto const pRules = RulesExt::Global();
-	Debug::LogAndMessage("%d \n",pRules->RegroupWhenMCVDeploy);
 	if (!pRules->RegroupWhenMCVDeploy)
 		return SkipRegroup;
 	else

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -105,7 +105,7 @@ DEFINE_HOOK(0x739920, UnitClass_TryToDeploy_DisableRegroupAtNewConYard, 0x6)
 	enum { SkipRegroup = 0x73992B, DoNotSkipRegroup = 0 };
 
 	auto const pRules = RulesExt::Global();
-	if (!pRules->RegroupWhenMCVDeploy)
+	if (!pRules->GatherWhenMCVDeploy)
 		return SkipRegroup;
 	else
 		return DoNotSkipRegroup;

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -106,8 +106,5 @@ DEFINE_HOOK(0x739920, UnitClass_TryToDeploy_DisableRegroupAtNewConYard, 0x6)
 
 	auto const pRules = RulesExt::Global();
 
-	if (!pRules->GatherWhenMCVDeploy)
-		return SkipRegroup;
-	else
-		return DoNotSkipRegroup;
+	 return pRules->GatherWhenMCVDeploy ? DoNotSkipRegroup : SkipRegroup;
 }


### PR DESCRIPTION
### Skirmish AI behavior dehardcode

- In vanilla, there is a hardcoded behavior that when an skirmish AI player has no factory and has not taken damage for a while, it will sell its buildings and set its units to hunt. This can be customized now.
  - `[General]->AISellAllOnLastLegs` and `[General]->AIAllInOnLastLegs` control whether the AI will act selling and hunting respectively.
  - `[General]->AISellAllDelay` defines a timer, it will only work if `[General]->AISellAllOnLastLegs` is set to `true`. When the first time the AI reaches the trigger condition of vanilla behavior, the timer starts and prevents the selling behavior from happening until the timer is expired.
  - You can use these flags to make the AIs "all in" before they are defeated.
- Another hardcoded behavior is that, when the AI deploys a MCV, it will regroup all of its forces to that place. This can be toggle off now.
  - `[General]->RegroupWhenMCVDeploy` controls this behavior.

In `rulesmd.ini`:
```ini
[General]
AISellAllOnLastLegs=true   ; boolean
AISellAllDelay=0           ; integer, number of frames
AIAllInOnLastLegs=true     ; boolean
RegroupWhenMCVDeploy=true  ; boolean
```
### Global setting for `[Country House]->RepairBaseNodes` and `[Basic]->MCVRedeploys`

- Self-evident.