### PR TITLE
[Minor] Fix LimboKill function

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -353,6 +353,8 @@ This page lists all the individual contributions to the project by their author.
   - Re-enable the Veinhole Monster and Weeds from TS
   - Recreate the weed-charging of SWs like the TS Chemical Missile
   - Allow to change the speed of gas particles
+- **CrimRecya**
+  - Fix a mistake of `LimboKill` that it did not update the iterators correctly
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -354,7 +354,7 @@ This page lists all the individual contributions to the project by their author.
   - Recreate the weed-charging of SWs like the TS Chemical Missile
   - Allow to change the speed of gas particles
 - **CrimRecya**
-  - Fix a mistake of `LimboKill` that it did not update the iterators correctly
+  - Fix `LimboKill` not working reliably
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -564,7 +564,7 @@ Phobos fixes:
 - Fixed frame by frame hotkey description to read `TXT_FRAME_BY_FRAME_DESC` instead of `TXT_DISPLAY_DAMAGE_DESC` (by DeathFishAtEase)
 - Buildings considered vehicles (`ConsideredVehicle=true` or not set in conjunction with `UndeploysInto` & 1x1 foundation) are now considered units by affected target enum checks (by Starkku)
 - Fixed Phobos Warhead effects not reliably being applied on damage area as opposed to full weapon-based Warhead detonation (by Starkku)
-- Fix a mistake of `LimboKill` that it did not update the iterators correctly (by CrimRecya)
+- Fix `LimboKill` not working reliably (by CrimRecya)
 
 Fixes / interactions with other extensions:
 - `IsSimpleDeployer` units with Hover locomotor and `DeployToLand` no longer get stuck after deploying or play their move sound indefinitely (by Starkku)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -564,6 +564,7 @@ Phobos fixes:
 - Fixed frame by frame hotkey description to read `TXT_FRAME_BY_FRAME_DESC` instead of `TXT_DISPLAY_DAMAGE_DESC` (by DeathFishAtEase)
 - Buildings considered vehicles (`ConsideredVehicle=true` or not set in conjunction with `UndeploysInto` & 1x1 foundation) are now considered units by affected target enum checks (by Starkku)
 - Fixed Phobos Warhead effects not reliably being applied on damage area as opposed to full weapon-based Warhead detonation (by Starkku)
+- Fix a mistake of `LimboKill` that it did not update the iterators correctly (by CrimRecya)
 
 Fixes / interactions with other extensions:
 - `IsSimpleDeployer` units with Hover locomotor and `DeployToLand` no longer get stuck after deploying or play their move sound indefinitely (by Starkku)

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -120,20 +120,6 @@ inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 	}
 }
 
-inline void LimboDelete(BuildingClass* pBuilding, HouseClass* pTargetHouse)
-{
-	auto pOwnerExt = HouseExt::ExtMap.Find(pTargetHouse);
-
-	// Remove building from list of owned limbo buildings
-	auto& vec = pOwnerExt->OwnedLimboDeliveredBuildings;
-	vec.erase(std::remove(vec.begin(), vec.end(), pBuilding), vec.end());
-
-	pBuilding->Stun();
-	pBuilding->Limbo();
-	pBuilding->RegisterDestruction(nullptr);
-	pBuilding->UnInit();
-}
-
 void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 {
 	// random mode
@@ -174,13 +160,25 @@ void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
 			if (EnumFunctions::CanTargetHouse(this->LimboKill_Affected, pHouse, pTargetHouse))
 			{
 				auto const pHouseExt = HouseExt::ExtMap.Find(pTargetHouse);
+				auto& vec = pHouseExt->OwnedLimboDeliveredBuildings;
 
-				for (const auto& pBuilding : pHouseExt->OwnedLimboDeliveredBuildings)
+				for (auto it = vec.begin(); it != vec.end();)
 				{
+					BuildingClass* const pBuilding = *it;
 					auto const pBuildingExt = BuildingExt::ExtMap.Find(pBuilding);
 
 					if (pBuildingExt->LimboID == limboKillID)
-						LimboDelete(pBuilding, pTargetHouse);
+					{
+						it = vec.erase(it);
+						pBuilding->Stun();
+						pBuilding->Limbo();
+						pBuilding->RegisterDestruction(nullptr);
+						pBuilding->UnInit();
+					}
+					else
+					{
+						++it;
+					}
 				}
 			}
 		}

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -162,7 +162,7 @@ void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
 				auto const pHouseExt = HouseExt::ExtMap.Find(pTargetHouse);
 				auto& vec = pHouseExt->OwnedLimboDeliveredBuildings;
 
-				for (auto it = vec.begin(); it != vec.end();)
+				for (auto it = vec.begin(); it != vec.end(); )
 				{
 					BuildingClass* const pBuilding = *it;
 					auto const pBuildingExt = BuildingExt::ExtMap.Find(pBuilding);


### PR DESCRIPTION
Fix a mistake of `LimboKill` that it did not update the iterators correctly that cause it unable to correctly remove all buildings with the same ID.