### PR TITLE
Allow customizing dock unit repair

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -247,6 +247,7 @@ This page lists all the individual contributions to the project by their author.
   - Buildings considered as destroyable pathfinding obstacles
   - Animation visibility customization settings
   - Light effect customizations
+  - Building unit repair customizations
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -172,6 +172,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Removed 0 damage effect on jumpjet infantries from `InfDeath=9` warhead.
 - Fixed Nuke & Dominator Level lighting not applying to AircraftTypes.
 - Projectiles created from `AirburstWeapon` now remember the WeaponType and can apply radiation etc.
+- Fixed damaged aircraft not repairing on `UnitReload=true` docks unless they land on the dock first.
 
 ## Fixes / interactions with other extensions
 
@@ -298,6 +299,24 @@ In `rulesmd.ini`:
 ```ini
 [SOMEBUILDING]          ; BuildingType
 AircraftDockingDir(N)=  ; Direction type (integers from 0-255)
+```
+
+### Unit repair customization
+
+- It is now possible to customize the repairing of units by `UnitRepair=true` and `UnitReload=true` buildings.
+  - `Units.RepairRate` customizes the rate at which the units are repaired. This defaults to `[General]`->`ReloadRate` if `UnitReload=true` and if overridden per AircraftType (Ares feature) can tick at different time for each docked aircraft. Setting this overrides that behaviour. For `UnitRepair=true` buildings this defaults to `[General]`->`URepairRate`.
+    - On `UnitReload=true` building setting this to negative value will fully disable the repair functionality.
+  - `Units.RepairStep` how much `Strength` is restored per repair tick. Defaults to `[General]`->`RepairStep`.
+  - `Units.RepairPercent` is a multiplier to cost of repairing (cost / (maximum health / repair step)). Defaults to `[General]`->`RepairPercent`. Note that the final cost is set to 1 if it is less than that.
+    - `Units.DisableRepairCost` if set to true disables the repair cost entirely.
+
+In `rulesmd.ini`:
+```ini
+[SOMEBUILDING]                 ; BuildingType
+Units.RepairRate=              ; floating point value, ingame minutes
+Units.RepairStep=              ; integer
+Units.RepairPercent=           ; floating point value, percents or absolute
+Units.DisableRepairCost=false  ; boolean
 ```
 
 ### Airstrike target eligibility

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -459,6 +459,7 @@ New:
 - Buildings considered as destroyable pathfinding obstacles (by Starkku)
 - Animation visibility customization settings (by Starkku)
 - Light effect customizations (by Starkku)
+- Building unit repair customizations (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
@@ -536,6 +537,7 @@ Vanilla fixes:
 - Fixed Nuke & Dominator Level lighting not applying to AircraftTypes (by Starkku)
 - Removed the 0 damage effect from `InfDeath=9` warheads to in-air infantries (by Trsdy)
 - Projectiles created from `AirburstWeapon` now remember their WeaponType and can apply radiation etc. (by Starkku)
+- Fixed damaged aircraft not repairing on `UnitReload=true` docks unless they land on the dock first (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -152,6 +152,11 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->FactoryPlant_AllowTypes.Read(exINI, pSection, "FactoryPlant.AllowTypes");
 	this->FactoryPlant_DisallowTypes.Read(exINI, pSection, "FactoryPlant.DisallowTypes");
 
+	this->Units_RepairRate.Read(exINI, pSection, "Units.RepairRate");
+	this->Units_RepairStep.Read(exINI, pSection, "Units.RepairStep");
+	this->Units_RepairPercent.Read(exINI, pSection, "Units.RepairPercent");
+	this->Units_DisableRepairCost.Read(exINI, pSection, "Units.DisableRepairCost");
+
 	if (pThis->NumberOfDocks > 0)
 	{
 		this->AircraftDockingDirs.clear();
@@ -267,6 +272,10 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->FactoryPlant_AllowTypes)
 		.Process(this->FactoryPlant_DisallowTypes)
 		.Process(this->IsDestroyableObstacle)
+		.Process(this->Units_RepairRate)
+		.Process(this->Units_RepairStep)
+		.Process(this->Units_RepairPercent)
+		.Process(this->Units_DisableRepairCost)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -69,6 +69,11 @@ public:
 		ValueableVector<TechnoTypeClass*> FactoryPlant_AllowTypes;
 		ValueableVector<TechnoTypeClass*> FactoryPlant_DisallowTypes;
 
+		Nullable<double> Units_RepairRate;
+		Nullable<int> Units_RepairStep;
+		Nullable<double> Units_RepairPercent;
+		Valueable<bool> Units_DisableRepairCost;
+
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
 			, PowersUp_Buildings {}
@@ -110,6 +115,10 @@ public:
 			, FactoryPlant_AllowTypes {}
 			, FactoryPlant_DisallowTypes {}
 			, IsDestroyableObstacle { false }
+			, Units_RepairRate {}
+			, Units_RepairStep {}
+			, Units_RepairPercent {}
+			, Units_DisableRepairCost { false }
 		{ }
 
 		// Ares 0.A functions

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -968,3 +968,21 @@ DEFINE_HOOK(0x5B11DD, MechLocomotionClass_ProcessMoving_SlowdownDistance, 0x9)
 }
 
 DEFINE_JUMP(LJMP, 0x517FF5, 0x518016); // Warhead with InfDeath=9 versus infantry in air
+
+// Fixes docks not repairing docked aircraft unless they enter the dock first e.g just built ones.
+// Also potential edge cases with unusual docking offsets, original had a distance check for 64 leptons which is replaced with IsInAir here.
+DEFINE_HOOK(0x44985B, BuildingClass_Mission_Guard_UnitReload, 0x6)
+{
+	enum { AssignRepairMission = 0x449942 };
+
+	GET(BuildingClass*, pThis, ESI);
+	GET(TechnoClass*, pLink, EDI);
+
+	if (pThis->Type->UnitReload && pLink->WhatAmI() == AbstractType::Aircraft && !pLink->IsInAir()
+		&& pThis->SendCommand(RadioCommand::QueryMoving, pLink) == RadioCommand::AnswerPositive)
+	{
+		return AssignRepairMission;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
### Unit repair customization

- It is now possible to customize the repairing of units by `UnitRepair=true` and `UnitReload=true` buildings.
  - `Units.RepairRate` customizes the rate at which the units are repaired. This defaults to `[General]`->`ReloadRate` if `UnitReload=true` and if overridden per AircraftType (Ares feature) can tick at different time for each docked aircraft. Setting this overrides that behaviour. For `UnitRepair=true` buildings this defaults to `[General]`->`URepairRate`.
    - On `UnitReload=true` building setting this to negative value will fully disable the repair functionality.
  - `Units.RepairStep` how much `Strength` is restored per repair tick. Defaults to `[General]`->`RepairStep`.
  - `Units.RepairPercent` is a multiplier to cost of repairing (cost / (maximum health / repair step)). Defaults to `[General]`->`RepairPercent`. Note that the final cost is set to 1 if it is less than that.
    - `Units.DisableRepairCost` if set to true disables the repair cost entirely.

In `rulesmd.ini`:
```ini
[SOMEBUILDING]                 ; BuildingType
Units.RepairRate=              ; floating point value, ingame minutes
Units.RepairStep=              ; integer
Units.RepairPercent=           ; floating point value, percents or absolute
Units.DisableRepairCost=false  ; boolean
```

Other changes:
- Fixed damaged aircraft not repairing on `UnitReload=true` docks unless they land on the dock first.