### PR TITLE
[Customized] Change the scrolling action of the sidebar

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -386,6 +386,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix for sidebar not updating queued unit numbers when on hold
   - New Parabola trajectory
   - Enhanced Bombard trajectory
+  - Change the scrolling action of the sidebar and trigger hook of mouse wheel scroll
 - **Ollerus**
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -642,12 +642,14 @@ SaveGameOnScenarioStart=true ; boolean
 
 - Allow players to decide for themselves:
   - Whether can use mouse wheel to scroll sidebar strip when the mouse is not on it by `ScrollSidebarStripInTactical` .
-  - Whether can use mouse wheel to scroll sidebar strip when pressing Ctrl, Alt, or Shift by `ScrollSidebarStripWhenHoldKey`.
+  - Whether can use mouse wheel to scroll sidebar strip when pressing Ctrl by `ScrollSidebarStripWhenHoldCtrl`, Alt by `ScrollSidebarStripWhenHoldAlt`, or Shift by `ScrollSidebarStripWhenHoldShift`.
 
 In `RA2MD.ini`:
 
 ```ini
 [Phobos]
-ScrollSidebarStripInTactical=true   ; boolean
-ScrollSidebarStripWhenHoldKey=true  ; boolean
+ScrollSidebarStripInTactical=true     ; boolean
+ScrollSidebarStripWhenHoldAlt=true    ; boolean
+ScrollSidebarStripWhenHoldCtrl=true   ; boolean
+ScrollSidebarStripWhenHoldShift=true  ; boolean
 ```

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -637,3 +637,17 @@ In `RA2MD.ini`:
 [Phobos]
 SaveGameOnScenarioStart=true ; boolean
 ```
+
+### Change the scrolling action of the sidebar
+
+- Allow players to decide for themselves:
+  - Whether can use mouse wheel to scroll sidebar strip when the mouse is not on it by `ScrollSidebarStripInTactical` .
+  - Whether can use mouse wheel to scroll sidebar strip when pressing Ctrl, Alt, or Shift by `ScrollSidebarStripWhenHoldKey`.
+
+In `RA2MD.ini`:
+
+```ini
+[Phobos]
+ScrollSidebarStripInTactical=true   ; boolean
+ScrollSidebarStripWhenHoldKey=true  ; boolean
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -324,6 +324,7 @@ New:
 - Raise alert when technos are taking damage (by TaranDahl)
 - Enhanced Bombard trajectory (by CrimRecya & Ollerus, based on knowledge of NaotoYuuki)
 - Toggle waypoint for building (by TaranDahl)
+- Change the scrolling action of the sidebar and trigger hook of mouse wheel scroll (by CrimRecya)
 
 Vanilla fixes:
 - Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft is ordered to move onto water surface and instead the movement order changes to a shore nearby (by CrimRecya)

--- a/src/Commands/Commands.cpp
+++ b/src/Commands/Commands.cpp
@@ -69,25 +69,16 @@ DEFINE_HOOK(0x777998, Game_WndProc_ScrollMouseWheel, 0x6)
 	return 0;
 }
 
+static inline bool CheckSkipScrollSidebar()
+{
+	return !Phobos::Config::ScrollSidebarStripWhenHoldAlt && InputManagerClass::Instance->IsForceMoveKeyPressed()
+		|| !Phobos::Config::ScrollSidebarStripWhenHoldCtrl && InputManagerClass::Instance->IsForceFireKeyPressed()
+		|| !Phobos::Config::ScrollSidebarStripWhenHoldShift && InputManagerClass::Instance->IsForceSelectKeyPressed()
+		|| !Phobos::Config::ScrollSidebarStripInTactical && WWMouseClass::Instance->XY1.X < Make_Global<int>(0xB0CE30); // TacticalClass::view_bound.Width
+}
+
 DEFINE_HOOK(0x533F50, Game_ScrollSidebar_Skip, 0x5)
 {
 	enum { SkipScrollSidebar = 0x533FC3 };
-
-	if (!Phobos::Config::ScrollSidebarStripWhenHoldKey)
-	{
-		const auto pInput = InputManagerClass::Instance();
-
-		if (pInput->IsForceFireKeyPressed() || pInput->IsForceMoveKeyPressed() || pInput->IsForceSelectKeyPressed())
-			return SkipScrollSidebar;
-	}
-
-	if (!Phobos::Config::ScrollSidebarStripInTactical)
-	{
-		const auto pMouse = WWMouseClass::Instance();
-
-		if (pMouse->XY1.X < Make_Global<int>(0xB0CE30)) // TacticalClass::view_bound.Width
-			return SkipScrollSidebar;
-	}
-
-	return 0;
+	return CheckSkipScrollSidebar() ? SkipScrollSidebar : 0;
 }

--- a/src/Commands/Commands.cpp
+++ b/src/Commands/Commands.cpp
@@ -1,4 +1,3 @@
-#include <CCINIClass.h>
 #include "Commands.h"
 
 #include "ObjectInfo.h"
@@ -10,6 +9,13 @@
 #include "ToggleDigitalDisplay.h"
 #include "ToggleDesignatorRange.h"
 #include "SaveVariablesToFile.h"
+
+#include <CCINIClass.h>
+#include <InputManagerClass.h>
+#include <MouseClass.h>
+#include <WWMouseClass.h>
+
+#include <Utilities/Macro.h>
 
 DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 {
@@ -32,6 +38,55 @@ DEFINE_HOOK(0x533066, CommandClassCallback_Register, 0x6)
 		MakeCommand<FrameStepCommandClass<15>>(); // Speed 3
 		MakeCommand<FrameStepCommandClass<30>>(); // Speed 4
 		MakeCommand<FrameStepCommandClass<60>>(); // Speed 5
+	}
+
+	return 0;
+}
+
+static void MouseWheelDownCommand()
+{
+//	Debug::LogAndMessage("[Frame: %d] Mouse Wheel Down", Unsorted::CurrentFrame());
+
+//	SomeCommand->Execute(WWKey);
+}
+
+static void MouseWheelUpCommand()
+{
+//	Debug::LogAndMessage("[Frame: %d] Mouse Wheel Up", Unsorted::CurrentFrame());
+
+//	SomeCommand->Execute(WWKey);
+}
+
+DEFINE_HOOK(0x777998, Game_WndProc_ScrollMouseWheel, 0x6)
+{
+	GET(const WPARAM, WParam, ECX);
+
+	if (WParam & 0x80000000u)
+		MouseWheelDownCommand();
+	else
+		MouseWheelUpCommand();
+
+	return 0;
+}
+
+DEFINE_HOOK(0x533F50, Game_ScrollSidebar_Skip, 0x5)
+{
+	enum { SkipScrollSidebar = 0x533FC3 };
+
+	if (!Phobos::Config::ScrollSidebarStripWhenHoldKey)
+	{
+		const auto pInput = InputManagerClass::Instance();
+
+		if (pInput->IsForceFireKeyPressed() || pInput->IsForceMoveKeyPressed() || pInput->IsForceSelectKeyPressed())
+			return SkipScrollSidebar;
+	}
+
+	if (!Phobos::Config::ScrollSidebarStripInTactical)
+	{
+		const auto pMouse = WWMouseClass::Instance();
+
+		if (pMouse->XY1.X < Make_Global<int>(0xB0CE30)) // TacticalClass::view_bound.Width
+			return SkipScrollSidebar;
 	}
 
 	return 0;

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -58,7 +58,9 @@ bool Phobos::Config::HideLightFlashEffects = true;
 bool Phobos::Config::ShowFlashOnSelecting = false;
 bool Phobos::Config::UnitPowerDrain = false;
 bool Phobos::Config::ScrollSidebarStripInTactical = true;
-bool Phobos::Config::ScrollSidebarStripWhenHoldKey = true;
+bool Phobos::Config::ScrollSidebarStripWhenHoldAlt = true;
+bool Phobos::Config::ScrollSidebarStripWhenHoldCtrl = true;
+bool Phobos::Config::ScrollSidebarStripWhenHoldShift = true;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -82,7 +84,9 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::HideLightFlashEffects = CCINIClass::INI_RA2MD->ReadBool("Phobos", "HideLightFlashEffects", false);
 	Phobos::Config::ShowFlashOnSelecting = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowFlashOnSelecting", false);
 	Phobos::Config::ScrollSidebarStripInTactical = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ScrollSidebarStripInTactical", true);
-	Phobos::Config::ScrollSidebarStripWhenHoldKey = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ScrollSidebarStripWhenHoldKey", true);
+	Phobos::Config::ScrollSidebarStripWhenHoldAlt = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ScrollSidebarStripWhenHoldAlt", true);
+	Phobos::Config::ScrollSidebarStripWhenHoldCtrl = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ScrollSidebarStripWhenHoldCtrl", true);
+	Phobos::Config::ScrollSidebarStripWhenHoldShift = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ScrollSidebarStripWhenHoldShift", true);
 
 	// Custom game speeds, 6 - i so that GS6 is index 0, just like in the engine
 	Phobos::Config::CampaignDefaultGameSpeed = 6 - CCINIClass::INI_RA2MD->ReadInteger("Phobos", "CampaignDefaultGameSpeed", 4);

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -57,6 +57,8 @@ bool Phobos::Config::ShowWeedsCounter = false;
 bool Phobos::Config::HideLightFlashEffects = true;
 bool Phobos::Config::ShowFlashOnSelecting = false;
 bool Phobos::Config::UnitPowerDrain = false;
+bool Phobos::Config::ScrollSidebarStripInTactical = true;
+bool Phobos::Config::ScrollSidebarStripWhenHoldKey = true;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -79,6 +81,8 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::ShowWeedsCounter = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowWeedsCounter", true);
 	Phobos::Config::HideLightFlashEffects = CCINIClass::INI_RA2MD->ReadBool("Phobos", "HideLightFlashEffects", false);
 	Phobos::Config::ShowFlashOnSelecting = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ShowFlashOnSelecting", false);
+	Phobos::Config::ScrollSidebarStripInTactical = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ScrollSidebarStripInTactical", true);
+	Phobos::Config::ScrollSidebarStripWhenHoldKey = CCINIClass::INI_RA2MD->ReadBool("Phobos", "ScrollSidebarStripWhenHoldKey", true);
 
 	// Custom game speeds, 6 - i so that GS6 is index 0, just like in the engine
 	Phobos::Config::CampaignDefaultGameSpeed = 6 - CCINIClass::INI_RA2MD->ReadInteger("Phobos", "CampaignDefaultGameSpeed", 4);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -93,7 +93,9 @@ public:
 		static bool ShowFlashOnSelecting;
 		static bool UnitPowerDrain;
 		static bool ScrollSidebarStripInTactical;
-		static bool ScrollSidebarStripWhenHoldKey;
+		static bool ScrollSidebarStripWhenHoldAlt;
+		static bool ScrollSidebarStripWhenHoldCtrl;
+		static bool ScrollSidebarStripWhenHoldShift;
 	};
 
 	class Misc

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -92,6 +92,8 @@ public:
 		static bool HideLightFlashEffects;
 		static bool ShowFlashOnSelecting;
 		static bool UnitPowerDrain;
+		static bool ScrollSidebarStripInTactical;
+		static bool ScrollSidebarStripWhenHoldKey;
 	};
 
 	class Misc


### PR DESCRIPTION
- Allow players to decide for themselves:
  - Whether can use mouse wheel to scroll sidebar strip when the mouse is not on it by `ScrollSidebarStripInTactical` .
  - Whether can use mouse wheel to scroll sidebar strip when pressing Ctrl by `ScrollSidebarStripWhenHoldCtrl`, Alt by `ScrollSidebarStripWhenHoldAlt`, or Shift by `ScrollSidebarStripWhenHoldShift`.

In `RA2MD.ini`:

```ini
[Phobos]
ScrollSidebarStripInTactical=true     ; boolean
ScrollSidebarStripWhenHoldAlt=true    ; boolean
ScrollSidebarStripWhenHoldCtrl=true   ; boolean
ScrollSidebarStripWhenHoldShift=true  ; boolean
```

I also prepared a trigger hook to catch the state when mouse wheel scrolling.