### PR TITLE
[New Feature] Techno type conversion expanded

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -407,4 +407,4 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
-- **Aephiex** - techno type conversion when swaps ownership into a side or country
+- **Aephiex** - techno type conversion when swaps ownership into a side or country, when enters or leaves a transport

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -407,3 +407,4 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
+- **Aephiex** - techno type conversion when swaps ownership into a side or country

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1363,6 +1363,7 @@ Promote.EliteAnimation=           ; Animation
   - `Convert.ToUSSR=FLAKT` meaning the unit will be converted into a Flak Trooper when changing ownership into Russia. Country config has higher priority than side config.
   - If this feature is used alongside with `Convert.HumanToComputer` or `Convert.ComputerToHuman`, the latter will take presedence.
 - These only happen when a unit changes ownership. If it was gained through other means that do not involve the changing of ownership, nothing happens and the unit doesn't convert.
+- Ares' depiloting doesn't count as change in ownership.
 
 In `rulesmd.ini`:
 ```ini
@@ -1378,6 +1379,32 @@ This feature has the same limitations as [Ares' Type Conversion](https://ares-de
 
 ```{warning}
 This feature requires Ares 3.0 or higher to function! When Ares 3.0+ is not detected, not all properties of a unit may be updated.
+```
+
+### Convert TechnoType on enter or leave a transport or building
+- You can change a unit's type when it enters or leaves a transport.
+- You can also make the transport change its passenger's type when it loads or unloads a passenger.
+  - `Convert.OnLoadN.From` (where N is 0, 1, 2...) specifies which TechnoTypes are valid for conversion. This entry can have many types listed, meanging that many types will be converted at once. When no types are included, conversion will affect all valid targets.
+  - `Convert.OnLoadN.To` specifies the TechnoType which is the result of conversion.
+  - `Convert.OnLoadN.AffectedHouses` specifies whose units can be converted.
+  - `Convert.OnLoad.From`, `Convert.OnLoad.To` and `Convert.OnLoad.AffectedHouses` (without numbers) are a valid alternative to `Convert.OnLoad0.From`, `Convert.OnLoad0.To` and `Convert.OnLoad0.AffectedHouses` if only one pair is specified.
+  - The same rules apply to `Convert.OnUnload`.
+- This works when the techno is abducted.
+- Leaving a war factory when built doesn't count as leaving a building here.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]
+Convert.EnterTransport  =                      ; TechnoType;
+Convert.LeaveTransport  =                      ; TechnoType;
+
+[SOMETECHNO]
+Convert.OnLoad.From=                           ; list of TechnoType;
+Convert.OnLoad.To=                             ; TechnoType;
+Convert.OnLoad.AffectedHouses=all              ; list of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+Convert.OnUnload.From=
+Convert.OnUnload.To=
+Convert.OnUnload.AffectedHouses=all
 ```
 
 ## Terrain

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1357,13 +1357,27 @@ Promote.EliteAnimation=           ; Animation
 ```
 
 ### Convert TechnoType on owner house change
-- You can now change a unit's type when changing ownership from human to computer or from computer to human.
+- You can change a unit's type when changing ownership from human to computer or from computer to human.
+- You can change a unit's type when changing ownership into a certain side or country.
+  - `Convert.ToNod=E2` meaning the unit will be converted into a Conscript when changing ownership into a Soviet country.
+  - `Convert.ToUSSR=FLAKT` meaning the unit will be converted into a Flak Trooper when changing ownership into Russia. Country config has higher priority than side config.
+  - If this feature is used alongside with `Convert.HumanToComputer` or `Convert.ComputerToHuman`, the latter will take presedence.
+- These only happen when a unit changes ownership. If it was gained through other means that do not involve the changing of ownership, nothing happens and the unit doesn't convert.
 
 In `rulesmd.ini`:
 ```ini
 [SOMETECHNO]
 Convert.HumanToComputer =   ; TechnoType
 Convert.ComputerToHuman =   ; TechnoType
+Convert.To*             =   ; TechnoType; * can be any of [Sides] or [Countries]
+```
+
+```{warning}
+This feature has the same limitations as [Ares' Type Conversion](https://ares-developers.github.io/Ares-docs/new/typeconversion.html). This feature does not support BuildingTypes.
+```
+
+```{warning}
+This feature requires Ares 3.0 or higher to function! When Ares 3.0+ is not detected, not all properties of a unit may be updated.
 ```
 
 ## Terrain

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1383,14 +1383,15 @@ This feature requires Ares 3.0 or higher to function! When Ares 3.0+ is not dete
 
 ### Convert TechnoType on enter or leave a transport or building
 - You can change a unit's type when it enters or leaves a transport.
+  - Getting ejected from a transport when it is destroyed counts as leaving it.
 - You can also make the transport change its passenger's type when it loads or unloads a passenger.
   - `Convert.OnLoadN.From` (where N is 0, 1, 2...) specifies which TechnoTypes are valid for conversion. This entry can have many types listed, meanging that many types will be converted at once. When no types are included, conversion will affect all valid targets.
   - `Convert.OnLoadN.To` specifies the TechnoType which is the result of conversion.
   - `Convert.OnLoadN.AffectedHouses` specifies whose units can be converted.
   - `Convert.OnLoad.From`, `Convert.OnLoad.To` and `Convert.OnLoad.AffectedHouses` (without numbers) are a valid alternative to `Convert.OnLoad0.From`, `Convert.OnLoad0.To` and `Convert.OnLoad0.AffectedHouses` if only one pair is specified.
   - The same rules apply to `Convert.OnUnload`.
+    - Having passengers ejected when destroyed counts as unloading them.
 - This works when the techno is abducted.
-- Leaving a war factory when built doesn't count as leaving a building here.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1390,7 +1390,7 @@ This feature requires Ares 3.0 or higher to function! When Ares 3.0+ is not dete
   - `Convert.OnLoadN.AffectedHouses` specifies whose units can be converted.
   - `Convert.OnLoad.From`, `Convert.OnLoad.To` and `Convert.OnLoad.AffectedHouses` (without numbers) are a valid alternative to `Convert.OnLoad0.From`, `Convert.OnLoad0.To` and `Convert.OnLoad0.AffectedHouses` if only one pair is specified.
   - The same rules apply to `Convert.OnUnload`.
-    - Having passengers ejected when destroyed counts as unloading them.
+    - Having passengers ejected when the transport is destroyed counts as unloading them.
 - This works when the techno is abducted.
 
 In `rulesmd.ini`:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -469,6 +469,7 @@ New:
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps (by Starkku)
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
 - Unit `Speed` setting now accepts floating point values (by Starkku)
+- Allow techno type conversion when swap ownership into a side or country (by Aephiex)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -469,7 +469,7 @@ New:
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps (by Starkku)
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
 - Unit `Speed` setting now accepts floating point values (by Starkku)
-- Allow techno type conversion when swap ownership into a side or country (by Aephiex)
+- Techno type conversion when swaps ownership into a side or country, when enters or leaves a transport (by Aephiex)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -212,8 +212,25 @@ DEFINE_HOOK(0x7015C9, TechnoClass_Captured_UpdateTracking, 0x6)
 	{
 		bool I_am_human = pThis->Owner->IsControlledByHuman();
 		bool You_are_human = pNewOwner->IsControlledByHuman();
-		auto pConvertTo = (I_am_human && !You_are_human) ? pExt->TypeExtData->Convert_HumanToComputer.Get() :
+		TechnoTypeClass* pConvertTo = (I_am_human && !You_are_human) ? pExt->TypeExtData->Convert_HumanToComputer.Get() :
 			(!I_am_human && You_are_human) ? pExt->TypeExtData->Convert_ComputerToHuman.Get() : nullptr;
+
+		if (!pConvertTo)
+		{
+			auto& map = pExt->TypeExtData->Convert_ToHouseOrCountry;
+			if (map.contains(pNewOwner->Type))
+			{
+				pConvertTo = map.get_or_default(pNewOwner->Type);
+			}
+			else
+			{
+				SideClass* pSide;
+				if (map.contains(pSide = SideClass::Array->Items[pNewOwner->Type->SideIndex]))
+				{
+					pConvertTo = map.get_or_default(pSide);
+				}
+			}
+		}
 
 		if (pConvertTo && pConvertTo->WhatAmI() == pType->WhatAmI())
 			TechnoExt::ConvertToType(pMe, pConvertTo);

--- a/src/Ext/Techno/Hooks.Transport.cpp
+++ b/src/Ext/Techno/Hooks.Transport.cpp
@@ -90,7 +90,7 @@ DEFINE_HOOK(0x71067B, TechnoClass_EnterTransport, 0x7)
 		}
 
 		TechnoTypeClass* pConvertTo;
-		if (pConvertTo = pExt->TypeExtData->Convert_EnterTransport)
+		if ((pConvertTo = pExt->TypeExtData->Convert_EnterTransport))
 		{
 			TechnoExt::ConvertToType(pPassenger, pConvertTo);
 		}
@@ -130,7 +130,7 @@ DEFINE_HOOK(0x4DE722, FootClass_LeaveTransport, 0x6)
 		}
 
 		TechnoTypeClass* pConvertTo;
-		if (pConvertTo = pExt->TypeExtData->Convert_LeaveTransport)
+		if ((pConvertTo = pExt->TypeExtData->Convert_LeaveTransport))
 		{
 			TechnoExt::ConvertToType(pPassenger, pConvertTo);
 		}

--- a/src/Ext/Techno/Hooks.Transport.cpp
+++ b/src/Ext/Techno/Hooks.Transport.cpp
@@ -88,6 +88,17 @@ DEFINE_HOOK(0x71067B, TechnoClass_EnterTransport, 0x7)
 		{
 			ScenarioExt::Global()->TransportReloaders.push_back(pExt);
 		}
+
+		TechnoTypeClass* pConvertTo;
+		if (pConvertTo = pExt->TypeExtData->Convert_EnterTransport)
+		{
+			TechnoExt::ConvertToType(pPassenger, pConvertTo);
+		}
+
+		if (pTransTypeExt->ConvertOnLoad_Pairs.size() > 0)
+		{
+			TypeConvertGroup::Convert(pPassenger, pTransTypeExt->ConvertOnLoad_Pairs, pPassenger->GetOwningHouse());
+		}
 	}
 
 	return 0;
@@ -116,6 +127,17 @@ DEFINE_HOOK(0x4DE722, FootClass_LeaveTransport, 0x6)
 			pExt->OriginalPassengerOwner)
 		{
 			pPassenger->SetOwningHouse(pExt->OriginalPassengerOwner, false);
+		}
+
+		TechnoTypeClass* pConvertTo;
+		if (pConvertTo = pExt->TypeExtData->Convert_LeaveTransport)
+		{
+			TechnoExt::ConvertToType(pPassenger, pConvertTo);
+		}
+
+		if (pTransTypeExt->ConvertOnUnload_Pairs.size() > 0)
+		{
+			TypeConvertGroup::Convert(pPassenger, pTransTypeExt->ConvertOnUnload_Pairs, pPassenger->GetOwningHouse());
 		}
 	}
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -435,6 +435,32 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Convert_HumanToComputer.Read(exINI, pSection, "Convert.HumanToComputer");
 	this->Convert_ComputerToHuman.Read(exINI, pSection, "Convert.ComputerToHuman");
 
+	char tempBuffer[32];
+
+	this->Convert_ToHouseOrCountry.clear();
+	Nullable<TechnoTypeClass*> technoType;
+	// put all sides into the map
+	for (auto const& pSide : *SideClass::Array)
+	{
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "Convert.To%s", pSide->ID);
+		technoType.Read(exINI, pSection, tempBuffer);
+		if (technoType.isset())
+		{
+			this->Convert_ToHouseOrCountry.insert(pSide, technoType.Get());
+		}
+	}
+
+	// put all countries into the map
+	for (auto const& pTHouse : *HouseTypeClass::Array)
+	{
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "Convert.To%s", pTHouse->ID);
+		technoType.Read(exINI, pSection, tempBuffer);
+		if (technoType.isset())
+		{
+			this->Convert_ToHouseOrCountry.insert(pTHouse, technoType.Get());
+		}
+	}
+
 	this->CrateGoodie_RerollChance.Read(exINI, pSection, "CrateGoodie.RerollChance");
 
 	this->Tint_Color.Read(exINI, pSection, "Tint.Color");
@@ -470,8 +496,6 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// Ares 0.C
 	this->NoAmmoWeapon.Read(exINI, pSection, "NoAmmoWeapon");
 	this->NoAmmoAmount.Read(exINI, pSection, "NoAmmoAmount");
-
-	char tempBuffer[32];
 
 	if (this->OwnerObject()->Gunner && this->Insignia_Weapon.empty())
 	{
@@ -802,6 +826,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->Convert_HumanToComputer)
 		.Process(this->Convert_ComputerToHuman)
+		.Process(this->Convert_ToHouseOrCountry)
 
 		.Process(this->CrateGoodie_RerollChance)
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -434,6 +434,10 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Convert_HumanToComputer.Read(exINI, pSection, "Convert.HumanToComputer");
 	this->Convert_ComputerToHuman.Read(exINI, pSection, "Convert.ComputerToHuman");
+	this->Convert_EnterTransport.Read(exINI, pSection, "Convert.EnterTransport");
+	this->Convert_LeaveTransport.Read(exINI, pSection, "Convert.LeaveTransport");
+	TypeConvertGroup::Parse(this->ConvertOnLoad_Pairs, exINI, pSection, AffectedHouse::All, "Convert.OnLoad");
+	TypeConvertGroup::Parse(this->ConvertOnUnload_Pairs, exINI, pSection, AffectedHouse::All, "Convert.OnUnload");
 
 	char tempBuffer[32];
 
@@ -826,6 +830,10 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->Convert_HumanToComputer)
 		.Process(this->Convert_ComputerToHuman)
+		.Process(this->Convert_EnterTransport)
+		.Process(this->Convert_LeaveTransport)
+		.Process(this->ConvertOnLoad_Pairs)
+		.Process(this->ConvertOnUnload_Pairs)
 		.Process(this->Convert_ToHouseOrCountry)
 
 		.Process(this->CrateGoodie_RerollChance)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -204,6 +204,7 @@ public:
 
 		Valueable<TechnoTypeClass*> Convert_HumanToComputer;
 		Valueable<TechnoTypeClass*> Convert_ComputerToHuman;
+		PhobosMap<AbstractTypeClass*, TechnoTypeClass*> Convert_ToHouseOrCountry;
 
 		Valueable<double> CrateGoodie_RerollChance;
 
@@ -427,6 +428,7 @@ public:
 
 			, Convert_HumanToComputer { }
 			, Convert_ComputerToHuman { }
+			, Convert_ToHouseOrCountry { }
 
 			, CrateGoodie_RerollChance { 0.0 }
 

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -12,6 +12,7 @@
 #include <New/Type/Affiliated/PassengerDeletionTypeClass.h>
 #include <New/Type/DigitalDisplayTypeClass.h>
 #include <New/Type/Affiliated/DroppodTypeClass.h>
+#include <New/Type/Affiliated/TypeConvertGroup.h>
 
 class Matrix3D;
 
@@ -204,6 +205,10 @@ public:
 
 		Valueable<TechnoTypeClass*> Convert_HumanToComputer;
 		Valueable<TechnoTypeClass*> Convert_ComputerToHuman;
+		Valueable<TechnoTypeClass*> Convert_EnterTransport;
+		Valueable<TechnoTypeClass*> Convert_LeaveTransport;
+		std::vector<TypeConvertGroup> ConvertOnLoad_Pairs;
+		std::vector<TypeConvertGroup> ConvertOnUnload_Pairs;
 		PhobosMap<AbstractTypeClass*, TechnoTypeClass*> Convert_ToHouseOrCountry;
 
 		Valueable<double> CrateGoodie_RerollChance;
@@ -428,6 +433,10 @@ public:
 
 			, Convert_HumanToComputer { }
 			, Convert_ComputerToHuman { }
+			, Convert_EnterTransport { }
+			, Convert_LeaveTransport { }
+			, ConvertOnLoad_Pairs { }
+			, ConvertOnUnload_Pairs { }
 			, Convert_ToHouseOrCountry { }
 
 			, CrateGoodie_RerollChance { 0.0 }

--- a/src/New/Type/Affiliated/TypeConvertGroup.cpp
+++ b/src/New/Type/Affiliated/TypeConvertGroup.cpp
@@ -42,17 +42,24 @@ bool TypeConvertGroup::Save(PhobosStreamWriter& stm) const
 
 void TypeConvertGroup::Parse(std::vector<TypeConvertGroup>& list, INI_EX& exINI, const char* pSection, AffectedHouse defaultAffectHouse)
 {
+	Parse(list, exINI, pSection, defaultAffectHouse, "Convert");
+}
+
+// Note that if the header's length plus "1.AffectedHouse" exceeds the capacity of the tempBuffer then the game will crash.
+// Longer headers ask for greater capacity of the tempBuffer.
+void TypeConvertGroup::Parse(std::vector<TypeConvertGroup>& list, INI_EX& exINI, const char* pSection, AffectedHouse defaultAffectHouse, const char* header)
+{
+	char tempBuffer[40];
 	for (size_t i = 0; ; ++i)
 	{
-		char tempBuffer[32];
 		ValueableVector<TechnoTypeClass*> convertFrom;
 		Nullable<TechnoTypeClass*> convertTo;
 		Nullable<AffectedHouse> convertAffectedHouses;
-		_snprintf_s(tempBuffer, sizeof(tempBuffer), "Convert%d.From", i);
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "%s%d.From", header, i);
 		convertFrom.Read(exINI, pSection, tempBuffer);
-		_snprintf_s(tempBuffer, sizeof(tempBuffer), "Convert%d.To", i);
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "%s%d.To", header, i);
 		convertTo.Read(exINI, pSection, tempBuffer);
-		_snprintf_s(tempBuffer, sizeof(tempBuffer), "Convert%d.AffectedHouses", i);
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "%s%d.AffectedHouses", header, i);
 		convertAffectedHouses.Read(exINI, pSection, tempBuffer);
 
 		if (!convertTo.isset())
@@ -66,9 +73,12 @@ void TypeConvertGroup::Parse(std::vector<TypeConvertGroup>& list, INI_EX& exINI,
 	ValueableVector<TechnoTypeClass*> convertFrom;
 	Nullable<TechnoTypeClass*> convertTo;
 	Nullable<AffectedHouse> convertAffectedHouses;
-	convertFrom.Read(exINI, pSection, "Convert.From");
-	convertTo.Read(exINI, pSection, "Convert.To");
-	convertAffectedHouses.Read(exINI, pSection, "Convert.AffectedHouses");
+	_snprintf_s(tempBuffer, sizeof(tempBuffer), "%s.From", header);
+	convertFrom.Read(exINI, pSection, tempBuffer);
+	_snprintf_s(tempBuffer, sizeof(tempBuffer), "%s.To", header);
+	convertTo.Read(exINI, pSection, tempBuffer);
+	_snprintf_s(tempBuffer, sizeof(tempBuffer), "%s.AffectedHouses", header);
+	convertAffectedHouses.Read(exINI, pSection, tempBuffer);
 	if (convertTo.isset())
 	{
 		if (!convertAffectedHouses.isset())

--- a/src/New/Type/Affiliated/TypeConvertGroup.h
+++ b/src/New/Type/Affiliated/TypeConvertGroup.h
@@ -14,6 +14,8 @@ public:
 
 	static void Parse(std::vector<TypeConvertGroup>& list, INI_EX& exINI, const char* section, AffectedHouse defaultAffectHouse);
 
+	static void Parse(std::vector<TypeConvertGroup>& list, INI_EX& exINI, const char* section, AffectedHouse defaultAffectHouse, const char* header);
+
 	static void Convert(FootClass* pTargetFoot, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner);
 
 private:


### PR DESCRIPTION
1. Allows techno type conversion when unit swaps ownership into a side or country.
2. Allows techno type conversion when unit enters or leaves a transport.

This will be incorporated into an upcoming event trigger system, so I'm converting this draft.