### PR TITLE
[Minor] Attach & Discard AE by Health Percentage

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -17,6 +17,8 @@ This page describes all the engine features that are either new and introduced b
     - `drain`: Discard when the object is being affected by a weapon with `DrainWeapon=true`.
     - `inrange`: Discard if within weapon range from current target. Distance can be overridden via `DiscardOn.RangeOverride`.
     - `outofrange`: Discard if outside weapon range from current target. Distance can be overridden via `DiscardOn.RangeOverride`.
+  - If `DiscardOn.AbovePercent` or `DiscardOn.BelowPercent` is set, the effect is discarded when the object's health percentage is above/below that value.
+  - If `AffectAbovePercent` or `AffectBelowPercent` is set, the effect can be applied only when the object's health percentage is above/below that value.
   - If `PenetratesIronCurtain` is not set to true, the effect is not applied on currently invulnerable objects.
     - `PenetratesForceShield` can be used to set this separately for Force Shielded objects, defaults to value of `PenetratesIronCurtain`.
   - `Animation` defines animation to play in an indefinite loop for as long as the effect is active on the object it is attached to.
@@ -80,6 +82,10 @@ Cumulative.MaxCount=-1                         ; integer
 Powered=false                                  ; boolean
 DiscardOn=none                                 ; list of discard condition enumeration (none|entry|move|stationary|drain|inrange|outofrange)
 DiscardOn.RangeOverride=                       ; floating point value, distance in cells
+DiscardOn.AbovePercent=                        ; floating point value, percents or absolute (0.0-1.0)
+DiscardOn.BelowPercent=                        ; floating point value, percents or absolute (0.0-1.0)
+AffectAbovePercent=                            ; floating point value, percents or absolute (0.0-1.0)
+AffectBelowPercent=                            ; floating point value, percents or absolute (0.0-1.0)
 PenetratesIronCurtain=false                    ; boolean
 PenetratesForceShield=                         ; boolean
 Animation=                                     ; Animation

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -376,6 +376,12 @@ bool AttachEffectClass::AllowedToBeActive() const
 {
 	auto const pTechno = this->Techno;
 
+	if (this->Type->DiscardOn_AbovePercent.isset() && pTechno->GetHealthPercentage() >= this->Type->DiscardOn_AbovePercent.Get())
+		return false;
+
+	if (this->Type->DiscardOn_BelowPercent.isset() && pTechno->GetHealthPercentage() <= this->Type->DiscardOn_BelowPercent.Get())
+		return false;
+
 	if (auto const pFoot = abstract_cast<FootClass*>(pTechno))
 	{
 		bool isMoving = pFoot->Locomotor->Is_Moving();
@@ -571,6 +577,12 @@ AttachEffectClass* AttachEffectClass::CreateAndAttach(AttachEffectTypeClass* pTy
 	HouseClass* pInvokerHouse, TechnoClass* pInvoker, AbstractClass* pSource, int durationOverride, int delay, int initialDelay, int recreationDelay)
 {
 	if (!pType || !pTarget)
+		return nullptr;
+
+	if (pType->AffectAbovePercent.isset() && pTarget->GetHealthPercentage() < pType->AffectAbovePercent.Get())
+		return nullptr;
+
+	if (pType->AffectBelowPercent.isset() && pTarget->GetHealthPercentage() > pType->AffectBelowPercent.Get())
 		return nullptr;
 
 	if (pTarget->IsIronCurtained())

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -101,6 +101,10 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	this->Powered.Read(exINI, pSection, "Powered");
 	this->DiscardOn.Read(exINI, pSection, "DiscardOn");
 	this->DiscardOn_RangeOverride.Read(exINI, pSection, "DiscardOn.RangeOverride");
+	this->DiscardOn_AbovePercent.Read(exINI, pSection, "DiscardOn.AbovePercent");
+	this->DiscardOn_BelowPercent.Read(exINI, pSection, "DiscardOn.BelowPercent");
+	this->AffectAbovePercent.Read(exINI, pSection, "AffectAbovePercent");
+	this->AffectBelowPercent.Read(exINI, pSection, "AffectBelowPercent");
 	this->PenetratesIronCurtain.Read(exINI, pSection, "PenetratesIronCurtain");
 
 	this->Animation.Read(exINI, pSection, "Animation");
@@ -164,6 +168,10 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->Powered)
 		.Process(this->DiscardOn)
 		.Process(this->DiscardOn_RangeOverride)
+		.Process(this->DiscardOn_AbovePercent)
+		.Process(this->DiscardOn_BelowPercent)
+		.Process(this->AffectAbovePercent)
+		.Process(this->AffectBelowPercent)
 		.Process(this->PenetratesIronCurtain)
 		.Process(this->Animation)
 		.Process(this->CumulativeAnimations)

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -18,6 +18,10 @@ public:
 	Valueable<bool> Powered;
 	Valueable<DiscardCondition> DiscardOn;
 	Nullable<Leptons> DiscardOn_RangeOverride;
+	Nullable<double> DiscardOn_AbovePercent;
+	Nullable<double> DiscardOn_BelowPercent;
+	Nullable<double> AffectAbovePercent;
+	Nullable<double> AffectBelowPercent;
 	Valueable<bool> PenetratesIronCurtain;
 	Nullable<bool> PenetratesForceShield;
 	Valueable<AnimTypeClass*> Animation;
@@ -66,6 +70,10 @@ public:
 		, Powered { false }
 		, DiscardOn { DiscardCondition::None }
 		, DiscardOn_RangeOverride {}
+		, DiscardOn_AbovePercent {}
+		, DiscardOn_BelowPercent {}
+		, AffectAbovePercent {}
+		, AffectBelowPercent {}
 		, PenetratesIronCurtain { false }
 		, PenetratesForceShield {}
 		, Animation {}


### PR DESCRIPTION
  - If `DiscardOn.AbovePercent` or `DiscardOn.BelowPercent` is set, the effect is discarded when the object's health percentage is above/below that value.
  - If `AffectAbovePercent` or `AffectBelowPercent` is set, the effect can be applied only when the object's health percentage is above/below that value.

In `rulesmd.ini`:
```ini
[SOMEATTACHEFFECT]                             ; AttachEffectType
DiscardOn.AbovePercent=                        ; floating point value, percents or absolute (0.0-1.0)
DiscardOn.BelowPercent=                        ; floating point value, percents or absolute (0.0-1.0)
AffectAbovePercent=                            ; floating point value, percents or absolute (0.0-1.0)
AffectBelowPercent=                            ; floating point value, percents or absolute (0.0-1.0)
```