### PR TITLE
[Minor] Another reloader crash fix

### DIFF
--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -23,7 +23,7 @@ TechnoExt::ExtData::~ExtData()
 		vec.erase(std::remove(vec.begin(), vec.end(), this), vec.end());
 	}
 
-	if (pThis->Transporter && pThis->WhatAmI() != AbstractType::Aircraft && pThis->WhatAmI() != AbstractType::Building
+	if (pThis->WhatAmI() != AbstractType::Aircraft && pThis->WhatAmI() != AbstractType::Building
 		&& pType->Ammo > 0 && pTypeExt->ReloadInTransport)
 	{
 		auto& vec = ScenarioExt::Global()->TransportReloaders;


### PR DESCRIPTION
Current techno destructor will only clear TransportReloader list when the techno has a Transporter. This might cause issue when the Transporter somehow being destroyed earlier than the techno, resulting in the list fails to be cleared and crash. Removed that Transporter condition to prevent this