### PR TITLE
[New Feature] Crush expanded & weapon detonation when infiltrates

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -410,3 +410,4 @@ This page lists all the individual contributions to the project by their author.
 - **Aephiex**
   - Crush level system
   - Weapon detonation events when unit crushes something or gets crushed
+  - Weapon detonation events when unit infiltrates

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -407,3 +407,6 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
+- **Aephiex**
+  - Crush level system
+  - Weapon detonation events when unit crushes something or gets crushed

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1462,7 +1462,7 @@ WhenCrushed.Damage.(Rookie|Veteran|Elite)=           ; integer
   - If `WhenCrush.SupressVictim` is set to true, the victim's death rattle of `WhenCrushed.Weapon` and `WhenCrushed.Warhead` cannot trigger at all, much like how the [Scorpion Tanks](https://cnc-central.fandom.com/wiki/Scorpion_tank_(Tiberium_Wars)) with the Dozer blades upgrade supress the crush damage of [Disintegrators](https://cnc-central.fandom.com/wiki/Disintegrator).
     - Alternatively, `WhenCrush.SupressVictim.Weapons` and `WhenCrush.SupressVictim.Warheads` can be specified instead of full supression of death rattles. Note that if warheads are specified, not only the warhead-based death rattles are suppressed, but also the weapon-based death rattles that use the warhead are supressed as well.
 - It can also deal damage or fire a weapon on itself when it crushes something.
-  - `WhenCrush.Warhead` and `WhenCrush.Weapon` can be specified much like `WhenCrushed.Warhead/Weapon/Damage`, and the same rules are followed. If weapon is specified then warhead and damage on the same veterancy level are ignored.
+  - `WhenCrush.Warhead` and `WhenCrush.Weapon` can be specified much like `WhenCrushed.(Warhead|Weapon|Damage)`, and the same rules are followed. If weapon is specified then warhead and damage on the same veterancy level are ignored.
   - The warhead or weapon is detonated where the unit itself is, the damage come from itself and is viewed the same house as it.
   - Normally it doesn't damage itself in the process, unless it has `DamageSelf=true` or the warhead has `AllowDamageOnSelf=yes`. The same is true for negative damage when crush heal is intended.
   - If multiple infantries are crushed at once, so will the crush detonation occure that many times.
@@ -1495,6 +1495,26 @@ WhenCrush.Damage.Elite=                     ; integer
 WhenCrush.DamageMult.Infantries=100%        ; double
 WhenCrush.DamageMult.Units=100%             ; double
 WhenCrush.DamageMult.Overlays=0%            ; double
+```
+
+### When techno infiltrates a structure
+
+- A techno can now deal damage or fire a weapon when it infiltrates a structure. What makes this different from `SpyEffect.VictimSuperWeapon=` is it can be configured per agent techno type.
+  - `WhenInfiltrate.Warhead` and `WhenInfiltrate.Weapon` can be specified much like `WhenCrushed.(Warhead|Weapon|Damage)`, and the same rules are followed. If weapon is specified then warhead and damage on the same veterancy level are ignored.
+  - The warhead or weapon is detonated where the structure is, the damage come from the infantry and is viewed the same house as it.
+  - Note that the `IvanBomb` feature in Ares does not work with this. If `WhenInfiltrate.Weapon=IvanBomber` is set, nothing happens when the unit infiltrates, aside from the normal infiltration effect.
+
+In `rulesmd.ini`
+```ini
+
+[SOMETECHNO]                                         ; TechnoType
+WhenInfiltrate.Warhead=                              ; WarheadType
+WhenInfiltrate.Warhead.(Rookie|Veteran|Elite)=       ; WarheadType
+WhenInfiltrate.Warhead.Full=true                     ; boolean
+WhenInfiltrate.Weapon=                               ; WeaponType
+WhenInfiltrate.Weapon.(Rookie|Veteran|Elite)=        ; WeaponType
+WhenInfiltrate.Damage=                               ; integer
+WhenInfiltrate.Damage.(Rookie|Veteran|Elite)=        ; integer
 ```
 
 ## Terrain

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1466,8 +1466,8 @@ WhenCrushed.Damage.(Rookie|Veteran|Elite)=           ; integer
   - The warhead or weapon is detonated where the unit itself is, the damage come from itself and is viewed the same house as it.
   - Normally it doesn't damage itself in the process, unless it has `DamageSelf=true` or the warhead has `AllowDamageOnSelf=yes`. The same is true for negative damage when crush heal is intended.
   - If multiple infantries are crushed at once, so will the crush detonation occure that many times.
-  - You can also specify the damage multiplier according to the victim's archetype, such as `WehnCrush.DamageMult.Infantries=50%` meaning the damage value is halved if the victim is an infantry. The archetypes are `Infantries`, `Units`, and `Others`. If the multiplier against an archetype is 0%, no detonation will happen when the unit crushes something in that archetype.
-    - By default, the multiplier on `Infantries` and `Units` are 100%, and the multiplier on `Others` is 0%.
+  - You can also specify the damage multiplier according to the victim's archetype, such as `WehnCrush.DamageMult.Infantries=50%` meaning the damage value is halved if the victim is an infantry. The archetypes are `Infantries`, `Units`, and `Overlays`. If the multiplier against an archetype is 0%, no detonation will happen when the unit crushes something in that archetype.
+    - By default, the multiplier on `Infantries` and `Units` are 100%, and the multiplier on `Overlays` is 0%.
 
 
 In `rulesmd.ini`

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -470,6 +470,7 @@ New:
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
 - Unit `Speed` setting now accepts floating point values (by Starkku)
 - Crush expanded: crusher level system, weapon detonation events when unit crushes something or gets crushed (by Aephiex)
+- Weapon detonation events when unit infiltrates (by Aephiex)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -469,6 +469,7 @@ New:
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps (by Starkku)
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
 - Unit `Speed` setting now accepts floating point values (by Starkku)
+- Crush expanded: crusher level system, weapon detonation events when unit crushes something or gets crushed (by Aephiex)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)
@@ -597,6 +598,7 @@ Phobos fixes:
 - Fixed `SelfHealGainType=none` not working (changed to `noheal`) (by Starkku)
 - Fixed AircraftTypes gaining self-healing from `UnitsGainSelfHeal` by default (while not displaying the pip) when they should not (by Starkku)
 - Fixed `LaunchSW.IgnoreInhibitors` and `SW.Next.IgnoreInhibitors` overriding corresponding `IgnoreDesignators` settings (by Ollerus)
+- Fixed `PassengerDeletion.Soylent` not taking the passengers of the deleted passenger into account when calculating the soylent (by Aephiex)
 
 Fixes / interactions with other extensions:
 - Weapons fired by EMPulse superweapons *(Ares feature)* now fully respect the firing building's FLH.

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -207,6 +207,13 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->CombatLightDetailLevel.Read(exINI, GameStrings::AudioVisual, "CombatLightDetailLevel");
 	this->LightFlashAlphaImageDetailLevel.Read(exINI, GameStrings::AudioVisual, "LightFlashAlphaImageDetailLevel");
 
+	this->CrusherLevelEnabled.Read(exINI, GameStrings::General, "CrusherLevelEnabled");
+	this->CrusherLevel_Defaults_Crusher.Read(exINI, GameStrings::General, "CrusherLevel.Defaults.Crusher");
+	this->CrusherLevel_Defaults_OmniCrusher.Read(exINI, GameStrings::General, "CrusherLevel.Defaults.OmniCrusher");
+	this->CrushableLevel_Defaults_Uncrushable_Infantry.Read(exINI, GameStrings::General, "CrushableLevel.Defaults.Uncrushable.Infantry");
+	this->CrushableLevel_Defaults_Uncrushable_Others.Read(exINI, GameStrings::General, "CrushableLevel.Defaults.Uncrushable.Others");
+	this->CrushableLevel_Defaults_OmniCrushResistant.Read(exINI, GameStrings::General, "CrushableLevel.Defaults.OmniCrushResistant");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -389,6 +396,12 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->WarheadParticleAlphaImageIsLightFlash)
 		.Process(this->CombatLightDetailLevel)
 		.Process(this->LightFlashAlphaImageDetailLevel)
+		.Process(this->CrusherLevelEnabled)
+		.Process(this->CrusherLevel_Defaults_Crusher)
+		.Process(this->CrusherLevel_Defaults_OmniCrusher)
+		.Process(this->CrushableLevel_Defaults_Uncrushable_Infantry)
+		.Process(this->CrushableLevel_Defaults_Uncrushable_Others)
+		.Process(this->CrushableLevel_Defaults_OmniCrushResistant)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -165,6 +165,13 @@ public:
 		Valueable<int> CombatLightDetailLevel;
 		Valueable<int> LightFlashAlphaImageDetailLevel;
 
+		Valueable<bool> CrusherLevelEnabled;
+		Valueable<int> CrusherLevel_Defaults_Crusher;
+		Valueable<int> CrusherLevel_Defaults_OmniCrusher;
+		Valueable<int> CrushableLevel_Defaults_Uncrushable_Infantry;
+		Valueable<int> CrushableLevel_Defaults_Uncrushable_Others;
+		Valueable<int> CrushableLevel_Defaults_OmniCrushResistant;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -284,6 +291,13 @@ public:
 			, WarheadParticleAlphaImageIsLightFlash { false }
 			, CombatLightDetailLevel { 0 }
 			, LightFlashAlphaImageDetailLevel { 0 }
+
+			, CrusherLevelEnabled { false }
+			, CrusherLevel_Defaults_Crusher { 1 }
+			, CrusherLevel_Defaults_OmniCrusher { 3 }
+			, CrushableLevel_Defaults_Uncrushable_Infantry { 1 }
+			, CrushableLevel_Defaults_Uncrushable_Others { 2 }
+			, CrushableLevel_Defaults_OmniCrushResistant { 3 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -294,6 +294,10 @@ void TechnoExt::ExtData::EatPassengers()
 						EnumFunctions::CanTargetHouse(pDelType->SoylentAllowedHouses, pThis->Owner, pPassenger->Owner))
 					{
 						int nMoneyToGive = (int)(pPassenger->GetTechnoType()->GetRefund(pPassenger->Owner, true) * pDelType->SoylentMultiplier);
+						if (pPassenger->Passengers.NumPassengers > 0)
+						{
+							nMoneyToGive += GetTotalSoylentOfPassengers(pThis, pDelType->DontScore, pDelType->SoylentMultiplier, pPassenger);
+						}
 
 						if (nMoneyToGive > 0)
 						{

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -372,6 +372,31 @@ bool TechnoExt::IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource)
 	return false;
 }
 
+// Does what it says.
+// Note that this function is intended for when the transport is grinded or sold. Every unit in the transport will be destroyed in the process.
+int TechnoExt::GetTotalSoylentOfPassengers(TechnoClass* pThis, bool dontScore, double soylentMultiplier, TechnoClass* pTransport)
+{
+	TechnoClass* pPassenger;
+	int nMoneyToGive = 0;
+	while (pTransport->Passengers.NumPassengers > 0)
+	{
+		pPassenger = pTransport->Passengers.RemoveFirstPassenger();
+		if (pPassenger)
+		{
+			auto pSource = dontScore ? nullptr : pThis;
+			nMoneyToGive += (int)(pPassenger->GetTechnoType()->GetRefund(pPassenger->Owner, true) * soylentMultiplier);
+			if (pPassenger->Passengers.NumPassengers > 0)
+			{
+				nMoneyToGive += GetTotalSoylentOfPassengers(pThis, dontScore, soylentMultiplier, pPassenger);
+			}
+			pPassenger->KillPassengers(pSource);
+			pPassenger->RegisterDestruction(pSource);
+			pPassenger->UnInit();
+		}
+	}
+	return nMoneyToGive;
+}
+
 /// <summary>
 /// Gets whether or not techno has listed AttachEffect types active on it
 /// </summary>

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -164,6 +164,7 @@ public:
 	static bool ConvertToType(FootClass* pThis, TechnoTypeClass* toType);
 	static bool CanDeployIntoBuilding(UnitClass* pThis, bool noDeploysIntoDefaultValue = false);
 	static bool IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource);
+	static int GetTotalSoylentOfPassengers(TechnoClass* pThis, bool dontScore, double soylentMultiplier, TechnoClass* pTransport);
 	static int GetTintColor(TechnoClass* pThis, bool invulnerability, bool airstrike, bool berserk);
 	static int GetCustomTintColor(TechnoClass* pThis);
 	static int GetCustomTintIntensity(TechnoClass* pThis);

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -183,6 +183,37 @@ public:
 		Valueable<double> CrushOverlayExtraForwardTilt;
 		Valueable<double> CrushSlowdownMultiplier;
 
+		Nullable<int> CrusherLevel;
+		Nullable<int> CrushableLevel;
+		Nullable<int> DeployedCrushableLevel;
+
+		// When crush: sells the crushed victim for money
+		Valueable<bool> WhenCrush_Soylent;
+		Valueable<double> WhenCrush_SoylentMultiplier;
+		Valueable<bool> WhenCrush_DisplaySoylent;
+		Valueable<AffectedHouse> WhenCrush_DisplaySoylentToHouses;
+		Valueable<Point2D> WhenCrush_DisplaySoylentOffset;
+
+		// When crush: supresses the victim's WhenCrushed= configs
+		Valueable<bool> WhenCrush_SupressVictim;
+		ValueableVector<WarheadTypeClass*> WhenCrush_SupressVictim_Warheads;
+		ValueableVector<WeaponTypeClass*> WhenCrush_SupressVictim_Weapons;
+
+		// When crush: detonates a weapon or damage
+		Promotable<WarheadTypeClass*> WhenCrush_Warhead;
+		Promotable<WeaponTypeClass*> WhenCrush_Weapon;
+		Promotable<int> WhenCrush_Damage;
+		Valueable<bool> WhenCrush_Warhead_Full;
+		Valueable<double> WhenCrush_DamageMult_Infantries;
+		Valueable<double> WhenCrush_DamageMult_Units;
+		Valueable<double> WhenCrush_DamageMult_Overlays;
+
+		// When crushed: detonates a weapon or damage
+		Promotable<WarheadTypeClass*> WhenCrushed_Warhead;
+		Promotable<WeaponTypeClass*> WhenCrushed_Weapon;
+		Promotable<int> WhenCrushed_Damage;
+		Valueable<bool> WhenCrushed_Warhead_Full;
+
 		Valueable<bool> DigitalDisplay_Disable;
 		ValueableVector<DigitalDisplayTypeClass*> DigitalDisplayTypes;
 
@@ -405,6 +436,32 @@ public:
 			, CrushForwardTiltPerFrame {}
 			, CrushOverlayExtraForwardTilt { 0.02 }
 
+			, CrusherLevel {}
+			, CrushableLevel {}
+			, DeployedCrushableLevel {}
+
+			, WhenCrush_Soylent { false }
+			, WhenCrush_SoylentMultiplier { 1.0 }
+			, WhenCrush_DisplaySoylent { false }
+			, WhenCrush_DisplaySoylentToHouses { AffectedHouse::All }
+			, WhenCrush_DisplaySoylentOffset { { 0, 0 } }
+			, WhenCrush_SupressVictim { false }
+			, WhenCrush_SupressVictim_Warheads {}
+			, WhenCrush_SupressVictim_Weapons {}
+
+			, WhenCrush_Warhead {}
+			, WhenCrush_Weapon {}
+			, WhenCrush_Damage {}
+			, WhenCrush_Warhead_Full { true }
+			, WhenCrush_DamageMult_Infantries { 1.0 }
+			, WhenCrush_DamageMult_Units { 1.0 }
+			, WhenCrush_DamageMult_Overlays { 0.0 }
+
+			, WhenCrushed_Warhead {}
+			, WhenCrushed_Weapon {}
+			, WhenCrushed_Damage {}
+			, WhenCrushed_Warhead_Full { true }
+
 			, DigitalDisplay_Disable { false }
 			, DigitalDisplayTypes {}
 
@@ -464,6 +521,12 @@ public:
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 
 		void ApplyTurretOffset(Matrix3D* mtx, double factor = 1.0);
+
+		int GetCrusherLevel(FootClass* pCrusher);
+		int GetCrushableLevel(FootClass* pVictim);
+
+		void WhenCrushes(TechnoClass* pCrusher, TechnoClass* pVictim) const;
+		void WhenCrushedBy(TechnoClass* pCrusher, TechnoClass* pVictim) const;
 
 		// Ares 0.A
 		const char* GetSelectionGroupID() const;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -214,6 +214,12 @@ public:
 		Promotable<int> WhenCrushed_Damage;
 		Valueable<bool> WhenCrushed_Warhead_Full;
 
+		// When infiltrates: detonates a weapon or damage
+		Promotable<WarheadTypeClass*> WhenInfiltrate_Warhead;
+		Promotable<WeaponTypeClass*> WhenInfiltrate_Weapon;
+		Promotable<int> WhenInfiltrate_Damage;
+		Valueable<bool> WhenInfiltrate_Warhead_Full;
+
 		Valueable<bool> DigitalDisplay_Disable;
 		ValueableVector<DigitalDisplayTypeClass*> DigitalDisplayTypes;
 
@@ -462,6 +468,11 @@ public:
 			, WhenCrushed_Damage {}
 			, WhenCrushed_Warhead_Full { true }
 
+			, WhenInfiltrate_Warhead {}
+			, WhenInfiltrate_Weapon {}
+			, WhenInfiltrate_Damage {}
+			, WhenInfiltrate_Warhead_Full { true }
+
 			, DigitalDisplay_Disable { false }
 			, DigitalDisplayTypes {}
 
@@ -527,6 +538,8 @@ public:
 
 		void WhenCrushes(TechnoClass* pCrusher, TechnoClass* pVictim) const;
 		void WhenCrushedBy(TechnoClass* pCrusher, TechnoClass* pVictim) const;
+
+		void WhenInfiltratesInto(InfantryClass* pSpy, BuildingClass* pBuilding) const;
 
 		// Ares 0.A
 		const char* GetSelectionGroupID() const;

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -116,6 +116,17 @@ DEFINE_HOOK(0x711FDF, TechnoTypeClass_RefundAmount_FactoryPlant, 0x8)
 	return 0;
 }
 
+DEFINE_HOOK(0x51A002, InfantryClass_UpdatePosition_BeforeInfiltrate, 6)
+{
+	GET(InfantryClass*, pSpy, ESI);
+	GET(BuildingClass*, pBuilding, EDI);
+
+	auto const pSpyExt = TechnoTypeExt::ExtMap.Find(pSpy->Type);
+	pSpyExt->WhenInfiltratesInto(pSpy, pBuilding);
+
+	return 0;
+}
+
 
 DEFINE_HOOK(0x71464A, TechnoTypeClass_ReadINI_Speed, 0x7)
 {


### PR DESCRIPTION
1. The implementation of `CrusherLevel` and `CrushableLevel` system.
2. Weapon triggers and more when unit crushes something.
3. Weapon triggers when unit gets crushed.
4. Weapon triggers when unit infiltrates.
5. By the way fixed `PassengerDeletion.Soylent` miscalculating the soylent.

This will be incorporated into an upcoming event trigger system, so I'm converting this draft.