### PR TITLE
[Minor] Fix incorrect interaction between techno convertion and chrono weapon

### DIFF
--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -316,7 +316,7 @@ bool TechnoExt::ConvertToType(FootClass* pThis, TechnoTypeClass* pToType)
 	// Detach CLEG targeting
 	auto tempUsing = pThis->TemporalImUsing;
 	if (tempUsing && tempUsing->Target)
-		tempUsing->Detach();
+		tempUsing->LetGo();
 
 	HouseClass* const pOwner = pThis->Owner;
 

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -38,6 +38,11 @@ ObjectClass* __fastcall CreateInitialPayload(TechnoTypeClass* type, void*, House
 	return instance;
 }
 
+void __fastcall LetGo(TemporalClass* pTemporal)
+{
+	pTemporal->LetGo();
+}
+
 void Apply_Ares3_0_Patches()
 {
 	// Abductor fix:
@@ -53,6 +58,9 @@ void Apply_Ares3_0_Patches()
 
 	// InitialPayload creation:
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x43D5D, &CreateInitialPayload);
+	
+	// Replace the TemporalClass::Detach call by LetGo in convert function:
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x436DA, &LetGo);
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -72,4 +80,7 @@ void Apply_Ares3_0p1_Patches()
 
 	// InitialPayload creation:
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x4483D, &CreateInitialPayload);
+	
+	// Replace the TemporalClass::Detach call by LetGo in convert function:
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x441BA, &LetGo);
 }


### PR DESCRIPTION
AFAIK, `Detach()` is only called inside `TemporalClass`. All external calls use `LetGo` (for most cases) or `JustLetGo` (when used for DestroyAll).