### PR TITLE
Add powered infantry/vehicle/aircraft logic

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -271,8 +271,9 @@ This page lists all the individual contributions to the project by their author.
   - Show designator & inhibitor range
   - Dump variables to file on scenario end / hotkey
   - "House owns TechnoType" and "House doesn't own TechnoType" trigger events
-  - Help with docs
   - Voxel light source position customization
+  - Extending `Power` to all TechnoTypes
+  - Help with docs
 - **ChrisLv_CN** (work relicensed under [following permission](https://github.com/Phobos-developers/Phobos/blob/develop/images/ChrisLv-relicense.png)):
    - General assistance
    - Interceptor logic prototype

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -187,6 +187,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 - Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft is ordered to move onto water surface and instead the movement order changes to a shore nearby.
+- Extending `Power` to all TechnoTypes: infantry, vehicles and aircraft can now provide or drain power just like buildings.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -187,7 +187,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Unit `Speed` setting now accepts floating-point values. Internally parsed values are clamped down to maximum of 100, multiplied by 256 and divided by 100, the result (which at this point is converted to an integer) then clamped down to maximum of 255 giving effective internal speed value range of 0 to 255, e.g leptons traveled per game frame.
 - Subterranean movement now benefits from speed multipliers from all sources such as veterancy, AttachEffect etc.
 - Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft is ordered to move onto water surface and instead the movement order changes to a shore nearby.
-- Extending `Power` to all TechnoTypes: infantry, vehicles and aircraft can now provide or drain power just like buildings.
 
 ## Fixes / interactions with other extensions
 
@@ -931,6 +930,19 @@ SpawnsPipFrame=1                     ; integer, frame of pips.shp (buildings) or
 EmptySpawnsPipFrame=0                ; integer, frame of pips.shp (buildings) or pips2.shp (others) (zero-based)
 SpawnsPipSize=                       ; X,Y, increment in pixels to next pip
 SpawnsPipOffset=0,0                  ; X,Y, position offset from default
+```
+
+### Power drain for units
+
+- Infantry, vehicles and aircraft can now drain or provide `Power` if `UnitPowerDrain=true` is set.
+
+In `rulesmd.ini`:
+```ini
+[General]
+UnitPowerDrain=false                 ; boolean
+
+[SOMETECHNO] ; TechnoType
+Power=0                              ; integer, positive means output, negative means drain
 ```
 
 ### Re-enable obsolete [JumpjetControls]

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -939,10 +939,10 @@ SpawnsPipOffset=0,0                  ; X,Y, position offset from default
 In `rulesmd.ini`:
 ```ini
 [General]
-UnitPowerDrain=false                 ; boolean
+UnitPowerDrain=false  ; boolean
 
-[SOMETECHNO] ; TechnoType
-Power=0                              ; integer, positive means output, negative means drain
+[SOMETECHNO]          ; TechnoType
+Power=0               ; integer, positive means output, negative means drain
 ```
 
 ### Re-enable obsolete [JumpjetControls]

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -492,6 +492,7 @@ New:
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps (by Starkku)
 - Allow customizing charge turret delays per burst on a weapon (by Starkku)
 - Unit `Speed` setting now accepts floating point values (by Starkku)
+- Extending `Power` to all TechnoTypes (by Morton)
 
 Vanilla fixes:
 - Allow AI to repair structures built from base nodes/trigger action 125/SW delivery in single player missions (by Trsdy)

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -43,6 +43,44 @@ DEFINE_HOOK(0x508CF2, HouseClass_UpdatePower_PowerOutput, 0x7)
 	return 0x508D07;
 }
 
+// Trigger power recalculation on gain/loss of any techno, not just buildings.
+DEFINE_HOOK_AGAIN(0x5025F0, HouseClass_RegisterGain, 0x5) // RegisterLoss
+DEFINE_HOOK(0x502A80, HouseClass_RegisterGain, 0x8)
+{
+	GET(HouseClass*, pThis, ECX);
+
+	pThis->RecheckPower = true;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x508D8D, HouseClass_UpdatePower_Techno, 0x6)
+{
+	GET(HouseClass*, pThis, ESI);
+
+	auto updateDrainForThisType = [pThis](const TechnoTypeClass* pType)
+	{
+			const int count = pThis->CountOwnedAndPresent(pType);
+			if (count == 0)
+				return;
+			const auto pExt = TechnoTypeExt::ExtMap.Find(pType);
+			if (pExt->Power > 0)
+				pThis->PowerOutput += pExt->Power * count;
+			else
+				pThis->PowerDrain -= pExt->Power * count;
+	};
+
+	for (const auto pType : *InfantryTypeClass::Array)
+		updateDrainForThisType(pType);
+	for (const auto pType : *UnitTypeClass::Array)
+		updateDrainForThisType(pType);
+	for (const auto pType : *AircraftTypeClass::Array)
+		updateDrainForThisType(pType);
+	// Don't do this for buildings, they've already been counted.
+
+	return 0;
+}
+
 DEFINE_HOOK(0x73E474, UnitClass_Unload_Storage, 0x6)
 {
 	GET(BuildingClass* const, pBuilding, EDI);

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -47,6 +47,9 @@ DEFINE_HOOK(0x508CF2, HouseClass_UpdatePower_PowerOutput, 0x7)
 DEFINE_HOOK_AGAIN(0x5025F0, HouseClass_RegisterGain, 0x5) // RegisterLoss
 DEFINE_HOOK(0x502A80, HouseClass_RegisterGain, 0x8)
 {
+	if (!Phobos::Config::UnitPowerDrain)
+		return 0;
+
 	GET(HouseClass*, pThis, ECX);
 
 	pThis->RecheckPower = true;
@@ -56,6 +59,9 @@ DEFINE_HOOK(0x502A80, HouseClass_RegisterGain, 0x8)
 
 DEFINE_HOOK(0x508D8D, HouseClass_UpdatePower_Techno, 0x6)
 {
+	if (!Phobos::Config::UnitPowerDrain)
+		return 0;
+
 	GET(HouseClass*, pThis, ESI);
 
 	auto updateDrainForThisType = [pThis](const TechnoTypeClass* pType)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -461,6 +461,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->KeepTargetOnMove.Read(exINI, pSection, "KeepTargetOnMove");
 	this->KeepTargetOnMove_ExtraDistance.Read(exINI, pSection, "KeepTargetOnMove.ExtraDistance");
 
+	this->Power.Read(exINI, pSection, "Power");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -834,6 +836,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->KeepTargetOnMove)
 		.Process(this->KeepTargetOnMove_ExtraDistance)
+
+		.Process(this->Power)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -233,6 +233,8 @@ public:
 		Valueable<bool> KeepTargetOnMove;
 		Valueable<Leptons> KeepTargetOnMove_ExtraDistance;
 
+		Valueable<int> Power;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -251,7 +253,6 @@ public:
 		std::vector<std::vector<CoordStruct>> EliteCrouchedWeaponBurstFLHs;
 		std::vector<std::vector<CoordStruct>> DeployedWeaponBurstFLHs;
 		std::vector<std::vector<CoordStruct>> EliteDeployedWeaponBurstFLHs;
-
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -458,6 +459,8 @@ public:
 
 			, KeepTargetOnMove { false }
 			, KeepTargetOnMove_ExtraDistance { Leptons(0) }
+
+			, Power { }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -82,6 +82,9 @@ inline int PhobosToolTip::GetPower(TechnoTypeClass* pType) const
 	case AbstractType::InfantryType:
 	case AbstractType::UnitType:
 		{
+			if (!Phobos::Config::UnitPowerDrain)
+				return 0;
+
 			const auto pExt = TechnoTypeExt::ExtMap.Find(pType);
 			return pExt->Power;
 		}

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -76,10 +76,23 @@ inline int PhobosToolTip::GetBuildTime(TechnoTypeClass* pType) const
 
 inline int PhobosToolTip::GetPower(TechnoTypeClass* pType) const
 {
-	if (auto const pBldType = abstract_cast<BuildingTypeClass*>(pType))
-		return pBldType->PowerBonus - pBldType->PowerDrain;
-
-	return 0;
+	switch (pType->WhatAmI())
+	{
+	case AbstractType::AircraftType:
+	case AbstractType::InfantryType:
+	case AbstractType::UnitType:
+		{
+			const auto pExt = TechnoTypeExt::ExtMap.Find(pType);
+			return pExt->Power;
+		}
+	case AbstractType::BuildingType:
+		{
+			auto pBldType = (BuildingTypeClass*)pType;
+			return pBldType->PowerBonus - pBldType->PowerDrain;
+		}
+	default:
+		return 0;
+	}
 }
 
 inline const wchar_t* PhobosToolTip::GetBuffer() const

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -56,6 +56,7 @@ bool Phobos::Config::ShowPowerDelta = true;
 bool Phobos::Config::ShowWeedsCounter = false;
 bool Phobos::Config::HideLightFlashEffects = true;
 bool Phobos::Config::ShowFlashOnSelecting = false;
+bool Phobos::Config::UnitPowerDrain = false;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -183,7 +184,7 @@ DEFINE_HOOK(0x52D21F, InitRules_ThingsThatShouldntBeSerailized, 0x6)
 	RulesClass::Instance->Read_JumpjetControls(pINI_RULESMD);
 
 	Phobos::Config::ArtImageSwap = pINI_RULESMD->ReadBool(GameStrings::General, "ArtImageSwap", false);
-
+	Phobos::Config::UnitPowerDrain = pINI_RULESMD->ReadBool(GameStrings::General, "UnitPowerDrain", false);
 
 	Phobos::Misc::CustomGS = pINI_RULESMD->ReadBool(GameStrings::General, "CustomGS", false);
 

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -91,6 +91,7 @@ public:
 		static bool ShowPlanningPath;
 		static bool HideLightFlashEffects;
 		static bool ShowFlashOnSelecting;
+		static bool UnitPowerDrain;
 	};
 
 	class Misc


### PR DESCRIPTION
### Power drain for units

- Infantry, vehicles and aircraft can now drain or provide `Power` if `UnitPowerDrain=true` is set.

In `rulesmd.ini`:
```ini
[General]
UnitPowerDrain=false                 ; boolean

[SOMETECHNO] ; TechnoType
Power=0                              ; integer, positive means output, negative means drain
```

![image](https://github.com/user-attachments/assets/590d5409-a948-4e0e-bb1d-41a8256ff3ed)
