### PR TITLE
[Minor] Fix build-45’s issue of excessive cell spread effect range

### DIFF
--- a/src/Utilities/Helpers.Alex.h
+++ b/src/Utilities/Helpers.Alex.h
@@ -176,6 +176,10 @@ namespace Helpers
 							if (dist > spreadMult)
 								continue;
 						}
+						else if (pTechno->Location.DistanceFrom(coords) > spreadMult)
+						{
+							continue;
+						}
 
 						set.insert(pTechno);
 					}


### PR DESCRIPTION
Fix the issue of attaching effects (EMP, IC, AE...) to technos that are out of cell spread range.