### PR TITLE
Manually empty and reload ammo

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -377,6 +377,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix `Stop` command not working so well in some cases
   - Fix aircraft `MovementZone` and `SpeedType` inconsistencies
   - Use 2D distance instead of 3D to check whether in air team members have arrived destination
+  - Manually empty and reload ammo
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="src\Commands\NextIdleHarvester.cpp" />
     <ClCompile Include="src\Commands\ObjectInfo.cpp" />
     <ClCompile Include="src\Commands\QuickSave.cpp" />
+    <ClCompile Include="src\Commands\ManualReloadAmmo.cpp" />
     <ClCompile Include="src\Commands\ToggleDesignatorRange.cpp" />
     <ClCompile Include="src\Commands\ToggleDigitalDisplay.cpp" />
     <ClCompile Include="src\Commands\SaveVariablesToFile.cpp" />
@@ -40,6 +41,7 @@
     <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
     <ClCompile Include="src\Ext\CaptureManager\Hooks.cpp" />
     <ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
+    <ClCompile Include="src\Ext\Event\Body.cpp" />
     <ClCompile Include="src\Ext\OverlayType\Body.cpp" />
     <ClCompile Include="src\Ext\OverlayType\Hooks.cpp" />
     <ClCompile Include="src\Ext\ParticleType\Body.cpp" />
@@ -193,12 +195,14 @@
     <ClInclude Include="src\Commands\Commands.h" />
     <ClInclude Include="src\Commands\DamageDisplay.h" />
     <ClInclude Include="src\Commands\QuickSave.h" />
+    <ClInclude Include="src\Commands\ManualReloadAmmo.h" />
     <ClInclude Include="src\Commands\ToggleDesignatorRange.h" />
     <ClInclude Include="src\Commands\ToggleDigitalDisplay.h" />
     <ClInclude Include="src\Commands\SaveVariablesToFile.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />
+    <ClInclude Include="src\Ext\Event\Body.h" />
     <ClInclude Include="src\Ext\OverlayType\Body.h" />
     <ClInclude Include="src\Ext\ParticleType\Body.h" />
     <ClInclude Include="src\Ext\Sidebar\Body.h" />

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1366,6 +1366,18 @@ Convert.HumanToComputer =   ; TechnoType
 Convert.ComputerToHuman =   ; TechnoType
 ```
 
+### Manually empty and reload ammo
+
+- You can now use the shortcut key to manually empty and reload ammo for units. Aircraft still needs to return to the airport to reload.
+  - `CanManualReload` controls whether this type of techno can manually empty and reload ammo.
+  - For shortcut keys, see [User Interface -> Manually Reload](User-Interface.md#Manual-Reload).
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]            ; TechnoType
+CanManualReload=false   ; boolean
+```
+
 ## Terrain
 
 ### Destroy animation & sound

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -317,6 +317,11 @@ SelectionFlashDuration=0  ; integer, number of frames
 - Switches on/off [frame by frame mode](Miscellanous.html#frame-step-in).
 - For localization add `TXT_FRAME_BY_FRAME` and `TXT_FRAME_BY_FRAME_DESC` into your `.csf` file.
 
+### `[ ]` Manual Reload
+
+- Manually empty and reload ammo if [CanManualReload=true](New-or-Enhanced-Logics.md#Manually-empty-and-reload-ammo).
+- For localization add `TXT_MANUAL_RELOAD` and `TXT_MANUAL_RELOAD_DESC` into your `.csf` file.
+
 ## Loading screen
 
 - PCX files can now be used as loadscreen images.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -470,6 +470,7 @@ New:
 - Allow infantry to use land sequences in water (by Starkku)
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps (by Starkku)
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
+- Manually empty and reload ammo (by CrimRecya)
 - Unit `Speed` setting now accepts floating point values (by Starkku)
 
 Vanilla fixes:

--- a/src/Commands/Commands.cpp
+++ b/src/Commands/Commands.cpp
@@ -10,6 +10,7 @@
 #include "ToggleDigitalDisplay.h"
 #include "ToggleDesignatorRange.h"
 #include "SaveVariablesToFile.h"
+#include "ManualReloadAmmo.h"
 
 DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 {
@@ -19,6 +20,7 @@ DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 	MakeCommand<QuickSaveCommandClass>();
 	MakeCommand<ToggleDigitalDisplayCommandClass>();
 	MakeCommand<ToggleDesignatorRangeCommandClass>();
+	MakeCommand<ManualReloadAmmoCommandClass>();
 
 	if (Phobos::Config::DevelopmentCommands)
 	{

--- a/src/Commands/ManualReloadAmmo.cpp
+++ b/src/Commands/ManualReloadAmmo.cpp
@@ -1,0 +1,38 @@
+#include "ManualReloadAmmo.h"
+
+#include <HouseClass.h>
+
+#include <Ext/TechnoType/Body.h>
+#include <Ext/Event/Body.h>
+
+const char* ManualReloadAmmoCommandClass::GetName() const
+{
+	return "Manual Reload Ammo";
+}
+
+const wchar_t* ManualReloadAmmoCommandClass::GetUIName() const
+{
+	return GeneralUtils::LoadStringUnlessMissing("TXT_MANUAL_RELOAD", L"Manual Reload Ammo");
+}
+
+const wchar_t* ManualReloadAmmoCommandClass::GetUICategory() const
+{
+	return CATEGORY_CONTROL;
+}
+
+const wchar_t* ManualReloadAmmoCommandClass::GetUIDescription() const
+{
+	return GeneralUtils::LoadStringUnlessMissing("TXT_MANUAL_RELOAD_DESC", L"Manual Reload Ammo");
+}
+
+void ManualReloadAmmoCommandClass::Execute(WWKey eInput) const
+{
+	for (const auto& pObj : ObjectClass::CurrentObjects())
+	{
+		if (const auto pTechno = abstract_cast<TechnoClass*>(pObj))
+		{
+			if (pTechno->Owner->IsControlledByCurrentPlayer())
+				EventExt::RaiseManualReloadEvent(pTechno);
+		}
+	}
+}

--- a/src/Commands/ManualReloadAmmo.h
+++ b/src/Commands/ManualReloadAmmo.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Commands.h"
+
+// Select next idle harvester
+class ManualReloadAmmoCommandClass : public CommandClass
+{
+public:
+	// CommandClass
+	virtual const char* GetName() const override;
+	virtual const wchar_t* GetUIName() const override;
+	virtual const wchar_t* GetUICategory() const override;
+	virtual const wchar_t* GetUIDescription() const override;
+	virtual void Execute(WWKey eInput) const override;
+};

--- a/src/Ext/Event/Body.cpp
+++ b/src/Ext/Event/Body.cpp
@@ -1,8 +1,10 @@
-/*
 #include "Body.h"
 
 #include <Helpers/Macro.h>
 #include <EventClass.h>
+#include <HouseClass.h>
+
+#include <Ext/TechnoType/Body.h>
 
 bool EventExt::AddEvent()
 {
@@ -13,9 +15,39 @@ void EventExt::RespondEvent()
 {
 	switch (this->Type)
 	{
-	case EventTypeExt::Sample:
-		// Place the handler here
+	case EventTypeExt::ManualReload:
+		this->RespondToManualReloadEvent();
 		break;
+	}
+}
+
+void EventExt::RaiseManualReloadEvent(TechnoClass* pTechno)
+{
+	EventExt eventExt {};
+	eventExt.Type = EventTypeExt::ManualReload;
+	eventExt.HouseIndex = static_cast<char>(pTechno->Owner->ArrayIndex);
+	eventExt.Frame = Unsorted::CurrentFrame;
+	eventExt.ManualReloadEvent.Who = TargetClass(pTechno);
+	eventExt.AddEvent();
+	Debug::LogGame("Adding event MANUAL_RELOAD\n");
+}
+
+void EventExt::RespondToManualReloadEvent()
+{
+	if (const auto pTechno = this->ManualReloadEvent.Who.As_Techno())
+	{
+		if (pTechno->Ammo > 0 && pTechno->IsAlive && !pTechno->Berzerk)
+		{
+			const auto pType = pTechno->GetTechnoType();
+
+			if (pType && pTechno->Ammo != pType->Ammo && TechnoTypeExt::ExtMap.Find(pType)->CanManualReload)
+			{
+				pTechno->Ammo = 0;
+
+				if (pTechno->WhatAmI() != AbstractType::Aircraft)
+					pTechno->StartReloading();
+			}
+		}
 	}
 }
 
@@ -23,8 +55,8 @@ size_t EventExt::GetDataSize(EventTypeExt type)
 {
 	switch (type)
 	{
-	case EventTypeExt::Sample:
-		return sizeof(EventExt::Sample);
+	case EventTypeExt::ManualReload:
+		return sizeof(EventExt::ManualReloadEvent);
 	}
 
 	return 0;
@@ -42,9 +74,7 @@ DEFINE_HOOK(0x4C6CC8, Networking_RespondToEvent, 0x5)
 	GET(EventExt*, pEvent, ESI);
 
 	if (EventExt::IsValidType(pEvent->Type))
-	{
 		pEvent->RespondEvent();
-	}
 
 	return 0;
 }
@@ -98,4 +128,3 @@ DEFINE_HOOK(0x64C30E, sub_64BDD0_GetEventSize2, 0x6)
 
 	return 0;
 }
-*/

--- a/src/Ext/Event/Body.h
+++ b/src/Ext/Event/Body.h
@@ -1,7 +1,9 @@
 #pragma once
-/*
+
 #include <cstddef>
 #include <stdint.h>
+#include <TechnoClass.h>
+#include <TargetClass.h>
 
 enum class EventTypeExt : uint8_t
 {
@@ -9,10 +11,10 @@ enum class EventTypeExt : uint8_t
 	// CnCNet reserved Events from 0x30 to 0x3F
 	// Ares used Events 0x60 and 0x61
 
-	Sample = 0x40, // Sample event, remove it when Phobos needs its own events
+	ManualReload = 0x81,
 
-	FIRST = Sample,
-	LAST = Sample
+	FIRST = ManualReload,
+	LAST = ManualReload
 };
 
 #pragma pack(push, 1)
@@ -27,14 +29,17 @@ public:
 	{
 		char DataBuffer[104];
 
-		struct Sample
+		struct ManualReloadEvent
 		{
-			char DataBuffer[104];
-		} Sample;
+			TargetClass Who;
+		} ManualReloadEvent;
 	};
 
 	bool AddEvent();
 	void RespondEvent();
+
+	static void RaiseManualReloadEvent(TechnoClass* pTechno);
+	void RespondToManualReloadEvent();
 
 	static size_t GetDataSize(EventTypeExt type);
 	static bool IsValidType(EventTypeExt type);
@@ -43,4 +48,3 @@ public:
 static_assert(sizeof(EventExt) == 111);
 static_assert(offsetof(EventExt, DataBuffer) == 7);
 #pragma pack(pop)
-*/

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -454,6 +454,9 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->BuildLimitGroup_ExtraLimit_Nums.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.Nums");
 	this->BuildLimitGroup_ExtraLimit_MaxCount.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.MaxCount");
 	this->BuildLimitGroup_ExtraLimit_MaxNum.Read(exINI, pSection, "BuildLimitGroup.ExtraLimit.MaxNum");
+
+	this->CanManualReload.Read(exINI, pSection, "CanManualReload");
+
 	this->Wake.Read(exINI, pSection, "Wake");
 	this->Wake_Grapple.Read(exINI, pSection, "Wake.Grapple");
 	this->Wake_Sinking.Read(exINI, pSection, "Wake.Sinking");
@@ -824,6 +827,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BuildLimitGroup_ExtraLimit_Nums)
 		.Process(this->BuildLimitGroup_ExtraLimit_MaxCount)
 		.Process(this->BuildLimitGroup_ExtraLimit_MaxNum)
+
+		.Process(this->CanManualReload)
 
 		.Process(this->Wake)
 		.Process(this->Wake_Grapple)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -226,6 +226,8 @@ public:
 		ValueableVector<int> BuildLimitGroup_ExtraLimit_MaxCount;
 		Valueable<int> BuildLimitGroup_ExtraLimit_MaxNum;
 
+		Valueable<bool> CanManualReload;
+
 		Nullable<AnimTypeClass*> Wake;
 		Nullable<AnimTypeClass*> Wake_Grapple;
 		Nullable<AnimTypeClass*> Wake_Sinking;
@@ -448,6 +450,8 @@ public:
 			, BuildLimitGroup_ExtraLimit_Nums {}
 			, BuildLimitGroup_ExtraLimit_MaxCount {}
 			, BuildLimitGroup_ExtraLimit_MaxNum { 0 }
+
+			, CanManualReload { false }
 
 			, Wake { }
 			, Wake_Grapple { }


### PR DESCRIPTION
- You can now use the shortcut key to manually empty and reload ammo for units. Aircraft still needs to return to the airport to reload.
  - `CanManualReload` controls whether this type of techno can manually empty and reload ammo.
  - For shortcut keys’ localization add `TXT_MANUAL_RELOAD` and `TXT_MANUAL_RELOAD_DESC` into your `.csf` file.

In `rulesmd.ini`:
```ini
[SOMETECHNO]            ; TechnoType
CanManualReload=false   ; boolean
```

You can also combine `CanManualReload`, `NoAmmoWeapon`, `FeedbackWeapon` and `AttachEffect` to make some special attack effects.