### PR TITLE
Customize Planning Mode

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -319,6 +319,7 @@ This page lists all the individual contributions to the project by their author.
 - **NetsuNegi**
    - Forbidding parallel AI queues by type
    - Jumpjet crash speed fix when crashing onto building
+   - Customize planning mode
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**
    - Customizable ShowTimer priority of superweapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1254,6 +1254,15 @@ Convert.HumanToComputer =   ; TechnoType
 Convert.ComputerToHuman =   ; TechnoType
 ```
 
+### Customize Planning Mode
+- It is possible to control who can use planning mode now. You can disallow a unit to use planning mode or allow an aircraft to use it.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]
+CanUsePlanningMode=     ; boolean (default to true for infantry and unit, false for aircraft and building)
+```
+
 ## Terrain
 
 ### Destroy animation & sound

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -687,6 +687,7 @@ New:
 - Animated (non-tiberium spawning) TerrainTypes (by Starkku)
 - Toggleable passenger killing for Explodes=true units (by Starkku)
 - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist (by FlyStar)
+- Customize Planning Mode (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode (by Kerbiter, ChrisLv_CN)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -315,6 +315,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Wake_Grapple.Read(exINI, pSection, "Wake.Grapple");
 	this->Wake_Sinking.Read(exINI, pSection, "Wake.Sinking");
 
+	this->CanUsePlanningMode.Read(exINI, pSection, "CanUsePlanningMode");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -680,6 +682,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Wake)
 		.Process(this->Wake_Grapple)
 		.Process(this->Wake_Sinking)
+
+		.Process(this->CanUsePlanningMode)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -229,6 +229,8 @@ public:
 		Nullable<AnimTypeClass*> Wake_Grapple;
 		Nullable<AnimTypeClass*> Wake_Sinking;
 
+		Nullable<bool> CanUsePlanningMode;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -453,6 +455,8 @@ public:
 			, Wake { }
 			, Wake_Grapple { }
 			, Wake_Sinking { }
+
+			, CanUsePlanningMode { }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -847,3 +847,15 @@ DEFINE_HOOK(0x737F05, UnitClass_ReceiveDamage_SinkingWake, 0x6)
 
 	return 0x737F0B;
 }
+
+//Allow Aircraft and Building use planningmode
+//Author : NetsuNegi
+DEFINE_HOOK(0x639DCC, TechnoClass_CanUseWaypoint, 0xA)
+{
+	enum { CanUse = 0x639DDA, CannotUse = 0x639DE1 };
+
+	GET(TechnoClass*, pThis, ESI);
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+	return pTypeExt->CanUsePlanningMode.Get(pThis->CanUseWaypoint()) ? CanUse : CannotUse;
+}


### PR DESCRIPTION
It is possible to control who can use planning mode now. You can disallow a unit to use planning mode or allow an aircraft to use it.

In `rulesmd.ini`
```ini
[SOMETECHNO]
CanUsePlanningMode=boolean (default to true for infantry and unit, false for aircraft and building)
```