### PR TITLE
Use 2D distance to check whether team members have arrived destination

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -375,7 +375,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix `LimboKill` not working reliably
   - Allow using waypoints, area guard and attack move with aircraft
   - Fix `Stop` command not working so well in some cases
-  - Use 2D distance instead of 3D distance to check whether team members have arrived destination
+  - Use 2D distance instead of 3D to check whether in air team members have arrived destination
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -375,6 +375,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix `LimboKill` not working reliably
   - Allow using waypoints, area guard and attack move with aircraft
   - Fix `Stop` command not working so well in some cases
+  - Use 2D distance instead of 3D distance to check whether team members have arrived destination
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -182,6 +182,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - Aircraft no longer find airport twice and overlap.
   - Aircraft no longer briefly pause in the air before returning.
   - Aircraft with `AirportBound=no` continue moving forward.
+- Now the team members use the 2D distance instead of the 3D distance to judge whether to reach the mission destination, so as to prevent the problem that the mission is stuck and cannot continue in some cases (such as when the jumpjet stops on the building).
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -182,7 +182,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - Aircraft no longer find airport twice and overlap.
   - Aircraft no longer briefly pause in the air before returning.
   - Aircraft with `AirportBound=no` continue moving forward.
-- Now the team members use the 2D distance instead of the 3D distance to judge whether to reach the mission destination, so as to prevent the problem that the mission is stuck and cannot continue in some cases (such as when the jumpjet stops on the building).
+- Now in air team members will use the 2D distance instead of the 3D distance to judge whether have reached the mission destination, so as to prevent the problem that the mission is stuck and cannot continue in some cases (such as when the jumpjet stops on the building).
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -554,6 +554,7 @@ Vanilla fixes:
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers (by Starkku)
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix (by tyuah8)
 - Fix `Stop` command not working so well in some cases (by CrimRecya)
+- Use 2D distance instead of 3D distance to check whether team members have arrived destination (by CrimRecya)
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc. (by Starkku)
 
 Phobos fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -554,7 +554,7 @@ Vanilla fixes:
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers (by Starkku)
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix (by tyuah8)
 - Fix `Stop` command not working so well in some cases (by CrimRecya)
-- Use 2D distance instead of 3D distance to check whether team members have arrived destination (by CrimRecya)
+- Use 2D distance instead of 3D to check whether in air team members have arrived destination (by CrimRecya)
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc. (by Starkku)
 
 Phobos fixes:

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1141,7 +1141,7 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 int __fastcall Check2DDistanceInsteadOf3D(ObjectClass* pSource, void* _, AbstractClass* pTarget)
 {
 	return (pSource->IsInAir() && pSource->WhatAmI() != AbstractType::Aircraft) // Jumpjets or sth in the air
-		? pSource->DistanceFrom(pTarget) // 2D distance
+		? (pSource->DistanceFrom(pTarget) * 2) // 2D distance (2x is the bonus to units in the air)
 		: reinterpret_cast<int(__thiscall*)(ObjectClass*, AbstractClass*)>(0x5F6360)(pSource, pTarget); // 3D distance (vanilla)
 }
 DEFINE_JUMP(CALL, 0x6EBCC9, GET_OFFSET(Check2DDistanceInsteadOf3D));

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1143,25 +1143,17 @@ int __fastcall Check2DDistanceInsteadOf3D(AbstractClass* pSource, void* _, Abstr
 	const auto sourceCoords = pSource->GetCoords();
 	const auto targetCoords = pTarget->GetCoords();
 
-	int distance = Game::F2I(Point2D { sourceCoords.X - targetCoords.X, sourceCoords.Y - targetCoords.Y }.Magnitude());
+	// Aircraft has its own unique treatment, and it will not be changed here
+	int distance = Game::F2I((pSource->IsInAir() && pSource->WhatAmI() != AbstractType::Aircraft) ? // Jumpjets or sth in the air ?
+		(Point2D { sourceCoords.X - targetCoords.X, sourceCoords.Y - targetCoords.Y }.Magnitude() * 2) : // bonus to units in the air
+		sourceCoords.DistanceFrom(targetCoords)); // Original
 
 	if (const auto pBuilding = abstract_cast<BuildingClass*>(pTarget)) // Vanilla bonus to building
 		distance -= ((pBuilding->Type->GetFoundationWidth() + pBuilding->Type->GetFoundationHeight(false)) << 6);
 
-	return distance;
+	return Math::max(0, distance);
 }
-DEFINE_JUMP(CALL, 0x6EB686, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToObject - TeamSpawnCell
-DEFINE_JUMP(CALL, 0x6EB8FF, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToGuard - TeamSpawnCell1
-DEFINE_JUMP(CALL, 0x6EB9C8, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToGuard - TeamSpawnCell2
-DEFINE_JUMP(CALL, 0x6EBB8C, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToCell - TeamSpawnCell
-DEFINE_JUMP(CALL, 0x6EBCC9, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToCell - TeamFocus
-DEFINE_JUMP(CALL, 0x6EBD6E, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToCell - SelfDestination
-DEFINE_JUMP(CALL, 0x6EC1BB, GET_OFFSET(Check2DDistanceInsteadOf3D)); // InlineCall - CheckStray
-DEFINE_JUMP(CALL, 0x6ED390, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToLoad - TeamSpawnCell
-DEFINE_JUMP(CALL, 0x6ED562, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToDeploy - TeamSpawnCell
-DEFINE_JUMP(CALL, 0x6ED873, GET_OFFSET(Check2DDistanceInsteadOf3D)); // NewMission - TeamSpawnCell1
-DEFINE_JUMP(CALL, 0x6ED958, GET_OFFSET(Check2DDistanceInsteadOf3D)); // NewMission - TeamSpawnCell2
-DEFINE_JUMP(CALL, 0x6EF1AE, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToUnload - TeamSpawnCell
+DEFINE_JUMP(CALL, 0x6EBCC9, GET_OFFSET(Check2DDistanceInsteadOf3D));
 
 #pragma endregion
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1148,6 +1148,9 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 
 int __fastcall Check2DDistanceInsteadOf3D(ObjectClass* pSource, void* _, AbstractClass* pTarget)
 {
+	// At present, it seems that aircraft use their own mapcoords and the team destination's mapcoords to check.
+    // During the previous test, it was found that if the aircraft uses this and needs to return to the airport
+	// with the script first, it will interrupt the remaining tasks for unknown reasons - CrimRecya
 	return (pSource->IsInAir() && pSource->WhatAmI() != AbstractType::Aircraft) // Jumpjets or sth in the air
 		? (pSource->DistanceFrom(pTarget) * 2) // 2D distance (2x is the bonus to units in the air)
 		: pSource->DistanceFrom3D(pTarget); // 3D distance (vanilla)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1136,6 +1136,35 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 
 #pragma endregion
 
+#pragma region TeamCloseRangeFix
+
+int __fastcall Check2DDistanceInsteadOf3D(AbstractClass* pSource, void* _, AbstractClass* pTarget)
+{
+	const auto sourceCoords = pSource->GetCoords();
+	const auto targetCoords = pTarget->GetCoords();
+
+	int distance = Game::F2I(Point2D { sourceCoords.X - targetCoords.X, sourceCoords.Y - targetCoords.Y }.Magnitude());
+
+	if (const auto pBuilding = abstract_cast<BuildingClass*>(pTarget)) // Vanilla bonus to building
+		distance -= ((pBuilding->Type->GetFoundationWidth() + pBuilding->Type->GetFoundationHeight(false)) << 6);
+
+	return distance;
+}
+DEFINE_JUMP(CALL, 0x6EB686, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToObject - TeamSpawnCell
+DEFINE_JUMP(CALL, 0x6EB8FF, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToGuard - TeamSpawnCell1
+DEFINE_JUMP(CALL, 0x6EB9C8, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToGuard - TeamSpawnCell2
+DEFINE_JUMP(CALL, 0x6EBB8C, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToCell - TeamSpawnCell
+DEFINE_JUMP(CALL, 0x6EBCC9, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToCell - TeamFocus
+DEFINE_JUMP(CALL, 0x6EBD6E, GET_OFFSET(Check2DDistanceInsteadOf3D)); // MoveToCell - SelfDestination
+DEFINE_JUMP(CALL, 0x6EC1BB, GET_OFFSET(Check2DDistanceInsteadOf3D)); // InlineCall - CheckStray
+DEFINE_JUMP(CALL, 0x6ED390, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToLoad - TeamSpawnCell
+DEFINE_JUMP(CALL, 0x6ED562, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToDeploy - TeamSpawnCell
+DEFINE_JUMP(CALL, 0x6ED873, GET_OFFSET(Check2DDistanceInsteadOf3D)); // NewMission - TeamSpawnCell1
+DEFINE_JUMP(CALL, 0x6ED958, GET_OFFSET(Check2DDistanceInsteadOf3D)); // NewMission - TeamSpawnCell2
+DEFINE_JUMP(CALL, 0x6EF1AE, GET_OFFSET(Check2DDistanceInsteadOf3D)); // TryToUnload - TeamSpawnCell
+
+#pragma endregion
+
 // This shouldn't be here
 // Author: tyuah8
 DEFINE_HOOK_AGAIN(0x4AF94D, EndPiggyback_PowerOn, 0x7) // Drive

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1138,20 +1138,11 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 
 #pragma region TeamCloseRangeFix
 
-int __fastcall Check2DDistanceInsteadOf3D(AbstractClass* pSource, void* _, AbstractClass* pTarget)
+int __fastcall Check2DDistanceInsteadOf3D(ObjectClass* pSource, void* _, AbstractClass* pTarget)
 {
-	const auto sourceCoords = pSource->GetCoords();
-	const auto targetCoords = pTarget->GetCoords();
-
-	// Aircraft has its own unique treatment, and it will not be changed here
-	int distance = Game::F2I((pSource->IsInAir() && pSource->WhatAmI() != AbstractType::Aircraft) ? // Jumpjets or sth in the air ?
-		(Point2D { sourceCoords.X - targetCoords.X, sourceCoords.Y - targetCoords.Y }.Magnitude() * 2) : // bonus to units in the air
-		sourceCoords.DistanceFrom(targetCoords)); // Original
-
-	if (const auto pBuilding = abstract_cast<BuildingClass*>(pTarget)) // Vanilla bonus to building
-		distance -= ((pBuilding->Type->GetFoundationWidth() + pBuilding->Type->GetFoundationHeight(false)) << 6);
-
-	return Math::max(0, distance);
+	return (pSource->IsInAir() && pSource->WhatAmI() != AbstractType::Aircraft) // Jumpjets or sth in the air
+		? pSource->DistanceFrom(pTarget) // 2D distance
+		: reinterpret_cast<int(__thiscall*)(ObjectClass*, AbstractClass*)>(0x5F6360)(pSource, pTarget); // 3D distance (vanilla)
 }
 DEFINE_JUMP(CALL, 0x6EBCC9, GET_OFFSET(Check2DDistanceInsteadOf3D));
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1142,7 +1142,7 @@ int __fastcall Check2DDistanceInsteadOf3D(ObjectClass* pSource, void* _, Abstrac
 {
 	return (pSource->IsInAir() && pSource->WhatAmI() != AbstractType::Aircraft) // Jumpjets or sth in the air
 		? (pSource->DistanceFrom(pTarget) * 2) // 2D distance (2x is the bonus to units in the air)
-		: reinterpret_cast<int(__thiscall*)(ObjectClass*, AbstractClass*)>(0x5F6360)(pSource, pTarget); // 3D distance (vanilla)
+		: pSource->DistanceFrom3D(pTarget); // 3D distance (vanilla)
 }
 DEFINE_JUMP(CALL, 0x6EBCC9, GET_OFFSET(Check2DDistanceInsteadOf3D));
 


### PR DESCRIPTION
- Now the team members use the 2D distance instead of the 3D distance to judge whether to reach the mission destination, so as to prevent the problem that the mission is stuck and cannot continue in some cases (such as when the jumpjet stops on the building).