### PR TITLE
More aircraft actions enhancement for #1366

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -375,6 +375,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix `LimboKill` not working reliably
   - Allow using waypoints, area guard and attack move with aircraft
   - Fix `Stop` command not working so well in some cases
+  - Fix aircraft `MovementZone` and `SpeedType` inconsistencies
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -185,7 +185,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - Aircraft with `AirportBound=no` continue moving forward.
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
-- Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft was ordered to move onto water surface.
+- Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft is ordered to move onto water surface and instead the movement order changes to a shore nearby.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -236,7 +236,7 @@ LandingDir=     ; Direction type (integers from 0-255). Accepts negative values 
 
 ### Extended Aircraft Missions
 
-- Aircraft will now be able to use waypoints.
+- Aircraft will now be able to use waypoints and fly towards the water surface normally.
 - When a `guard` command (`[G]` by default) is issued, the aircraft will search for targets around the current location and return immediately when target is not found, target is destroyed or ammos are depleted.
   - If the target is destroyed but ammos are not depleted yet, it will also return because the aircraft's command is one-time.
 - When an `attack move` command (`[Ctrl]+[Shift]`) is issued, the aircraft will move towards the destination and search for nearby targets on the route for attack. Once ammo is depleted or the destination is reached, it will return.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -185,6 +185,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - Aircraft with `AirportBound=no` continue moving forward.
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
+- Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft was ordered to move onto water surface.
 
 ## Fixes / interactions with other extensions
 
@@ -237,7 +238,7 @@ LandingDir=     ; Direction type (integers from 0-255). Accepts negative values 
 
 ### Extended Aircraft Missions
 
-- Aircraft will now be able to use waypoints and fly towards the water surface normally.
+- Aircraft will now be able to use waypoints.
 - When a `guard` command (`[G]` by default) is issued, the aircraft will search for targets around the current location and return immediately when target is not found, target is destroyed or ammos are depleted.
   - If the target is destroyed but ammos are not depleted yet, it will also return because the aircraft's command is one-time.
 - When an `attack move` command (`[Ctrl]+[Shift]`) is issued, the aircraft will move towards the destination and search for nearby targets on the route for attack. Once ammo is depleted or the destination is reached, it will return.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -555,7 +555,7 @@ Vanilla fixes:
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix (by tyuah8)
 - Fix `Stop` command not working so well in some cases (by CrimRecya)
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc. (by Starkku)
-- Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft was ordered to move onto water surface (by CrimRecya)
+- Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft is ordered to move onto water surface and instead the movement order changes to a shore nearby (by CrimRecya)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -555,6 +555,7 @@ Vanilla fixes:
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix (by tyuah8)
 - Fix `Stop` command not working so well in some cases (by CrimRecya)
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc. (by Starkku)
+- Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft was ordered to move onto water surface (by CrimRecya)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -362,7 +362,7 @@ DEFINE_HOOK(0x416A0A, AircraftClass_Mission_Move_SmoothMoving, 0x5)
 	return EnterIdleAndReturn;
 }
 
-DEFINE_HOOK(0x4DDD66, FootClass_vt_entry_550_ReplaceHardcode, 0x5) // To avoid that the aircraft cannot fly towards the water surface normally
+DEFINE_HOOK(0x4DDD66, FootClass_IsLandZoneClear_ReplaceHardcode, 0x6) // To avoid that the aircraft cannot fly towards the water surface normally
 {
 	enum { SkipGameCode = 0x4DDD8A };
 

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -356,7 +356,7 @@ DEFINE_HOOK(0x416A0A, AircraftClass_Mission_Move_SmoothMoving, 0x5)
 		return (R->Origin() == 0x4168C7 ? ContinueMoving1 : ContinueMoving2);
 
 	// Try next planning waypoint first, then return to air base if it does not exist or cannot be taken
-	if (!reinterpret_cast<bool(__thiscall*)(AircraftClass*)>(0x6385C0)(pThis))
+	if (!pThis->TryNextPlanningTokenNode())
 		pThis->EnterIdleMode(false, true);
 
 	return EnterIdleAndReturn;

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -351,13 +351,30 @@ DEFINE_HOOK(0x416A0A, AircraftClass_Mission_Move_SmoothMoving, 0x5)
 	const int distance = Game::F2I(Point2D { pCoords->X, pCoords->Y }.DistanceFrom(Point2D { pThis->Location.X, pThis->Location.Y }));
 
 	// When the horizontal distance between the aircraft and its destination is greater than half of its deceleration distance
-	// or its turning radius, continue to move forward, otherwise return to airbase or execute the next planning path
+	// or its turning radius, continue to move forward, otherwise return to airbase or execute the next planning waypoint
 	if (distance > std::max((pType->SlowdownDistance >> 1), (2048 / pType->ROT)))
 		return (R->Origin() == 0x4168C7 ? ContinueMoving1 : ContinueMoving2);
 
-	pThis->EnterIdleMode(false, true);
+	// Try next planning waypoint first, then return to air base if it does not exist or cannot be taken
+	if (!reinterpret_cast<bool(__thiscall*)(AircraftClass*)>(0x6385C0)(pThis))
+		pThis->EnterIdleMode(false, true);
 
 	return EnterIdleAndReturn;
+}
+
+DEFINE_HOOK(0x4DDD66, FootClass_vt_entry_550_ReplaceHardcode, 0x5) // To avoid that the aircraft cannot fly towards the water surface normally
+{
+	enum { SkipGameCode = 0x4DDD8A };
+
+	GET(FootClass* const, pThis, EBP);
+	GET_STACK(CellStruct, cell, STACK_OFFSET(0x20, 0x4));
+
+	const auto pType = pThis->GetTechnoType();
+
+	// In vanilla, only aircrafts or `foots with fly locomotion` will call this virtual function
+	// So I don't know why WW use hard-coded `SpeedType::Track` and `MovementZone::Normal` to check this
+	R->AL(MapClass::Instance->GetCellAt(cell)->IsClearToMove(pType->SpeedType, false, false, -1, pType->MovementZone, -1, true));
+	return SkipGameCode;
 }
 
 // AreaGuard: return when no ammo or first target died


### PR DESCRIPTION
1. Fix aircrafts planning waypoint problem - At the end of each task, all units with planning waypoints will generate an mega event to the next planning waypoint and respond after 1 frame. This is really no problem for most units, but for aircrafts, they will always return to the airport after each task. So they will try to return to the airport in the frame before it respond to event. There will be looked like a "shaking", if the `Speed` and `ROT` of the aircraft are fast. To solve this problem, I check the waypoints of aircrafts and let them wait before returning.
2. Fix a vanilla issue - Now aircrafts can fly towards the water surface normally.
