### PR TITLE
[BugFix] Select allied country units that have been cloaked

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -323,6 +323,7 @@ This page lists all the individual contributions to the project by their author.
 - **FlyStar**
    - Campaign load screen PCX support
    - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist
+   - Fix for friendly units that have been cloaked not being able to be selected
 - **NetsuNegi**
    - Forbidding parallel AI queues by type
    - Jumpjet crash speed fix when crashing onto building

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -169,6 +169,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed `Temporal=true` Warheads potentially crashing game if used to attack `Slaved=true` infantry.
 - Fixed some locomotors (Tunnel, Walk, Mech) getting stuck when moving too fast.
 - Animations with `MakeInfantry` and `UseNormalLight=false` that are drawn in unit palette will now have cell lighting changes applied on them (by Starkku)
+- Fix for friendly units that have been cloaked not being able to be selected.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -569,6 +569,7 @@ Phobos fixes:
 - Fixed Phobos Warhead effects not reliably being applied on damage area as opposed to full weapon-based Warhead detonation (by Starkku)
 - Fix `LimboKill` not working reliably (by CrimRecya)
 - Fixed `SelfHealGainType=none` not working (changed to `noheal`) (by Starkku)
+- Fix for friendly units that have been cloaked not being able to be selected (by Fly-Star)
 
 Fixes / interactions with other extensions:
 - `IsSimpleDeployer` units with Hover locomotor and `DeployToLand` no longer get stuck after deploying or play their move sound indefinitely (by Starkku)

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -1077,13 +1077,13 @@ bool HouseExt::ReachedBuildLimit(const HouseClass* pHouse, const TechnoTypeClass
 }
 #pragma endregion
 
-bool HouseExt::CanSelectOwner(HouseClass* pThis, HouseClass* pPlayer)
+bool HouseExt::CanBeSelectedBy(HouseClass* pOwner, HouseClass* pSelectingPlayer)
 {
-	if (!pThis || !pPlayer)
+	if (!pOwner || !pSelectingPlayer)
 		return false;
 
-	return pThis == pPlayer ||
-		pPlayer->IsCurrentPlayerObserver() ||
-		(pThis->IsAlliedWith(pPlayer) &&
-		pPlayer->IsAlliedWith(pThis));
+	return pOwner == pSelectingPlayer ||
+		pSelectingPlayer->IsCurrentPlayerObserver() ||
+		(pOwner->IsAlliedWith(pSelectingPlayer) &&
+		pSelectingPlayer->IsAlliedWith(pOwner));
 }

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -1076,3 +1076,14 @@ bool HouseExt::ReachedBuildLimit(const HouseClass* pHouse, const TechnoTypeClass
 	return false;
 }
 #pragma endregion
+
+bool HouseExt::CanSelectOwner(HouseClass* pThis, HouseClass* pPlayer)
+{
+	if (!pThis || !pPlayer)
+		return false;
+
+	return pThis == pPlayer ||
+		pPlayer->IsCurrentPlayerObserver() ||
+		(pThis->IsAlliedWith(pPlayer) &&
+		pPlayer->IsAlliedWith(pThis));
+}

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -170,5 +170,5 @@ public:
 	static CanBuildResult BuildLimitGroupCheck(const HouseClass* pThis, const TechnoTypeClass* pItem, bool buildLimitOnly, bool includeQueued);
 	static bool ReachedBuildLimit(const HouseClass* pHouse, const TechnoTypeClass* pType, bool ignoreQueued);
 
-	static bool CanSelectOwner(HouseClass* pThis, HouseClass* pPlayer);
+	static bool CanBeSelectedBy(HouseClass* pOwner, HouseClass* pSelectingPlayer);
 };

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -169,4 +169,6 @@ public:
 
 	static CanBuildResult BuildLimitGroupCheck(const HouseClass* pThis, const TechnoTypeClass* pItem, bool buildLimitOnly, bool includeQueued);
 	static bool ReachedBuildLimit(const HouseClass* pHouse, const TechnoTypeClass* pType, bool ignoreQueued);
+
+	static bool CanSelectOwner(HouseClass* pThis, HouseClass* pPlayer);
 };

--- a/src/Ext/Techno/Hooks.Cloak.cpp
+++ b/src/Ext/Techno/Hooks.Cloak.cpp
@@ -1,4 +1,5 @@
 #include "Body.h"
+#include <Ext/House/Body.h>
 
 namespace CloakTemp
 {
@@ -147,4 +148,58 @@ DEFINE_HOOK(0x4579A5, BuildingClass_ShouldNotCloak_Sensors, 0x6)
 		return Skip;
 
 	return Continue;
+}
+
+// When a friendly unit goes cloaked, UIName can be displayed normally when hovering the mouse.
+DEFINE_HOOK(0x4AE616, DisplayClass_GetToolTip_PlayControl, 0x6)
+{
+	GET(TechnoClass*, pThis, ECX);
+	enum { SkipGameCode = 0x4AE654 };
+
+	R->ESI(pThis);
+
+	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+		SkipGameCode : 0;
+}
+
+// When a friendly unit goes cloaked, the DrawExtra() function can be triggered normally on mouse hover.
+DEFINE_HOOK(0x69252D, DisplayClass_ProcessClickCoords_PlayControl, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+	enum { SkipGameCode = 0x692585 };
+
+	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+		SkipGameCode : 0;
+}
+
+// When a friendly unit goes cloaked, the mouse pointer will change.
+DEFINE_HOOK(0x692686, DisplayClass_DecideAction_PlayControl, 0x6)
+{
+	GET(TechnoClass*, pThis, EDI);
+	enum { SkipGameCode = 0x6926DB };
+
+	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+		SkipGameCode : 0;
+}
+
+// Block out Deselect() when a friendly unit goes cloakd.
+DEFINE_HOOK(0x6F4F10, TechnoClass_Sensed_DisableDSelect, 0x5)
+{
+	GET(TechnoClass* const, pThis, ESI);
+	enum { SkipGameCode = 0x6F4F3A, Continue = 0x6F4F21 };
+
+	R->EAX(HouseClass::CurrentPlayer());
+
+	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+		SkipGameCode : 0;
+}
+
+// Block out Deselect() when a friendly unit goes cloakd.
+DEFINE_HOOK(0x703819, TechnoClass_Cloak_DisableDSelect, 0x6)
+{
+	GET(TechnoClass* const, pThis, ESI);
+	enum { SkipGameCode = 0x70383C, Continue = 0x703828 };
+	
+	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+		SkipGameCode : 0;
 }

--- a/src/Ext/Techno/Hooks.Cloak.cpp
+++ b/src/Ext/Techno/Hooks.Cloak.cpp
@@ -158,7 +158,7 @@ DEFINE_HOOK(0x4AE616, DisplayClass_GetToolTip_PlayControl, 0x6)
 
 	R->ESI(pThis);
 
-	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+	return HouseExt::CanBeSelectedBy(pThis->Owner, HouseClass::CurrentPlayer()) ?
 		SkipGameCode : 0;
 }
 
@@ -168,7 +168,7 @@ DEFINE_HOOK(0x69252D, DisplayClass_ProcessClickCoords_PlayControl, 0x6)
 	GET(TechnoClass*, pThis, ESI);
 	enum { SkipGameCode = 0x692585 };
 
-	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+	return HouseExt::CanBeSelectedBy(pThis->Owner, HouseClass::CurrentPlayer()) ?
 		SkipGameCode : 0;
 }
 
@@ -178,28 +178,28 @@ DEFINE_HOOK(0x692686, DisplayClass_DecideAction_PlayControl, 0x6)
 	GET(TechnoClass*, pThis, EDI);
 	enum { SkipGameCode = 0x6926DB };
 
-	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+	return HouseExt::CanBeSelectedBy(pThis->Owner, HouseClass::CurrentPlayer()) ?
 		SkipGameCode : 0;
 }
 
-// Block out Deselect() when a friendly unit goes cloakd.
+// Do not forcibly deselect when a friendly unit goes cloaked.
 DEFINE_HOOK(0x6F4F10, TechnoClass_Sensed_DisableDSelect, 0x5)
 {
 	GET(TechnoClass* const, pThis, ESI);
-	enum { SkipGameCode = 0x6F4F3A, Continue = 0x6F4F21 };
+	enum { SkipGameCode = 0x6F4F3A };
 
 	R->EAX(HouseClass::CurrentPlayer());
 
-	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+	return HouseExt::CanBeSelectedBy(pThis->Owner, HouseClass::CurrentPlayer()) ?
 		SkipGameCode : 0;
 }
 
-// Block out Deselect() when a friendly unit goes cloakd.
+// Do not forcibly deselect when a friendly unit goes cloaked.
 DEFINE_HOOK(0x703819, TechnoClass_Cloak_DisableDSelect, 0x6)
 {
 	GET(TechnoClass* const, pThis, ESI);
-	enum { SkipGameCode = 0x70383C, Continue = 0x703828 };
+	enum { SkipGameCode = 0x70383C };
 	
-	return HouseExt::CanSelectOwner(pThis->Owner, HouseClass::CurrentPlayer()) ?
+	return HouseExt::CanBeSelectedBy(pThis->Owner, HouseClass::CurrentPlayer()) ?
 		SkipGameCode : 0;
 }


### PR DESCRIPTION
Phobos allow the player to observe friendly units that have been cloaked, but they cannot be selected unless a unit with Sensors=yes is present nearby.
![bug](https://github.com/user-attachments/assets/94006472-4daf-41aa-858a-202e85fb866e)

So I made a short fix to select units with Sensors=yes even if they don't exist nearby.
![fix](https://github.com/user-attachments/assets/09d068fc-72cc-483e-878d-7d98ee37328b)
