### PR TITLE
Fix `Stop` command not working so well in some cases

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -371,6 +371,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow to change the speed of gas particles
 - **CrimRecya**
   - Fix `LimboKill` not working reliably
+  - Fix `Stop` command not working so well in some cases
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -176,6 +176,9 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps.
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers.
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
+- Prevent jumpjets from falling into a state of standing idly by when receive the stop(shortcut: s) command.
+- Prevent technos from being unable to stop the attack move mission when receive the stop(shortcut: s) command.
+- Prevent aircrafts from briefly pausing in the air before returning when receive the stop(shortcut: s) command.
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -178,6 +178,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
 - Prevent jumpjets from falling into a state of standing idly by when receive the stop(shortcut: s) command.
 - Prevent technos from being unable to stop the attack move mission when receive the stop(shortcut: s) command.
+- Prevent aircrafts from duplicatedly finding airport and overlapping when receive the stop(shortcut: s) command.
 - Prevent aircrafts from briefly pausing in the air before returning when receive the stop(shortcut: s) command.
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -180,6 +180,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Prevent technos from being unable to stop the attack move mission when receive the stop(shortcut: s) command.
 - Prevent aircrafts from duplicatedly finding airport and overlapping when receive the stop(shortcut: s) command.
 - Prevent aircrafts from briefly pausing in the air before returning when receive the stop(shortcut: s) command.
+- Prevent aircrafts with `AirportBound=no` continue moving forward when receive the stop(shortcut: s) command.
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -552,6 +552,7 @@ Vanilla fixes:
 - Fixed objects with ally target and `AttackFriendlies=true` having their target reset every frame, particularly AI-owned buildings (by Starkku)
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers (by Starkku)
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix (by tyuah8)
+- Fix `Stop` command not working so well in some cases (by CrimRecya)
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc. (by Starkku)
 
 Phobos fixes:

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1090,7 +1090,7 @@ DEFINE_HOOK(0x4C75E6, EventClass_RespondToEvent_Stop, 0x5)
 		pTechno->vt_entry_4A8(); // pTechno->ClearMegaMissionData()
 
 	// To avoid aircrafts pausing in the air and let they returning to air base immediately
-	if (pTechno->WhatAmI() == AbstractType::Aircraft && !pTechno->Airstrike && !pTechno->Spawned && pTechno->GetHeight() > Unsorted::CellHeight)
+	if (pTechno->WhatAmI() == AbstractType::Aircraft && !pTechno->Airstrike && !pTechno->Spawned && static_cast<AircraftClass*>(pTechno)->Type->AirportBound && pTechno->GetHeight() > Unsorted::CellHeight)
 		pTechno->EnterIdleMode(false, true);
 
 	return SkipGameCode;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1064,6 +1064,40 @@ DEFINE_HOOK(0x743664, UnitClass_ReadFromINI_Follower3, 0x6)
 
 #pragma endregion
 
+#pragma region StopEventFix
+
+DEFINE_HOOK(0x4C75E6, EventClass_RespondToEvent_Stop, 0x5)
+{
+	enum { SkipGameCode = 0x4C762A };
+
+	GET(TechnoClass* const, pTechno, ESI);
+
+	// Clearing the current target should still be necessary for all technos
+	pTechno->SetTarget(nullptr);
+	const auto pFoot = abstract_cast<FootClass*>(pTechno);
+	const auto pJumpjetLoco = pFoot ? locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor) : nullptr;
+
+	// To avoid jumpjets falling into a state of standing idly by
+	if (!pJumpjetLoco) // If is not jumpjet, clear the destination is enough
+		pTechno->SetDestination(nullptr, true);
+	else if (!pFoot->Destination) // When in attack move and have had a target, the destination will be cleaned up, enter the guard mission can prevent the jumpjets stuck in a status of standing idly by
+		pTechno->QueueMission(Mission::Guard, true);
+	else if (static_cast<int>(CellClass::Coord2Cell(pFoot->Destination->GetCoords()).DistanceFromSquared(pTechno->GetMapCoords())) > 2) // If the jumpjet is moving, find the forward cell then stop in it
+		pTechno->SetDestination(pTechno->GetCell()->GetNeighbourCell(static_cast<FacingType>(((((pJumpjetLoco->LocomotionFacing.Current().Raw) >> 12) + 1) >> 1) & 7)), true);
+
+	// To avoid technos being unable to stop in attack move mega mission
+	if (pTechno->vt_entry_4C4()) // pTechno->MegaMissionIsAttackMove()
+		pTechno->vt_entry_4A8(); // pTechno->ClearMegaMissionData()
+
+	// To avoid aircrafts pausing in the air and let they returning to air base immediately
+	if (pTechno->WhatAmI() == AbstractType::Aircraft && !pTechno->Airstrike && !pTechno->Spawned && pTechno->GetHeight() > Unsorted::CellHeight)
+		pTechno->EnterIdleMode(false, true);
+
+	return SkipGameCode;
+}
+
+#pragma endregion
+
 // This shouldn't be here
 // Author: tyuah8
 DEFINE_HOOK_AGAIN(0x4AF94D, EndPiggyback_PowerOn, 0x7) // Drive

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1078,9 +1078,10 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 	// Check aircrafts
 	const auto pAircraft = abstract_cast<AircraftClass*>(pTechno);
 	const bool commonAircraft = pAircraft && !pAircraft->Airstrike && !pAircraft->Spawned;
+	const auto mission = pTechno->CurrentMission;
 
 	// To avoid aircrafts overlap by keep link if is returning or is in airport now.
-	if (!commonAircraft || pAircraft->CurrentMission != Mission::Enter || !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+	if (!commonAircraft || (mission != Mission::Sleep && mission != Mission::Guard && mission != Mission::Enter) || !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
 		pTechno->SendToEachLink(RadioCommand::NotifyUnlink);
 
 	// To avoid technos being unable to stop in attack move mega mission

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1080,7 +1080,7 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 	const bool commonAircraft = pAircraft && !pAircraft->Airstrike && !pAircraft->Spawned;
 
 	// To avoid aircrafts overlap by keep link if is returning or is in airport now.
-	if (!commonAircraft || !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+	if (!commonAircraft || pAircraft->CurrentMission != Mission::Enter || !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
 		pTechno->SendToEachLink(RadioCommand::NotifyUnlink);
 
 	// To avoid technos being unable to stop in attack move mega mission
@@ -1098,13 +1098,15 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 			if (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink())) // If the aircraft have no valid dock, try to find a new one
 				pAircraft->EnterIdleMode(false, true);
 		}
-		else if (const auto pDestination = pAircraft->Destination)
+		else if (pAircraft->Ammo)
 		{
 			// To avoid `AirportBound=no` aircrafts ignoring the stop task or directly return to the airport.
-			if (pAircraft->Ammo && static_cast<int>(CellClass::Coord2Cell(pDestination->GetCoords()).DistanceFromSquared(pAircraft->GetMapCoords())) > 2) // If the aircraft is moving, find the forward cell then stop in it
+			if (pAircraft->Destination && static_cast<int>(CellClass::Coord2Cell(pAircraft->Destination->GetCoords()).DistanceFromSquared(pAircraft->GetMapCoords())) > 2) // If the aircraft is moving, find the forward cell then stop in it
 				pAircraft->SetDestination(pAircraft->GetCell()->GetNeighbourCell(static_cast<FacingType>(pAircraft->PrimaryFacing.Current().GetValue<3>())), true);
-			else if (!pAircraft->Ammo && (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink())))
-				pAircraft->EnterIdleMode(false, true);
+		}
+		else if (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+		{
+			pAircraft->EnterIdleMode(false, true);
 		}
 		// Otherwise landing or idling normally without answering the stop command
 	}

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1083,7 +1083,7 @@ DEFINE_HOOK(0x4C75E6, EventClass_RespondToEvent_Stop, 0x5)
 	else if (!pFoot->Destination) // When in attack move and have had a target, the destination will be cleaned up, enter the guard mission can prevent the jumpjets stuck in a status of standing idly by
 		pTechno->QueueMission(Mission::Guard, true);
 	else if (static_cast<int>(CellClass::Coord2Cell(pFoot->Destination->GetCoords()).DistanceFromSquared(pTechno->GetMapCoords())) > 2) // If the jumpjet is moving, find the forward cell then stop in it
-		pTechno->SetDestination(pTechno->GetCell()->GetNeighbourCell(static_cast<FacingType>(((((pJumpjetLoco->LocomotionFacing.Current().Raw) >> 12) + 1) >> 1) & 7)), true);
+		pTechno->SetDestination(pTechno->GetCell()->GetNeighbourCell(static_cast<FacingType>(pJumpjetLoco->LocomotionFacing.Current().GetValue<3>())), true);
 
 	// To avoid technos being unable to stop in attack move mega mission
 	if (pTechno->vt_entry_4C4()) // pTechno->MegaMissionIsAttackMove()

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1066,6 +1066,9 @@ DEFINE_HOOK(0x743664, UnitClass_ReadFromINI_Follower3, 0x6)
 
 #pragma region StopEventFix
 
+DEFINE_JUMP(LJMP, 0x444021, 0x44402E) // Skip useless tether when kick out aircrafts (temporary)
+// TODO: this is already in #1366, should delete if merge
+
 DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 {
 	enum { SkipGameCode = 0x4C762A };
@@ -1074,10 +1077,10 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 
 	// Check aircrafts
 	const auto pAircraft = abstract_cast<AircraftClass*>(pTechno);
-	const bool findAirport = pAircraft && !pAircraft->Airstrike && !pAircraft->Spawned && pAircraft->Type->AirportBound;
+	const bool commonAircraft = pAircraft && !pAircraft->Airstrike && !pAircraft->Spawned;
 
 	// To avoid aircrafts overlap by keep link if is returning or is in airport now.
-	if (!findAirport || !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+	if (!commonAircraft || !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
 		pTechno->SendToEachLink(RadioCommand::NotifyUnlink);
 
 	// To avoid technos being unable to stop in attack move mega mission
@@ -1087,11 +1090,23 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 	// Clearing the current target should still be necessary for all technos
 	pTechno->SetTarget(nullptr);
 
-	if (findAirport)
+	if (commonAircraft)
 	{
-		// To avoid aircrafts pausing in the air and let they returning to air base immediately.
-		if (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
-			pAircraft->EnterIdleMode(false, true);
+		if (pAircraft->Type->AirportBound)
+		{
+			// To avoid `AirportBound=yes` aircrafts pausing in the air and let they returning to air base immediately.
+			if (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink())) // If the aircraft have no valid dock, try to find a new one
+				pAircraft->EnterIdleMode(false, true);
+		}
+		else if (const auto pDestination = pAircraft->Destination)
+		{
+			// To avoid `AirportBound=no` aircrafts ignoring the stop task or directly return to the airport.
+			if (pAircraft->Ammo && static_cast<int>(CellClass::Coord2Cell(pDestination->GetCoords()).DistanceFromSquared(pAircraft->GetMapCoords())) > 2) // If the aircraft is moving, find the forward cell then stop in it
+				pAircraft->SetDestination(pAircraft->GetCell()->GetNeighbourCell(static_cast<FacingType>(pAircraft->PrimaryFacing.Current().GetValue<3>())), true);
+			else if (!pAircraft->Ammo && (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink())))
+				pAircraft->EnterIdleMode(false, true);
+		}
+		// Otherwise landing or idling normally without answering the stop command
 	}
 	else
 	{
@@ -1106,6 +1121,7 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 			pTechno->QueueMission(Mission::Guard, true);
 		else if (static_cast<int>(CellClass::Coord2Cell(pFoot->Destination->GetCoords()).DistanceFromSquared(pTechno->GetMapCoords())) > 2) // If the jumpjet is moving, find the forward cell then stop in it
 			pTechno->SetDestination(pTechno->GetCell()->GetNeighbourCell(static_cast<FacingType>(pJumpjetLoco->LocomotionFacing.Current().GetValue<3>())), true);
+		// Otherwise landing or idling normally without answering the stop command
 	}
 
 	return SkipGameCode;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1066,32 +1066,47 @@ DEFINE_HOOK(0x743664, UnitClass_ReadFromINI_Follower3, 0x6)
 
 #pragma region StopEventFix
 
-DEFINE_HOOK(0x4C75E6, EventClass_RespondToEvent_Stop, 0x5)
+DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 {
 	enum { SkipGameCode = 0x4C762A };
 
 	GET(TechnoClass* const, pTechno, ESI);
 
-	// Clearing the current target should still be necessary for all technos
-	pTechno->SetTarget(nullptr);
-	const auto pFoot = abstract_cast<FootClass*>(pTechno);
-	const auto pJumpjetLoco = pFoot ? locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor) : nullptr;
+	// Check aircrafts
+	const auto pAircraft = abstract_cast<AircraftClass*>(pTechno);
+	const bool findAirport = pAircraft && !pAircraft->Airstrike && !pAircraft->Spawned && pAircraft->Type->AirportBound;
 
-	// To avoid jumpjets falling into a state of standing idly by
-	if (!pJumpjetLoco) // If is not jumpjet, clear the destination is enough
-		pTechno->SetDestination(nullptr, true);
-	else if (!pFoot->Destination) // When in attack move and have had a target, the destination will be cleaned up, enter the guard mission can prevent the jumpjets stuck in a status of standing idly by
-		pTechno->QueueMission(Mission::Guard, true);
-	else if (static_cast<int>(CellClass::Coord2Cell(pFoot->Destination->GetCoords()).DistanceFromSquared(pTechno->GetMapCoords())) > 2) // If the jumpjet is moving, find the forward cell then stop in it
-		pTechno->SetDestination(pTechno->GetCell()->GetNeighbourCell(static_cast<FacingType>(pJumpjetLoco->LocomotionFacing.Current().GetValue<3>())), true);
+	// To avoid aircrafts overlap by keep link if is returning or is in airport now.
+	if (!findAirport || !pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+		pTechno->SendToEachLink(RadioCommand::NotifyUnlink);
 
 	// To avoid technos being unable to stop in attack move mega mission
 	if (pTechno->vt_entry_4C4()) // pTechno->MegaMissionIsAttackMove()
 		pTechno->vt_entry_4A8(); // pTechno->ClearMegaMissionData()
 
-	// To avoid aircrafts pausing in the air and let they returning to air base immediately
-	if (pTechno->WhatAmI() == AbstractType::Aircraft && !pTechno->Airstrike && !pTechno->Spawned && static_cast<AircraftClass*>(pTechno)->Type->AirportBound && pTechno->GetHeight() > Unsorted::CellHeight)
-		pTechno->EnterIdleMode(false, true);
+	// Clearing the current target should still be necessary for all technos
+	pTechno->SetTarget(nullptr);
+
+	if (findAirport)
+	{
+		// To avoid aircrafts pausing in the air and let they returning to air base immediately.
+		if (!pAircraft->DockNowHeadingTo || (pAircraft->DockNowHeadingTo != pAircraft->GetNthLink()))
+			pAircraft->EnterIdleMode(false, true);
+	}
+	else
+	{
+		// Check Jumpjets
+		const auto pFoot = abstract_cast<FootClass*>(pTechno);
+		const auto pJumpjetLoco = pFoot ? locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor) : nullptr;
+
+		// To avoid jumpjets falling into a state of standing idly by
+		if (!pJumpjetLoco) // If is not jumpjet, clear the destination is enough
+			pTechno->SetDestination(nullptr, true);
+		else if (!pFoot->Destination) // When in attack move and have had a target, the destination will be cleaned up, enter the guard mission can prevent the jumpjets stuck in a status of standing idly by
+			pTechno->QueueMission(Mission::Guard, true);
+		else if (static_cast<int>(CellClass::Coord2Cell(pFoot->Destination->GetCoords()).DistanceFromSquared(pTechno->GetMapCoords())) > 2) // If the jumpjet is moving, find the forward cell then stop in it
+			pTechno->SetDestination(pTechno->GetCell()->GetNeighbourCell(static_cast<FacingType>(pJumpjetLoco->LocomotionFacing.Current().GetValue<3>())), true);
+	}
 
 	return SkipGameCode;
 }


### PR DESCRIPTION
When receive the stop(shortcut: s) command:
- Prevent jumpjets from falling into a state of standing idly by.
- Prevent technos from being unable to stop the attack move mission.
- Prevent aircrafts from briefly pausing in the air before returning.
- Prevent aircrafts from duplicatedly finding airport and overlapping.
- Prevent aircrafts with `AirportBound=no` continue moving forward.

The position of the hook and one of its functions overlap with #1366 .