### PR TITLE
[Highly Customized] Grey cameo preview and cameo overlays

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -372,6 +372,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow to change the speed of gas particles
 - **CrimRecya**
   - Fix `LimboKill` not working reliably
+  - Grey cameo preview and cameo overlays
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -367,6 +367,45 @@ In `rulesmd.ini`:
 MissingCameo=XXICON.SHP  ; filename - including the .shp/.pcx extension
 ```
 
+### Show cameo when unbuildable
+
+- A setting that allows you to preview information. This feature can be used as before, playing "new construction options" and clearing the specific production queue when prerequisites loss.
+  - `Cameo.AlwaysExist` controls whether you can see the cameo when the prerequisite have not satisfied (`TechnoLevel`, `Owner`, `RequiredHouses` and `ForbiddenHouses` should be satisfied). Defaults to `[AudioVisual]` -> `Cameo.AlwaysExist`.
+  - `ShowBuildingStatistics` controls whether the number of buildings of this type that you currently own needs to be displayed in the upper right corner of the building cameo (requires the cameo exist).
+  - `Cameo.OverlayShapes` controls the drawn image file.
+  - `Cameo.OverlayFrames` controls which frame in `Cameo.OverlayShapes` to draw in three different situations: currently owned this building type, grey cameo and have its prerequisite, grey cameo but have no prerequisite (The last situation requires `Cameo.AlwaysExist` to be true). When set to a negative number, it means that there is no need to draw under the corresponding conditions.
+  - `Cameo.OverlayPalette` the color palette used when drawing `Cameo.OverlayShapes`.
+  - If `Cameo.AuxTechnos` is not set, in addition to basic conditions, the grey cameo will only show when `AIBasePlanningSide` condition is satisfied. Otherwise, the grey cameo will only show when at least one of these types is owned by you or its `TechnoLevel`, `Owner`, `RequiredHouses`, `ForbiddenHouses`, `Cameo.AuxTechnos` (use `AIBasePlanningSide` if not set) and `Cameo.NegTechnos` (if set) conditions are satisfied.
+  - If `Cameo.NegTechnos` is set, the grey cameo will not show when you have a techno in one of these types.
+  - The `UIDescription.Unbuildable` is like `UIDescription`, but this only appearing when the techno is truly unbuildable.
+
+In `ra2md.ini`:
+```ini
+[Phobos]
+ShowBuildingStatistics=false     ; boolean
+```
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+Cameo.AlwaysExist=false          ; boolean
+Cameo.OverlayShapes=pips.shp     ; filename - including the .shp extension
+Cameo.OverlayFrames=-1,-1,-1     ; integer - owned this building, grey and have its prerequisite, grey but have no prerequisite
+Cameo.OverlayPalette=palette.pal ; filename - including the .pal extension
+
+[SOMETECHNO]                     ; TechnoType
+Cameo.AlwaysExist=               ; boolean
+Cameo.AuxTechnos=                ; List of TechnoTypes
+Cameo.NegTechnos=                ; List of TechnoTypes
+UIDescription.Unbuildable=       ; CSF entry key
+```
+
+In `artmd.ini`:
+```ini
+[SOMETECHNO]                     ; TechnoType
+GreyCameoPCX=                    ; PCX filename - including the .pcx extension
+```
+
 ### Harvester counter
 
 ![image](_static/images/harvestercounter-01.gif)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -441,6 +441,7 @@ New:
 - Allow customizing extra tint intensity for Iron Curtain & Force Shield (by Starkku)
 - Option to enable parsing 8-bit RGB values from `[ColorAdd]` instead of RGB565 (by Starkku)
 - Customizing height and speed at which subterranean units travel (by Starkku)
+- Grey cameo preview and cameo overlays (by CrimRecya)
 - Option for Warhead damage to penetrate Iron Curtain or Force Shield (by Starkku)
 - Option for Warhead to remove all shield types at once (by Starkku)
 - Allow customizing voxel light source position (by Kerbiter, Morton, based on knowledge of thomassnedon)

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -3,6 +3,7 @@
 #include <SuperClass.h>
 #include <SuperWeaponTypeClass.h>
 
+#include <Ext/TechnoType/Body.h>
 #include <Helpers/Macro.h>
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
@@ -165,4 +166,6 @@ public:
 	static int GetEnhancedPower(BuildingClass* pBuilding, HouseClass* pHouse);
 	static bool CanUpgrade(BuildingClass* pBuilding, BuildingTypeClass* pUpgradeType, HouseClass* pUpgradeOwner);
 	static int GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass* pHouse);
+	static bool ShouldExistGreyCameo(const TechnoTypeExt::ExtData* const pTypeExt);
+	static CanBuildResult CheckAlwaysExistCameo(const TechnoTypeClass* const pType, CanBuildResult canBuild);
 };

--- a/src/Ext/BuildingType/Hooks.Upgrade.cpp
+++ b/src/Ext/BuildingType/Hooks.Upgrade.cpp
@@ -74,18 +74,15 @@ int BuildLimitRemaining(HouseClass const* const pHouse, BuildingTypeClass const*
 		return -BuildLimit - pHouse->CountOwnedEver(pItem);
 }
 
-int CheckBuildLimit(HouseClass const* const pHouse, BuildingTypeClass const* const pItem, bool const includeQueued)
+CanBuildResult CheckBuildLimit(HouseClass const* const pHouse, BuildingTypeClass const* const pItem, bool const includeQueued)
 {
-	enum { NotReached = 1, ReachedPermanently = -1, ReachedTemporarily = 0 };
-
 	int BuildLimit = pItem->BuildLimit;
 	int Remaining = BuildLimitRemaining(pHouse, pItem);
 
 	if (BuildLimit >= 0 && Remaining <= 0)
-		return (includeQueued && FactoryClass::FindByOwnerAndProduct(pHouse, pItem)) ? NotReached : ReachedPermanently;
+		return (includeQueued && FactoryClass::FindByOwnerAndProduct(pHouse, pItem)) ? CanBuildResult::Buildable : CanBuildResult::Unbuildable;
 
-	return Remaining > 0 ? NotReached : ReachedTemporarily;
-
+	return Remaining > 0 ? CanBuildResult::Buildable : CanBuildResult::TemporarilyUnbuildable;
 }
 
 DEFINE_HOOK(0x4F8361, HouseClass_CanBuild_UpgradesInteraction, 0x5)
@@ -94,25 +91,32 @@ DEFINE_HOOK(0x4F8361, HouseClass_CanBuild_UpgradesInteraction, 0x5)
 	GET_STACK(TechnoTypeClass const* const, pItem, 0x4);
 	GET_STACK(bool, buildLimitOnly, 0x8);
 	GET_STACK(bool const, includeInProduction, 0xC);
-	GET(CanBuildResult const, resultOfAres, EAX);
+	GET(CanBuildResult, canBuild, EAX); // resultOfAres
 
-	if (auto const pBuilding = abstract_cast<BuildingTypeClass const* const>(pItem))
+	if (canBuild == CanBuildResult::Buildable)
 	{
-		if (auto pBuildingExt = BuildingTypeExt::ExtMap.Find(pBuilding))
+		if (auto const pBuilding = abstract_cast<BuildingTypeClass const* const>(pItem))
 		{
-			if (pBuildingExt->PowersUp_Buildings.size() > 0 && resultOfAres == CanBuildResult::Buildable)
-				R->EAX(CheckBuildLimit(pThis, pBuilding, includeInProduction));
+			if (auto pBuildingExt = BuildingTypeExt::ExtMap.Find(pBuilding))
+			{
+				if (pBuildingExt->PowersUp_Buildings.size() > 0)
+					canBuild = CheckBuildLimit(pThis, pBuilding, includeInProduction);
+			}
 		}
 	}
 
-	if (resultOfAres == CanBuildResult::Buildable)
+	if (canBuild == CanBuildResult::Buildable)
 	{
-		R->EAX(HouseExt::BuildLimitGroupCheck(pThis, pItem, buildLimitOnly, includeInProduction));
+		canBuild = HouseExt::BuildLimitGroupCheck(pThis, pItem, buildLimitOnly, includeInProduction);
 
 		if (HouseExt::ReachedBuildLimit(pThis, pItem, true))
-			R->EAX(CanBuildResult::TemporarilyUnbuildable);
+			canBuild = CanBuildResult::TemporarilyUnbuildable;
 	}
 
+	if (!buildLimitOnly && includeInProduction && pThis == HouseClass::CurrentPlayer()) // Eliminate any non-producible calls to change the list safely
+		canBuild = BuildingTypeExt::CheckAlwaysExistCameo(pItem, canBuild);
+
+	R->EAX(canBuild);
 	return 0;
 }
 

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -257,7 +257,7 @@ DEFINE_HOOK(0x65E997, HouseClass_SendAirstrike_PlaceAircraft, 0x6)
 	return result ? SkipGameCode : SkipGameCodeNoSuccess;
 }
 
-DEFINE_HOOK(0x50B669, HouseClass_ShouldDisableCameo, 0x5)
+DEFINE_HOOK(0x50B669, HouseClass_ShouldDisableCameo_GreyCameo, 0x5)
 {
 	GET(HouseClass*, pThis, ECX);
 	GET_STACK(TechnoTypeClass*, pType, 0x4);
@@ -267,7 +267,44 @@ DEFINE_HOOK(0x50B669, HouseClass_ShouldDisableCameo, 0x5)
 		return 0;
 
 	if (HouseExt::ReachedBuildLimit(pThis, pType, false))
+	{
 		R->EAX(true);
+	}
+	else if (pThis == HouseClass::CurrentPlayer)
+	{
+		GET(int*, pAddress, ESP);
+
+		if (*pAddress == 0x6A5FED || *pAddress == 0x6A97EF || *pAddress == 0x6AB65B)
+		{
+			const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+			// The types exist in the list means that they are not buildable now
+			if (pTypeExt && pTypeExt->Cameo_AlwaysExist.Get(RulesExt::Global()->Cameo_AlwaysExist))
+			{
+				auto& vec = ScenarioExt::Global()->OwnedExistCameoTechnoTypes;
+
+				if (std::find(vec.begin(), vec.end(), pTypeExt) != vec.end())
+					R->EAX(true);
+			}
+		}
+	}
+
+	return 0;
+}
+
+// All technos have Cameo_AlwaysExist=true need to change the EVA_NewConstructionOptions playing time
+DEFINE_HOOK(0x6A640B, SideBarClass_AddCameo_DoNotPlayEVA, 0x5)
+{
+	enum { SkipPlaying = 0x6A641A };
+
+	GET(AbstractType, absType, ESI);
+	GET(int, idxType, EBP);
+
+	if (const auto pType = ObjectTypeClass::GetTechnoType(absType, idxType))
+	{
+		if (TechnoTypeExt::ExtMap.Find(pType)->Cameo_AlwaysExist.Get(RulesExt::Global()->Cameo_AlwaysExist))
+			return SkipPlaying;
+	}
 
 	return 0;
 }

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -137,6 +137,11 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		this->HeightShadowScaling = false;
 	this->HeightShadowScaling_MinScale.Read(exINI, GameStrings::AudioVisual, "HeightShadowScaling.MinScale");
 
+	this->Cameo_AlwaysExist.Read(exINI, GameStrings::AudioVisual, "Cameo.AlwaysExist");
+	this->Cameo_OverlayShapes.Read(exINI, GameStrings::AudioVisual, "Cameo.OverlayShapes");
+	this->Cameo_OverlayFrames.Read(exINI, GameStrings::AudioVisual, "Cameo.OverlayFrames");
+	this->Cameo_OverlayPalette.LoadFromINI(pINI, GameStrings::AudioVisual, "Cameo.OverlayPalette");
+
 	this->AllowParallelAIQueues.Read(exINI, "GlobalControls", "AllowParallelAIQueues");
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Aircraft");
 	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
@@ -330,6 +335,10 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AirShadowBaseScale_log)
 		.Process(this->HeightShadowScaling)
 		.Process(this->HeightShadowScaling_MinScale)
+		.Process(this->Cameo_AlwaysExist)
+		.Process(this->Cameo_OverlayShapes)
+		.Process(this->Cameo_OverlayFrames)
+		.Process(this->Cameo_OverlayPalette)
 		.Process(this->AllowParallelAIQueues)
 		.Process(this->ForbidParallelAIQueues_Aircraft)
 		.Process(this->ForbidParallelAIQueues_Building)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -93,6 +93,11 @@ public:
 		Valueable<double> HeightShadowScaling_MinScale;
 		double AirShadowBaseScale_log;
 
+		Valueable<bool> Cameo_AlwaysExist;
+		Valueable<SHPStruct*> Cameo_OverlayShapes;
+		Valueable<Vector3D<int>> Cameo_OverlayFrames;
+		CustomPalette Cameo_OverlayPalette;
+
 		Valueable<bool> AllowParallelAIQueues;
 		Valueable<bool> ForbidParallelAIQueues_Aircraft;
 		Valueable<bool> ForbidParallelAIQueues_Building;
@@ -222,6 +227,11 @@ public:
 			, HeightShadowScaling { false }
 			, HeightShadowScaling_MinScale { 0.0 }
 			, AirShadowBaseScale_log { 0.693376137 }
+
+			, Cameo_AlwaysExist { false }
+			, Cameo_OverlayShapes { FileSystem::PIPS_SHP }
+			, Cameo_OverlayFrames { { -1, -1, -1 } }
+			, Cameo_OverlayPalette {}
 
 			, AllowParallelAIQueues { true }
 			, ForbidParallelAIQueues_Aircraft { false }

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -162,6 +162,7 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->BriefingTheme)
 		.Process(this->AutoDeathObjects)
 		.Process(this->TransportReloaders)
+		.Process(this->OwnedExistCameoTechnoTypes)
 		;
 }
 

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -36,6 +36,8 @@ public:
 		std::vector<TechnoExt::ExtData*> AutoDeathObjects;
 		std::vector<TechnoExt::ExtData*> TransportReloaders; // Objects that can reload ammo in limbo
 
+		std::vector<TechnoTypeExt::ExtData*> OwnedExistCameoTechnoTypes;
+
 		ExtData(ScenarioClass* OwnerObject) : Extension<ScenarioClass>(OwnerObject)
 			, ShowBriefing { false }
 			, BriefingTheme { -1 }
@@ -43,6 +45,7 @@ public:
 			, Variables { }
 			, AutoDeathObjects {}
 			, TransportReloaders {}
+			, OwnedExistCameoTechnoTypes {}
 		{ }
 
 		void SetVariableToByID(bool bIsGlobal, int nIndex, char bState);

--- a/src/Ext/Sidebar/Hooks.cpp
+++ b/src/Ext/Sidebar/Hooks.cpp
@@ -3,7 +3,13 @@
 #include <HouseClass.h>
 #include <FactoryClass.h>
 #include <FileSystem.h>
+
 #include <Ext/Side/Body.h>
+#include <Ext/House/Body.h>
+#include <Ext/TechnoType/Body.h>
+#include <Ext/Scenario/Body.h>
+#include <Utilities/Macro.h>
+#include <Utilities/ShapeTextPrinter.h>
 
 DEFINE_HOOK(0x6A593E, SidebarClass_InitForHouse_AdditionalFiles, 0x5)
 {
@@ -93,6 +99,98 @@ DEFINE_HOOK(0x72FCB5, InitSideRectangles_CenterBackground, 0x5)
 		pRect->Y = (height - 32 - pRect->Height) / 2;
 
 		R->EAX(pRect);
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6A9BC5, StripClass_Draw_DrawGreyCameoExtraCover, 0x6)
+{
+	GET(const bool, greyCameo, EBX);
+	GET(const int, destX, ESI);
+	GET(const int, destY, EBP);
+	GET_STACK(const RectangleStruct, boundingRect, STACK_OFFSET(0x48C, -0x3E0));
+	GET_STACK(TechnoTypeClass* const, pType, STACK_OFFSET(0x48C, -0x458));
+
+	const auto position = Point2D { destX + 30, destY + 24 };
+	const auto pRulesExt = RulesExt::Global();
+	const auto frames = pRulesExt->Cameo_OverlayFrames.Get();
+
+	if (greyCameo) // Only draw extras over grey cameos
+	{
+		auto frame = frames.Y;
+		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+		if (pTypeExt && pTypeExt->Cameo_AlwaysExist.Get(RulesExt::Global()->Cameo_AlwaysExist))
+		{
+			auto& vec = ScenarioExt::Global()->OwnedExistCameoTechnoTypes;
+
+			if (std::find(vec.begin(), vec.end(), pTypeExt) != vec.end())
+			{
+				if (const auto CameoPCX = pTypeExt->GreyCameoPCX.GetSurface())
+				{
+					auto drawRect = RectangleStruct { destX, destY, 60, 48 };
+					PCX::Instance->BlitToSurface(&drawRect, DSurface::Sidebar, CameoPCX);
+				}
+
+				frame = frames.Z;
+			}
+		}
+
+		if (frame >= 0)
+		{
+			DSurface::Sidebar->DrawSHP(
+				pRulesExt->Cameo_OverlayPalette.GetOrDefaultConvert(FileSystem::PALETTE_PAL),
+				pRulesExt->Cameo_OverlayShapes,
+				frame,
+				&position,
+				&boundingRect,
+				BlitterFlags(0x600),
+				0, 0,
+				ZGradient::Ground,
+				1000, 0, 0, 0, 0, 0);
+		}
+	}
+
+	const auto pBuildingType = abstract_cast<BuildingTypeClass*>(pType);
+
+	if (pBuildingType) // Only count owned buildings
+	{
+		const auto pHouse = HouseClass::CurrentPlayer();
+		auto count = BuildingTypeExt::GetUpgradesAmount(pBuildingType, pHouse);
+
+		if (count == -1)
+			count = pHouse->CountOwnedAndPresent(pBuildingType);
+
+		if (count > 0)
+		{
+			if (frames.X >= 0)
+			{
+				DSurface::Sidebar->DrawSHP(
+					pRulesExt->Cameo_OverlayPalette.GetOrDefaultConvert(FileSystem::PALETTE_PAL),
+					pRulesExt->Cameo_OverlayShapes,
+					frames.X,
+					&position,
+					&boundingRect,
+					BlitterFlags(0x600),
+					0, 0,
+					ZGradient::Ground,
+					1000, 0, 0, 0, 0, 0);
+			}
+
+			if (Phobos::Config::ShowBuildingStatistics)
+			{
+				GET_STACK(RectangleStruct, surfaceRect, STACK_OFFSET(0x48C, -0x438));
+
+				const COLORREF color = Drawing::RGB_To_Int(Drawing::TooltipColor);
+				const TextPrintType printType = TextPrintType::Background | TextPrintType::Right | TextPrintType::FullShadow | TextPrintType::Point8;
+				auto textPosition = Point2D { destX + 60, destY + 1 };
+
+				wchar_t text[0x20];
+				swprintf_s(text, L"%d", count);
+				DSurface::Sidebar->DrawTextA(text, &surfaceRect, &textPosition, color, 0, printType);
+			}
+		}
 	}
 
 	return 0;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -454,6 +454,12 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->BuildLimitGroup_ExtraLimit_Nums.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.Nums");
 	this->BuildLimitGroup_ExtraLimit_MaxCount.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.MaxCount");
 	this->BuildLimitGroup_ExtraLimit_MaxNum.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.MaxNum");
+
+	this->Cameo_AlwaysExist.Read(exINI, pSection, "Cameo.AlwaysExist");
+	this->Cameo_AuxTechnos.Read(exINI, pSection, "Cameo.AuxTechnos");
+	this->Cameo_NegTechnos.Read(exINI, pSection, "Cameo.NegTechnos");
+	this->UIDescription_Unbuildable.Read(exINI, pSection, "UIDescription.Unbuildable");
+
 	this->Wake.Read(exINI, pSection, "Wake");
 	this->Wake_Grapple.Read(exINI, pSection, "Wake.Grapple");
 	this->Wake_Sinking.Read(exINI, pSection, "Wake.Sinking");
@@ -504,6 +510,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// Art tags
 	INI_EX exArtINI(CCINIClass::INI_Art);
 	auto pArtSection = pThis->ImageFile;
+
+	this->GreyCameoPCX.Read(&CCINIClass::INI_Art, pArtSection, "GreyCameoPCX");
 
 	this->TurretOffset.Read(exArtINI, pArtSection, "TurretOffset");
 	this->TurretShadow.Read(exArtINI, pArtSection, "TurretShadow");
@@ -824,6 +832,13 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BuildLimitGroup_ExtraLimit_Nums)
 		.Process(this->BuildLimitGroup_ExtraLimit_MaxCount)
 		.Process(this->BuildLimitGroup_ExtraLimit_MaxNum)
+
+		.Process(this->Cameo_AlwaysExist)
+		.Process(this->Cameo_AuxTechnos)
+		.Process(this->Cameo_NegTechnos)
+		.Process(this->CameoCheckMutex)
+		.Process(this->UIDescription_Unbuildable)
+		.Process(this->GreyCameoPCX)
 
 		.Process(this->Wake)
 		.Process(this->Wake_Grapple)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -226,6 +226,13 @@ public:
 		ValueableVector<int> BuildLimitGroup_ExtraLimit_MaxCount;
 		Valueable<int> BuildLimitGroup_ExtraLimit_MaxNum;
 
+		Nullable<bool> Cameo_AlwaysExist;
+		ValueableVector<TechnoTypeClass*> Cameo_AuxTechnos;
+		ValueableVector<TechnoTypeClass*> Cameo_NegTechnos;
+		bool CameoCheckMutex; // Not read from ini
+		Valueable<CSFText> UIDescription_Unbuildable;
+		PhobosPCXFile GreyCameoPCX;
+
 		Nullable<AnimTypeClass*> Wake;
 		Nullable<AnimTypeClass*> Wake_Grapple;
 		Nullable<AnimTypeClass*> Wake_Sinking;
@@ -448,6 +455,13 @@ public:
 			, BuildLimitGroup_ExtraLimit_Nums {}
 			, BuildLimitGroup_ExtraLimit_MaxCount {}
 			, BuildLimitGroup_ExtraLimit_MaxNum { 0 }
+
+			, Cameo_AlwaysExist {}
+			, Cameo_AuxTechnos {}
+			, Cameo_NegTechnos {}
+			, CameoCheckMutex { false }
+			, UIDescription_Unbuildable {}
+			, GreyCameoPCX {}
 
 			, Wake { }
 			, Wake_Grapple { }

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -17,6 +17,7 @@
 #include <Ext/Side/Body.h>
 #include <Ext/Surface/Body.h>
 #include <Ext/House/Body.h>
+#include <Ext/Scenario/Body.h>
 
 #include <sstream>
 #include <iomanip>
@@ -32,6 +33,13 @@ inline const wchar_t* PhobosToolTip::GetUIDescription(TechnoTypeExt::ExtData* pD
 {
 	return Phobos::Config::ToolTipDescriptions && !pData->UIDescription.Get().empty()
 		? pData->UIDescription.Get().Text
+		: nullptr;
+}
+
+inline const wchar_t* PhobosToolTip::GetUnbuildableUIDescription(TechnoTypeExt::ExtData* pData) const
+{
+	return Phobos::Config::ToolTipDescriptions && !pData->UIDescription_Unbuildable.Get().empty()
+		? pData->UIDescription_Unbuildable.Get().Text
 		: nullptr;
 }
 
@@ -141,6 +149,17 @@ void PhobosToolTip::HelpText_Techno(TechnoTypeClass* pType)
 
 	if (auto pDesc = this->GetUIDescription(pData))
 		oss << L"\n" << pDesc;
+
+	if (pData->Cameo_AlwaysExist.Get(RulesExt::Global()->Cameo_AlwaysExist))
+	{
+		auto& vec = ScenarioExt::Global()->OwnedExistCameoTechnoTypes;
+
+		if (std::find(vec.begin(), vec.end(), pData) != vec.end())
+		{
+			if (auto pExDesc = this->GetUnbuildableUIDescription(pData))
+				oss << L"\n" << pExDesc;
+		}
+	}
 
 	this->TextBuffer = oss.str();
 }

--- a/src/Misc/PhobosToolTip.h
+++ b/src/Misc/PhobosToolTip.h
@@ -20,6 +20,7 @@ public:
 
 private:
 	inline const wchar_t* GetUIDescription(TechnoTypeExt::ExtData* pData) const;
+	inline const wchar_t* GetUnbuildableUIDescription(TechnoTypeExt::ExtData* pData) const;
 	inline const wchar_t* GetUIDescription(SWTypeExt::ExtData* pData) const;
 	inline int GetBuildTime(TechnoTypeClass* pType) const;
 	inline int GetPower(TechnoTypeClass* pType) const;

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -43,6 +43,7 @@ bool Phobos::Config::ShowPlanningPath = false;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::ShowPlacementPreview = false;
 bool Phobos::Config::DigitalDisplay_Enable = false;
+bool Phobos::Config::ShowBuildingStatistics = false;
 bool Phobos::Config::RealTimeTimers = false;
 bool Phobos::Config::RealTimeTimers_Adaptive = false;
 int Phobos::Config::CampaignDefaultGameSpeed = 2;
@@ -70,6 +71,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::RealTimeTimers = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers", false);
 	Phobos::Config::RealTimeTimers_Adaptive = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers.Adaptive", false);
 	Phobos::Config::DigitalDisplay_Enable = CCINIClass::INI_RA2MD->ReadBool("Phobos", "DigitalDisplay.Enable", false);
+	Phobos::Config::ShowBuildingStatistics = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowBuildingStatistics", false);
 	Phobos::Config::SaveGameOnScenarioStart = CCINIClass::INI_RA2MD->ReadBool("Phobos", "SaveGameOnScenarioStart", true);
 	Phobos::Config::ShowBriefing = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowBriefing", true);
 	Phobos::Config::ShowPowerDelta = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowPowerDelta", true);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -77,6 +77,7 @@ public:
 		static bool ShowPlacementPreview;
 		static bool EnableBuildingPlacementPreview;
 		static bool DigitalDisplay_Enable;
+		static bool ShowBuildingStatistics;
 		static bool RealTimeTimers;
 		static bool RealTimeTimers_Adaptive;
 		static int CampaignDefaultGameSpeed;


### PR DESCRIPTION
- A setting that allows you to preview information. This feature can be used as before, playing "new construction options" and clearing the specific production queue when prerequisites loss.
  - `Cameo.AlwaysExist` controls whether you can see the cameo when the prerequisite have not satisfied (`TechnoLevel`, `Owner`, `RequiredHouses` and `ForbiddenHouses` should be satisfied). Defaults to `[AudioVisual]` -> `Cameo.AlwaysExist`.
  - `ShowBuildingStatistics` controls whether the number of buildings of this type that you currently own needs to be displayed in the upper right corner of the building cameo (requires the cameo exist).
  - `Cameo.OverlayShapes` controls the drawn image file.
  - `Cameo.OverlayFrames` controls which frame in `Cameo.OverlayShapes` to draw in three different situations: currently owned this building type, grey cameo and have its prerequisite, grey cameo but have no prerequisite (The last situation requires `Cameo.AlwaysExist` to be true). When set to a negative number, it means that there is no need to draw under the corresponding conditions.
  - `Cameo.OverlayPalette` the color palette used when drawing `Cameo.OverlayShapes`.
  - If `Cameo.AuxTechnos` is not set, in addition to basic conditions, the grey cameo will only show when `AIBasePlanningSide` condition is satisfied. Otherwise, the grey cameo will only show when at least one of these types is owned by you or its `TechnoLevel`, `Owner`, `RequiredHouses`, `ForbiddenHouses`, `Cameo.AuxTechnos` (use `AIBasePlanningSide` if not set) and `Cameo.NegTechnos` (if set) conditions are satisfied.
  - If `Cameo.NegTechnos` is set, the grey cameo will not show when you have a techno in one of these types.
  - The `UIDescription.Unbuildable` is like `UIDescription`, but this only appearing when the techno is truly unbuildable.

In `ra2md.ini`:
```ini
[Phobos]
ShowBuildingStatistics=false     ; boolean
```

In `rulesmd.ini`:
```ini
[AudioVisual]
Cameo.AlwaysExist=false          ; boolean
Cameo.OverlayShapes=pips.shp     ; filename - including the .shp extension
Cameo.OverlayFrames=-1,-1,-1     ; integer - owned this building, grey and have its prerequisite, grey but have no prerequisite
Cameo.OverlayPalette=palette.pal ; filename - including the .pal extension

[SOMETECHNO]                     ; TechnoType
Cameo.AlwaysExist=               ; boolean
Cameo.AuxTechnos=                ; List of TechnoTypes
Cameo.NegTechnos=                ; List of TechnoTypes
UIDescription.Unbuildable=       ; CSF entry key
```

In `artmd.ini`:
```ini
[SOMETECHNO]                     ; TechnoType
GreyCameoPCX=                    ; PCX filename - including the .pcx extension
```