### PR TITLE
Rewrite frame CRC generation

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -291,6 +291,7 @@ This page lists all the individual contributions to the project by their author.
   - Wall overlay unit sell exploit fix
   - Fix vehicles disguised as trees incorrectly displaying veterancy insignia when they shouldn't
   - GapGen + SpySat desync fix
+  - Frame CRC generation rewrite
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -324,6 +324,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Enabled playing ingame movie in non-campaign modes (i.e. trigger action `100 Play Sidebar Movie...` and `117 Play Sidebar Movie and pause...`).
 - `ElectricAssault` weapons can now auto acquire allies' overpowerable defenses.
 - Fixed the issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions.
+- Purely visual animations and particles are no longer included in frame CRC generation and are thus exempt from any sync checks between players in multiplayer games.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -652,6 +652,7 @@ Vanilla fixes:
 - Enabled playing ingame movie in non-campaign modes (i.e. trigger action `100 Play Sidebar Movie...` and `117 Play Sidebar Movie and pause...`) (by TaranDahl)
 - `ElectricAssault` weapons can now auto acquire allies' overpowerable defenses (by Ollerus)
 - Fixed the issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions (by TaranDahl)
+- Purely visual animations and particles excluded from sync checks (by Starkku)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -543,24 +543,28 @@ DEFINE_HOOK(0x7013A0, TechnoClass_OverrideMission_SyncLog, 0x5)
 	return 0;
 }
 
-}
-
 #pragma region FrameCRC
 
-static bool IsHashable(ObjectClass* pObj)
+class ObjectFake : public ObjectClass
 {
-	auto const rtti = pObj->WhatAmI();
+public:
+	inline bool _IsCRCHashable();
+};
+
+bool ObjectFake::_IsCRCHashable()
+{
+	auto const rtti = this->WhatAmI();
 
 	if (rtti == AbstractType::Anim)
 	{
-		if (pObj->UniqueID == -2)
+		if (this->UniqueID == -2)
 			return false;
 
-		auto const pAnim = static_cast<AnimClass*>(pObj);
+		auto const pAnim = static_cast<AnimClass*>((ObjectClass*)this);
 		auto const pType = pAnim->Type;
 
 		if (pType->Damage != 0.0 || pType->Bouncer || pType->IsMeteor || pType->IsTiberium || pType->TiberiumChainReaction
-			|| pType->IsAnimatedTiberium || pType->MakeInfantry != -1 || AnimTypeExt::ExtMap.Find(pType)->CreateUnit)
+			|| pType->IsAnimatedTiberium || pType->MakeInfantry != -1 || AnimTypeExt::ExtMap.Find(pType)->CreateUnitType.get())
 		{
 			return true;
 		}
@@ -569,7 +573,7 @@ static bool IsHashable(ObjectClass* pObj)
 	}
 	else if (rtti == AbstractType::Particle)
 	{
-		auto const pParticle = static_cast<ParticleClass*>(pObj);
+		auto const pParticle = static_cast<ParticleClass*>((ObjectClass*)this);
 		auto const pType = pParticle->Type;
 
 		if (pType->Damage)
@@ -591,30 +595,30 @@ static int __forceinline GetCoordHash(CoordStruct location)
 	return location.X / 10 + ((location.Y / 10) << 16);
 }
 
-static void __fastcall ComputeGameCRC()
+static void ComputeGameCRC()
 {
 	EventClass::CurrentFrameCRC = 0;
 
-	for (auto const pInf : *InfantryClass::Array)
+	for (auto const pInf : InfantryClass::Array)
 	{
 		int primaryFacing = pInf->PrimaryFacing.Current().GetValue<8>();
 		AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pInf->Location) + primaryFacing);
 	}
 
-	for (auto const pUnit : *UnitClass::Array)
+	for (auto const pUnit : UnitClass::Array)
 	{
 		int primaryFacing = pUnit->PrimaryFacing.Current().GetValue<8>();
 		int secondaryFacing = pUnit->SecondaryFacing.Current().GetValue<8>();
 		AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pUnit->Location) + primaryFacing + secondaryFacing);
 	}
 
-	for (auto const pBuilding : *BuildingClass::Array)
+	for (auto const pBuilding : BuildingClass::Array)
 	{
 		int primaryFacing = pBuilding->PrimaryFacing.Current().GetValue<8>();
 		AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pBuilding->Location) + primaryFacing);
 	}
 
-	for (auto const pHouse : *HouseClass::Array)
+	for (auto const pHouse : HouseClass::Array)
 	{
 		AddCRC(&EventClass::CurrentFrameCRC, pHouse->MapIsClear);
 	}
@@ -625,7 +629,7 @@ static void __fastcall ComputeGameCRC()
 
 		for (auto const pObj : *layer)
 		{
-			if (IsHashable(pObj))
+			if (((ObjectFake*)pObj)->_IsCRCHashable())
 				AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
 		}
 	}
@@ -634,14 +638,15 @@ static void __fastcall ComputeGameCRC()
 
 	for (auto const pObj : logic)
 	{
-		if (IsHashable(pObj))
+		if (((ObjectFake*)pObj)->_IsCRCHashable())
 			AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
 	}
 
 	AddCRC(&EventClass::CurrentFrameCRC, ScenarioClass::Instance->Random.Random());
 	Game::LogFrameCRC(Unsorted::CurrentFrame % 256);
+}
 
-DEFINE_JUMP(CALL, 0x64731C, GET_OFFSET(ComputeGameCRC));
-DEFINE_JUMP(CALL, 0x647684, GET_OFFSET(ComputeGameCRC));
+DEFINE_FUNCTION_JUMP(CALL, 0x64731C, ComputeGameCRC);
+DEFINE_FUNCTION_JUMP(CALL, 0x647684, ComputeGameCRC);
 
 #pragma endregion

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -557,20 +557,25 @@ bool ObjectFake::_IsCRCHashable()
 
 	if (rtti == AbstractType::Anim)
 	{
+		// Game creates animation from [General] -> MoveFlash with this UniqueID
+		// in FootClass::Active_Click_With() (0x4D7D50) - this is local-client only code
+		// which is why these animations have to be ignored in sync check.
 		if (this->UniqueID == -2)
 			return false;
 
-		auto const pAnim = static_cast<AnimClass*>((ObjectClass*)this);
+		auto const pAnim = reinterpret_cast<AnimClass*>(this);
 		auto pType = pAnim->Type;
 
 		while (pType)
 		{
+			// If animation type has logic that affects game simulation, don't ignore.
 			if (pType->Damage != 0.0 || pType->Bouncer || pType->IsMeteor || pType->IsTiberium || pType->TiberiumChainReaction
 				|| pType->IsAnimatedTiberium || pType->MakeInfantry != -1 || AnimTypeExt::ExtMap.Find(pType)->CreateUnitType.get())
 			{
 				return true;
 			}
 
+			// Check anim's Next type recursively until not present.
 			pType = pType->Next;
 		}
 
@@ -578,12 +583,14 @@ bool ObjectFake::_IsCRCHashable()
 	}
 	else if (rtti == AbstractType::Particle)
 	{
-		auto const pParticle = static_cast<ParticleClass*>((ObjectClass*)this);
+		auto const pParticle = reinterpret_cast<ParticleClass*>(this);
 		auto pType = pParticle->Type;
 
+		// If particle type deals damage don't ignore.
 		if (pType->Damage)
 			return true;
 
+		// Check particle's NextParticle type recursively until not present.
 		int index = pType->NextParticle;
 
 		while (index != -1)
@@ -602,12 +609,12 @@ bool ObjectFake::_IsCRCHashable()
 	return true;
 }
 
-static void __forceinline AddCRC(DWORD* crc, unsigned int val)
+static void inline AddCRC(DWORD* crc, unsigned int val)
 {
 	*crc = val + (*crc >> 31) + (*crc << 1);
 }
 
-static int __forceinline GetCoordHash(CoordStruct location)
+static int inline GetCoordHash(CoordStruct location)
 {
 	return location.X / 10 + ((location.Y / 10) << 16);
 }

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -561,12 +561,17 @@ bool ObjectFake::_IsCRCHashable()
 			return false;
 
 		auto const pAnim = static_cast<AnimClass*>((ObjectClass*)this);
-		auto const pType = pAnim->Type;
+		auto pType = pAnim->Type;
 
-		if (pType->Damage != 0.0 || pType->Bouncer || pType->IsMeteor || pType->IsTiberium || pType->TiberiumChainReaction
-			|| pType->IsAnimatedTiberium || pType->MakeInfantry != -1 || AnimTypeExt::ExtMap.Find(pType)->CreateUnitType.get())
+		while (pType)
 		{
-			return true;
+			if (pType->Damage != 0.0 || pType->Bouncer || pType->IsMeteor || pType->IsTiberium || pType->TiberiumChainReaction
+				|| pType->IsAnimatedTiberium || pType->MakeInfantry != -1 || AnimTypeExt::ExtMap.Find(pType)->CreateUnitType.get())
+			{
+				return true;
+			}
+
+			pType = pType->Next;
 		}
 
 		return false;
@@ -574,10 +579,15 @@ bool ObjectFake::_IsCRCHashable()
 	else if (rtti == AbstractType::Particle)
 	{
 		auto const pParticle = static_cast<ParticleClass*>((ObjectClass*)this);
-		auto const pType = pParticle->Type;
+		auto pType = pParticle->Type;
 
-		if (pType->Damage)
-			return true;
+		while (pType)
+		{
+			if (pType->Damage)
+				return true;
+
+			pType = pType->NextParticle;
+		}
 
 		return false;
 	}

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -545,69 +545,79 @@ DEFINE_HOOK(0x7013A0, TechnoClass_OverrideMission_SyncLog, 0x5)
 
 }
 
-static bool __forceinline DisallowObject(ObjectClass* pObj)
+#pragma region FrameCRC
+
+static bool IsHashable(ObjectClass* pObj)
 {
 	auto const rtti = pObj->WhatAmI();
 
 	if (rtti == AbstractType::Anim)
 	{
 		if (pObj->UniqueID == -2)
-			return true;
+			return false;
 
-		auto const pAnim = abstract_cast<AnimClass*>(pObj);
+		auto const pAnim = static_cast<AnimClass*>(pObj);
 		auto const pType = pAnim->Type;
 
 		if (pType->Damage != 0.0 || pType->Bouncer || pType->IsMeteor || pType->IsTiberium || pType->TiberiumChainReaction
 			|| pType->IsAnimatedTiberium || pType->MakeInfantry != -1 || AnimTypeExt::ExtMap.Find(pType)->CreateUnit)
 		{
-			return false;
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 	else if (rtti == AbstractType::Particle)
 	{
-		auto const pParticle = abstract_cast<ParticleClass*>(pObj);
+		auto const pParticle = static_cast<ParticleClass*>(pObj);
 		auto const pType = pParticle->Type;
 
 		if (pType->Damage)
-			return false;
+			return true;
 
-		return true;
+		return false;
 	}
 
-	return false;
+	return true;
 }
 
-DEFINE_HOOK(0x64DAB0, ComputeFrameCRC, 0x6)
+static void __forceinline AddCRC(DWORD* crc, unsigned int val)
 {
-	enum { SkipGameCode = 0x64DE7C };
+	*crc = val + (*crc >> 31) + (*crc << 1);
+}
 
+static int __forceinline GetCoordHash(CoordStruct location)
+{
+	return location.X / 10 + ((location.Y / 10) << 16);
+}
+
+void __fastcall ComputeGameCRC()
+{
 	auto& GameCRC = EventClass::CurrentFrameCRC.get();
 	GameCRC = 0;
 
 	for (auto const pInf : *InfantryClass::Array)
 	{
-		int primaryFacing = (((pInf->PrimaryFacing.Current().Raw >> 7) + 1) >> 1);
-		GameCRC = pInf->Location.X / 10 + ((pInf->Location.Y / 10) << 16) + primaryFacing + (GameCRC >> 31) + 2 * GameCRC;
+		int primaryFacing = pInf->PrimaryFacing.Current().GetValue<8>();
+		AddCRC(&GameCRC, GetCoordHash(pInf->Location) + primaryFacing);
 	}
 
 	for (auto const pUnit : *UnitClass::Array)
 	{
-		int primaryFacing = (((pUnit->PrimaryFacing.Current().Raw >> 7) + 1) >> 1);
-		int secondaryFacing = (((pUnit->SecondaryFacing.Current().Raw >> 7) + 1) >> 1);
-		GameCRC = pUnit->Location.X / 10 + ((pUnit->Location.Y / 10) << 16) + primaryFacing + secondaryFacing + (GameCRC >> 31) + 2 * GameCRC;
+		int primaryFacing = pUnit->PrimaryFacing.Current().GetValue<8>();
+		int secondaryFacing = pUnit->SecondaryFacing.Current().GetValue<8>();
+		AddCRC(&GameCRC, GetCoordHash(pUnit->Location) + primaryFacing + secondaryFacing);
 	}
 
 	for (auto const pBuilding : *BuildingClass::Array)
 	{
-		int primaryFacing = (((pBuilding->PrimaryFacing.Current().Raw >> 7) + 1) >> 1);
-		GameCRC = pBuilding->Location.X / 10 + ((pBuilding->Location.Y / 10) << 16) + primaryFacing + (GameCRC >> 31) + 2 * GameCRC;
+		int primaryFacing = pBuilding->PrimaryFacing.Current().GetValue<8>();
+		AddCRC(&GameCRC, GetCoordHash(pBuilding->Location) + primaryFacing);
 	}
 
 	for (auto const pHouse : *HouseClass::Array)
 	{
-		GameCRC = pHouse->MapIsClear + (GameCRC >> 31) + 2 * GameCRC;
+		AddCRC(&GameCRC, pHouse->MapIsClear);
 	}
 
 	for (int i = 0; i < 5; i++)
@@ -616,23 +626,22 @@ DEFINE_HOOK(0x64DAB0, ComputeFrameCRC, 0x6)
 
 		for (auto const pObj : *layer)
 		{
-			if (DisallowObject(pObj))
-				continue;
-
-			GameCRC = pObj->Location.X / 10 + ((pObj->Location.Y / 10) << 16) + (int)pObj->WhatAmI() + (GameCRC >> 31) + 2 * GameCRC;
+			if (IsHashable(pObj))
+				AddCRC(&GameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
 		}
 	}
 
 	auto const& logic = LogicClass::Instance.get();
 	for (auto const pObj : logic)
 	{
-		if (DisallowObject(pObj))
-			continue;
-
-		GameCRC = pObj->Location.X / 10 + ((pObj->Location.Y / 10) << 16) + (int)pObj->WhatAmI() + (GameCRC >> 31) + 2 * GameCRC;
+		if (IsHashable(pObj))
+			AddCRC(&GameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
 	}
 
-	GameCRC = ScenarioClass::Instance->Random.Random() + (GameCRC >> 31) + 2 * GameCRC;
+	AddCRC(&GameCRC, ScenarioClass::Instance->Random.Random());
 	Game::LogFrameCRC(Unsorted::CurrentFrame % 256);
 
-	return SkipGameCode;
+DEFINE_JUMP(CALL, 0x64731C, GET_OFFSET(ComputeGameCRC));
+DEFINE_JUMP(CALL, 0x647684, GET_OFFSET(ComputeGameCRC));
+
+#pragma endregion

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -609,12 +609,12 @@ bool ObjectFake::_IsCRCHashable()
 	return true;
 }
 
-static void inline AddCRC(DWORD* crc, unsigned int val)
+static void AddCRC(DWORD* crc, unsigned int val)
 {
 	*crc = val + (*crc >> 31) + (*crc << 1);
 }
 
-static int inline GetCoordHash(CoordStruct location)
+static int GetCoordHash(CoordStruct location)
 {
 	return location.X / 10 + ((location.Y / 10) << 16);
 }

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -591,33 +591,32 @@ static int __forceinline GetCoordHash(CoordStruct location)
 	return location.X / 10 + ((location.Y / 10) << 16);
 }
 
-void __fastcall ComputeGameCRC()
+static void __fastcall ComputeGameCRC()
 {
-	auto& GameCRC = EventClass::CurrentFrameCRC.get();
-	GameCRC = 0;
+	EventClass::CurrentFrameCRC = 0;
 
 	for (auto const pInf : *InfantryClass::Array)
 	{
 		int primaryFacing = pInf->PrimaryFacing.Current().GetValue<8>();
-		AddCRC(&GameCRC, GetCoordHash(pInf->Location) + primaryFacing);
+		AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pInf->Location) + primaryFacing);
 	}
 
 	for (auto const pUnit : *UnitClass::Array)
 	{
 		int primaryFacing = pUnit->PrimaryFacing.Current().GetValue<8>();
 		int secondaryFacing = pUnit->SecondaryFacing.Current().GetValue<8>();
-		AddCRC(&GameCRC, GetCoordHash(pUnit->Location) + primaryFacing + secondaryFacing);
+		AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pUnit->Location) + primaryFacing + secondaryFacing);
 	}
 
 	for (auto const pBuilding : *BuildingClass::Array)
 	{
 		int primaryFacing = pBuilding->PrimaryFacing.Current().GetValue<8>();
-		AddCRC(&GameCRC, GetCoordHash(pBuilding->Location) + primaryFacing);
+		AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pBuilding->Location) + primaryFacing);
 	}
 
 	for (auto const pHouse : *HouseClass::Array)
 	{
-		AddCRC(&GameCRC, pHouse->MapIsClear);
+		AddCRC(&EventClass::CurrentFrameCRC, pHouse->MapIsClear);
 	}
 
 	for (int i = 0; i < 5; i++)
@@ -627,18 +626,19 @@ void __fastcall ComputeGameCRC()
 		for (auto const pObj : *layer)
 		{
 			if (IsHashable(pObj))
-				AddCRC(&GameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
+				AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
 		}
 	}
 
-	auto const& logic = LogicClass::Instance.get();
+	LogicClass const& logic = LogicClass::Instance;
+
 	for (auto const pObj : logic)
 	{
 		if (IsHashable(pObj))
-			AddCRC(&GameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
+			AddCRC(&EventClass::CurrentFrameCRC, GetCoordHash(pObj->Location) + (int)pObj->WhatAmI());
 	}
 
-	AddCRC(&GameCRC, ScenarioClass::Instance->Random.Random());
+	AddCRC(&EventClass::CurrentFrameCRC, ScenarioClass::Instance->Random.Random());
 	Game::LogFrameCRC(Unsorted::CurrentFrame % 256);
 
 DEFINE_JUMP(CALL, 0x64731C, GET_OFFSET(ComputeGameCRC));

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -1,6 +1,8 @@
 #include "SyncLogging.h"
 
 #include <Helpers/Macro.h>
+#include <EventClass.h>
+#include <Ext/AnimType/Body.h>
 #include <Utilities/Debug.h>
 #include <Utilities/GeneralUtils.h>
 #include <Utilities/AresHelper.h>
@@ -19,7 +21,6 @@ SyncLogEventBuffer<TargetChangeSyncLogEvent, TargetChanges_Size> SyncLogger::Tar
 SyncLogEventBuffer<TargetChangeSyncLogEvent, DestinationChanges_Size> SyncLogger::DestinationChanges;
 SyncLogEventBuffer<MissionOverrideSyncLogEvent, MissionOverrides_Size> SyncLogger::MissionOverrides;
 SyncLogEventBuffer<AnimCreationSyncLogEvent, AnimCreations_Size> SyncLogger::AnimCreations;
-
 
 void __forceinline MakeCallerRelative(unsigned int& caller)
 {
@@ -541,3 +542,97 @@ DEFINE_HOOK(0x7013A0, TechnoClass_OverrideMission_SyncLog, 0x5)
 
 	return 0;
 }
+
+}
+
+static bool __forceinline DisallowObject(ObjectClass* pObj)
+{
+	auto const rtti = pObj->WhatAmI();
+
+	if (rtti == AbstractType::Anim)
+	{
+		if (pObj->UniqueID == -2)
+			return true;
+
+		auto const pAnim = abstract_cast<AnimClass*>(pObj);
+		auto const pType = pAnim->Type;
+
+		if (pType->Damage != 0.0 || pType->Bouncer || pType->IsMeteor || pType->IsTiberium || pType->TiberiumChainReaction
+			|| pType->IsAnimatedTiberium || pType->MakeInfantry != -1 || AnimTypeExt::ExtMap.Find(pType)->CreateUnit)
+		{
+			return false;
+		}
+
+		return true;
+	}
+	else if (rtti == AbstractType::Particle)
+	{
+		auto const pParticle = abstract_cast<ParticleClass*>(pObj);
+		auto const pType = pParticle->Type;
+
+		if (pType->Damage)
+			return false;
+
+		return true;
+	}
+
+	return false;
+}
+
+DEFINE_HOOK(0x64DAB0, ComputeFrameCRC, 0x6)
+{
+	enum { SkipGameCode = 0x64DE7C };
+
+	auto& GameCRC = EventClass::CurrentFrameCRC.get();
+	GameCRC = 0;
+
+	for (auto const pInf : *InfantryClass::Array)
+	{
+		int primaryFacing = (((pInf->PrimaryFacing.Current().Raw >> 7) + 1) >> 1);
+		GameCRC = pInf->Location.X / 10 + ((pInf->Location.Y / 10) << 16) + primaryFacing + (GameCRC >> 31) + 2 * GameCRC;
+	}
+
+	for (auto const pUnit : *UnitClass::Array)
+	{
+		int primaryFacing = (((pUnit->PrimaryFacing.Current().Raw >> 7) + 1) >> 1);
+		int secondaryFacing = (((pUnit->SecondaryFacing.Current().Raw >> 7) + 1) >> 1);
+		GameCRC = pUnit->Location.X / 10 + ((pUnit->Location.Y / 10) << 16) + primaryFacing + secondaryFacing + (GameCRC >> 31) + 2 * GameCRC;
+	}
+
+	for (auto const pBuilding : *BuildingClass::Array)
+	{
+		int primaryFacing = (((pBuilding->PrimaryFacing.Current().Raw >> 7) + 1) >> 1);
+		GameCRC = pBuilding->Location.X / 10 + ((pBuilding->Location.Y / 10) << 16) + primaryFacing + (GameCRC >> 31) + 2 * GameCRC;
+	}
+
+	for (auto const pHouse : *HouseClass::Array)
+	{
+		GameCRC = pHouse->MapIsClear + (GameCRC >> 31) + 2 * GameCRC;
+	}
+
+	for (int i = 0; i < 5; i++)
+	{
+		auto const layer = DisplayClass::GetLayer((Layer)i);
+
+		for (auto const pObj : *layer)
+		{
+			if (DisallowObject(pObj))
+				continue;
+
+			GameCRC = pObj->Location.X / 10 + ((pObj->Location.Y / 10) << 16) + (int)pObj->WhatAmI() + (GameCRC >> 31) + 2 * GameCRC;
+		}
+	}
+
+	auto const& logic = LogicClass::Instance.get();
+	for (auto const pObj : logic)
+	{
+		if (DisallowObject(pObj))
+			continue;
+
+		GameCRC = pObj->Location.X / 10 + ((pObj->Location.Y / 10) << 16) + (int)pObj->WhatAmI() + (GameCRC >> 31) + 2 * GameCRC;
+	}
+
+	GameCRC = ScenarioClass::Instance->Random.Random() + (GameCRC >> 31) + 2 * GameCRC;
+	Game::LogFrameCRC(Unsorted::CurrentFrame % 256);
+
+	return SkipGameCode;

--- a/src/Misc/SyncLogging.cpp
+++ b/src/Misc/SyncLogging.cpp
@@ -581,12 +581,19 @@ bool ObjectFake::_IsCRCHashable()
 		auto const pParticle = static_cast<ParticleClass*>((ObjectClass*)this);
 		auto pType = pParticle->Type;
 
-		while (pType)
+		if (pType->Damage)
+			return true;
+
+		int index = pType->NextParticle;
+
+		while (index != -1)
 		{
+			pType = ParticleTypeClass::Array[index];
+
 			if (pType->Damage)
 				return true;
 
-			pType = pType->NextParticle;
+			index = pType->NextParticle;
 		}
 
 		return false;


### PR DESCRIPTION
Reimplements game's frame CRC generation function, only change logic-wise is that it now excludes `AnimClass` and `ParticleClass` objects that are purely visual.