### PR TITLE
[Minor] Observer sidebar in skirmish game mode

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -355,6 +355,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow to change the speed of gas particles
 - **CrimRecya**
   - Fix `LimboKill` not working reliably
+  - Observer sidebar in skirmish game mode
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -167,6 +167,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - The otherwise unused setting `[AI]` -> `PowerSurplus` (defaults to 50) which determines how much surplus power AI players will strive to have can be restored by setting `[AI]` -> `EnablePowerSurplus` to true.
 - Planning paths are now shown for all units under player control or when `[GlobalControls]->DebugPlanningPaths=yes` in singleplayer game modes.
 - Fixed `Temporal=true` Warheads potentially crashing game if used to attack `Slaved=true` infantry.
+- Enable the observer data panel, which could only be displayed in multiplayer games, to also be displayed in skirmish games.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -522,6 +522,7 @@ Vanilla fixes:
 - Fixed disguised units not using the correct palette if target has custom palette (by NetsuNegi)
 - Building upgrades now consistently use building's `PowerUpN` animation settings corresponding to the upgrade's `PowersUpToLevel` where possible (by Starkku)
 - Subterranean units are no longer allowed to perform deploy functions like firing weapons or `IsSimpleDeployer` while burrowed or burrowing, they will instead emerge first like they do for transport unloading (by Starkku)
+- Observer sidebar in skirmish game mode (by CrimRecya)
 - Fixed `Temporal=true` Warheads potentially crashing game if used to attack `Slaved=true` infantry (by Starkku)
 
 Phobos fixes:

--- a/src/Ext/Sidebar/Hooks.cpp
+++ b/src/Ext/Sidebar/Hooks.cpp
@@ -97,3 +97,30 @@ DEFINE_HOOK(0x72FCB5, InitSideRectangles_CenterBackground, 0x5)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x6A557A, SidebarClass_Init_IO_RecordDiplomacyHouses1, 0x5)
+{
+	enum { SkipGameCode = 0x6A5830, ContinueGameCode = 0x6A558D };
+
+	const GameMode mode = SessionClass::Instance->GameMode;
+
+	return (mode == GameMode::Skirmish || mode == GameMode::LAN || mode == GameMode::Internet) ? ContinueGameCode : SkipGameCode;
+}
+
+DEFINE_HOOK(0x6A55BF, SidebarClass_Init_IO_RecordDiplomacyHouses2, 0x7)
+{
+	enum { ContinueLoop = 0x6A55CF, BreakLoop = 0x6A55C8 };
+
+	GET(HouseClass*, pHouse, EAX);
+
+	return (pHouse->IsHumanPlayer || HouseClass::CurrentPlayer == HouseClass::Observer) ? BreakLoop : ContinueLoop;
+}
+
+DEFINE_HOOK(0x6A57F6, SidebarClass_Init_IO_RecordDiplomacyHouses3, 0x7)
+{
+	enum { ContinueLoop = 0x6A580E, MeetCondition = 0x6A57FF };
+
+	GET(HouseClass*, pHouse, EAX);
+
+	return (pHouse->IsHumanPlayer || HouseClass::CurrentPlayer == HouseClass::Observer) ? MeetCondition : ContinueLoop;
+}


### PR DESCRIPTION
Enable the observer data panel, which could only be displayed in multiplayer games, to also be displayed in skirmish games.
![observer](https://github.com/user-attachments/assets/50892996-d8eb-41c3-ae43-77eddd640f97)
