### PR TITLE
Fix inconsistencies with Strafing.Shots logic

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1943,6 +1943,7 @@ FeedbackWeapon=  ; WeaponType
   - `Strafing.Shots` controls the number of times the weapon is fired during a single strafe run, defaults to 5 if not set. `Ammo` is only deducted at the end of the strafe run, regardless of the number of shots fired.
   - `Strafing.SimulateBurst` controls whether or not the shots fired during strafing simulate behavior of `Burst`, allowing for alternating firing offset. Only takes effect if weapon has `Burst` set to 1 or undefined.
   - `Strafing.UseAmmoPerShot`, if set to `true` overrides the usual behaviour of only deducting ammo after a strafing run and instead doing it after each individual shot.
+  - `Strafing.EndDelay` can be used to override the delay after firing last shot in strafing run before aircraft resumes another strafing run or returns to base. Defaults to (Weapon `Range` * 256 + 1024) / Aircraft `Speed`. Note that using a short delay with aircraft that can do multiple strafing runs with their ammo can cause undesired behaviour.
 - There is a special case for aircraft spawned by `Type=SpyPlane` superweapons on `SpyPlane Approach` or `SpyPlane Overfly` mission where `Strafing.Shots` only if explicitly set on its primary weapon, determines the maximum number of times the map revealing effect can activate irregardless of other factors.
 
 In `rulesmd.ini`:
@@ -1952,6 +1953,7 @@ Strafing=                      ; boolean
 Strafing.Shots=                ; integer
 Strafing.SimulateBurst=false   ; boolean
 Strafing.UseAmmoPerShot=false  ; boolean
+Strafing.EndDelay=             ; integer, game frames
 ```
 
 ### Weapon targeting filter

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -21,6 +21,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 #### From post-0.3 devbuilds
 
+- Aircraft with weapons that have `Strafing.Shots` < 5 will now keep flying after last shot like those with `Strafing.Shots` >= 5 do. This delay can now be customized explicitly by setting `Strafing.EndDelay` on the weapon.
 - Selecting weapons other than primary against walls based on `Wall=true` on Warhead etc. now requires `[CombatDamage]`->`AllowWeaponSelectAgainstWalls` to be set to true first.
 - Lunar theater tileset parsing unhardcoding is now only applied if `lunarmd.ini` has `[General]` -> `ApplyLunarFixes` set to true.
 - `Units.DisableRepairCost` was changed to `Units.UseRepairCost` (note inverted expected value) as it no longer has discrete default value and affects `Hospital=true` buildings, infantry do not have repair cost by default.

--- a/src/Ext/Aircraft/Body.cpp
+++ b/src/Ext/Aircraft/Body.cpp
@@ -8,16 +8,15 @@
 
 // TODO: Implement proper extended AircraftClass.
 
-void AircraftExt::FireWeapon(AircraftClass* pThis, AbstractClass* pTarget, int shotNumber = 0)
+void AircraftExt::FireWeapon(AircraftClass* pThis, AbstractClass* pTarget)
 {
-	if (!pTarget)
-		return;
-
 	auto weaponIndex = TechnoExt::ExtMap.Find(pThis)->CurrentAircraftWeaponIndex;
 
 	if (weaponIndex < 0)
 		weaponIndex = pThis->SelectWeapon(pTarget);
 
+	bool isStrafe = pThis->Is_Strafe();
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
 	auto const pWeapon = pThis->GetWeapon(weaponIndex)->WeaponType;
 	auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
 
@@ -25,15 +24,29 @@ void AircraftExt::FireWeapon(AircraftClass* pThis, AbstractClass* pTarget, int s
 	{
 		for (int i = 0; i < pWeapon->Burst; i++)
 		{
-			if (pWeapon->Burst < 2 && pWeaponExt->Strafing_SimulateBurst)
-				pThis->CurrentBurstIndex = shotNumber;
+			if (isStrafe && pWeapon->Burst < 2 && pWeaponExt->Strafing_SimulateBurst)
+				pThis->CurrentBurstIndex = pExt->Strafe_BombsDroppedThisRound % 2 == 0;
 
 			pThis->Fire(pTarget, weaponIndex);
 		}
-	}
 
-	if (pThis->Is_Strafe())
-		TechnoExt::ExtMap.Find(pThis)->Strafe_BombsDroppedThisRound++;
+		if (isStrafe)
+		{
+			pExt->Strafe_BombsDroppedThisRound++;
+
+			if (pWeaponExt->Strafing_UseAmmoPerShot)
+			{
+				pThis->Ammo--;
+				pThis->ShouldLoseAmmo = false;
+
+				if (!pThis->Ammo)
+				{
+					pThis->SetTarget(nullptr);
+					pThis->SetDestination(nullptr, true);
+				}
+			}
+		}
+	}
 }
 
 // Spy plane, airstrike etc.

--- a/src/Ext/Aircraft/Body.h
+++ b/src/Ext/Aircraft/Body.h
@@ -6,7 +6,7 @@
 class AircraftExt
 {
 public:
-	static void FireWeapon(AircraftClass* pThis, AbstractClass* pTarget, int shotNumber);
+	static void FireWeapon(AircraftClass* pThis, AbstractClass* pTarget);
 	static bool PlaceReinforcementAircraft(AircraftClass* pThis, CellStruct edgeCell);
 	static DirType GetLandingDir(AircraftClass* pThis, BuildingClass* pDock = nullptr);
 };

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -87,6 +87,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Strafing_Shots.Read(exINI, pSection, "Strafing.Shots");
 	this->Strafing_SimulateBurst.Read(exINI, pSection, "Strafing.SimulateBurst");
 	this->Strafing_UseAmmoPerShot.Read(exINI, pSection, "Strafing.UseAmmoPerShot");
+	this->Strafing_EndDelay.Read(exINI, pSection, "Strafing.EndDelay");
 	this->CanTarget.Read(exINI, pSection, "CanTarget");
 	this->CanTargetHouses.Read(exINI, pSection, "CanTargetHouses");
 	this->Burst_Delays.Read(exINI, pSection, "Burst.Delays");
@@ -131,6 +132,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Strafing_Shots)
 		.Process(this->Strafing_SimulateBurst)
 		.Process(this->Strafing_UseAmmoPerShot)
+		.Process(this->Strafing_EndDelay)
 		.Process(this->CanTarget)
 		.Process(this->CanTargetHouses)
 		.Process(this->RadType)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -32,6 +32,7 @@ public:
 		Nullable<int> Strafing_Shots;
 		Valueable<bool> Strafing_SimulateBurst;
 		Valueable<bool> Strafing_UseAmmoPerShot;
+		Nullable<int> Strafing_EndDelay;
 		Valueable<AffectedTarget> CanTarget;
 		Valueable<AffectedHouse> CanTargetHouses;
 		ValueableVector<int> Burst_Delays;
@@ -73,6 +74,7 @@ public:
 			, Strafing_Shots {}
 			, Strafing_SimulateBurst { false }
 			, Strafing_UseAmmoPerShot { false }
+			, Strafing_EndDelay {}
 			, CanTarget { AffectedTarget::All }
 			, CanTargetHouses { AffectedHouse::All }
 			, Burst_Delays {}


### PR DESCRIPTION
- Fixes an issue where last shot of strafing aircraft weapon with `Strafing.Shots` < 5 or if interrupted by ammo running out if `Strafing.UseAmmoPerShot=true` would not be followed by a similar delay before resuming strafing run or returning to base as there would otherwise be. The delay is also now explicitly customizable although I urge caution in using it in certain cases.

---------------------------------

- `Strafing.EndDelay` can be used to override the delay after firing last shot in strafing run before aircraft resumes another strafing run or returns to base. Defaults to (Weapon `Range` * 256 + 1024) / Aircraft `Speed`. Note that using a short delay with aircraft that can do multiple strafing runs with their ammo can cause undesired behaviour.
 
In `rulesmd.ini`:
```ini
[SOMEWEAPON]         ; WeaponType
Strafing.EndDelay=   ; integer, game frames
```