### PR TITLE
[Minor] Deactivated check & allow passenger deletion under EMP

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1056,6 +1056,7 @@ Spawner.AttackImmediately=false  ; boolean
     - `PassengerDeletion.SoylentAllowedHouses` determines which houses passengers can belong to be eligible for refunding.
     - `PassengerDeletion.DisplaySoylent` can be set to true to display the amount of credits refunded on the transport. `PassengerDeletion.DisplaySoylentToHouses` determines which houses can see this and `PassengerDeletion.DisplaySoylentOffset` can be used to adjust the display offset.
   - `PassengerDeletion.ReportSound` and `PassengerDeletion.Anim` can be used to specify a sound and animation to play when a passenger is erased, respectively.
+  - If `PassengerDeletion.UnderEMP` is set to true, the deletion will be processed when the transport is under EMP or deactivated.
 
 In `rulesmd.ini`:
 ```ini
@@ -1075,6 +1076,7 @@ PassengerDeletion.DisplaySoylentToHouses=All    ; Affected House Enumeration (no
 PassengerDeletion.DisplaySoylentOffset=0,0      ; X,Y, pixels relative to default
 PassengerDeletion.ReportSound=                  ; Sound
 PassengerDeletion.Anim=                         ; Animation
+PassengerDeletion.UnderEMP=false                ; boolean
 ```
 
 ### Automatic passenger owner change to match transport owner

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -207,10 +207,13 @@ void TechnoExt::ExtData::EatPassengers()
 	auto const pThis = this->OwnerObject();
 	auto const pTypeExt = this->TypeExtData;
 
-	if (!pTypeExt->PassengerDeletionType || !TechnoExt::IsActive(pThis))
+	if (!pTypeExt->PassengerDeletionType || !TechnoExt::IsActiveIgnoreEMP(pThis))
 		return;
 
 	auto pDelType = pTypeExt->PassengerDeletionType.get();
+
+	if (!pDelType->UnderEMP && (pThis->Deactivated || pThis->IsUnderEMP()))
+		return;
 
 	if (pTypeExt && (pDelType->Rate > 0 || pDelType->UseCostAsRate))
 	{

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -34,7 +34,7 @@ TechnoExt::ExtData::~ExtData()
 	AnimExt::InvalidateTechnoPointers(pThis);
 }
 
-bool TechnoExt::IsActive(TechnoClass* pThis)
+bool TechnoExt::IsActiveIgnoreEMP(TechnoClass* pThis)
 {
 	return pThis
 		&& pThis->IsAlive
@@ -42,6 +42,13 @@ bool TechnoExt::IsActive(TechnoClass* pThis)
 		&& !pThis->InLimbo
 		&& !pThis->TemporalTargetingMe
 		&& !pThis->BeingWarpedOut
+		;
+}
+
+bool TechnoExt::IsActive(TechnoClass* pThis)
+{
+	return TechnoExt::IsActiveIgnoreEMP(pThis)
+		&& !pThis->Deactivated
 		&& !pThis->IsUnderEMP()
 		;
 }

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -139,6 +139,7 @@ public:
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
 
 	static bool IsActive(TechnoClass* pThis);
+	static bool IsActiveIgnoreEMP(TechnoClass* pThis);
 
 	static bool IsHarvesting(TechnoClass* pThis);
 	static bool HasAvailableDock(TechnoClass* pThis);

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -326,7 +326,7 @@ DEFINE_HOOK(0x74691D, UnitClass_UpdateDisguise_EMP, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 	// Remove mirage disguise if under emp or being flipped, approximately 15 deg
-	if (pThis->IsUnderEMP() || std::abs(pThis->AngleRotatedForwards) > 0.25 || std::abs(pThis->AngleRotatedSideways) > 0.25)
+	if (pThis->Deactivated || pThis->IsUnderEMP() || std::abs(pThis->AngleRotatedForwards) > 0.25 || std::abs(pThis->AngleRotatedSideways) > 0.25)
 	{
 		pThis->ClearDisguise();
 		R->EAX(pThis->MindControlRingAnim);

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -103,7 +103,7 @@ DEFINE_HOOK(0x54D208, JumpjetLocomotionClass_MovementAI_EMPWobble, 0x5)
 	GET(JumpjetLocomotionClass* const, pThis, ESI);
 	enum { ZeroWobble = 0x54D22C };
 
-	if (pThis->LinkedTo->IsUnderEMP())
+	if (pThis->LinkedTo->Deactivated || pThis->LinkedTo->IsUnderEMP())
 		return ZeroWobble;
 
 	return 0;

--- a/src/New/Type/Affiliated/PassengerDeletionTypeClass.cpp
+++ b/src/New/Type/Affiliated/PassengerDeletionTypeClass.cpp
@@ -32,6 +32,7 @@ PassengerDeletionTypeClass::PassengerDeletionTypeClass(TechnoTypeClass* pOwnerTy
 	, DisplaySoylentOffset { { 0, 0 } }
 	, ReportSound {}
 	, Anim {}
+	, UnderEMP { false }
 { }
 void PassengerDeletionTypeClass::LoadFromINI(CCINIClass* pINI, const char* pSection)
 {
@@ -52,6 +53,7 @@ void PassengerDeletionTypeClass::LoadFromINI(CCINIClass* pINI, const char* pSect
 	this->DisplaySoylentOffset.Read(exINI, pSection, "PassengerDeletion.DisplaySoylentOffset");
 	this->ReportSound.Read(exINI, pSection, "PassengerDeletion.ReportSound");
 	this->Anim.Read(exINI, pSection, "PassengerDeletion.Anim");
+	this->UnderEMP.Read(exINI, pSection, "PassengerDeletion.UnderEMP");
 }
 
 #pragma region(save/load)
@@ -76,6 +78,7 @@ bool PassengerDeletionTypeClass::Serialize(T& stm)
 		.Process(this->DisplaySoylentOffset)
 		.Process(this->ReportSound)
 		.Process(this->Anim)
+		.Process(this->UnderEMP)
 		.Success();
 }
 

--- a/src/New/Type/Affiliated/PassengerDeletionTypeClass.h
+++ b/src/New/Type/Affiliated/PassengerDeletionTypeClass.h
@@ -29,6 +29,7 @@ public:
 	Valueable<Point2D> DisplaySoylentOffset;
 	ValueableIdx<VocClass> ReportSound;
 	Valueable<AnimTypeClass*> Anim;
+	Valueable<bool> UnderEMP;
 
 	void LoadFromINI(CCINIClass* pINI, const char* pSection);
 	bool Load(PhobosStreamReader& stm, bool registerForChange);


### PR DESCRIPTION
For consistency: if `IsUnderEMP` is checked, then the techno's `Deactivated` should be checked in the same time. Added the remaining few cases where it's not being checked.

A logic that might be influence by this is `PassengerDeletion`, and idk why it even needs to check if the transport is EMP'd in the first time. Hence, I've added a tag to customize if passenger deletion should still be processed in such case.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                                    ; TechnoType
PassengerDeletion.UnderEMP=false                ; boolean
```