### PR TITLE
[Minor] Make quick save happens after main loop

### DIFF
--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -5,6 +5,7 @@
 #include <SessionClass.h>
 #include <MessageListClass.h>
 #include <HouseClass.h>
+#include <EventClass.h>
 
 #include <Utilities/Parser.h>
 #include <Utilities/GeneralUtils.h>
@@ -267,7 +268,8 @@ DEFINE_HOOK(0x55DBCD, MainLoop_SaveGame, 0x6)
 		scenario_saved = true;
 		if (Phobos::ShouldQuickSave)
 		{
-			Phobos::PassiveSaveGame();
+			// Phobos::PassiveSaveGame();
+			EventClass::AddEvent(EventClass(HouseClass::CurrentPlayer->ArrayIndex, EventType::SaveGame));
 			Phobos::ShouldQuickSave = false;
 			Phobos::CustomGameSaveDescription.clear();
 		}


### PR DESCRIPTION
According to what ZivDero told me, saving game inside the main loop may cause corruption. So we need to move it out of the main loop.
This needs to be used together with the unmerged yrpp-spawner feature to work properly.
It needs to be discussed about how we should interact with spawner. Maybe a flag like `CanUseSpawner` or sth alike.
Open a draft PR to keep this in mind.