### PR TITLE
use SW deferment on Phobos logic

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -371,6 +371,7 @@ This page lists all the individual contributions to the project by their author.
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude
+  - Allow superweapon launch behaviors to support `SW.Deferment`
 - **handama** - AI script action to jump back to previous script
 - **TaranDahl (航味麻酱)**
   - Skirmish AI "sell all buildings and set all technos to hunt" behavior dehardcode

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -568,14 +568,20 @@ PowerPlantEnhancer.Factor=1.0      ; floating point value
 
 - Additional espionage bonuses can be toggled with `SpyEffect.Custom`.
   - `SpyEffect.VictimSuperWeapon` instantly launches a Super Weapon for the owner of the infiltrated building at building's coordinates.
+    - `SpyEffect.VictimSuperWeapon.UseDeferment` delays the launch by a certain amount of frames determined by the superweapon's `SW.Deferment` if set to true, while `SpyEffect.VictimSuperWeapon.ExtraDeferment` adds an extra value to this delay.
   - `SpyEffect.InfiltratorSuperWeapon` behaves the same as above, with the Super Weapon's owner being the owner of the spying unit.
+    - `SpyEffect.InfiltratorSuperWeapon.UseDeferment` delays the launch by a certain amount of frames determined by the superweapon's `SW.Deferment` if set to true, while `SpyEffect.InfiltratorSuperWeapon.ExtraDeferment` adds an extra value to this delay.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEBUILDING]                     ; BuildingType
-SpyEffect.Custom=false            ; boolean
-SpyEffect.VictimSuperWeapon=      ; SuperWeaponType
-SpyEffect.InfiltratorSuperWeapon= ; SuperWeaponType
+[SOMEBUILDING]                                        ; BuildingType
+SpyEffect.Custom=false                                ; boolean
+SpyEffect.VictimSuperWeapon=                          ; SuperWeaponType
+SpyEffect.VictimSuperWeapon.UseDeferment=false        ; boolean
+SpyEffect.VictimSuperWeapon.ExtraDeferment=0          ; integer
+SpyEffect.InfiltratorSuperWeapon=                     ; SuperWeaponType
+SpyEffect.InfiltratorSuperWeapon.UseDeferment=false   ; boolean
+SpyEffect.InfiltratorSuperWeapon.ExtraDeferment=0     ; integer
 ```
 
 ## Infantry
@@ -910,6 +916,7 @@ Superweapons can now launch other superweapons at the same target. Launched type
   - `SW.Next.RealLaunch` controls whether the owner who fired the initial superweapon must own all listed superweapons and sufficient funds to support `Money.Amout`. Otherwise they will be launched forcibly.
   - `SW.Next.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of each superweapon, otherwise only non-inhibited superweapons are launched.
   - `SW.Next.IgnoreDesignators` ignores `SW.Designators`/`SW.AnyDesignator` respectively.
+  - `SW.Next.UseDeferment` delays the launch by a certain amount of frames determined by the next superweapon's `SW.Deferment` if set to true, while `SW.Next.ExtraDeferment` adds an extra value to this delay.
 
 In `rulesmd.ini`:
 ```ini
@@ -920,6 +927,8 @@ SW.Next.IgnoreInhibitors=false  ; boolean
 SW.Next.IgnoreDesignators=true  ; boolean
 SW.Next.RollChances=            ; List of percentages.
 SW.Next.RandomWeightsN=         ; List of integers.
+SW.Next.UseDeferment=false      ; boolean
+SW.Next.ExtraDeferment=0        ; integer
 ```
 
 ### Warhead or Weapon detonation at target cell
@@ -1546,6 +1555,7 @@ PenetratesForceShield=       ; boolean
   - `LaunchSW.RealLaunch` controls whether the owner who fired the warhead must own all listed superweapons. Otherwise they will be launched out of nowhere.
   - `LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of each superweapon, otherwise only non-inhibited superweapons are launched.
   - `LaunchSW.IgnoreDesignators` ignores `SW.Designators`/`SW.AnyDesignator` respectively.
+  - `LaunchSW.UseDeferment` delays the launch by a certain amount of frames determined by the superweapon's `SW.Deferment` if set to true, while `LaunchSW.ExtraDeferment` adds an extra value to this delay.
   - `LaunchSW.DisplayMoney` can be set to display the amount of credits given or deducted by the launched superweapon by `Money.Amount`. The number is displayed in green if given, red if deducted and will move upwards after appearing.
     - `LaunchSW.DisplayMoney.Houses` determines which houses can see the credits display.
     - `LaunchSW.DisplayMoney.Offset` is additional pixel offset for the center of the credits display, by default (0,0) at superweapon's target cell.
@@ -1565,6 +1575,8 @@ LaunchSW=                         ; list of superweapons
 LaunchSW.RealLaunch=true          ; boolean
 LaunchSW.IgnoreInhibitors=false   ; boolean
 LaunchSW.IgnoreDesignators=true   ; boolean
+LaunchSW.UseDeferment=false       ; boolean
+LaunchSW.ExtraDeferment=0         ; integer
 LaunchSW.DisplayMoney=false       ; boolean
 LaunchSW.DisplayMoney.Houses=all  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 LaunchSW.DisplayMoney.Offset=0,0  ; X,Y, pixels relative to default

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -465,6 +465,7 @@ New:
 - Allow customizing which building types provide build area for a building (by Starkku)
 - `Scorch` / `Flamer` fire animation customization (by Starkku)
 - Warheads parasite removal customization (by Starkku)
+- Allow superweapon launch behaviors to support `SW.Deferment` (by Ollerus)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -190,7 +190,11 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		this->SuperWeapons.Read(exINI, pSection, "SuperWeapons");
 
 		this->SpyEffect_VictimSuperWeapon.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon");
+		this->SpyEffect_VictimSuperWeapon_UseDeferment.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon.UseDeferment");
+		this->SpyEffect_VictimSuperWeapon_ExtraDeferment.Read(exINI, pSection, "SpyEffect.VictimSuperWeapon.ExtraDeferment");
 		this->SpyEffect_InfiltratorSuperWeapon.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon");
+		this->SpyEffect_InfiltratorSuperWeapon_UseDeferment.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon.UseDeferment");
+		this->SpyEffect_InfiltratorSuperWeapon_ExtraDeferment.Read(exINI, pSection, "SpyEffect.InfiltratorSuperWeapon.ExtraDeferment");
 	}
 
 	if (pThis->MaxNumberOccupants > 10)
@@ -268,7 +272,11 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PlacementPreview_Translucency)
 		.Process(this->SpyEffect_Custom)
 		.Process(this->SpyEffect_VictimSuperWeapon)
+		.Process(this->SpyEffect_VictimSuperWeapon_UseDeferment)
+		.Process(this->SpyEffect_VictimSuperWeapon_ExtraDeferment)
 		.Process(this->SpyEffect_InfiltratorSuperWeapon)
+		.Process(this->SpyEffect_InfiltratorSuperWeapon_UseDeferment)
+		.Process(this->SpyEffect_InfiltratorSuperWeapon_ExtraDeferment)
 		.Process(this->ConsideredVehicle)
 		.Process(this->ZShapePointMove_OnBuildup)
 		.Process(this->SellBuildupLength)

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -57,7 +57,11 @@ public:
 
 		Valueable<bool> SpyEffect_Custom;
 		ValueableIdx<SuperWeaponTypeClass> SpyEffect_VictimSuperWeapon;
+		Valueable<bool> SpyEffect_VictimSuperWeapon_UseDeferment;
+		Valueable<int> SpyEffect_VictimSuperWeapon_ExtraDeferment;
 		ValueableIdx<SuperWeaponTypeClass> SpyEffect_InfiltratorSuperWeapon;
+		Valueable<bool> SpyEffect_InfiltratorSuperWeapon_UseDeferment;
+		Valueable<int> SpyEffect_InfiltratorSuperWeapon_ExtraDeferment;
 
 		Nullable<bool> ConsideredVehicle;
 		Valueable<bool> ZShapePointMove_OnBuildup;
@@ -111,7 +115,11 @@ public:
 			, PlacementPreview_Translucency {}
 			, SpyEffect_Custom { false }
 			, SpyEffect_VictimSuperWeapon {}
+			, SpyEffect_VictimSuperWeapon_UseDeferment { false }
+			, SpyEffect_VictimSuperWeapon_ExtraDeferment { 0 }
 			, SpyEffect_InfiltratorSuperWeapon {}
+			, SpyEffect_InfiltratorSuperWeapon_UseDeferment { false }
+			, SpyEffect_InfiltratorSuperWeapon_ExtraDeferment { 0 }
 			, ConsideredVehicle {}
 			, ZShapePointMove_OnBuildup { false }
 			, SellBuildupLength { 23 }

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -25,6 +25,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_InitialReady)
 		.Process(this->SW_PostDependent)
 		.Process(this->SW_MaxCount)
+		.Process(this->SW_Deferment)
 		.Process(this->UIDescription)
 		.Process(this->CameoPriority)
 		.Process(this->LimboDelivery_Types)
@@ -45,6 +46,8 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_Next_IgnoreDesignators)
 		.Process(this->SW_Next_RandomWeightsData)
 		.Process(this->SW_Next_RollChances)
+		.Process(this->SW_Next_UseDeferment)
+		.Process(this->SW_Next_ExtraDeferment)
 		.Process(this->ShowTimer_Priority)
 		.Process(this->Convert_Pairs)
 		.Process(this->ShowDesignatorRange)
@@ -87,6 +90,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SW_InitialReady.Read(exINI, pSection, "SW.InitialReady");
 	this->SW_PostDependent.Read(exINI, pSection, "SW.PostDependent");
 	this->SW_MaxCount.Read(exINI, pSection, "SW.MaxCount");
+	this->SW_Deferment.Read(exINI, pSection, "SW.Deferment");
 
 	this->UIDescription.Read(exINI, pSection, "UIDescription");
 	this->CameoPriority.Read(exINI, pSection, "CameoPriority");
@@ -100,6 +104,8 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SW_Next_IgnoreInhibitors.Read(exINI, pSection, "SW.Next.IgnoreInhibitors");
 	this->SW_Next_IgnoreDesignators.Read(exINI, pSection, "SW.Next.IgnoreDesignators");
 	this->SW_Next_RollChances.Read(exINI, pSection, "SW.Next.RollChances");
+	this->SW_Next_UseDeferment.Read(exINI, pSection, "SW.Next.UseDeferment");
+	this->SW_Next_ExtraDeferment.Read(exINI, pSection, "SW.Next.ExtraDeferment");
 
 	this->ShowTimer_Priority.Read(exINI, pSection, "ShowTimer.Priority");
 

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -37,6 +37,7 @@ public:
 		Valueable<bool> SW_InitialReady;
 		ValueableIdx<SuperWeaponTypeClass> SW_PostDependent;
 		Valueable<int> SW_MaxCount;
+		Valueable<int> SW_Deferment;
 
 		Valueable<CSFText> UIDescription;
 		Valueable<int> CameoPriority;
@@ -51,6 +52,8 @@ public:
 		Valueable<bool> SW_Next_IgnoreInhibitors;
 		Valueable<bool> SW_Next_IgnoreDesignators;
 		ValueableVector<float> SW_Next_RollChances;
+		Valueable<bool> SW_Next_UseDeferment;
+		Valueable<int> SW_Next_ExtraDeferment;
 
 		Valueable<int> ShowTimer_Priority;
 
@@ -93,6 +96,7 @@ public:
 			, SW_InitialReady { false }
 			, SW_PostDependent {}
 			, SW_MaxCount { -1 }
+			, SW_Deferment { 0 }
 			, UIDescription {}
 			, CameoPriority { 0 }
 			, LimboDelivery_Types {}
@@ -113,6 +117,8 @@ public:
 			, SW_Next_IgnoreDesignators { true }
 			, SW_Next_RollChances {}
 			, SW_Next_RandomWeightsData {}
+			, SW_Next_UseDeferment { false }
+			, SW_Next_ExtraDeferment { 0 }
 			, ShowTimer_Priority { 0 }
 			, Convert_Pairs {}
 			, ShowDesignatorRange { true }

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -250,16 +250,8 @@ void SWTypeExt::ExtData::ApplySWNext(SuperClass* pSW, const CellStruct& cell)
 					if ((this->SW_Next_IgnoreInhibitors || !pNextTypeExt->HasInhibitor(pHouse, cell))
 						&& (this->SW_Next_IgnoreDesignators || pNextTypeExt->HasDesignator(pHouse, cell)))
 					{
-						int oldstart = pSuper->RechargeTimer.StartTime;
-						int oldleft = pSuper->RechargeTimer.TimeLeft;
-						pSuper->SetReadiness(true);
-						pSuper->Launch(cell, pHouse->IsCurrentPlayer());
-						pSuper->Reset();
-						if (!this->SW_Next_RealLaunch)
-						{
-							pSuper->RechargeTimer.StartTime = oldstart;
-							pSuper->RechargeTimer.TimeLeft = oldleft;
-						}
+						int deferment = this->SW_Next_ExtraDeferment + (this->SW_Next_UseDeferment ? pNextTypeExt->SW_Deferment : 0);
+						ScenarioExt::Global()->LaunchSWs.push_back(SWFireState(pSuper, deferment, cell, pHouse->IsCurrentPlayer(), this->SW_Next_RealLaunch));
 					}
 				}
 			}

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -115,6 +115,30 @@ void ScenarioExt::ExtData::UpdateTransportReloaders()
 	}
 }
 
+void ScenarioExt::ExtData::UpdateLaunchSWs()
+{
+	std::vector<SWFireState>::iterator it;
+
+	for (it = this->LaunchSWs.begin(); it != this->LaunchSWs.end(); )
+	{
+		auto const pSWFireType = it;
+
+		if (pSWFireType->deferment.Completed())
+		{
+			pSWFireType->SW->SetReadiness(true);
+			pSWFireType->SW->Launch(pSWFireType->cell, pSWFireType->playerControl);
+			pSWFireType->SW->Reset();
+			pSWFireType->SW->RechargeTimer.StartTime = pSWFireType->oldstart;
+			pSWFireType->SW->RechargeTimer.TimeLeft = pSWFireType->oldleft;
+			it = this->LaunchSWs.erase(it);
+		}
+		else
+		{
+			it++;
+		}
+	}
+}
+
 // =============================
 // load / save
 
@@ -163,6 +187,7 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->BriefingTheme)
 		.Process(this->AutoDeathObjects)
 		.Process(this->TransportReloaders)
+		.Process(this->LaunchSWs)
 		;
 }
 
@@ -188,6 +213,34 @@ bool ScenarioExt::SaveGlobals(PhobosStreamWriter& Stm)
 	return Stm.Success();
 }
 
+// SW Deferment
+
+#pragma region(save/load)
+
+template <class T>
+bool SWFireState::Serialize(T& stm)
+{
+	return stm
+		.Process(this->SW)
+		.Process(this->deferment)
+		.Process(this->cell)
+		.Process(this->playerControl)
+		.Process(this->oldstart)
+		.Process(this->oldleft)
+		.Success();
+}
+
+bool SWFireState::Load(PhobosStreamReader& stm, bool registerForChange)
+{
+	return this->Serialize(stm);
+}
+
+bool SWFireState::Save(PhobosStreamWriter& stm) const
+{
+	return const_cast<SWFireState*>(this)->Serialize(stm);
+}
+
+#pragma endregion(save/load)
 
 // =============================
 // container hooks
@@ -271,6 +324,7 @@ DEFINE_HOOK(0x55B4E1, LogicClass_Update_BeforeAll, 0x5)
 
 	ScenarioExt::Global()->UpdateAutoDeathObjectsInLimbo();
 	ScenarioExt::Global()->UpdateTransportReloaders();
+	ScenarioExt::Global()->UpdateLaunchSWs();
 
 	return 0;
 }

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -400,13 +400,7 @@ bool TActionExt::RunSuperWeaponAt(TActionClass* pThis, int X, int Y)
 		{
 			if (auto const pSuper = pHouse->Supers.GetItem(swIdx))
 			{
-				int oldstart = pSuper->RechargeTimer.StartTime;
-				int oldleft = pSuper->RechargeTimer.TimeLeft;
-				pSuper->SetReadiness(true);
-				pSuper->Launch(targetLocation, false);
-				pSuper->Reset();
-				pSuper->RechargeTimer.StartTime = oldstart;
-				pSuper->RechargeTimer.TimeLeft = oldleft;
+				ScenarioExt::Global()->LaunchSWs.push_back(SWFireState(pSuper, 0, targetLocation, false, false));
 			}
 		}
 	}

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -238,6 +238,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->LaunchSW_RealLaunch.Read(exINI, pSection, "LaunchSW.RealLaunch");
 	this->LaunchSW_IgnoreInhibitors.Read(exINI, pSection, "LaunchSW.IgnoreInhibitors");
 	this->LaunchSW_IgnoreDesignators.Read(exINI, pSection, "LaunchSW.IgnoreDesignators");
+	this->LaunchSW_UseDeferment.Read(exINI, pSection, "LaunchSW.UseDeferment");
+	this->LaunchSW_ExtraDeferment.Read(exINI, pSection, "LaunchSW.ExtraDeferment");
 	this->LaunchSW_DisplayMoney.Read(exINI, pSection, "LaunchSW.DisplayMoney");
 	this->LaunchSW_DisplayMoney_Houses.Read(exINI, pSection, "LaunchSW.DisplayMoney.Houses");
 	this->LaunchSW_DisplayMoney_Offset.Read(exINI, pSection, "LaunchSW.DisplayMoney.Offset");
@@ -455,6 +457,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->LaunchSW_RealLaunch)
 		.Process(this->LaunchSW_IgnoreInhibitors)
 		.Process(this->LaunchSW_IgnoreDesignators)
+		.Process(this->LaunchSW_UseDeferment)
+		.Process(this->LaunchSW_ExtraDeferment)
 		.Process(this->LaunchSW_DisplayMoney)
 		.Process(this->LaunchSW_DisplayMoney_Houses)
 		.Process(this->LaunchSW_DisplayMoney_Offset)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -116,6 +116,8 @@ public:
 		Valueable<bool> LaunchSW_RealLaunch;
 		Valueable<bool> LaunchSW_IgnoreInhibitors;
 		Valueable<bool> LaunchSW_IgnoreDesignators;
+		Valueable<bool> LaunchSW_UseDeferment;
+		Valueable<int> LaunchSW_ExtraDeferment;
 		Valueable<bool> LaunchSW_DisplayMoney;
 		Valueable<AffectedHouse> LaunchSW_DisplayMoney_Houses;
 		Valueable<Point2D> LaunchSW_DisplayMoney_Offset;
@@ -268,6 +270,8 @@ public:
 			, LaunchSW_RealLaunch { true }
 			, LaunchSW_IgnoreInhibitors { false }
 			, LaunchSW_IgnoreDesignators { true }
+			, LaunchSW_UseDeferment { false }
+			, LaunchSW_ExtraDeferment { 0 }
 			, LaunchSW_DisplayMoney { false }
 			, LaunchSW_DisplayMoney_Houses { AffectedHouse::All }
 			, LaunchSW_DisplayMoney_Offset { { 0, 0 } }

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -13,6 +13,7 @@
 #include <Ext/Bullet/Body.h>
 #include <Ext/BulletType/Body.h>
 #include <Ext/SWType/Body.h>
+#include <Ext/Scenario/Body.h>
 #include <Misc/FlyingStrings.h>
 #include <Utilities/Helpers.Alex.h>
 #include <Utilities/EnumFunctions.h>
@@ -83,20 +84,11 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 						if (this->LaunchSW_DisplayMoney && pSWExt->Money_Amount != 0)
 							FlyingStrings::AddMoneyString(pSWExt->Money_Amount, pHouse, this->LaunchSW_DisplayMoney_Houses, coords, this->LaunchSW_DisplayMoney_Offset);
 
-						int oldstart = pSuper->RechargeTimer.StartTime;
-						int oldleft = pSuper->RechargeTimer.TimeLeft;
 						// If you don't set it ready, NewSWType::Active will give false in Ares if RealLaunch=false
 						// and therefore it will reuse the vanilla routine, which will crash inside of it
-						pSuper->SetReadiness(true);
 						// TODO: Can we use ClickFire instead of Launch?
-						pSuper->Launch(cell, pHouse->IsCurrentPlayer());
-						pSuper->Reset();
-
-						if (!this->LaunchSW_RealLaunch)
-						{
-							pSuper->RechargeTimer.StartTime = oldstart;
-							pSuper->RechargeTimer.TimeLeft = oldleft;
-						}
+						int deferment = this->LaunchSW_ExtraDeferment + (this->LaunchSW_UseDeferment ? pSWExt->SW_Deferment : 0);
+						ScenarioExt::Global()->LaunchSWs.push_back(SWFireState(pSuper, deferment, cell, pHouse->IsCurrentPlayer(), this->LaunchSW_RealLaunch));
 					}
 				}
 			}


### PR DESCRIPTION
Previously several Phobos super weapon launching logic (e.g. `SW.Next` and `LaunchSW`) didn't support `SW.Deferment`. This pull request implements a workaround to enable this. `UseDeferment` tags delay the launch by a certain amount of frames determined by the superweapon's `SW.Deferment` if set to true, while `ExtraDeferment` tags add an extra value to this delay.

In `rulesmd.ini`:
```ini
[SOMEWARHEAD]                     ; Warhead
LaunchSW.UseDeferment=false       ; boolean
LaunchSW.ExtraDeferment=0         ; integer

[SOMESW]                        ; Super Weapon
SW.Next.UseDeferment=false      ; boolean
SW.Next.ExtraDeferment=0        ; integer

[SOMEBUILDING]                                        ; BuildingType
SpyEffect.VictimSuperWeapon.UseDeferment=false        ; boolean
SpyEffect.VictimSuperWeapon.ExtraDeferment=0          ; integer
SpyEffect.InfiltratorSuperWeapon.UseDeferment=false   ; boolean
SpyEffect.InfiltratorSuperWeapon.ExtraDeferment=0     ; integer
```

I was hoping to add this for the fire superweapon action as well, but it already has all the params used. Maybe this one could simply rely on elapse time action instead.