### PR TITLE
bugfix(TAction): SaveGame will no longer break the trigger contains this action after loading the game

### DIFF
--- a/src/Ext/TAction/Body.h
+++ b/src/Ext/TAction/Body.h
@@ -7,6 +7,9 @@
 
 #include <TActionClass.h>
 
+#include <string>
+#include <optional>
+
 class HouseClass;
 
 enum class PhobosTriggerAction : unsigned int
@@ -58,6 +61,8 @@ public:
 
 #undef ACTION_FUNC
 #pragma pop_macro("ACTION_FUNC")
+
+	static std::optional<std::wstring> PendingSaveGameByTrigger;
 
 	class ExtContainer final : public Container<TActionExt>
 	{


### PR DESCRIPTION
The old implementation for this TAction has a bug which will break the trigger use it after you load the save.

Here is an example to reproduce:
1. Create a **repeatable** trigger with event `Time Elapsed...` 5 seconds
2. Set the trigger action with `Disable Trigger` itself and `SaveGame`
3. Use a trigger to enable the SaveGame trigger, twice or more

You will find out this SaveGame trigger will only be executed at the first time, that's because we implemented this SaveGame trigger while executing the trigger, which will save the status of trigger immediately. The proper implementation is make this save request pending, and do it at the beginning of next game frame so no unfinished game objects will be affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new game state management feature for handling pending save games.
	- Added user feedback during the save process, enhancing the overall experience.
- **Bug Fixes**
	- Streamlined the save game process by resetting the pending save state correctly.
- **Documentation**
	- Enhanced message handling and string localization for better user communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->