### PR TITLE
[Framework] Rework Extras draw 

### DIFF
--- a/src/Ext/Techno/Body.Visuals.cpp
+++ b/src/Ext/Techno/Body.Visuals.cpp
@@ -273,9 +273,6 @@ Point2D TechnoExt::GetBuildingSelectBracketPosition(TechnoClass* pThis, Building
 
 void TechnoExt::ProcessDigitalDisplays(TechnoClass* pThis)
 {
-	if (!Phobos::Config::DigitalDisplay_Enable)
-		return;
-
 	const auto pType = pThis->GetTechnoType();
 	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
 

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -49,16 +49,6 @@ DEFINE_HOOK(0x73D223, UnitClass_DrawIt_OreGath, 0x6)
 	return 0x73D28C;
 }
 
-DEFINE_HOOK(0x6F64A9, TechnoClass_DrawHealthBar_Hide, 0x5)
-{
-	GET(TechnoClass*, pThis, ECX);
-	auto pTypeData = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
-	if (pTypeData->HealthBar_Hide)
-		return 0x6F6AB6;
-
-	return 0;
-}
-
 // Issue #503
 // Author : Otamaa
 DEFINE_HOOK(0x4AE670, DisplayClass_GetToolTip_EnemyUIName, 0x8)


### PR DESCRIPTION
Everyone (e.g. #1287  #1309  #1395  #1418 #1148) is doing their own work separately and creating overhead and incompatibilities.
As we've stated before the entire Healthbar drawing system needs to be overwritten completely.

This settles the framework for all these.

TODO: 
* BarType + DigitalsType
* For : HP, SP, IC timer, Temporal, ROF timer, Reload timer, Factory progress, SW progress, ...
* Condition: selected/always
* Location: Attached/ Global