### PR TITLE
[Minor]fixed bug that event 601 & 602 don't work properly in single player maps

### DIFF
--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -173,7 +173,7 @@ bool TEventExt::HouseOwnsTechnoTypeTEvent(TEventClass* pThis)
 	if (!pType)
 		return false;
 
-	auto pHouse = HouseClass::FindByIndex(pThis->Value);
+	auto pHouse = HouseClass::Index_IsMP(pThis->Value) ? HouseClass::FindByIndex(pThis->Value) : HouseClass::FindByCountryIndex(pThis->Value);
 	if (!pHouse)
 		return false;
 


### PR DESCRIPTION
Trigger event 601 & 602 don't work properly in single player maps, while 604 & 605 do. The only distinction between them is what I've changed. You can test the result with this map:
[all01umd.zip](https://github.com/user-attachments/files/17784794/all01umd.zip)

By the way, phobos's new events and actions use FindByIndex/Array->GetItem instead of FindByCountryIndex, which leads to  inconsistency with the vanilla events and actions, for they use country index instead of house index. In single player map with whole new houses (like official RA2 campaign, they use BadGuy1, GoodGuy1 etc.), it begins with 14 by country index, but 0 by house index. This may make map editing and FA2 adaptation more complicated, so I want to know your opinions.

If you want to restore the vanilla habit, just modify in this way
![B17A4FF7777CB422DB89F0CE84E77E66](https://github.com/user-attachments/assets/0e0a0478-2b5b-4762-830b-e3c6b22e7fcf)
