### PR TITLE
[Minor] Fix an issue that limbo building only increases without decreasing in `AutoDeath.XX.AllowLimboed` count

### DIFF
--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -182,6 +182,7 @@ void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
 					{
 						it = vec.erase(it);
 
+						// Remove limbo buildings' tracking here because their are not truely InLimbo
 						if (!pBuilding->Type->Insignificant && !pBuilding->Type->DontScore)
 							HouseExt::ExtMap.Find(pBuilding->Owner)->RemoveFromLimboTracking(pBuilding->Type);
 

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -689,9 +689,10 @@ void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, Anim
 				pFoot->ParasiteImUsing->ExitUnit();
 		}
 
+		// Remove limbo buildings' tracking here because their are not truely InLimbo
 		if (auto const pBuilding = abstract_cast<BuildingClass*>(pThis))
 		{
-			if (!pBuilding->Type->Insignificant && !pBuilding->Type->DontScore)
+			if (!pBuilding->InLimbo && !pBuilding->Type->Insignificant && !pBuilding->Type->DontScore)
 				HouseExt::ExtMap.Find(pBuilding->Owner)->RemoveFromLimboTracking(pBuilding->Type);
 		}
 


### PR DESCRIPTION
Fix limbo building cannot correctly count by `AutoDeath.XX.AllowLimboed` after being `LimboKill`ed or `AutoDeath`ed, i.e. limbo building only increases without decreasing