### PR TITLE
[Highly Customized] Unit base normal and new placing grids

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -372,6 +372,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow to change the speed of gas particles
 - **CrimRecya**
   - Fix `LimboKill` not working reliably
+  - Unit base normal and new placing grids
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -166,6 +166,7 @@
     <ClCompile Include="src\Misc\Hooks.SkirmishColors.cpp" />
     <ClCompile Include="src\New\Type\Affiliated\TypeConvertGroup.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
+    <ClCompile Include="src\Ext\BuildingType\Hooks.Placing.cpp" />
     <ClCompile Include="src\Phobos.COM.cpp" />
     <ClCompile Include="src\Phobos.CRT.cpp" />
     <ClCompile Include="src\Phobos.Ext.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1023,6 +1023,22 @@ ForbidParallelAIQueues.Building=no  ; boolean
 ForbidParallelAIQueues=false        ; boolean
 ```
 
+### Check building adjacent by using units
+
+- You can now set `CheckUnitBaseNormal` to true to use units to expand the construction scope of the base.
+  - `UnitBaseNormal` controls whether our own buildings can be place around it like vanilla `BaseNormal` do.
+  - `UnitBaseForAllyBuilding` controls whether ally buildings can be place around it like vanilla `EligibileForAllyBuilding` do.
+
+In `rulesmd.ini`:
+```ini
+[General]
+CheckUnitBaseNormal=false      ; boolean
+
+[SOMEUNIT]                     ; UnitType
+UnitBaseNormal=false           ; boolean
+UnitBaseForAllyBuilding=false  ; boolean
+```
+
 ## Terrains
 
 ### Animated TerrainTypes

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -276,6 +276,26 @@ In `rulesmd.ini`:
 SelectionFlashDuration=0  ; integer, number of frames
 ```
 
+### More display styles for placing grids
+
+- This feature is highly compatible with `ExpandBuildingPlace`. If set `DrawAdjacentBoundary` to true, it will display the four corners of the `Adjacent` boundary. If set `PlacementGrid.Expand` to true, it will display the placing grids with `place.shp` and following corresponding frame number.
+  - `PlacementGrid.LandFrames` controls the placing grids frames on non-water cell. The three numbers respectively represent "Some technos that can command departure have occupied this area", "This cell is actually beyond the scope, but there is still at least one cell inside the entire region" and "Here is no problem, everything is OK".
+  - `PlacementGrid.WaterFrames` controls the placing grids frames on water cell. Each item corresponds to the same as above.
+
+In `ra2md.ini`:
+```ini
+[Phobos]
+DrawAdjacentBoundary=false       ; boolean
+```
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+PlacementGrid.Expand=false       ; boolean
+PlacementGrid.LandFrames=1,0,0   ; integer, zero-based frame index - have technos, near boundary, is normal
+PlacementGrid.WaterFrames=1,0,0  ; integer, zero-based frame index - have technos, near boundary, is normal
+```
+
 ## Hotkey Commands
 
 ### `[ ]` Display Damage Numbers

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -441,6 +441,7 @@ New:
 - Allow customizing extra tint intensity for Iron Curtain & Force Shield (by Starkku)
 - Option to enable parsing 8-bit RGB values from `[ColorAdd]` instead of RGB565 (by Starkku)
 - Customizing height and speed at which subterranean units travel (by Starkku)
+- Unit base normal and new placing grids (by CrimRecya)
 - Option for Warhead damage to penetrate Iron Curtain or Force Shield (by Starkku)
 - Option for Warhead to remove all shield types at once (by Starkku)
 - Allow customizing voxel light source position (by Kerbiter, Morton, based on knowledge of thomassnedon)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -1,7 +1,9 @@
 #include "Body.h"
 
-#include <Ext/House/Body.h>
+#include <TacticalClass.h>
+
 #include <Utilities/GeneralUtils.h>
+#include <Ext/House/Body.h>
 #include <Ext/SWType/Body.h>
 
 BuildingTypeExt::ExtContainer BuildingTypeExt::ExtMap;
@@ -95,6 +97,90 @@ int BuildingTypeExt::GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass*
 	}
 
 	return isUpgrade ? result : -1;
+}
+
+void BuildingTypeExt::DrawAdjacentLines()
+{
+	const auto pBuilding = abstract_cast<BuildingClass*>(DisplayClass::Instance->CurrentBuilding);
+
+	if (!pBuilding)
+		return;
+
+	const auto pType = pBuilding->Type;
+	const auto adjacent = static_cast<short>(pType->Adjacent + 1);
+
+	if (adjacent <= 0)
+		return;
+
+	const auto foundation = CellStruct { pType->GetFoundationWidth(), pType->GetFoundationHeight(false) };
+
+	if (foundation == CellStruct::Empty)
+		return;
+
+	const auto topLeft = DisplayClass::Instance->CurrentFoundation_CenterCell + DisplayClass::Instance->CurrentFoundation_TopLeftOffset;
+	const auto min = CellStruct { static_cast<short>(topLeft.X - adjacent), static_cast<short>(topLeft.Y - adjacent) };
+	const auto max = CellStruct { static_cast<short>(topLeft.X + foundation.X + adjacent - 1), static_cast<short>(topLeft.Y + foundation.Y + adjacent - 1) };
+
+	auto rect = DSurface::Temp->GetRect();
+	rect.Height -= 32;
+
+	if (const auto pCell = MapClass::Instance->TryGetCellAt(min))
+	{
+		auto point = TacticalClass::Instance->CoordsToClient(CellClass::Cell2Coord(pCell->MapCoords, (1 + pCell->GetFloorHeight(Point2D::Empty)))).first;
+		point.Y -= 1;
+		auto nextPoint = point;
+
+		point.Y -= 14;
+		nextPoint.X += 29;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+
+		point.X -= 1;
+		nextPoint.X -= 59;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+	}
+
+	if (const auto pCell = MapClass::Instance->TryGetCellAt(CellStruct{ min.X, max.Y }))
+	{
+		auto point = TacticalClass::Instance->CoordsToClient(CellClass::Cell2Coord(pCell->MapCoords, (1 + pCell->GetFloorHeight(Point2D::Empty)))).first;
+		point.X -= 1;
+		auto nextPoint = point;
+
+		point.X -= 29;
+		nextPoint.Y += 14;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+
+		point.Y -= 1;
+		nextPoint.Y -= 29;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+	}
+
+	if (const auto pCell = MapClass::Instance->TryGetCellAt(max))
+	{
+		auto point = TacticalClass::Instance->CoordsToClient(CellClass::Cell2Coord(pCell->MapCoords, (1 + pCell->GetFloorHeight(Point2D::Empty)))).first;
+		auto nextPoint = point;
+
+		point.Y += 14;
+		nextPoint.X += 29;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+
+		point.X -= 1;
+		nextPoint.X -= 59;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+	}
+
+	if (const auto pCell = MapClass::Instance->TryGetCellAt(CellStruct{ max.X, min.Y }))
+	{
+		auto point = TacticalClass::Instance->CoordsToClient(CellClass::Cell2Coord(pCell->MapCoords, (1 + pCell->GetFloorHeight(Point2D::Empty)))).first;
+		auto nextPoint = point;
+
+		point.X += 29;
+		nextPoint.Y += 14;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+
+		point.Y -= 1;
+		nextPoint.Y -= 29;
+		DSurface::Temp->DrawLineEx(&rect, &point, &nextPoint, COLOR_WHITE);
+	}
 }
 
 void BuildingTypeExt::ExtData::Initialize()

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -165,4 +165,5 @@ public:
 	static int GetEnhancedPower(BuildingClass* pBuilding, HouseClass* pHouse);
 	static bool CanUpgrade(BuildingClass* pBuilding, BuildingTypeClass* pUpgradeType, HouseClass* pUpgradeOwner);
 	static int GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass* pHouse);
+	static void DrawAdjacentLines();
 };

--- a/src/Ext/BuildingType/Hooks.Placing.cpp
+++ b/src/Ext/BuildingType/Hooks.Placing.cpp
@@ -1,0 +1,184 @@
+#include "Body.h"
+
+#include <TacticalClass.h>
+
+#include <Ext/House/Body.h>
+#include <Ext/Scenario/Body.h>
+
+// Buildable Proximity Helper
+namespace ProximityTemp
+{
+	bool Build = false;
+	bool Exist = false;
+	CellClass* CurrentCell = nullptr;
+	BuildingTypeClass* BuildType = nullptr;
+}
+
+// BaseNormal extra checking Hook #1-1 -> sub_4A8EB0 - Set context and clear up data
+DEFINE_HOOK(0x4A8F20, DisplayClass_BuildingProximityCheck_SetContext, 0x5)
+{
+	GET(BuildingTypeClass*, pType, ESI);
+
+	if (RulesExt::Global()->PlacementGrid_Expand)
+		ScenarioExt::Global()->BaseNormalCells.clear();
+
+	ProximityTemp::Build = false;
+	ProximityTemp::BuildType = pType;
+
+	return 0;
+}
+
+// BaseNormal extra checking Hook #1-2 -> sub_4A8EB0 - Check unit base normal
+DEFINE_HOOK(0x4A8FCA, DisplayClass_BuildingProximityCheck_BaseNormalExtra, 0x7)
+{
+	enum { CanBuild = 0x4A9027, ContinueCheck = 0x4A8FD1 };
+
+	GET(CellClass*, pCell, EAX);
+	GET_STACK(const int, idxHouse, STACK_OFFSET(0x30, 0x8));
+
+	ProximityTemp::CurrentCell = pCell;
+
+	if (RulesExt::Global()->CheckUnitBaseNormal)
+	{
+		if (const auto pUnit = pCell->GetUnit(false))
+		{
+			if (const auto pOwner = pUnit->Owner)
+			{
+				if (const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pUnit->Type))
+				{
+					if (pOwner->ArrayIndex == idxHouse && pTypeExt->UnitBaseNormal)
+						return CanBuild;
+					else if (RulesClass::Instance->BuildOffAlly && pOwner->IsAlliedWith(HouseClass::Array->Items[idxHouse]) && pTypeExt->UnitBaseForAllyBuilding)
+						return CanBuild;
+				}
+			}
+		}
+	}
+
+	R->EAX(pCell->GetBuilding());
+	return ContinueCheck;
+}
+
+// BaseNormal extra checking Hook #1-3 -> sub_4A8EB0 - Check allowed building
+DEFINE_HOOK(0x4A8FD7, DisplayClass_BuildingProximityCheck_BuildArea, 0x6)
+{
+	enum { SkipBuilding = 0x4A902C };
+
+	GET(BuildingClass*, pCellBuilding, ESI);
+
+	auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pCellBuilding->Type);
+
+	if (pTypeExt->NoBuildAreaOnBuildup && pCellBuilding->CurrentMission == Mission::Construction)
+		return SkipBuilding;
+
+	auto const& pBuildingsAllowed = BuildingTypeExt::ExtMap.Find(ProximityTemp::BuildType)->Adjacent_Allowed;
+
+	if (pBuildingsAllowed.size() > 0 && !pBuildingsAllowed.Contains(pCellBuilding->Type))
+		return SkipBuilding;
+
+	auto const& pBuildingsDisallowed = BuildingTypeExt::ExtMap.Find(ProximityTemp::BuildType)->Adjacent_Disallowed;
+
+	if (pBuildingsDisallowed.size() > 0 && pBuildingsDisallowed.Contains(pCellBuilding->Type))
+		return SkipBuilding;
+
+	return 0;
+}
+
+// BaseNormal extra checking Hook #1-4 -> sub_4A8EB0 - Break loop or record cell for drawing
+DEFINE_HOOK(0x4A902C, MapClass_PassesProximityCheck_BaseNormalExtra, 0x5)
+{
+	enum { CheckCompleted = 0x4A904E };
+
+	REF_STACK(bool, canBuild, STACK_OFFSET(0x30, 0xC));
+
+	if (canBuild)
+	{
+		if (!RulesExt::Global()->PlacementGrid_Expand)
+			return CheckCompleted;
+
+		canBuild = false;
+		ProximityTemp::Build = true;
+		ScenarioExt::Global()->BaseNormalCells.push_back(ProximityTemp::CurrentCell->MapCoords);
+	}
+
+	return 0;
+}
+
+// BaseNormal extra checking Hook #1-5 -> sub_4A8EB0 - Restore the correct result
+DEFINE_HOOK(0x4A904E, MapClass_PassesProximityCheck_RestoreResult, 0x5)
+{
+	if (RulesExt::Global()->PlacementGrid_Expand)
+		R->Stack<bool>(STACK_OFFSET(0x30, 0xC), ProximityTemp::Build);
+
+	return 0;
+}
+
+// BaseNormal for units Hook #2-1 -> sub_4AAC10 - Let the game do the PassesProximityCheck when the cell which mouse is pointing at has not changed
+DEFINE_HOOK(0x4AACD9, MapClass_TacticalAction_BaseNormalRecheck, 0x5)
+{
+	return (RulesExt::Global()->CheckUnitBaseNormal && !(Unsorted::CurrentFrame % 8)) ? 0x4AACF5 : 0;
+}
+
+// BaseNormal for units Hook #2-2 -> sub_4A91B0 - Let the game do the PassesProximityCheck when the cell which mouse is pointing at has not changed
+DEFINE_HOOK(0x4A9361, MapClass_CallBuildingPlaceCheck_BaseNormalRecheck, 0x5)
+{
+	return (RulesExt::Global()->CheckUnitBaseNormal && !(Unsorted::CurrentFrame % 8)) ? 0x4A9371 : 0;
+}
+
+// Buildable-upon TechnoTypes Hook #2-1 -> sub_47EC90 - Record cell before draw it then skip vanilla AltFlags check
+DEFINE_HOOK(0x47EEBC, CellClass_DrawPlaceGrid_RecordCell, 0x6)
+{
+	enum { DontDrawAlt = 0x47EF1A, DrawVanillaAlt = 0x47EED6 };
+
+	GET(CellClass* const, pCell, ESI);
+	GET(const bool, zero, EDX);
+
+	const BlitterFlags flags = BlitterFlags::Centered | BlitterFlags::bf_400;
+	ProximityTemp::CurrentCell = pCell;
+
+	R->EDX<BlitterFlags>(flags | (zero ? BlitterFlags::Zero : BlitterFlags::Nonzero));
+	return (pCell->AltFlags & AltCellFlags::ContainsBuilding) ? DontDrawAlt : DrawVanillaAlt;
+}
+
+// Buildable-upon TechnoTypes Hook #2-2 -> sub_47EC90 - Draw different color grid
+DEFINE_HOOK(0x47EF52, CellClass_DrawPlaceGrid_DrawGrids, 0x6)
+{
+	const auto pRules = RulesExt::Global();
+
+	if (!pRules->PlacementGrid_Expand)
+		return 0;
+
+	const auto pCell = ProximityTemp::CurrentCell;
+	const auto cell = pCell->MapCoords;
+	const auto pObj = DisplayClass::Instance->CurrentBuildingType;
+	const auto range = static_cast<short>((pObj && pObj->WhatAmI() == AbstractType::BuildingType) ? static_cast<BuildingTypeClass*>(pObj)->Adjacent + 1 : 0);
+
+	const auto maxX = static_cast<short>(cell.X + range);
+	const auto maxY = static_cast<short>(cell.Y + range);
+	const auto minX = static_cast<short>(cell.X - range);
+	const auto minY = static_cast<short>(cell.Y - range);
+
+	bool green = false;
+	const auto& cells = ScenarioExt::Global()->BaseNormalCells;
+
+	for (const auto& baseCell : cells)
+	{
+		if (baseCell.X >= minX && baseCell.Y >= minY && baseCell.X <= maxX && baseCell.Y <= maxY)
+		{
+			green = true;
+			break;
+		}
+	}
+
+	const auto foot = ProximityTemp::Exist;
+	ProximityTemp::Exist = false;
+	const bool land = pCell->LandType != LandType::Water;
+	const auto frames = land ? pRules->PlacementGrid_LandFrames.Get() : pRules->PlacementGrid_WaterFrames.Get();
+	auto frame = foot ? frames.X : (green ? frames.Z : frames.Y);
+
+	if (frame >= Make_Global<SHPStruct*>(0x8A03FC)->Frames) // place.shp
+		frame = 0;
+
+	R->EDI(frame);
+	return 0;
+}

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -69,6 +69,9 @@ DEFINE_HOOK(0x6D528A, TacticalClass_DrawPlacement_PlacementPreview, 0x6)
 {
 	auto pRules = RulesExt::Global();
 
+	if (Phobos::Config::DrawAdjacentBoundary)
+		BuildingTypeExt::DrawAdjacentLines();
+
 	if (!pRules->PlacementPreview || !Phobos::Config::ShowPlacementPreview)
 		return 0;
 
@@ -217,45 +220,3 @@ DEFINE_HOOK(0x5F5416, ObjectClass_ReceiveDamage_CanC4DamageRounding, 0x6)
 
 	return SkipGameCode;
 }
-
-#pragma region BuildingProximity
-
-namespace ProximityTemp
-{
-	BuildingTypeClass* pType = nullptr;
-}
-
-DEFINE_HOOK(0x4A8F20, isplayClass_BuildingProximityCheck_SetContext, 0x5)
-{
-	GET(BuildingTypeClass*, pType, ESI);
-
-	ProximityTemp::pType = pType;
-
-	return 0;
-}
-
-DEFINE_HOOK(0x4A8FD7, DisplayClass_BuildingProximityCheck_BuildArea, 0x6)
-{
-	enum { SkipBuilding = 0x4A902C };
-
-	GET(BuildingClass*, pCellBuilding, ESI);
-
-	auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pCellBuilding->Type);
-
-	if (pTypeExt->NoBuildAreaOnBuildup && pCellBuilding->CurrentMission == Mission::Construction)
-		return SkipBuilding;
-
-	auto const& pBuildingsAllowed = BuildingTypeExt::ExtMap.Find(ProximityTemp::pType)->Adjacent_Allowed;
-
-	if (pBuildingsAllowed.size() > 0 && !pBuildingsAllowed.Contains(pCellBuilding->Type))
-		return SkipBuilding;
-
-	auto const& pBuildingsDisallowed = BuildingTypeExt::ExtMap.Find(ProximityTemp::pType)->Adjacent_Disallowed;
-
-	if (pBuildingsDisallowed.size() > 0 && pBuildingsDisallowed.Contains(pCellBuilding->Type))
-		return SkipBuilding;
-
-	return 0;
-}
-
-#pragma endregion

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -137,6 +137,11 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		this->HeightShadowScaling = false;
 	this->HeightShadowScaling_MinScale.Read(exINI, GameStrings::AudioVisual, "HeightShadowScaling.MinScale");
 
+	this->CheckUnitBaseNormal.Read(exINI, GameStrings::General, "CheckUnitBaseNormal");
+	this->PlacementGrid_Expand.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.Expand");
+	this->PlacementGrid_LandFrames.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.LandFrames");
+	this->PlacementGrid_WaterFrames.Read(exINI, GameStrings::AudioVisual, "PlacementGrid.WaterFrames");
+
 	this->AllowParallelAIQueues.Read(exINI, "GlobalControls", "AllowParallelAIQueues");
 	this->ForbidParallelAIQueues_Aircraft.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Aircraft");
 	this->ForbidParallelAIQueues_Building.Read(exINI, "GlobalControls", "ForbidParallelAIQueues.Building");
@@ -330,6 +335,10 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AirShadowBaseScale_log)
 		.Process(this->HeightShadowScaling)
 		.Process(this->HeightShadowScaling_MinScale)
+		.Process(this->CheckUnitBaseNormal)
+		.Process(this->PlacementGrid_Expand)
+		.Process(this->PlacementGrid_LandFrames)
+		.Process(this->PlacementGrid_WaterFrames)
 		.Process(this->AllowParallelAIQueues)
 		.Process(this->ForbidParallelAIQueues_Aircraft)
 		.Process(this->ForbidParallelAIQueues_Building)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -93,6 +93,11 @@ public:
 		Valueable<double> HeightShadowScaling_MinScale;
 		double AirShadowBaseScale_log;
 
+		Valueable<bool> CheckUnitBaseNormal;
+		Valueable<bool> PlacementGrid_Expand;
+		Valueable<Vector3D<int>> PlacementGrid_LandFrames;
+		Valueable<Vector3D<int>> PlacementGrid_WaterFrames;
+
 		Valueable<bool> AllowParallelAIQueues;
 		Valueable<bool> ForbidParallelAIQueues_Aircraft;
 		Valueable<bool> ForbidParallelAIQueues_Building;
@@ -222,6 +227,11 @@ public:
 			, HeightShadowScaling { false }
 			, HeightShadowScaling_MinScale { 0.0 }
 			, AirShadowBaseScale_log { 0.693376137 }
+
+			, CheckUnitBaseNormal { false }
+			, PlacementGrid_Expand { false }
+			, PlacementGrid_LandFrames { { 1, 0, 0 } }
+			, PlacementGrid_WaterFrames { { 1, 0, 0 } }
 
 			, AllowParallelAIQueues { true }
 			, ForbidParallelAIQueues_Aircraft { false }

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -162,6 +162,7 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->BriefingTheme)
 		.Process(this->AutoDeathObjects)
 		.Process(this->TransportReloaders)
+		.Process(this->BaseNormalCells)
 		;
 }
 

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -36,6 +36,8 @@ public:
 		std::vector<TechnoExt::ExtData*> AutoDeathObjects;
 		std::vector<TechnoExt::ExtData*> TransportReloaders; // Objects that can reload ammo in limbo
 
+		std::vector<CellStruct> BaseNormalCells;
+
 		ExtData(ScenarioClass* OwnerObject) : Extension<ScenarioClass>(OwnerObject)
 			, ShowBriefing { false }
 			, BriefingTheme { -1 }
@@ -43,6 +45,7 @@ public:
 			, Variables { }
 			, AutoDeathObjects {}
 			, TransportReloaders {}
+			, BaseNormalCells {}
 		{ }
 
 		void SetVariableToByID(bool bIsGlobal, int nIndex, char bState);

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -454,6 +454,10 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->BuildLimitGroup_ExtraLimit_Nums.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.Nums");
 	this->BuildLimitGroup_ExtraLimit_MaxCount.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.MaxCount");
 	this->BuildLimitGroup_ExtraLimit_MaxNum.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.MaxNum");
+
+	this->UnitBaseNormal.Read(exINI, pSection, "UnitBaseNormal");
+	this->UnitBaseForAllyBuilding.Read(exINI, pSection, "UnitBaseForAllyBuilding");
+
 	this->Wake.Read(exINI, pSection, "Wake");
 	this->Wake_Grapple.Read(exINI, pSection, "Wake.Grapple");
 	this->Wake_Sinking.Read(exINI, pSection, "Wake.Sinking");
@@ -824,6 +828,9 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BuildLimitGroup_ExtraLimit_Nums)
 		.Process(this->BuildLimitGroup_ExtraLimit_MaxCount)
 		.Process(this->BuildLimitGroup_ExtraLimit_MaxNum)
+
+		.Process(this->UnitBaseNormal)
+		.Process(this->UnitBaseForAllyBuilding)
 
 		.Process(this->Wake)
 		.Process(this->Wake_Grapple)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -226,6 +226,9 @@ public:
 		ValueableVector<int> BuildLimitGroup_ExtraLimit_MaxCount;
 		Valueable<int> BuildLimitGroup_ExtraLimit_MaxNum;
 
+		Valueable<bool> UnitBaseNormal;
+		Valueable<bool> UnitBaseForAllyBuilding;
+
 		Nullable<AnimTypeClass*> Wake;
 		Nullable<AnimTypeClass*> Wake_Grapple;
 		Nullable<AnimTypeClass*> Wake_Sinking;
@@ -448,6 +451,9 @@ public:
 			, BuildLimitGroup_ExtraLimit_Nums {}
 			, BuildLimitGroup_ExtraLimit_MaxCount {}
 			, BuildLimitGroup_ExtraLimit_MaxNum { 0 }
+
+			, UnitBaseNormal { false }
+			, UnitBaseForAllyBuilding { false }
 
 			, Wake { }
 			, Wake_Grapple { }

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -43,6 +43,7 @@ bool Phobos::Config::ShowPlanningPath = false;
 bool Phobos::Config::ArtImageSwap = false;
 bool Phobos::Config::ShowPlacementPreview = false;
 bool Phobos::Config::DigitalDisplay_Enable = false;
+bool Phobos::Config::DrawAdjacentBoundary = false;
 bool Phobos::Config::RealTimeTimers = false;
 bool Phobos::Config::RealTimeTimers_Adaptive = false;
 int Phobos::Config::CampaignDefaultGameSpeed = 2;
@@ -70,6 +71,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::RealTimeTimers = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers", false);
 	Phobos::Config::RealTimeTimers_Adaptive = CCINIClass::INI_RA2MD->ReadBool("Phobos", "RealTimeTimers.Adaptive", false);
 	Phobos::Config::DigitalDisplay_Enable = CCINIClass::INI_RA2MD->ReadBool("Phobos", "DigitalDisplay.Enable", false);
+	Phobos::Config::DrawAdjacentBoundary = CCINIClass::INI_RA2MD->ReadBool("Phobos", "DrawAdjacentBoundary", false);
 	Phobos::Config::SaveGameOnScenarioStart = CCINIClass::INI_RA2MD->ReadBool("Phobos", "SaveGameOnScenarioStart", true);
 	Phobos::Config::ShowBriefing = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowBriefing", true);
 	Phobos::Config::ShowPowerDelta = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowPowerDelta", true);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -77,6 +77,7 @@ public:
 		static bool ShowPlacementPreview;
 		static bool EnableBuildingPlacementPreview;
 		static bool DigitalDisplay_Enable;
+		static bool DrawAdjacentBoundary;
 		static bool RealTimeTimers;
 		static bool RealTimeTimers_Adaptive;
 		static int CampaignDefaultGameSpeed;


### PR DESCRIPTION
- You can now set `CheckUnitBaseNormal` to true to use units to expand the construction scope of the base.
  - `UnitBaseNormal` controls whether our own buildings can be place around it like vanilla `BaseNormal` do.
  - `UnitBaseForAllyBuilding` controls whether ally buildings can be place around it like vanilla `EligibileForAllyBuilding` do.

In `rulesmd.ini`:
```ini
[General]
CheckUnitBaseNormal=false      ; boolean

[SOMEUNIT]                     ; UnitType
UnitBaseNormal=false           ; boolean
UnitBaseForAllyBuilding=false  ; boolean
```

- This feature is highly compatible with `ExpandBuildingPlace`. If set `DrawAdjacentBoundary` to true, it will display the four corners of the `Adjacent` boundary. If set `PlacementGrid.Expand` to true, it will display the placing grids with `place.shp` and following corresponding frame number.
  - `PlacementGrid.LandFrames` controls the placing grids frames on non-water cell. The three numbers respectively represent "Some technos that can command departure have occupied this area", "This cell is actually beyond the scope, but there is still at least one cell inside the entire region" and "Here is no problem, everything is OK".
  - `PlacementGrid.WaterFrames` controls the placing grids frames on water cell. Each item corresponds to the same as above.

In `ra2md.ini`:
```ini
[Phobos]
DrawAdjacentBoundary=false       ; boolean
```

In `rulesmd.ini`:
```ini
[AudioVisual]
PlacementGrid.Expand=false       ; boolean
PlacementGrid.LandFrames=1,0,0   ; integer, zero-based frame index - have technos, near boundary, is normal
PlacementGrid.WaterFrames=1,0,0  ; integer, zero-based frame index - have technos, near boundary, is normal
```

Splits from #1335  .