### PR TITLE
New feature: Deals damage or fires a weapon when crushed

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -405,3 +405,4 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
+- **Aephiex** - Added `WhenCrushed=` logic

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1369,13 +1369,13 @@ Convert.ComputerToHuman =   ; TechnoType
 ### Deals damage or fires a weapon when crushed
 
 - A techno can now deal damage or fire a weapon when crushed.
-  - If both `WhenCrushed.Warhead` and `WhenCrushed.Weapon` are set, `WhenCrushed.Warhead` related are completely ignored.
+  - If both `WhenCrushed.Warhead` and `WhenCrushed.Weapon` are set, `WhenCrushed.Warhead` will be ignored.
   - `WhenCrushed.Warhead`, if not set, defaults to `C4Warhead`.
   - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects.
-  - `WhenCrushed.Damage`, if not set, defaults to weapon `Damage` for `WhenCrushed.Weapon` and 0 for `WhenCrushed.Warhead`. If set, the weapon's damage will be completely ignored, including the veteran and elite weapons.
+  - `WhenCrushed.Damage`, if not set, defaults to weapon `Damage` for `WhenCrushed.Weapon` and 0 for `WhenCrushed.Warhead`. If set to any non-negative value, the weapon's damage will be ignored.
   - The damage or the weapon comes from the victim and is viewed as the victim's house.
-  - Each configuration has a Veteran and Elite version that checks the victim's veterancy. If the elite version is not set, it is fallbacked to the veteran version. If the veteran version is not set, it is fallbacked to the regular version.
-  - Note that if this feature is used on an infantry type you can also define the infantry's `CrushSound=` to be the same as the infantry's `DieSound=` instead of the generic `InfantrySquish`. For example, if this feature is applied on Crazy Ivan to allow his death weapon to trigger when crushed, the code can be:
+  - Each configuration can be varied based on the unit's veterancy.
+  - Note that if this feature is used on an infantry type you can also define the infantry's `CrushSound=` to be the same as the infantry's `DieSound=` instead of the generic `InfantrySquish`. For example, if this feature is applied to Crazy Ivan to allow his death weapon to trigger when crushed, the code can be:
     ```
     [IVAN]
     CrushSound=CrazyIvanDie
@@ -1386,17 +1386,14 @@ Convert.ComputerToHuman =   ; TechnoType
 In `rulesmd.ini`
 ```ini
 
-[SOMETECHNO]                        ; TechnoType
-WhenCrushed.Warhead=                ; WarheadType
-WhenCrushed.Warhead.Veteran=        ; WarheadType
-WhenCrushed.Warhead.Elite=          ; WarheadType
-WhenCrushed.Warhead.Full=true       ; boolean
-WhenCrushed.Weapon=                 ; WeaponType
-WhenCrushed.Weapon.Veteran=         ; WeaponType
-WhenCrushed.Weapon.Elite=           ; WeaponType
-WhenCrushed.Damage=                 ; integer
-WhenCrushed.Damage.Veteran=         ; integer
-WhenCrushed.Damage.Elite=           ; integer
+[SOMETECHNO]                                         ; TechnoType
+WhenCrushed.Warhead=                                 ; WarheadType
+WhenCrushed.Warhead.(Rookie|Veteran|Elite)=          ; WarheadType
+WhenCrushed.Warhead.Full=true                        ; boolean
+WhenCrushed.Weapon=                                  ; WeaponType
+WhenCrushed.Weapon.(Rookie|Veteran|Elite)=           ; WeaponType
+WhenCrushed.Damage=                                  ; integer
+WhenCrushed.Damage.(Rookie|Veteran|Elite)=           ; integer
 ```
 
 ## Terrain

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1371,7 +1371,7 @@ Convert.ComputerToHuman =   ; TechnoType
 - A techno can now deal damage or fire a weapon when crushed.
   - If `WhenCrushed.Weapon` is set at a veterancy level, `WhenCrushed.Warhead` and `WhenCrushed.Damage` at the same veterancy level will be ignored.
   - `WhenCrushed.Warhead`, if not set, defaults to `C4Warhead`.
-  - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects. When not set, it is default to true.
+  - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects. If not set, defaults to true. If set false, no animation defined in the warhead will be played.
   - `WhenCrushed.Damage`, if not set, defaults to 0.
   - If `WhenCrushed.Weapon` is not set, `WhenCrushed.Warhead` is not set, and `WhenCrushed.Damage` is either not set or set to 0, no weapon or warhead detonation will occure at all at the veterancy level.
   - The weapon or the damage is fired from the victim, is detonated at the victim's coords, and is viewed as the victim's house.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1369,11 +1369,12 @@ Convert.ComputerToHuman =   ; TechnoType
 ### Deals damage or fires a weapon when crushed
 
 - A techno can now deal damage or fire a weapon when crushed.
-  - If both `WhenCrushed.Warhead` and `WhenCrushed.Weapon` are set, latter takes precedence.
+  - If both `WhenCrushed.Warhead` and `WhenCrushed.Weapon` are set, `WhenCrushed.Warhead` related are completely ignored.
   - `WhenCrushed.Warhead`, if not set, defaults to `C4Warhead`.
   - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects.
-  - `WhenCrushed.Damage`, if not set, defaults to weapon `Damage` for `WhenCrushed.Weapon` and 0 for `WhenCrushed.Warhead`.
-  - The damage or the weapon is sourceless, but is viewed as the victim's house.
+  - `WhenCrushed.Damage`, if not set, defaults to weapon `Damage` for `WhenCrushed.Weapon` and 0 for `WhenCrushed.Warhead`. If set, the weapon's damage will be completely ignored, including the veteran and elite weapons.
+  - The damage or the weapon comes from the victim and is viewed as the victim's house.
+  - Each configuration has a Veteran and Elite version that checks the victim's veterancy. If the elite version is not set, it is fallbacked to the veteran version. If the veteran version is not set, it is fallbacked to the regular version.
   - Note that if this feature is used on an infantry type you can also define the infantry's `CrushSound=` to be the same as the infantry's `DieSound=` instead of the generic `InfantrySquish`. For example, if this feature is applied on Crazy Ivan to allow his death weapon to trigger when crushed, the code can be:
     ```
     [IVAN]
@@ -1387,9 +1388,15 @@ In `rulesmd.ini`
 
 [SOMETECHNO]                        ; TechnoType
 WhenCrushed.Warhead=                ; WarheadType
+WhenCrushed.Warhead.Veteran=        ; WarheadType
+WhenCrushed.Warhead.Elite=          ; WarheadType
 WhenCrushed.Warhead.Full=true       ; boolean
 WhenCrushed.Weapon=                 ; WeaponType
+WhenCrushed.Weapon.Veteran=         ; WeaponType
+WhenCrushed.Weapon.Elite=           ; WeaponType
 WhenCrushed.Damage=                 ; integer
+WhenCrushed.Damage.Veteran=         ; integer
+WhenCrushed.Damage.Elite=           ; integer
 ```
 
 ## Terrain

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1374,6 +1374,13 @@ Convert.ComputerToHuman =   ; TechnoType
   - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects.
   - `WhenCrushed.Damage`, if not set, defaults to weapon `Damage` for `WhenCrushed.Weapon` and 0 for `WhenCrushed.Warhead`.
   - The damage or the weapon is sourceless, but is viewed as the victim's house.
+  - Note that if this feature is used on an infantry type you can also define the infantry's `CrushSound=` to be the same as the infantry's `DieSound=` instead of the generic `InfantrySquish`. For example, if this feature is applied on Crazy Ivan to allow his death weapon to trigger when crushed, the code can be:
+    ```
+    [IVAN]
+    CrushSound=CrazyIvanDie
+    WhenCrushed.Weapon=IvanDeath
+    ```
+    In this case crushing Crazy Ivan is equivalent to killing him with direct damage: he explodes with his iconic death cry under the crushing treeds.
 
 In `rulesmd.ini`
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1383,6 +1383,7 @@ Convert.ComputerToHuman =   ; TechnoType
     WhenCrushed.Weapon=IvanDeath
     ```
     In this case crushing Crazy Ivan is equivalent to killing him with direct damage: he explodes with his iconic death cry under the crushing treeds.
+  - Note that the `IvanBomb` feature in Ares does not work with this. If `WhenCrushed.Weapon=IvanBomber` is set, nothing happens when the crush occures.
 
 In `rulesmd.ini`
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1369,11 +1369,12 @@ Convert.ComputerToHuman =   ; TechnoType
 ### Deals damage or fires a weapon when crushed
 
 - A techno can now deal damage or fire a weapon when crushed.
-  - If both `WhenCrushed.Warhead` and `WhenCrushed.Weapon` are set, `WhenCrushed.Warhead` will be ignored.
+  - If `WhenCrushed.Weapon` is set at a veterancy level, `WhenCrushed.Warhead` and `WhenCrushed.Damage` at the same veterancy level will be ignored.
   - `WhenCrushed.Warhead`, if not set, defaults to `C4Warhead`.
-  - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects.
-  - `WhenCrushed.Damage`, if not set, defaults to weapon `Damage` for `WhenCrushed.Weapon` and 0 for `WhenCrushed.Warhead`. If set to any non-negative value, the weapon's damage will be ignored.
-  - The damage or the weapon comes from the victim and is viewed as the victim's house.
+  - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects. When not set, it is default to true.
+  - `WhenCrushed.Damage`, if not set, defaults to 0.
+  - If `WhenCrushed.Weapon` is not set, `WhenCrushed.Warhead` is not set, and `WhenCrushed.Damage` is either not set or set to 0, no weapon or warhead detonation will occure at all at the veterancy level.
+  - The weapon or the damage is fired from the victim, is detonated at the victim's coords, and is viewed as the victim's house.
   - Each configuration can be varied based on the unit's veterancy.
   - Note that if this feature is used on an infantry type you can also define the infantry's `CrushSound=` to be the same as the infantry's `DieSound=` instead of the generic `InfantrySquish`. For example, if this feature is applied to Crazy Ivan to allow his death weapon to trigger when crushed, the code can be:
     ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1366,6 +1366,25 @@ Convert.HumanToComputer =   ; TechnoType
 Convert.ComputerToHuman =   ; TechnoType
 ```
 
+### Deals damage or fires a weapon when crushed
+
+- A techno can now deal damage or fire a weapon when crushed.
+  - If both `WhenCrushed.Warhead` and `WhenCrushed.Weapon` are set, latter takes precedence.
+  - `WhenCrushed.Warhead`, if not set, defaults to `C4Warhead`.
+  - `WhenCrushed.Warhead.Full` customizes whether or not the Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects.
+  - `WhenCrushed.Damage`, if not set, defaults to weapon `Damage` for `WhenCrushed.Weapon` and 0 for `WhenCrushed.Warhead`.
+  - The damage or the weapon is sourceless, but is viewed as the victim's house.
+
+In `rulesmd.ini`
+```ini
+
+[SOMETECHNO]                        ; TechnoType
+WhenCrushed.Warhead=                ; WarheadType
+WhenCrushed.Warhead.Full=true       ; boolean
+WhenCrushed.Weapon=                 ; WeaponType
+WhenCrushed.Damage=                 ; integer
+```
+
 ## Terrain
 
 ### Destroy animation & sound

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -468,6 +468,7 @@ New:
 - Allow infantry to use land sequences in water (by Starkku)
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps (by Starkku)
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
+- Allow weapon or warhead detonation when techno type is crushed (by Aephiex)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -42,9 +42,9 @@ void TechnoTypeExt::ExtData::WhenCrushedBy(UnitClass* pCrusher, TechnoClass* pVi
 
 	if (pWeapon)
 	{
-		WeaponTypeExt::DetonateAt(pWeapon, pVictim->GetCoords(), pVictim, damage >= 0 ? damage : pWeapon->Damage, pVictim->GetOwningHouse());
+		WeaponTypeExt::DetonateAt(pWeapon, pVictim->GetCoords(), pVictim, damage > 0 ? damage : pWeapon->Damage, pVictim->GetOwningHouse());
 	}
-	else
+	else if (damage > 0)
 	{
 		if (!pWarhead)
 			pWarhead = RulesClass::Instance->C4Warhead;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -42,9 +42,9 @@ void TechnoTypeExt::ExtData::WhenCrushedBy(UnitClass* pCrusher, TechnoClass* pVi
 
 	if (pWeapon)
 	{
-		WeaponTypeExt::DetonateAt(pWeapon, pVictim->GetCoords(), pVictim, damage > 0 ? damage : pWeapon->Damage, pVictim->GetOwningHouse());
+		WeaponTypeExt::DetonateAt(pWeapon, pVictim->GetCoords(), pVictim, pWeapon->Damage, pVictim->GetOwningHouse());
 	}
-	else if (damage > 0)
+	else if (pWarhead || damage != 0)
 	{
 		if (!pWarhead)
 			pWarhead = RulesClass::Instance->C4Warhead;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -412,6 +412,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->CrushOverlayExtraForwardTilt.Read(exINI, pSection, "CrushOverlayExtraForwardTilt");
 	this->CrushSlowdownMultiplier.Read(exINI, pSection, "CrushSlowdownMultiplier");
 
+	this->WhenCrushed_Warhead.Read<true>(exINI, pSection, "WhenCrushed.Warhead");
+	this->WhenCrushed_Weapon.Read<true>(exINI, pSection, "WhenCrushed.Weapon");
+	this->WhenCrushed_Damage.Read(exINI, pSection, "WhenCrushed.Damage");
+	this->WhenCrushed_Warhead_Full.Read(exINI, pSection, "WhenCrushed.Warhead.Full");
+
 	this->DigitalDisplay_Disable.Read(exINI, pSection, "DigitalDisplay.Disable");
 	this->DigitalDisplayTypes.Read(exINI, pSection, "DigitalDisplayTypes");
 
@@ -777,6 +782,11 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->CrushForwardTiltPerFrame)
 		.Process(this->CrushOverlayExtraForwardTilt)
 		.Process(this->CrushSlowdownMultiplier)
+
+		.Process(this->WhenCrushed_Warhead)
+		.Process(this->WhenCrushed_Weapon)
+		.Process(this->WhenCrushed_Damage)
+		.Process(this->WhenCrushed_Warhead_Full)
 
 		.Process(this->DigitalDisplay_Disable)
 		.Process(this->DigitalDisplayTypes)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -46,6 +46,8 @@ void TechnoTypeExt::ExtData::WhenCrushedBy(UnitClass* pCrusher, TechnoClass* pVi
 	}
 	else
 	{
+		if (!pWarhead)
+			pWarhead = RulesClass::Instance->C4Warhead;
 		if (this->WhenCrushed_Warhead_Full)
 			WarheadTypeExt::DetonateAt(pWarhead, pVictim->GetCoords(), pVictim, damage, pVictim->GetOwningHouse());
 		else

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -11,6 +11,8 @@
 #include <Ext/BuildingType/Body.h>
 #include <Ext/BulletType/Body.h>
 #include <Ext/Techno/Body.h>
+#include <Ext/WarheadType/Body.h>
+#include <Ext/WeaponType/Body.h>
 
 #include <Utilities/GeneralUtils.h>
 
@@ -30,6 +32,65 @@ void TechnoTypeExt::ExtData::ApplyTurretOffset(Matrix3D* mtx, double factor)
 	float z = static_cast<float>(offset->Z * factor);
 
 	mtx->Translate(x, y, z);
+}
+
+void TechnoTypeExt::ExtData::WhenCrushedBy(UnitClass* pCrusher, ObjectClass* pVictim, TechnoClass* pVictimTechno)
+{
+	auto pWeapon = this->WhenCrushed_Weapon;
+	auto pWarhead = this->WhenCrushed_Warhead.Get(RulesClass::Instance->C4Warhead);
+	int damage;
+
+	if (pWeapon)
+	{
+		auto pWeaponV = this->WhenCrushed_Weapon_Veteran;
+		auto pWeaponE = this->WhenCrushed_Weapon_Elite;
+		if (pVictimTechno->Veterancy.IsElite())
+		{
+			if (pWeaponE)
+				pWeapon = pWeaponE;
+			else if (pWeaponV)
+				pWeapon = pWeaponV;
+			damage = this->WhenCrushed_Damage_Elite.Get(this->WhenCrushed_Damage_Veteran.Get(this->WhenCrushed_Damage.Get(pWeapon->Damage)));
+		}
+		else if (pVictimTechno->Veterancy.IsVeteran())
+		{
+			if (pWeaponV)
+				pWeapon = pWeaponV;
+			damage = this->WhenCrushed_Damage_Veteran.Get(this->WhenCrushed_Damage.Get(pWeapon->Damage));
+		}
+		else
+		{
+			damage = this->WhenCrushed_Damage.Get(pWeapon->Damage);
+		}
+		WeaponTypeExt::DetonateAt(pWeapon, pVictim->GetCoords(), pVictimTechno, damage, pVictim->GetOwningHouse());
+	}
+	else
+	{
+		auto pWarheadV = this->WhenCrushed_Warhead_Veteran.Get(pWarhead);
+		auto pWarheadE = this->WhenCrushed_Warhead_Elite.Get(pWarheadV);
+		if (pVictimTechno->Veterancy.IsElite())
+		{
+			if (pWarheadE)
+				pWarhead = pWarheadE;
+			else if (pWarheadV)
+				pWarhead = pWarheadV;
+			damage = this->WhenCrushed_Damage_Elite.Get(this->WhenCrushed_Damage_Veteran.Get(this->WhenCrushed_Damage.Get(0)));
+		}
+		else if (pVictimTechno->Veterancy.IsVeteran())
+		{
+			if (pWarheadV)
+				pWarhead = pWarheadV;
+			damage = this->WhenCrushed_Damage_Veteran.Get(this->WhenCrushed_Damage.Get(0));
+		}
+		else
+		{
+			damage = this->WhenCrushed_Damage.Get(0);
+		}
+		if (this->WhenCrushed_Warhead_Full)
+			WarheadTypeExt::DetonateAt(pWarhead, pVictim->GetCoords(), pVictimTechno, this->WhenCrushed_Damage.Get(0), pVictim->GetOwningHouse());
+		else
+			MapClass::DamageArea(pVictim->GetCoords(), this->WhenCrushed_Damage.Get(0), pVictimTechno, pWarhead, true, pVictim->GetOwningHouse());
+	}
 }
 
 // Ares 0.A source
@@ -413,8 +474,14 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->CrushSlowdownMultiplier.Read(exINI, pSection, "CrushSlowdownMultiplier");
 
 	this->WhenCrushed_Warhead.Read<true>(exINI, pSection, "WhenCrushed.Warhead");
+	this->WhenCrushed_Warhead_Veteran.Read<true>(exINI, pSection, "WhenCrushed.Warhead.Veteran");
+	this->WhenCrushed_Warhead_Elite.Read<true>(exINI, pSection, "WhenCrushed.Warhead.Elite");
 	this->WhenCrushed_Weapon.Read<true>(exINI, pSection, "WhenCrushed.Weapon");
+	this->WhenCrushed_Weapon_Veteran.Read<true>(exINI, pSection, "WhenCrushed.Weapon.Veteran");
+	this->WhenCrushed_Weapon_Elite.Read<true>(exINI, pSection, "WhenCrushed.Weapon.Elite");
 	this->WhenCrushed_Damage.Read(exINI, pSection, "WhenCrushed.Damage");
+	this->WhenCrushed_Damage_Veteran.Read(exINI, pSection, "WhenCrushed.Damage.Veteran");
+	this->WhenCrushed_Damage_Elite.Read(exINI, pSection, "WhenCrushed.Damage.Elite");
 	this->WhenCrushed_Warhead_Full.Read(exINI, pSection, "WhenCrushed.Warhead.Full");
 
 	this->DigitalDisplay_Disable.Read(exINI, pSection, "DigitalDisplay.Disable");
@@ -784,8 +851,14 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->CrushSlowdownMultiplier)
 
 		.Process(this->WhenCrushed_Warhead)
+		.Process(this->WhenCrushed_Warhead_Veteran)
+		.Process(this->WhenCrushed_Warhead_Elite)
 		.Process(this->WhenCrushed_Weapon)
+		.Process(this->WhenCrushed_Weapon_Veteran)
+		.Process(this->WhenCrushed_Weapon_Elite)
 		.Process(this->WhenCrushed_Damage)
+		.Process(this->WhenCrushed_Damage_Veteran)
+		.Process(this->WhenCrushed_Damage_Elite)
 		.Process(this->WhenCrushed_Warhead_Full)
 
 		.Process(this->DigitalDisplay_Disable)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -182,6 +182,11 @@ public:
 		Valueable<double> CrushOverlayExtraForwardTilt;
 		Valueable<double> CrushSlowdownMultiplier;
 
+		Nullable<WarheadTypeClass*> WhenCrushed_Warhead;
+		Valueable<WeaponTypeClass*> WhenCrushed_Weapon;
+		Nullable<int> WhenCrushed_Damage;
+		Valueable<bool> WhenCrushed_Warhead_Full;
+
 		Valueable<bool> DigitalDisplay_Disable;
 		ValueableVector<DigitalDisplayTypeClass*> DigitalDisplayTypes;
 
@@ -402,6 +407,11 @@ public:
 			, CrushSlowdownMultiplier { 0.2 }
 			, CrushForwardTiltPerFrame {}
 			, CrushOverlayExtraForwardTilt { 0.02 }
+
+			, WhenCrushed_Warhead {}
+			, WhenCrushed_Weapon {}
+			, WhenCrushed_Damage {}
+			, WhenCrushed_Warhead_Full { true }
 
 			, DigitalDisplay_Disable { false }
 			, DigitalDisplayTypes {}

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -410,7 +410,7 @@ public:
 
 			, WhenCrushed_Warhead {}
 			, WhenCrushed_Weapon {}
-			, WhenCrushed_Damage { -1 }
+			, WhenCrushed_Damage {}
 			, WhenCrushed_Warhead_Full { true }
 
 			, DigitalDisplay_Disable { false }

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -182,15 +182,9 @@ public:
 		Valueable<double> CrushOverlayExtraForwardTilt;
 		Valueable<double> CrushSlowdownMultiplier;
 
-		Nullable<WarheadTypeClass*> WhenCrushed_Warhead;
-		Nullable<WarheadTypeClass*> WhenCrushed_Warhead_Veteran;
-		Nullable<WarheadTypeClass*> WhenCrushed_Warhead_Elite;
-		Valueable<WeaponTypeClass*> WhenCrushed_Weapon;
-		Valueable<WeaponTypeClass*> WhenCrushed_Weapon_Veteran;
-		Valueable<WeaponTypeClass*> WhenCrushed_Weapon_Elite;
-		Nullable<int> WhenCrushed_Damage;
-		Nullable<int> WhenCrushed_Damage_Veteran;
-		Nullable<int> WhenCrushed_Damage_Elite;
+		Promotable<WarheadTypeClass*> WhenCrushed_Warhead;
+		Promotable<WeaponTypeClass*> WhenCrushed_Weapon;
+		Promotable<int> WhenCrushed_Damage;
 		Valueable<bool> WhenCrushed_Warhead_Full;
 
 		Valueable<bool> DigitalDisplay_Disable;
@@ -415,14 +409,8 @@ public:
 			, CrushOverlayExtraForwardTilt { 0.02 }
 
 			, WhenCrushed_Warhead {}
-			, WhenCrushed_Warhead_Veteran {}
-			, WhenCrushed_Warhead_Elite {}
 			, WhenCrushed_Weapon {}
-			, WhenCrushed_Weapon_Veteran {}
-			, WhenCrushed_Weapon_Elite {}
-			, WhenCrushed_Damage {}
-			, WhenCrushed_Damage_Veteran {}
-			, WhenCrushed_Damage_Elite {}
+			, WhenCrushed_Damage { -1 }
 			, WhenCrushed_Warhead_Full { true }
 
 			, DigitalDisplay_Disable { false }
@@ -485,7 +473,7 @@ public:
 
 		void ApplyTurretOffset(Matrix3D* mtx, double factor = 1.0);
 
-		void WhenCrushedBy(UnitClass* crusher, ObjectClass* victim, TechnoClass* techno);
+		void WhenCrushedBy(UnitClass* pCrusher, TechnoClass* pVictim);
 
 		// Ares 0.A
 		const char* GetSelectionGroupID() const;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -183,8 +183,14 @@ public:
 		Valueable<double> CrushSlowdownMultiplier;
 
 		Nullable<WarheadTypeClass*> WhenCrushed_Warhead;
+		Nullable<WarheadTypeClass*> WhenCrushed_Warhead_Veteran;
+		Nullable<WarheadTypeClass*> WhenCrushed_Warhead_Elite;
 		Valueable<WeaponTypeClass*> WhenCrushed_Weapon;
+		Valueable<WeaponTypeClass*> WhenCrushed_Weapon_Veteran;
+		Valueable<WeaponTypeClass*> WhenCrushed_Weapon_Elite;
 		Nullable<int> WhenCrushed_Damage;
+		Nullable<int> WhenCrushed_Damage_Veteran;
+		Nullable<int> WhenCrushed_Damage_Elite;
 		Valueable<bool> WhenCrushed_Warhead_Full;
 
 		Valueable<bool> DigitalDisplay_Disable;
@@ -409,8 +415,14 @@ public:
 			, CrushOverlayExtraForwardTilt { 0.02 }
 
 			, WhenCrushed_Warhead {}
+			, WhenCrushed_Warhead_Veteran {}
+			, WhenCrushed_Warhead_Elite {}
 			, WhenCrushed_Weapon {}
+			, WhenCrushed_Weapon_Veteran {}
+			, WhenCrushed_Weapon_Elite {}
 			, WhenCrushed_Damage {}
+			, WhenCrushed_Damage_Veteran {}
+			, WhenCrushed_Damage_Elite {}
 			, WhenCrushed_Warhead_Full { true }
 
 			, DigitalDisplay_Disable { false }
@@ -472,6 +484,8 @@ public:
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 
 		void ApplyTurretOffset(Matrix3D* mtx, double factor = 1.0);
+
+		void WhenCrushedBy(UnitClass* crusher, ObjectClass* victim, TechnoClass* techno);
 
 		// Ares 0.A
 		const char* GetSelectionGroupID() const;

--- a/src/Ext/Unit/Hooks.Crushing.cpp
+++ b/src/Ext/Unit/Hooks.Crushing.cpp
@@ -3,6 +3,8 @@
 #include <UnitClass.h>
 
 #include <Ext/TechnoType/Body.h>
+#include <Ext/WarheadType/Body.h>
+#include <Ext/WeaponType/Body.h>
 #include <Utilities/Macro.h>
 #include <Utilities/TemplateDef.h>
 

--- a/src/Ext/Unit/Hooks.Crushing.cpp
+++ b/src/Ext/Unit/Hooks.Crushing.cpp
@@ -56,6 +56,32 @@ DEFINE_HOOK(0x4B1150, DriveLocomotionClass_WhileMoving_CrushSlowdown, 0x9)
 
 }
 
+DEFINE_HOOK(0x7418AA, UnitClass_CrushCell_WhenCrushed, 6)
+{
+	GET(UnitClass* const, pThis, EDI);
+	GET(ObjectClass* const, pVictim, ESI);
+
+	if(auto const pTechno = abstract_cast<TechnoClass*>(pVictim)) {
+		auto pExt = TechnoTypeExt::ExtMap.Find(pVictim->GetTechnoType());
+
+		const auto pWeapon = pExt->WhenCrushed_Weapon;
+
+		auto const pWarhead = pExt->WhenCrushed_Warhead.Get(RulesClass::Instance->C4Warhead);
+
+		if (pWeapon)
+			WeaponTypeExt::DetonateAt(pWeapon, pThis->GetCoords(), nullptr, pExt->WhenCrushed_Damage.Get(pWeapon->Damage), pVictim->GetOwningHouse());
+		else
+		{
+			if (pExt->WhenCrushed_Warhead_Full)
+				WarheadTypeExt::DetonateAt(pWarhead, pThis->GetCoords(), nullptr, pExt->WhenCrushed_Damage.Get(0),  pVictim->GetOwningHouse());
+			else
+				MapClass::DamageArea(pThis->GetCoords(), pExt->WhenCrushed_Damage.Get(0), nullptr, pWarhead, true,  pVictim->GetOwningHouse());
+		}
+	}
+
+	return 0;
+}
+
 DEFINE_HOOK_AGAIN(0x4B1A4B, DriveLocomotionClass_WhileMoving_CrushTilt, 0xD)
 DEFINE_HOOK(0x4B19F7, DriveLocomotionClass_WhileMoving_CrushTilt, 0xD)
 {

--- a/src/Ext/Unit/Hooks.Crushing.cpp
+++ b/src/Ext/Unit/Hooks.Crushing.cpp
@@ -3,8 +3,6 @@
 #include <UnitClass.h>
 
 #include <Ext/TechnoType/Body.h>
-#include <Ext/WarheadType/Body.h>
-#include <Ext/WeaponType/Body.h>
 #include <Utilities/Macro.h>
 #include <Utilities/TemplateDef.h>
 
@@ -63,22 +61,11 @@ DEFINE_HOOK(0x7418AA, UnitClass_CrushCell_WhenCrushed, 6)
 	GET(UnitClass* const, pThis, EDI);
 	GET(ObjectClass* const, pVictim, ESI);
 
-	if(auto const pTechno = abstract_cast<TechnoClass*>(pVictim)) {
+	if (auto const pTechno = abstract_cast<TechnoClass*>(pVictim))
+	{
 		auto pExt = TechnoTypeExt::ExtMap.Find(pVictim->GetTechnoType());
 
-		const auto pWeapon = pExt->WhenCrushed_Weapon;
-
-		auto const pWarhead = pExt->WhenCrushed_Warhead.Get(RulesClass::Instance->C4Warhead);
-
-		if (pWeapon)
-			WeaponTypeExt::DetonateAt(pWeapon, pThis->GetCoords(), nullptr, pExt->WhenCrushed_Damage.Get(pWeapon->Damage), pVictim->GetOwningHouse());
-		else
-		{
-			if (pExt->WhenCrushed_Warhead_Full)
-				WarheadTypeExt::DetonateAt(pWarhead, pThis->GetCoords(), nullptr, pExt->WhenCrushed_Damage.Get(0),  pVictim->GetOwningHouse());
-			else
-				MapClass::DamageArea(pThis->GetCoords(), pExt->WhenCrushed_Damage.Get(0), nullptr, pWarhead, true,  pVictim->GetOwningHouse());
-		}
+		pExt->WhenCrushedBy(pThis, pVictim, pTechno);
 	}
 
 	return 0;

--- a/src/Ext/Unit/Hooks.Crushing.cpp
+++ b/src/Ext/Unit/Hooks.Crushing.cpp
@@ -61,11 +61,10 @@ DEFINE_HOOK(0x7418AA, UnitClass_CrushCell_WhenCrushed, 6)
 	GET(UnitClass* const, pThis, EDI);
 	GET(ObjectClass* const, pVictim, ESI);
 
-	if (auto const pTechno = abstract_cast<TechnoClass*>(pVictim))
+	if (auto const pVictimTechno = abstract_cast<TechnoClass*>(pVictim))
 	{
-		auto pExt = TechnoTypeExt::ExtMap.Find(pVictim->GetTechnoType());
-
-		pExt->WhenCrushedBy(pThis, pVictim, pTechno);
+		auto pVictimExt = TechnoTypeExt::ExtMap.Find(pVictim->GetTechnoType());
+		pVictimExt->WhenCrushedBy(pThis, pVictimTechno);
 	}
 
 	return 0;


### PR DESCRIPTION
Local tests:

1. Give civilian infantries with the following codes, and crush them with a Lasher Tank. The Ivan Bomb is confirmed to explode correctly, and even units standing aside can be damaged due to the `CellSpread` defined in the warhead.
- `WhenCrushed.Damage=420`
- `WhenCrushed.Warhead=IvanWH`
- `WhenCrushed.Warhead.Full=true`

2. The same as case 1, except `WhenCrushed.Warhead.Full=false`. Doesn't seem to be any different with case 1.

3. Give civilian infantries with the following codes, and crush them with Yuri's MCV. The vehicle doesn't appear to have been properly attached with the ivan bomb, or I wasn't patient enough to wait for the ticking sound or explosion. Note that, in my client this weapon is modified, which uses Ares custom ivan bomb mechanic instead of the YR mechanic.
- `WhenCrushed.Weapon=IvanBomber`

4. Give civilian infantries with the following codes, and crush them with Yuri's MCV. The death weapon of terrorist explodes and damages the MCV.
- `WhenCrushed.Weapon=TerrorBomb`