### PR TITLE
Allow customizing subterranean movement speed and allow parsing floating point Speed values

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -235,7 +235,7 @@ This page lists all the individual contributions to the project by their author.
   - Air unit tracking fix for large range / `CellSpread`
   - Extra tint intensity for Iron Curtain & Force Shield
   - Option to enable parsing 8-bit RGB values from `[ColorAdd]` instead of RGB565
-  - Customizing height at which subterranean units travel
+  - Customizing height and speed at which subterranean units travel
   - AI superweapon delay timer customization
   - Disabling `MultipleFactory` bonus from specific BuildingType
   - Customizable ChronoSphere teleport delays for units

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -176,6 +176,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps.
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers.
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
+- Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -921,21 +921,24 @@ AIAllToHunt=true          ; boolean
 GatherWhenMCVDeploy=true  ; boolean
 ```
 
-### Subterranean unit travel height
+### Subterranean unit travel height and speed
 
 - It is now possible to control the height at which units with subterranean (Tunnel) `Locomotor` travel, globally or per TechnoType.
+- It is also possible to change subterranean units to use their `Speed` and any speed modifiers when traveling underground, instead of hardcoded speed setting that would be roughly between `Speed=7` and `Speed=8`.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-SubterraneanHeight=-256  ; integer, height in leptons (1/256th of a cell)
+SubterraneanHeight=-256     ; integer, height in leptons (1/256th of a cell)
+SubterraneanUseSpeed=false  ; boolean
 
-[SOMETECHNO]             ; TechnoType
-SubterraneanHeight=      ; integer, height in leptons (1/256th of a cell)
+[SOMETECHNO]                ; TechnoType
+SubterraneanHeight=         ; integer, height in leptons (1/256th of a cell)
+SubterraneanUseSpeed=       ; boolean
 ```
 
 ```{warning}
-This expects negative values to be used and may behave erratically if set to above -50.
+SubterraneanHeight expects negative values to be used and may behave erratically if set to above -50.
 ```
 
 ### Voxel body multi-section shadows

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -177,6 +177,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers.
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
+- Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 
 ## Fixes / interactions with other extensions
 
@@ -925,17 +926,17 @@ GatherWhenMCVDeploy=true  ; boolean
 ### Subterranean unit travel height and speed
 
 - It is now possible to control the height at which units with subterranean (Tunnel) `Locomotor` travel, globally or per TechnoType.
-- It is also possible to change subterranean units to use their `Speed` and any speed modifiers when traveling underground, instead of hardcoded speed setting that would be roughly between `Speed=7` and `Speed=8`.
+- Subterranean movement speed is now also customizable, both globally and per TechnoType. If per-TechnoType value is negative, global value is used. This does not affect the speed at which the unit moves vertically when burrowing which is determined by `Speed` multiplied by `[General]`->`TunnelSpeed`.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-SubterraneanHeight=-256     ; integer, height in leptons (1/256th of a cell)
-SubterraneanUseSpeed=false  ; boolean
-
-[SOMETECHNO]                ; TechnoType
-SubterraneanHeight=         ; integer, height in leptons (1/256th of a cell)
-SubterraneanUseSpeed=       ; boolean
+SubterraneanHeight=-256  ; integer, height in leptons (1/256th of a cell)
+SubterraneanSpeed=7.5    ; floating point value
+                         
+[SOMETECHNO]             ; TechnoType
+SubterraneanHeight=      ; integer, height in leptons (1/256th of a cell)
+SubterraneanSpeed=-1     ; floating point value
 ```
 
 ```{warning}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -551,6 +551,7 @@ Vanilla fixes:
 - Fixed objects with ally target and `AttackFriendlies=true` having their target reset every frame, particularly AI-owned buildings (by Starkku)
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers (by Starkku)
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix (by tyuah8)
+- Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc. (by Starkku)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -468,6 +468,7 @@ New:
 - Allow infantry to use land sequences in water (by Starkku)
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps (by Starkku)
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
+- Unit `Speed` setting now accepts floating point values (by Starkku)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -439,7 +439,7 @@ New:
 - `ZAdjust` for OverlayTypes (by Starkku)
 - Allow customizing extra tint intensity for Iron Curtain & Force Shield (by Starkku)
 - Option to enable parsing 8-bit RGB values from `[ColorAdd]` instead of RGB565 (by Starkku)
-- Customizing height at which subterranean units travel (by Starkku)
+- Customizing height and speed at which subterranean units travel (by Starkku)
 - Option for Warhead damage to penetrate Iron Curtain or Force Shield (by Starkku)
 - Option for Warhead to remove all shield types at once (by Starkku)
 - Allow customizing voxel light source position (by Kerbiter, Morton, based on knowledge of thomassnedon)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -78,6 +78,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->ChronoSphereDelay.Read(exINI, GameStrings::General, "ChronoSphereDelay");
 	this->AIChronoSphereSW.Read(exINI, GameStrings::General, "AIChronoSphereSW");
 	this->AIChronoWarpSW.Read(exINI, GameStrings::General, "AIChronoWarpSW");
+	this->SubterraneanUseSpeed.Read(exINI, GameStrings::General, "SubterraneanUseSpeed");
 	this->SubterraneanHeight.Read(exINI, GameStrings::General, "SubterraneanHeight");
 	this->AISuperWeaponDelay.Read(exINI, GameStrings::General, "AISuperWeaponDelay");
 	this->UseGlobalRadApplicationDelay.Read(exINI, GameStrings::Radiation, "UseGlobalRadApplicationDelay");
@@ -285,6 +286,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ChronoSphereDelay)
 		.Process(this->AIChronoSphereSW)
 		.Process(this->AIChronoWarpSW)
+		.Process(this->SubterraneanUseSpeed)
 		.Process(this->SubterraneanHeight)
 		.Process(this->AISuperWeaponDelay)
 		.Process(this->UseGlobalRadApplicationDelay)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -78,7 +78,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->ChronoSphereDelay.Read(exINI, GameStrings::General, "ChronoSphereDelay");
 	this->AIChronoSphereSW.Read(exINI, GameStrings::General, "AIChronoSphereSW");
 	this->AIChronoWarpSW.Read(exINI, GameStrings::General, "AIChronoWarpSW");
-	this->SubterraneanUseSpeed.Read(exINI, GameStrings::General, "SubterraneanUseSpeed");
+
+	exINI.ReadSpeed(GameStrings::General, "SubterraneanSpeed", &this->SubterraneanSpeed);
 	this->SubterraneanHeight.Read(exINI, GameStrings::General, "SubterraneanHeight");
 	this->AISuperWeaponDelay.Read(exINI, GameStrings::General, "AISuperWeaponDelay");
 	this->UseGlobalRadApplicationDelay.Read(exINI, GameStrings::Radiation, "UseGlobalRadApplicationDelay");
@@ -286,7 +287,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ChronoSphereDelay)
 		.Process(this->AIChronoSphereSW)
 		.Process(this->AIChronoWarpSW)
-		.Process(this->SubterraneanUseSpeed)
+		.Process(this->SubterraneanSpeed)
 		.Process(this->SubterraneanHeight)
 		.Process(this->AISuperWeaponDelay)
 		.Process(this->UseGlobalRadApplicationDelay)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -44,7 +44,7 @@ public:
 		Valueable<int> ChronoSphereDelay;
 		ValueableIdx<SuperWeaponTypeClass> AIChronoSphereSW;
 		ValueableIdx<SuperWeaponTypeClass> AIChronoWarpSW;
-		Valueable<bool> SubterraneanUseSpeed;
+		int SubterraneanSpeed;
 		Valueable<int> SubterraneanHeight;
 		Nullable<int> AISuperWeaponDelay;
 		Valueable<bool> UseGlobalRadApplicationDelay;
@@ -178,7 +178,7 @@ public:
 			, ChronoSphereDelay { 0 }
 			, AIChronoSphereSW {}
 			, AIChronoWarpSW {}
-			, SubterraneanUseSpeed { false }
+			, SubterraneanSpeed { 19 }
 			, SubterraneanHeight { -256 }
 			, AISuperWeaponDelay {}
 			, UseGlobalRadApplicationDelay { true }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -44,6 +44,7 @@ public:
 		Valueable<int> ChronoSphereDelay;
 		ValueableIdx<SuperWeaponTypeClass> AIChronoSphereSW;
 		ValueableIdx<SuperWeaponTypeClass> AIChronoWarpSW;
+		Valueable<bool> SubterraneanUseSpeed;
 		Valueable<int> SubterraneanHeight;
 		Nullable<int> AISuperWeaponDelay;
 		Valueable<bool> UseGlobalRadApplicationDelay;
@@ -177,6 +178,7 @@ public:
 			, ChronoSphereDelay { 0 }
 			, AIChronoSphereSW {}
 			, AIChronoWarpSW {}
+			, SubterraneanUseSpeed { false }
 			, SubterraneanHeight { -256 }
 			, AISuperWeaponDelay {}
 			, UseGlobalRadApplicationDelay { true }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -344,6 +344,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->WarpOutWeapon.Read<true>(exINI, pSection, "WarpOutWeapon");
 	this->WarpInWeapon_UseDistanceAsDamage.Read(exINI, pSection, "WarpInWeapon.UseDistanceAsDamage");
 
+	this->SubterraneanUseSpeed.Read(exINI, pSection, "SubterraneanUseSpeed");
 	this->SubterraneanHeight.Read(exINI, pSection, "SubterraneanHeight");
 
 	this->OreGathering_Anims.Read(exINI, pSection, "OreGathering.Anims");
@@ -695,6 +696,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->WarpOutWeapon)
 		.Process(this->WarpInWeapon_UseDistanceAsDamage)
 
+		.Process(this->SubterraneanUseSpeed)
 		.Process(this->SubterraneanHeight)
 
 		.Process(this->OreGathering_Anims)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -344,7 +344,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->WarpOutWeapon.Read<true>(exINI, pSection, "WarpOutWeapon");
 	this->WarpInWeapon_UseDistanceAsDamage.Read(exINI, pSection, "WarpInWeapon.UseDistanceAsDamage");
 
-	this->SubterraneanUseSpeed.Read(exINI, pSection, "SubterraneanUseSpeed");
+	exINI.ReadSpeed(pSection, "SubterraneanSpeed", &this->SubterraneanSpeed);
 	this->SubterraneanHeight.Read(exINI, pSection, "SubterraneanHeight");
 
 	this->OreGathering_Anims.Read(exINI, pSection, "OreGathering.Anims");
@@ -696,7 +696,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->WarpOutWeapon)
 		.Process(this->WarpInWeapon_UseDistanceAsDamage)
 
-		.Process(this->SubterraneanUseSpeed)
+		.Process(this->SubterraneanSpeed)
 		.Process(this->SubterraneanHeight)
 
 		.Process(this->OreGathering_Anims)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -103,7 +103,7 @@ public:
 		Valueable<WeaponTypeClass*> WarpOutWeapon;
 		Valueable<bool> WarpInWeapon_UseDistanceAsDamage;
 
-		Nullable<bool> SubterraneanUseSpeed;
+		int SubterraneanSpeed;
 		Nullable<int> SubterraneanHeight;
 
 		ValueableVector<AnimTypeClass*> OreGathering_Anims;
@@ -298,7 +298,7 @@ public:
 			, WarpOutWeapon {}
 			, WarpInWeapon_UseDistanceAsDamage { false }
 
-			, SubterraneanUseSpeed {}
+			, SubterraneanSpeed { -1 }
 			, SubterraneanHeight {}
 
 			, OreGathering_Anims {}

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -103,6 +103,7 @@ public:
 		Valueable<WeaponTypeClass*> WarpOutWeapon;
 		Valueable<bool> WarpInWeapon_UseDistanceAsDamage;
 
+		Nullable<bool> SubterraneanUseSpeed;
 		Nullable<int> SubterraneanHeight;
 
 		ValueableVector<AnimTypeClass*> OreGathering_Anims;
@@ -297,6 +298,7 @@ public:
 			, WarpOutWeapon {}
 			, WarpInWeapon_UseDistanceAsDamage { false }
 
+			, SubterraneanUseSpeed {}
 			, SubterraneanHeight {}
 
 			, OreGathering_Anims {}

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -130,7 +130,7 @@ DEFINE_HOOK(0x71464A, TechnoTypeClass_ReadINI_Speed, 0x7)
 
 	double parsedSpeed = pINI->ReadDouble(pSection, "Speed", -1.0);
 
-	if (parsedSpeed != -1.0)
+	if (parsedSpeed >= 0.0)
 	{
 		int speed = Game::F2I((Math::min(parsedSpeed, 100.0) * 256.0) / 100.0);
 		pThis->Speed = Math::min(speed, 255);

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -115,3 +115,26 @@ DEFINE_HOOK(0x711FDF, TechnoTypeClass_RefundAmount_FactoryPlant, 0x8)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x71464A, TechnoTypeClass_ReadINI_Speed, 0x7)
+{
+	enum { SkipGameCode = 0x71469F };
+
+	GET(TechnoTypeClass*, pThis, EBP);
+	GET(CCINIClass*, pINI, ESI);
+	GET(char*, pSection, EBX);
+	GET(int, eliteAirstrikeRechargeTime, EAX);
+
+	// Restore overridden instructions.
+	pThis->EliteAirstrikeRechargeTime = eliteAirstrikeRechargeTime;
+
+	double parsedSpeed = pINI->ReadDouble(pSection, "Speed", -1.0);
+
+	if (parsedSpeed != -1.0)
+	{
+		int speed = Game::F2I((Math::min(parsedSpeed, 100.0) * 256.0) / 100.0);
+		pThis->Speed = Math::min(speed, 255);
+	}
+
+	return SkipGameCode;
+}

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -116,6 +116,7 @@ DEFINE_HOOK(0x711FDF, TechnoTypeClass_RefundAmount_FactoryPlant, 0x8)
 	return 0;
 }
 
+
 DEFINE_HOOK(0x71464A, TechnoTypeClass_ReadINI_Speed, 0x7)
 {
 	enum { SkipGameCode = 0x71469F };
@@ -125,16 +126,9 @@ DEFINE_HOOK(0x71464A, TechnoTypeClass_ReadINI_Speed, 0x7)
 	GET(char*, pSection, EBX);
 	GET(int, eliteAirstrikeRechargeTime, EAX);
 
-	// Restore overridden instructions.
-	pThis->EliteAirstrikeRechargeTime = eliteAirstrikeRechargeTime;
-
-	double parsedSpeed = pINI->ReadDouble(pSection, "Speed", -1.0);
-
-	if (parsedSpeed >= 0.0)
-	{
-		int speed = Game::F2I((Math::min(parsedSpeed, 100.0) * 256.0) / 100.0);
-		pThis->Speed = Math::min(speed, 255);
-	}
+	pThis->EliteAirstrikeRechargeTime = eliteAirstrikeRechargeTime; // Restore overridden instructions.
+	INI_EX exINI(pINI);
+	exINI.ReadSpeed(pSection, "Speed", &pThis->Speed);
 
 	return SkipGameCode;
 }

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -910,21 +910,22 @@ DEFINE_HOOK(0x7295C5, TunnelLocomotionClass_ProcessDigging_SlowdownDistance, 0x9
 	GET(TunnelLocomotionClass* const, pLoco, ESI);
 	GET(int const, distance, EAX);
 
-	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pLoco->LinkedTo->GetTechnoType());
-	int currentSpeed = 19;
-
 	// The movement speed was actually also hardcoded here to 19, so the distance check made sense
-	// It can now be lifted by setting this key on TechnoType or globally - Starkku
-	if (pTypeExt->SubterraneanUseSpeed.Get(RulesExt::Global()->SubterraneanUseSpeed))
-	{
-		// Subterranean locomotor doesn't normally use this so it would be 0.0 here and cause issues.
-		pLoco->LinkedTo->SpeedPercentage = 1.0;
-		currentSpeed = pLoco->LinkedTo->GetCurrentSpeed();
-	}
+	// It can now be customized globally or per TechnoType however - Starkku
+	auto const pType = pLoco->LinkedTo->GetTechnoType();
+	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+	int speed = pTypeExt->SubterraneanSpeed >= 0 ? pTypeExt->SubterraneanSpeed : RulesExt::Global()->SubterraneanSpeed;
 
-	TunnelLocomotionClass::TunnelMovementSpeed = currentSpeed;
+	// Calculate speed multipliers.
+	pLoco->LinkedTo->SpeedPercentage = 1.0; // Subterranean locomotor doesn't normally use this so it would be 0.0 here and cause issues.
+	int maxSpeed = pType->Speed;
+	pType->Speed = speed;
+	speed = pLoco->LinkedTo->GetCurrentSpeed();
+	pType->Speed = maxSpeed;
 
-	return distance >= currentSpeed + 1 ? KeepMoving : CloseEnough;
+	TunnelLocomotionClass::TunnelMovementSpeed = speed;
+
+	return distance >= speed + 1 ? KeepMoving : CloseEnough;
 }
 
 DEFINE_HOOK(0x75BD70, WalkLocomotionClass_ProcessMoving_SlowdownDistance, 0x9)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -910,7 +910,21 @@ DEFINE_HOOK(0x7295C5, TunnelLocomotionClass_ProcessDigging_SlowdownDistance, 0x9
 	GET(TunnelLocomotionClass* const, pLoco, ESI);
 	GET(int const, distance, EAX);
 
-	return distance >= pLoco->LinkedTo->GetCurrentSpeed() ? KeepMoving : CloseEnough;
+	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pLoco->LinkedTo->GetTechnoType());
+	int currentSpeed = 19;
+
+	// The movement speed was actually also hardcoded here to 19, so the distance check made sense
+	// It can now be lifted by setting this key on TechnoType or globally - Starkku
+	if (pTypeExt->SubterraneanUseSpeed.Get(RulesExt::Global()->SubterraneanUseSpeed))
+	{
+		// Subterranean locomotor doesn't normally use this so it would be 0.0 here and cause issues.
+		pLoco->LinkedTo->SpeedPercentage = 1.0;
+		currentSpeed = pLoco->LinkedTo->GetCurrentSpeed();
+	}
+
+	TunnelLocomotionClass::TunnelMovementSpeed = currentSpeed;
+
+	return distance >= currentSpeed + 1 ? KeepMoving : CloseEnough;
 }
 
 DEFINE_HOOK(0x75BD70, WalkLocomotionClass_ProcessMoving_SlowdownDistance, 0x9)

--- a/src/Utilities/INIParser.h
+++ b/src/Utilities/INIParser.h
@@ -39,6 +39,7 @@
 
 #include <Phobos.h>
 #include <CCINIClass.h>
+#include <Unsorted.h>
 
 class INI_EX
 {
@@ -148,6 +149,19 @@ public:
 	bool ReadArmor(const char* pSection, const char* pKey, int* nBuffer)
 	{
 		*nBuffer = IniFile->ReadArmorType(pSection, pKey, *nBuffer);
+		return (*nBuffer != -1);
+	}
+
+	bool ReadSpeed(const char* pSection, const char* pKey, int* nBuffer)
+	{
+		double parsedSpeed = IniFile->ReadDouble(pSection, pKey, -1.0);
+
+		if (parsedSpeed >= 0.0)
+		{
+			int speed = Game::F2I((Math::min(parsedSpeed, 100.0) * 256.0) / 100.0);
+			*nBuffer = Math::min(speed, 255);
+		}
+
 		return (*nBuffer != -1);
 	}
 


### PR DESCRIPTION
This should fix an issue introduced in 890eca0cd7eeb9298e876386cb2c3787bfb3e72b for tunnel locomotor where a distance check was made against unit's current speed without ensuring that `SpeedPercentage` which is normally not used by `TunnelLocomotionClass` is 1.0 instead of 0.0 and unhardcoding the subterranean movement speed.

### Subterranean unit travel speed

- Subterranean movement speed is now customizable, both globally and per TechnoType. If per-TechnoType value is negative, global value is used. This does not affect the speed at which the unit moves vertically when burrowing which is determined by `Speed` multiplied by `[General]`->`TunnelSpeed`.

In `rulesmd.ini`:
```ini
[General]
SubterraneanSpeed=7.5    ; floating point value
                         
[SOMETECHNO]             ; TechnoType
SubterraneanSpeed=-1     ; floating point value
```

-----

Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
