### PR TITLE
Build area customizations

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -248,6 +248,7 @@ This page lists all the individual contributions to the project by their author.
   - Animation visibility customization settings
   - Light effect customizations
   - Building unit repair customizations
+  - Build area customizations
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -505,6 +505,21 @@ DetachedReport=  ; sound entry
 
 ## Buildings
 
+### Build area customizations
+
+- There are now additional customizations available for building placement next to other buildings.
+  - `Adjacent.Allowed` lists BuildingTypes this BuildingType can be placed off (within distance defined by `Adjacent`). If empty, any BuildingType not listed in `Adjacent.Disallowed` is okay.
+  - `Adjacent.Disallowed` lists BuildingTypes this BuildingType cannot be placed next to. If empty, any BuildingTypes are okay as long as `Adjacent.Allowed` is empty or they are listed on it.
+  - If `NoBuildAreaOnBuildup` is set to true, no building can be built next to this building regardless of any other settings if it is currently displaying its buildup animation.
+  
+In `rulesmd.ini`:
+```ini
+[SOMEBUILDING]              ; BuildingType
+Adjacent.Allowed=           ; list of BuildingTypes
+Adjacent.Disallowed=        ; list of BuildingTypes
+NoBuildAreaOnBuildup=false  ; boolean
+```
+
 ### Extended building upgrades
 
 ![image](_static/images/powersup.owner-01.png)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -460,6 +460,8 @@ New:
 - Animation visibility customization settings (by Starkku)
 - Light effect customizations (by Starkku)
 - Building unit repair customizations (by Starkku)
+- Toggle to disallow buildings from providing build area during buildup (by Starkku)
+- Allow customizing which building types provide build area for a building (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -157,6 +157,10 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Units_RepairPercent.Read(exINI, pSection, "Units.RepairPercent");
 	this->Units_DisableRepairCost.Read(exINI, pSection, "Units.DisableRepairCost");
 
+	this->NoBuildAreaOnBuildup.Read(exINI, pSection, "NoBuildAreaOnBuildup");
+	this->Adjacent_Allowed.Read(exINI, pSection, "Adjacent.Allowed");
+	this->Adjacent_Disallowed.Read(exINI, pSection, "Adjacent.Disallowed");
+
 	if (pThis->NumberOfDocks > 0)
 	{
 		this->AircraftDockingDirs.clear();
@@ -276,6 +280,9 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Units_RepairStep)
 		.Process(this->Units_RepairPercent)
 		.Process(this->Units_DisableRepairCost)
+		.Process(this->NoBuildAreaOnBuildup)
+		.Process(this->Adjacent_Allowed)
+		.Process(this->Adjacent_Disallowed)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -74,6 +74,10 @@ public:
 		Nullable<double> Units_RepairPercent;
 		Valueable<bool> Units_DisableRepairCost;
 
+		Valueable<bool> NoBuildAreaOnBuildup;
+		ValueableVector<BuildingTypeClass*> Adjacent_Allowed;
+		ValueableVector<BuildingTypeClass*> Adjacent_Disallowed;
+
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
 			, PowersUp_Buildings {}
@@ -119,6 +123,9 @@ public:
 			, Units_RepairStep {}
 			, Units_RepairPercent {}
 			, Units_DisableRepairCost { false }
+			, NoBuildAreaOnBuildup { false }
+			, Adjacent_Allowed {}
+			, Adjacent_Disallowed {}
 		{ }
 
 		// Ares 0.A functions

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -217,3 +217,45 @@ DEFINE_HOOK(0x5F5416, ObjectClass_ReceiveDamage_CanC4DamageRounding, 0x6)
 
 	return SkipGameCode;
 }
+
+#pragma region BuildingProximity
+
+namespace ProximityTemp
+{
+	BuildingTypeClass* pType = nullptr;
+}
+
+DEFINE_HOOK(0x4A8F20, isplayClass_BuildingProximityCheck_SetContext, 0x5)
+{
+	GET(BuildingTypeClass*, pType, ESI);
+
+	ProximityTemp::pType = pType;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x4A8FD7, DisplayClass_BuildingProximityCheck_BuildArea, 0x6)
+{
+	enum { SkipBuilding = 0x4A902C };
+
+	GET(BuildingClass*, pCellBuilding, ESI);
+
+	auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pCellBuilding->Type);
+
+	if (pTypeExt->NoBuildAreaOnBuildup && pCellBuilding->CurrentMission == Mission::Construction)
+		return SkipBuilding;
+
+	auto const& pBuildingsAllowed = BuildingTypeExt::ExtMap.Find(ProximityTemp::pType)->Adjacent_Allowed;
+
+	if (pBuildingsAllowed.size() > 0 && !pBuildingsAllowed.Contains(pCellBuilding->Type))
+		return SkipBuilding;
+
+	auto const& pBuildingsDisallowed = BuildingTypeExt::ExtMap.Find(ProximityTemp::pType)->Adjacent_Disallowed;
+
+	if (pBuildingsDisallowed.size() > 0 && pBuildingsDisallowed.Contains(pCellBuilding->Type))
+		return SkipBuilding;
+
+	return 0;
+}
+
+#pragma endregion


### PR DESCRIPTION
### Build area customizations
- There are now additional customizations available for building placement next to other buildings.
  - `Adjacent.Allowed` lists BuildingTypes this BuildingType can be placed off (within distance defined by `Adjacent`). If empty, any BuildingType not listed in `Adjacent.Disallowed` is okay.
  - `Adjacent.Disallowed` lists BuildingTypes this BuildingType cannot be placed next to. If empty, any BuildingTypes are okay as long as `Adjacent.Allowed` is empty or they are listed on it.
  - If `NoBuildAreaOnBuildup` is set to true, no building can be built next to this building regardless of any other settings if it is currently displaying its buildup animation.
  
In `rulesmd.ini`:
```ini
[SOMEBUILDING]              ; BuildingType
Adjacent.Allowed=           ; list of BuildingTypes
Adjacent.Disallowed=        ; list of BuildingTypes
NoBuildAreaOnBuildup=false  ; boolean
```