### PR TITLE
[Minor] Clear jumpjets' redundant destination

### DIFF
--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -120,10 +120,10 @@ DEFINE_HOOK(0x736990, UnitClass_UpdateRotation_TurretFacing_EMP, 0x6)
 }
 
 // Bugfix: Align jumpjet turret's facing with body's
-DEFINE_HOOK_AGAIN(0x54BB80, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessAscending
-DEFINE_HOOK_AGAIN(0x54C2CB, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessCruising
-DEFINE_HOOK_AGAIN(0x54C376, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessCruising
-DEFINE_HOOK(0x54C64B, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessDescending
+DEFINE_HOOK_AGAIN(0x54BB80, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // Process_Ascending
+DEFINE_HOOK_AGAIN(0x54C2CB, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // Process_Cruising
+DEFINE_HOOK_AGAIN(0x54C376, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // Process_Cruising
+DEFINE_HOOK(0x54C64B, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // Process_Descending
 {
 	GET(FootClass* const, pThis, ECX);
 

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -120,17 +120,15 @@ DEFINE_HOOK(0x736990, UnitClass_UpdateRotation_TurretFacing_EMP, 0x6)
 }
 
 // Bugfix: Align jumpjet turret's facing with body's
-DEFINE_HOOK(0x736BA3, UnitClass_UpdateRotation_TurretFacing_Jumpjet, 0x6)
+DEFINE_HOOK_AGAIN(0x54BB80, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessAscending
+DEFINE_HOOK_AGAIN(0x54C2CB, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessCruising
+DEFINE_HOOK_AGAIN(0x54C376, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessCruising
+DEFINE_HOOK(0x54C64B, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7) // ProcessDescending
 {
-	GET(UnitClass* const, pThis, ESI);
-	enum { SkipCheckDestination = 0x736BCA, GetDirectionTowardsDestination = 0x736BBB };
-	// When jumpjets arrived at their FootClass::Destination, they seems stuck at the Move mission
-	// and therefore the turret facing was set to DirStruct{atan2(0,0)}==DirType::East at 0x736BBB
-	// that's why they will come back to normal when giving stop command explicitly
-	// so the best way is to fix the Mission if necessary, but I don't know how to do it
-	// so I skipped jumpjets check temporarily
-	if (!pThis->Type->TurretSpins && locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
-		return SkipCheckDestination;
+	GET(FootClass* const, pThis, ECX);
+
+	pThis->SetDestination(nullptr, true);
+	pThis->QueueMission(Mission::Guard, true);
 
 	return 0;
 }

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -128,10 +128,7 @@ DEFINE_HOOK(0x54C64B, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7)
 	GET(FootClass* const, pThis, ECX);
 
 	if (pThis->Destination == pThis->GetCell())
-	{
 		pThis->SetDestination(nullptr, true);
-		pThis->QueueMission(Mission::Guard, true);
-	}
 
 	return 0;
 }

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -127,8 +127,11 @@ DEFINE_HOOK(0x54C64B, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7)
 {
 	GET(FootClass* const, pThis, ECX);
 
-	pThis->SetDestination(nullptr, true);
-	pThis->QueueMission(Mission::Guard, true);
+	if (pThis->Destination == pThis->GetCell())
+	{
+		pThis->SetDestination(nullptr, true);
+		pThis->QueueMission(Mission::Guard, true);
+	}
 
 	return 0;
 }

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -128,7 +128,12 @@ DEFINE_HOOK(0x54C64B, JumpjetLocomotionClass_ProcessState_ClearDestination, 0x7)
 	GET(FootClass* const, pThis, ECX);
 
 	if (pThis->Destination == pThis->GetCell())
+	{
 		pThis->SetDestination(nullptr, true);
+
+		if (!pThis->Target)
+			pThis->QueueMission(Mission::Guard, true);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Clear jumpjets' redundant `Destination` when they change state to hovering.
This is for improving `align jumpjet turret's facing with body's`, and adapt to  #1308 .