### PR TITLE
Fix Pathfinding Bugs by Decoupling SpeedType from Hardcoded Values

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -351,6 +351,9 @@ This page lists all the individual contributions to the project by their author.
    - Tunnel/Walk/Mech locomotor being stuck when moving too fast bugfix
    - Assign Super Weapon cameo to any sidebar tab
    - Fix impassable invisible barrier created by chronosphere on uncrushable unit.
+   - 修复初始船只可能生成在陆地上的bug.
+   - 解除FreeUnit生成寻路的Wheel_SpeedType硬编码.
+   - 建筑反部署时使用目标载具的寻路方式.
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
    - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -350,10 +350,10 @@ This page lists all the individual contributions to the project by their author.
    - Disguised units not using the correct palette if target has custom palette bugfix
    - Tunnel/Walk/Mech locomotor being stuck when moving too fast bugfix
    - Assign Super Weapon cameo to any sidebar tab
-   - Fix impassable invisible barrier created by chronosphere on uncrushable unit.
-   - 修复初始船只可能生成在陆地上的bug.
-   - 解除FreeUnit生成寻路的Wheel_SpeedType硬编码.
-   - 建筑反部署时使用目标载具的寻路方式.
+   - Fix impassable invisible barrier created by chronosphere on uncrushable unit
+   - `FreeUnit` uses the unit's own `SpeedType` to find the spawn location
+   - The bug where naval ships as StartUnit might spawn on land has been fixed
+   - Fix the pathfinding issue when a building performs undeploy
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
    - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -188,9 +188,9 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Prevent the units with locomotors that cause problems from entering the tank bunker.
 - Fix an issue where a unit will leave an impassable invisible barrier in its original position when it is teleported by ChronoSphere onto an uncrushable unit and self destruct.
 - Fix the bug that destroyed unit may leaves sensors.
-- 修复初始船只可能生成在陆地上的bug.
-- 解除FreeUnit生成寻路的Wheel_SpeedType硬编码.
-- 建筑反部署时使用目标载具的寻路方式.
+- `FreeUnit` uses the unit's own `SpeedType` to find the spawn location.
+- The bug where naval ships as StartUnit might spawn on land has been fixed.
+- When a building undeploy, it will normally use the target VehicleType's pathfinding method to decide whether it can move to the target cell.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -188,6 +188,9 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Prevent the units with locomotors that cause problems from entering the tank bunker.
 - Fix an issue where a unit will leave an impassable invisible barrier in its original position when it is teleported by ChronoSphere onto an uncrushable unit and self destruct.
 - Fix the bug that destroyed unit may leaves sensors.
+- 修复初始船只可能生成在陆地上的bug.
+- 解除FreeUnit生成寻路的Wheel_SpeedType硬编码.
+- 建筑反部署时使用目标载具的寻路方式.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -593,9 +593,9 @@ Vanilla fixes:
 - Fix the bug that parasite will vanish if it missed its target when its previous cell is occupied (by 航味麻酱)
 - Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft is ordered to move onto water surface and instead the movement order changes to a shore nearby (by CrimRecya)
 - Fix the bug that destroyed unit may leaves sensors (by tyuah8 & NetsuNegi)
-- 修复初始船只可能生成在陆地上的bug (by NetsuNegi)
-- 解除FreeUnit生成寻路的Wheel_SpeedType硬编码 (by NetsuNegi)
-- 建筑反部署时使用目标载具的寻路方式 (by NetsuNegi)
+- `FreeUnit` uses the unit's own `SpeedType` to find the spawn location (by NetsuNegi)
+- The bug where naval ships as `StartUnit` might spawn on land has been fixed (by NetsuNegi)
+- Fix the pathfinding issue when a building performs undeploy (by NetsuNegi)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -593,6 +593,9 @@ Vanilla fixes:
 - Fix the bug that parasite will vanish if it missed its target when its previous cell is occupied (by 航味麻酱)
 - Aircraft will now behave as expected according to it's `MovementZone` and `SpeedType` when moving onto different surfaces. In particular, this fixes erratic behavior when vanilla aircraft is ordered to move onto water surface and instead the movement order changes to a shore nearby (by CrimRecya)
 - Fix the bug that destroyed unit may leaves sensors (by tyuah8 & NetsuNegi)
+- 修复初始船只可能生成在陆地上的bug (by NetsuNegi)
+- 解除FreeUnit生成寻路的Wheel_SpeedType硬编码 (by NetsuNegi)
+- 建筑反部署时使用目标载具的寻路方式 (by NetsuNegi)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1387,8 +1387,17 @@ msgstr "自定义超级武器所在栏"
 #: ../../../CREDITS.md:354
 msgid ""
 "Fix impassable invisible barrier created by chronosphere on uncrushable "
-"unit."
-msgstr "超时空传送超武在不可碾压单位上创建空气墙问题的修复"
+"unit"
+msgstr "修复了超时空传送超武将单位传送到一个不可碾压目标上并摧毁时在原位置创建空气墙的问题"
+
+msgid "`FreeUnit` uses the unit's own `SpeedType` to find the spawn location"
+msgstr "`FreeUnit` 使用单位自己的 `SpeedType` 来寻找生成位置"
+
+msgid "The bug where naval ships as StartUnit might spawn on land has been fixed"
+msgstr "修复初始船只可能生成在陆地上的 Bug"
+
+msgid "Fix the pathfinding issue when a building performs undeploy"
+msgstr "修复建筑执行 `UndeploysInto` 时的寻路问题"
 
 #: ../../../CREDITS.md:355
 msgid "**Apollo** - Translucent SHP drawing patches"

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1150,6 +1150,18 @@ msgid ""
 "uncrushable unit and self destruct."
 msgstr "修复了一个单位被超时空传送超武传送到一个不可碾压的单位上并自爆时会在原地留下空气墙的问题。"
 
+#: ../../Fixed-or-Improved-Logics.md:191
+msgid "`FreeUnit` uses the unit's own `SpeedType` to find the spawn location."
+msgstr "`FreeUnit` 使用单位自己的 `SpeedType` 来寻找生成位置。"
+
+#: ../../Fixed-or-Improved-Logics.md:192
+msgid "The bug where naval ships as StartUnit might spawn on land has been fixed."
+msgstr "修复初始船只可能生成在陆地上的 Bug。"
+
+#: ../../Fixed-or-Improved-Logics.md:193
+msgid "When a building undeploy, it will normally use the target VehicleType's pathfinding method to decide whether it can move to the target cell."
+msgstr "建筑反部署时使用目标载具的寻路方式来决定能否向目标单元格移动。"
+
 #: ../../Fixed-or-Improved-Logics.md:190
 msgid "Fix the bug that destroyed unit may leaves sensors."
 msgstr "修复了单位被摧毁仍会遗留反隐形探测效果的问题。"

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1315,3 +1315,78 @@ DEFINE_HOOK(0x54D06F, JumpjetLocomotionClass_ProcessCrashing_RemoveSensors, 0x5)
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x688F8C, ScenarioClass_ScanPlaceUnit_CheckMovement, 0x5)
+{
+	enum { NotUsableArea = 0x688FB9 };
+
+	GET(TechnoClass*, pTechno, EBX);
+	LEA_STACK(CoordStruct*, pCoords, STACK_OFFSET(0x6C, -0x30));
+
+	if (pTechno->WhatAmI() == BuildingClass::AbsID)
+		return 0;
+
+	const auto pCell = MapClass::Instance->GetCellAt(*pCoords);
+	const auto pTechnoType = pTechno->GetTechnoType();
+
+	return pCell->IsClearToMove(pTechnoType->SpeedType, false, false, -1, pTechnoType->MovementZone, -1, 1) ? 0 : NotUsableArea;
+}
+
+DEFINE_HOOK(0x68927B, ScenarioClass_ScanPlaceUnit_CheckMovement2, 0x5)
+{
+	enum { NotUsableArea = 0x689295 };
+
+	GET(TechnoClass*, pTechno, EDI);
+	LEA_STACK(CoordStruct*, pCoords, STACK_OFFSET(0x6C, -0xC));
+
+	if (pTechno->WhatAmI() == BuildingClass::AbsID)
+		return 0;
+
+	const auto pCell = MapClass::Instance->GetCellAt(*pCoords);
+	const auto pTechnoType = pTechno->GetTechnoType();
+
+	return pCell->IsClearToMove(pTechnoType->SpeedType, false, false, -1, pTechnoType->MovementZone, -1, 1) ? 0 : NotUsableArea;
+}
+
+DEFINE_HOOK(0x446BF4, BuildingClass_Place_FreeUnit_NearByLocation, 0x6)
+{
+	enum { SkipGameCode = 0x446CD2 };
+
+	GET(BuildingClass*, pThis, EBP);
+	GET(UnitClass*, pFreeUnit, EDI);
+	LEA_STACK(CellStruct*, outBuffer, STACK_OFFSET(0x68, -0x4C));
+	const auto mapCoords = CellClass::Coord2Cell(pThis->Location);
+	const auto movementZone = pFreeUnit->Type->MovementZone;
+	const auto currentZone = MapClass::Instance->GetMovementZoneType(mapCoords, movementZone, false);
+
+	R->EAX(MapClass::Instance->NearByLocation(*outBuffer, mapCoords, pFreeUnit->Type->SpeedType, currentZone, movementZone, false, 1, 1, true, true, false, false, CellStruct::Empty, false, false));
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x446D42, BuildingClass_Place_FreeUnit_NearByLocation2, 0x6)
+{
+	enum { SkipGameCode = 0x446E15 };
+
+	GET(BuildingClass*, pThis, EBP);
+	GET(UnitClass*, pFreeUnit, EDI);
+	LEA_STACK(CellStruct*, outBuffer, STACK_OFFSET(0x68, -0x4C));
+	const auto mapCoords = CellClass::Coord2Cell(pThis->Location);
+	const auto movementZone = pFreeUnit->Type->MovementZone;
+	const auto currentZone = MapClass::Instance->GetMovementZoneType(mapCoords, movementZone, false);
+
+	R->EAX(MapClass::Instance->NearByLocation(*outBuffer, mapCoords, pFreeUnit->Type->SpeedType, currentZone, movementZone, false, 1, 1, false, true, false, false, CellStruct::Empty, false, false));
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x449462, BuildingClass_IsCellOccupied_UndeploysInto, 0x6)
+{
+	enum { SkipGameCode = 0x449487 };
+
+	GET(BuildingTypeClass*, pType, EAX);
+	LEA_STACK(CellStruct*, pDest, 0x4);
+	const auto pCell = MapClass::Instance->GetCellAt(*pDest);
+	const auto pUndeploysInto = pType->UndeploysInto;
+
+	R->AL(pCell->IsClearToMove(pUndeploysInto->SpeedType, false, false, -1, pUndeploysInto->MovementZone, -1, 1));
+	return SkipGameCode;
+}


### PR DESCRIPTION
`FreeUnit` uses the unit's own `SpeedType` to find the spawn location.
The bug where naval ships as StartUnit might spawn on land has been fixed.
When a building undeploy, it will normally use the target VehicleType's pathfinding method to decide whether it can move to the target cell.