### PR TITLE
Optimize per-frame update logic

### DIFF
--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -21,9 +21,7 @@ DEFINE_HOOK(0x43FE69, BuildingClass_AI, 0xA)
 	auto const pExt = BuildingExt::ExtMap.Find(pThis);
 	pExt->DisplayIncomeString();
 	pExt->ApplyPoweredKillSpawns();
-
-	auto const pTechnoExt = TechnoExt::ExtMap.Find(pThis);
-	pTechnoExt->UpdateGattlingRateDownReset();
+	pExt->TechnoExtData->UpdateGattlingRateDownReset();
 
 	return 0;
 }

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -13,24 +13,17 @@
 
 #pragma region Update
 
-//After TechnoClass_AI?
+// After TechnoClass_AI
 DEFINE_HOOK(0x43FE69, BuildingClass_AI, 0xA)
 {
 	GET(BuildingClass*, pThis, ESI);
 
-	// Do not search this up again in any functions called here because it is costly for performance - Starkku
-	auto pExt = BuildingExt::ExtMap.Find(pThis);
-
-	/*
-	// Set only if unset or type has changed - Not currently useful as building type does not change.
-	auto pType = pThis->Type;
-
-	if (!pExt->TypeExtData || pExt->TypeExtData->OwnerObject() != pType)
-		pExt->TypeExtData = BuildingTypeExt::ExtMap.Find(pType);
-	*/
-
+	auto const pExt = BuildingExt::ExtMap.Find(pThis);
 	pExt->DisplayIncomeString();
 	pExt->ApplyPoweredKillSpawns();
+
+	auto const pTechnoExt = TechnoExt::ExtMap.Find(pThis);
+	pTechnoExt->UpdateGattlingRateDownReset();
 
 	return 0;
 }

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -17,14 +17,12 @@
 // It's not recommended to do anything more here it could have a better place for performance consideration
 void TechnoExt::ExtData::OnEarlyUpdate()
 {
-	auto pType = this->TypeExtData->OwnerObject();
+	auto pType = this->OwnerObject()->GetTechnoType();
 
 	// Set only if unset or type is changed
 	// Notice that Ares may handle type conversion in the same hook here, which is executed right before this one thankfully
-	if (!this->TypeExtData || this->OwnerObject()->GetTechnoType() != pType)
+	if (!this->TypeExtData || this->TypeExtData->OwnerObject() != pType)
 		this->UpdateTypeData(pType);
-	else if (this->PreviousType)
-		this->PreviousType = nullptr;
 
 	if (this->CheckDeathConditions())
 		return;
@@ -412,11 +410,11 @@ void TechnoExt::ExtData::ApplySpawnLimitRange()
 	}
 }
 
-void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pOldType)
+void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 {
 	auto const pThis = this->OwnerObject();
+	auto const pOldType = this->TypeExtData->OwnerObject();
 	auto const pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOldType);
-	auto const pCurrentType = pThis->GetTechnoType();
 	this->PreviousType = pOldType;
 	this->TypeExtData = TechnoTypeExt::ExtMap.Find(pCurrentType);
 
@@ -452,11 +450,12 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pOldType)
 	}
 }
 
-void TechnoExt::ExtData::UpdateTypeData_Foot(TechnoTypeClass* pOldType)
+void TechnoExt::ExtData::UpdateTypeData_Foot()
 {
 	auto const pThis = static_cast<FootClass*>(this->OwnerObject());
+	auto const pOldType = this->PreviousType;
+	auto const pCurrentType = this->TypeExtData->OwnerObject();
 	//auto const pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOldType);
-	auto const pCurrentType = pThis->GetTechnoType();
 
 	// Recreate Laser Trails
 	if (this->LaserTrails.size())
@@ -544,6 +543,8 @@ void TechnoExt::ExtData::UpdateTypeData_Foot(TechnoTypeClass* pOldType)
 			pPassenger = abstract_cast<FootClass*>(pPassenger->NextObject);
 		}
 	}
+
+	this->PreviousType = nullptr;
 }
 
 void TechnoExt::ExtData::UpdateLaserTrails()

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -478,7 +478,7 @@ void TechnoExt::ExtData::UpdateTypeData_Foot()
 			if (auto const count = pCurrentType->MoveSound.Count)
 			{
 				// Play a new sound.
-				int soundIndex = pCurrentType->MoveSound[Randomizer::Global->Random() % count];
+				int soundIndex = pCurrentType->MoveSound[Randomizer::Global.Random() % count];
 				VocClass::PlayAt(soundIndex, pThis->Location, &pThis->MoveSoundAudioController);
 				pThis->IsMoveSoundPlaying = true;
 			}
@@ -538,7 +538,7 @@ void TechnoExt::ExtData::UpdateTypeData_Foot()
 
 				// OpenTopped adds passengers to logic layer when enabled. Under normal conditions this does not need to be removed since
 				// OpenTopped state does not change while passengers are still in transport but in case of type conversion that can happen.
-				LogicClass::Instance->RemoveObject(pPassenger);
+				LogicClass::Instance.RemoveObject(pPassenger);
 			}
 
 			pPassenger = abstract_cast<FootClass*>(pPassenger->NextObject);

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -23,29 +23,20 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 	// Notice that Ares may handle type conversion in the same hook here, which is executed right before this one thankfully
 	if (!this->TypeExtData || this->TypeExtData->OwnerObject() != pType)
 		this->UpdateTypeData(pType);
-
-	// Update tunnel state on exit, TechnoClass::AI is only called when not in tunnel.
-	if (this->IsInTunnel)
-	{
-		this->IsInTunnel = false;
-
-		if (const auto pShieldData = this->Shield.get())
-			pShieldData->SetAnimationVisibility(true);
-	}
+	else if (this->PreviousType)
+		this->PreviousType = nullptr;
 
 	if (this->CheckDeathConditions())
 		return;
 
+	this->UpdateShield();
+	this->UpdateAttachEffects();
 	this->ApplyInterceptor();
 	this->EatPassengers();
-	this->UpdateShield();
 	this->ApplySpawnLimitRange();
-	this->UpdateLaserTrails();
-	this->DepletedAmmoActions();
-	this->UpdateAttachEffects();
+	this->ApplyMindControlRangeLimit();
 	this->UpdateRecountBurst();
 	this->UpdateRearmInEMPState();
-	this->UpdateGattlingRateDownReset();
 }
 
 void TechnoExt::ExtData::ApplyInterceptor()
@@ -107,11 +98,11 @@ void TechnoExt::ExtData::ApplyInterceptor()
 void TechnoExt::ExtData::DepletedAmmoActions()
 {
 	auto const pThis = specific_cast<UnitClass*>(this->OwnerObject());
-	if (!pThis || (pThis->Type->Ammo <= 0) || !pThis->Type->IsSimpleDeployer)
+
+	if (pThis->Type->Ammo <= 0 || !pThis->Type->IsSimpleDeployer)
 		return;
 
 	auto const pTypeExt = this->TypeExtData;
-
 	const bool skipMinimum = pTypeExt->Ammo_AutoDeployMinimumAmount < 0;
 	const bool skipMaximum = pTypeExt->Ammo_AutoDeployMaximumAmount < 0;
 
@@ -381,6 +372,14 @@ void TechnoExt::ExtData::UpdateOnTunnelEnter()
 	}
 }
 
+void TechnoExt::ExtData::UpdateOnTunnelExit()
+{
+	this->IsInTunnel = false;
+
+	if (const auto pShieldData = this->Shield.get())
+		pShieldData->SetAnimationVisibility(true);
+}
+
 void TechnoExt::ExtData::ApplySpawnLimitRange()
 {
 	auto const pThis = this->OwnerObject();
@@ -413,24 +412,15 @@ void TechnoExt::ExtData::ApplySpawnLimitRange()
 	}
 }
 
-void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
+void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pOldType)
 {
 	auto const pThis = this->OwnerObject();
-	auto const pOldTypeExt = this->TypeExtData;
-	auto const pOldType = this->TypeExtData->OwnerObject();
-
-	if (this->LaserTrails.size())
-		this->LaserTrails.clear();
-
+	auto const pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOldType);
+	auto const pCurrentType = pThis->GetTechnoType();
+	this->PreviousType = pOldType;
 	this->TypeExtData = TechnoTypeExt::ExtMap.Find(pCurrentType);
 
 	this->UpdateSelfOwnedAttachEffects();
-
-	// Recreate Laser Trails
-	for (auto const& entry : this->TypeExtData->LaserTrailData)
-	{
-		this->LaserTrails.emplace_back(entry.GetType(), pThis->Owner, entry.FLH, entry.IsOnTurret);
-	}
 
 	// Reset AutoDeath Timer
 	if (this->AutoDeathTimer.HasStarted())
@@ -460,8 +450,73 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 		auto& vec = ScenarioExt::Global()->TransportReloaders;
 		vec.erase(std::remove(vec.begin(), vec.end(), this), vec.end());
 	}
+}
+
+void TechnoExt::ExtData::UpdateTypeData_Foot(TechnoTypeClass* pOldType)
+{
+	auto const pThis = static_cast<FootClass*>(this->OwnerObject());
+	//auto const pOldTypeExt = TechnoTypeExt::ExtMap.Find(pOldType);
+	auto const pCurrentType = pThis->GetTechnoType();
+
+	// Recreate Laser Trails
+	if (this->LaserTrails.size())
+		this->LaserTrails.clear();
+
+	for (auto const& entry : this->TypeExtData->LaserTrailData)
+	{
+		this->LaserTrails.emplace_back(entry.GetType(), pThis->Owner, entry.FLH, entry.IsOnTurret);
+	}
+
+	// Update movement sound if still moving while type changed.
+	if (pThis->Locomotor->Is_Moving_Now() && pThis->IsMoveSoundPlaying)
+	{
+		if (pCurrentType->MoveSound != pOldType->MoveSound)
+		{
+			// End the old sound.
+			pThis->MoveSoundAudioController.End();
+
+			if (auto const count = pCurrentType->MoveSound.Count)
+			{
+				// Play a new sound.
+				int soundIndex = pCurrentType->MoveSound[Randomizer::Global->Random() % count];
+				VocClass::PlayAt(soundIndex, pThis->Location, &pThis->MoveSoundAudioController);
+				pThis->IsMoveSoundPlaying = true;
+			}
+			else
+			{
+				pThis->IsMoveSoundPlaying = false;
+			}
+
+			pThis->MoveSoundDelay = 0;
+		}
+	}
+
+	if (auto const pInf = specific_cast<InfantryClass*>(pThis))
+	{
+		// It's still not recommended to have such idea, please avoid using this
+		if (static_cast<InfantryTypeClass*>(pOldType)->Deployer && !static_cast<InfantryTypeClass*>(pCurrentType)->Deployer)
+		{
+			switch (pInf->SequenceAnim)
+			{
+			case Sequence::Deploy:
+			case Sequence::Deployed:
+			case Sequence::DeployedIdle:
+				pInf->PlayAnim(Sequence::Ready, true);
+				break;
+			case Sequence::DeployedFire:
+				pInf->PlayAnim(Sequence::FireUp, true);
+				break;
+			default:
+				break;
+			}
+		}
+	}
+
+	if (pOldType->Locomotor == LocomotionClass::CLSIDs::Teleport && pCurrentType->Locomotor != LocomotionClass::CLSIDs::Teleport && pThis->WarpingOut)
+		this->HasRemainingWarpInDelay = true;
 
 	// Update open topped state of potential passengers if transport's OpenTopped value changes.
+	// OpenTopped does not work properly with buildings to begin with which is why this is here rather than in the Techno update one.
 	bool toOpenTopped = pCurrentType->OpenTopped && !pOldType->OpenTopped;
 
 	if ((toOpenTopped || (!pCurrentType->OpenTopped && pOldType->OpenTopped)) && pThis->Passengers.NumPassengers > 0)
@@ -483,71 +538,17 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 
 				// OpenTopped adds passengers to logic layer when enabled. Under normal conditions this does not need to be removed since
 				// OpenTopped state does not change while passengers are still in transport but in case of type conversion that can happen.
-				LogicClass::Instance.RemoveObject(pPassenger);
+				LogicClass::Instance->RemoveObject(pPassenger);
 			}
 
 			pPassenger = abstract_cast<FootClass*>(pPassenger->NextObject);
 		}
-	}
-
-	// Update movement sound if still moving while type changed.
-	if (auto const pFoot = abstract_cast<FootClass*>(pThis))
-	{
-		if (pFoot->Locomotor->Is_Moving_Now() && pFoot->IsMoveSoundPlaying)
-		{
-			if (pCurrentType->MoveSound != pOldType->MoveSound)
-			{
-				// End the old sound.
-				pFoot->MoveSoundAudioController.End();
-
-				if (auto const count = pCurrentType->MoveSound.Count)
-				{
-					// Play a new sound.
-					int soundIndex = pCurrentType->MoveSound[Randomizer::Global.Random() % count];
-					VocClass::PlayAt(soundIndex, pFoot->Location, &pFoot->MoveSoundAudioController);
-					pFoot->IsMoveSoundPlaying = true;
-				}
-				else
-				{
-					pFoot->IsMoveSoundPlaying = false;
-				}
-
-				pFoot->MoveSoundDelay = 0;
-			}
-		}
-
-		if (auto pInf = specific_cast<InfantryClass*>(pFoot))
-		{
-			// It's still not recommended to have such idea, please avoid using this
-			if (static_cast<InfantryTypeClass*>(pOldType)->Deployer && !static_cast<InfantryTypeClass*>(pCurrentType)->Deployer)
-			{
-				switch (pInf->SequenceAnim)
-				{
-				case Sequence::Deploy:
-				case Sequence::Deployed:
-				case Sequence::DeployedIdle:
-					pInf->PlayAnim(Sequence::Ready, true);
-					break;
-				case Sequence::DeployedFire:
-					pInf->PlayAnim(Sequence::FireUp, true);
-					break;
-				default:
-					break;
-				}
-			}
-		}
-
-		if (pOldType->Locomotor == LocomotionClass::CLSIDs::Teleport && pCurrentType->Locomotor != LocomotionClass::CLSIDs::Teleport && pThis->WarpingOut)
-			this->HasRemainingWarpInDelay = true;
 	}
 }
 
 void TechnoExt::ExtData::UpdateLaserTrails()
 {
 	auto const pThis = generic_cast<FootClass*>(this->OwnerObject());
-
-	if (!pThis)
-		return;
 
 	// LaserTrails update routine is in TechnoClass::AI hook because LaserDrawClass-es are updated in LogicClass::AI
 	for (auto& trail : this->LaserTrails)
@@ -733,8 +734,10 @@ void TechnoExt::ApplyGainedSelfHeal(TechnoClass* pThis)
 	return;
 }
 
-void TechnoExt::ApplyMindControlRangeLimit(TechnoClass* pThis)
+void TechnoExt::ExtData::ApplyMindControlRangeLimit()
 {
+	auto const pThis = this->OwnerObject();
+
 	if (auto pCapturer = pThis->MindControlledBy)
 	{
 		auto pCapturerExt = TechnoTypeExt::ExtMap.Find(pCapturer->GetTechnoType());
@@ -907,6 +910,29 @@ void TechnoExt::ExtData::UpdateRearmInTemporal()
 
 	if (pThis->ReloadTimer.InProgress() && pTypeExt->NoReload_Temporal.Get(RulesExt::Global()->NoReload_Temporal))
 		pThis->ReloadTimer.StartTime++;
+}
+
+// Resets target if KeepTargetOnMove unit moves beyond weapon range.
+void TechnoExt::ExtData::UpdateKeepTargetOnMove()
+{
+	auto const pThis = this->OwnerObject();
+
+	if (this->KeepTargetOnMove && this->TypeExtData->KeepTargetOnMove && pThis->Target && pThis->CurrentMission == Mission::Move)
+	{
+		int weaponIndex = pThis->SelectWeapon(pThis->Target);
+
+		if (auto const pWeapon = pThis->GetWeapon(weaponIndex)->WeaponType)
+		{
+			int extraDistance = static_cast<int>(this->TypeExtData->KeepTargetOnMove_ExtraDistance.Get());
+			int range = pWeapon->Range;
+			pWeapon->Range += extraDistance; // Temporarily adjust weapon range based on the extra distance.
+
+			if (!pThis->IsCloseEnough(pThis->Target, weaponIndex))
+				pThis->SetTarget(nullptr);
+
+			pWeapon->Range = range;
+		}
+	}
 }
 
 // Updates state of all AttachEffects on techno.

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -17,11 +17,11 @@
 // It's not recommended to do anything more here it could have a better place for performance consideration
 void TechnoExt::ExtData::OnEarlyUpdate()
 {
-	auto pType = this->OwnerObject()->GetTechnoType();
+	auto pType = this->TypeExtData->OwnerObject();
 
 	// Set only if unset or type is changed
 	// Notice that Ares may handle type conversion in the same hook here, which is executed right before this one thankfully
-	if (!this->TypeExtData || this->TypeExtData->OwnerObject() != pType)
+	if (!this->TypeExtData || this->OwnerObject()->GetTechnoType() != pType)
 		this->UpdateTypeData(pType);
 	else if (this->PreviousType)
 		this->PreviousType = nullptr;
@@ -97,7 +97,7 @@ void TechnoExt::ExtData::ApplyInterceptor()
 
 void TechnoExt::ExtData::DepletedAmmoActions()
 {
-	auto const pThis = specific_cast<UnitClass*>(this->OwnerObject());
+	auto const pThis = static_cast<UnitClass*>(this->OwnerObject());
 
 	if (pThis->Type->Ammo <= 0 || !pThis->Type->IsSimpleDeployer)
 		return;
@@ -931,6 +931,23 @@ void TechnoExt::ExtData::UpdateKeepTargetOnMove()
 				pThis->SetTarget(nullptr);
 
 			pWeapon->Range = range;
+		}
+	}
+}
+
+void TechnoExt::ExtData::UpdateWarpInDelay()
+{
+	if (this->HasRemainingWarpInDelay)
+	{
+		if (this->LastWarpInDelay)
+		{
+			this->LastWarpInDelay--;
+		}
+		else
+		{
+			this->HasRemainingWarpInDelay = false;
+			this->IsBeingChronoSphered = false;
+			this->OwnerObject()->WarpingOut = false;
 		}
 	}
 }

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -551,6 +551,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->LaserTrails)
 		.Process(this->AttachedEffects)
 		.Process(this->AE)
+		.Process(this->PreviousType)
 		.Process(this->AnimRefCount)
 		.Process(this->ReceiveDamage)
 		.Process(this->PassengerDeletionTimer)
@@ -663,3 +664,4 @@ DEFINE_HOOK(0x70C264, TechnoClass_Save_Suffix, 0x5)
 
 	return 0;
 }
+

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -128,6 +128,7 @@ public:
 		void UpdateAttachEffects();
 		void UpdateGattlingRateDownReset();
 		void UpdateKeepTargetOnMove();
+		void UpdateWarpInDelay();
 		void UpdateCumulativeAttachEffects(AttachEffectTypeClass* pAttachEffectType, AttachEffectClass* pRemoved = nullptr);
 		void RecalculateStatMultipliers();
 		void UpdateTemporal();

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -28,6 +28,7 @@ public:
 		std::vector<LaserTrailClass> LaserTrails;
 		std::vector<std::unique_ptr<AttachEffectClass>> AttachedEffects;
 		AttachEffectTechnoProperties AE;
+		TechnoTypeClass* PreviousType; // Type change registered in TechnoClass::AI on current frame, will be unset there on next frame.
 		int AnimRefCount; // Used to keep track of how many times this techno is referenced in anims f.ex Invoker, ParentBuilding etc., for pointer invalidation.
 		bool ReceiveDamage;
 		bool LastKillWasTeamTarget;
@@ -73,6 +74,7 @@ public:
 			, LaserTrails {}
 			, AttachedEffects {}
 			, AE {}
+			, PreviousType { nullptr }
 			, AnimRefCount { 0 }
 			, ReceiveDamage { false }
 			, LastKillWasTeamTarget { false }
@@ -118,11 +120,14 @@ public:
 		void EatPassengers();
 		void UpdateShield();
 		void UpdateOnTunnelEnter();
+		void UpdateOnTunnelExit();
 		void ApplySpawnLimitRange();
-		void UpdateTypeData(TechnoTypeClass* currentType);
+		void UpdateTypeData(TechnoTypeClass* pOldType);
+		void UpdateTypeData_Foot(TechnoTypeClass* pOldType);
 		void UpdateLaserTrails();
 		void UpdateAttachEffects();
 		void UpdateGattlingRateDownReset();
+		void UpdateKeepTargetOnMove();
 		void UpdateCumulativeAttachEffects(AttachEffectTypeClass* pAttachEffectType, AttachEffectClass* pRemoved = nullptr);
 		void RecalculateStatMultipliers();
 		void UpdateTemporal();
@@ -135,6 +140,7 @@ public:
 		void UpdateSelfOwnedAttachEffects();
 		bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource, std::vector<int> const* minCounts, std::vector<int> const* maxCounts) const;
 		int GetAttachedEffectCumulativeCount(AttachEffectTypeClass* pAttachEffectType, bool ignoreSameSource = false, TechnoClass* pInvoker = nullptr, AbstractClass* pSource = nullptr) const;
+		void ApplyMindControlRangeLimit();
 
 		UnitTypeClass* GetUnitTypeExtra() const;
 
@@ -174,7 +180,6 @@ public:
 
 	static void ChangeOwnerMissionFix(FootClass* pThis);
 	static void KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, AnimTypeClass* pVanishAnimation, bool isInLimbo = false);
-	static void ApplyMindControlRangeLimit(TechnoClass* pThis);
 	static void ObjectKilledBy(TechnoClass* pThis, TechnoClass* pKiller);
 	static void UpdateSharedAmmo(TechnoClass* pThis);
 	static double GetCurrentSpeedMultiplier(FootClass* pThis);

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -28,7 +28,7 @@ public:
 		std::vector<LaserTrailClass> LaserTrails;
 		std::vector<std::unique_ptr<AttachEffectClass>> AttachedEffects;
 		AttachEffectTechnoProperties AE;
-		TechnoTypeClass* PreviousType; // Type change registered in TechnoClass::AI on current frame, will be unset there on next frame.
+		TechnoTypeClass* PreviousType; // Type change registered in TechnoClass::AI on current frame and used in FootClass::AI on same frame and reset after.
 		int AnimRefCount; // Used to keep track of how many times this techno is referenced in anims f.ex Invoker, ParentBuilding etc., for pointer invalidation.
 		bool ReceiveDamage;
 		bool LastKillWasTeamTarget;
@@ -122,8 +122,8 @@ public:
 		void UpdateOnTunnelEnter();
 		void UpdateOnTunnelExit();
 		void ApplySpawnLimitRange();
-		void UpdateTypeData(TechnoTypeClass* pOldType);
-		void UpdateTypeData_Foot(TechnoTypeClass* pOldType);
+		void UpdateTypeData(TechnoTypeClass* pCurrentType);
+		void UpdateTypeData_Foot();
 		void UpdateLaserTrails();
 		void UpdateAttachEffects();
 		void UpdateGattlingRateDownReset();

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -36,7 +36,6 @@ DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
 	if (pExt->PreviousType)
 		pExt->UpdateTypeData_Foot();
 
-	pExt->UpdateLaserTrails();
 	pExt->UpdateWarpInDelay();
 
 	return 0;
@@ -184,9 +183,7 @@ DEFINE_HOOK(0x6F42F7, TechnoClass_Init, 0x2)
 
 	pExt->CurrentShieldType = pExt->TypeExtData->ShieldType;
 	pExt->InitializeAttachEffects();
-
-	if ((pThis->AbstractFlags & AbstractFlags::Foot) != AbstractFlags::None)
-		pExt->InitializeLaserTrails();
+	pExt->InitializeLaserTrails();
 
 	if (pExt->TypeExtData->Harvester_Counted)
 		HouseExt::ExtMap.Find(pThis->Owner)->OwnedCountedHarvesters.push_back(pThis);

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -34,7 +34,7 @@ DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
 	auto const pExt = TechnoExt::ExtMap.Find(pThis);
 
 	if (pExt->PreviousType)
-		pExt->UpdateTypeData_Foot(pExt->PreviousType);
+		pExt->UpdateTypeData_Foot();
 
 	pExt->UpdateLaserTrails();
 	pExt->UpdateWarpInDelay();

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -16,13 +16,40 @@
 
 #pragma region Update
 
+// Early, before ObjectClass_AI
 DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 {
 	GET(TechnoClass*, pThis, ECX);
 
-	// Do not search this up again in any functions called here because it is costly for performance - Starkku
 	TechnoExt::ExtMap.Find(pThis)->OnEarlyUpdate();
-	TechnoExt::ApplyMindControlRangeLimit(pThis);
+
+	return 0;
+}
+
+// After TechnoClass_AI
+DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
+{
+	GET(FootClass*, pThis, ESI);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+
+	if (pExt->PreviousType)
+		pExt->UpdateTypeData_Foot(pExt->PreviousType);
+
+	pExt->UpdateLaserTrails();
+
+	return 0;
+}
+
+// After FootClass_AI
+DEFINE_HOOK(0x736480, UnitClass_AI, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	pExt->UpdateKeepTargetOnMove();
+	pExt->DepletedAmmoActions();
+	pExt->UpdateGattlingRateDownReset();
 
 	return 0;
 }
@@ -44,13 +71,24 @@ DEFINE_HOOK(0x71A88D, TemporalClass_AI, 0x0)
 	return R->EAX<int>() <= 0 ? 0x71A895 : 0x71AB08;
 }
 
-DEFINE_HOOK_AGAIN(0x51BAC7, FootClass_AI_Tunnel, 0x6)//InfantryClass_AI_Tunnel
-DEFINE_HOOK(0x7363B5, FootClass_AI_Tunnel, 0x6)//UnitClass_AI_Tunnel
+DEFINE_HOOK_AGAIN(0x51B389, FootClass_TunnelAI_Enter, 0x6) // InfantryClass_TunnelAI
+DEFINE_HOOK(0x735A26, FootClass_TunnelAI_Enter, 0x6)       // UnitClass_TunnelAI
 {
 	GET(FootClass*, pThis, ESI);
 
 	auto const pExt = TechnoExt::ExtMap.Find(pThis);
 	pExt->UpdateOnTunnelEnter();
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x51BA94, FootClass_TunnelAI_Exit, 0x7) // InfantryClass_TunnelAI
+DEFINE_HOOK(0x736005, FootClass_TunnelAI_Exit, 0x6)       // UnitClass_TunnelAI
+{
+	GET(FootClass*, pThis, ESI);
+
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	pExt->UpdateOnTunnelExit();
 
 	return 0;
 }
@@ -144,8 +182,10 @@ DEFINE_HOOK(0x6F42F7, TechnoClass_Init, 0x2)
 	pExt->TypeExtData = TechnoTypeExt::ExtMap.Find(pType);
 
 	pExt->CurrentShieldType = pExt->TypeExtData->ShieldType;
-	pExt->InitializeLaserTrails();
 	pExt->InitializeAttachEffects();
+
+	if ((pThis->AbstractFlags & AbstractFlags::Foot) != AbstractFlags::None)
+		pExt->InitializeLaserTrails();
 
 	if (pExt->TypeExtData->Harvester_Counted)
 		HouseExt::ExtMap.Find(pThis->Owner)->OwnedCountedHarvesters.push_back(pThis);
@@ -612,8 +652,6 @@ DEFINE_HOOK(0x73C602, UnitClass_DrawSHP_WaterType_Extra, 0x6)
 	return Continue;
 }
 
-#pragma region KeepTargetOnMove
-
 // Do not explicitly reset target for KeepTargetOnMove vehicles when issued move command.
 DEFINE_HOOK(0x4C7462, EventClass_Execute_KeepTargetOnMove, 0x5)
 {
@@ -645,37 +683,6 @@ DEFINE_HOOK(0x4C7462, EventClass_Execute_KeepTargetOnMove, 0x5)
 
 	return 0;
 }
-
-// Reset the target if beyond weapon range.
-// This was originally in UnitClass::Mission_Move() but because that
-// is only checked every ~15 frames, it can cause responsiveness issues.
-DEFINE_HOOK(0x736480, UnitClass_AI_KeepTargetOnMove, 0x6)
-{
-	GET(UnitClass*, pThis, ESI);
-
-	auto const pExt = TechnoExt::ExtMap.Find(pThis);
-
-	if (pExt->KeepTargetOnMove && pExt->TypeExtData->KeepTargetOnMove && pThis->Target && pThis->CurrentMission == Mission::Move)
-	{
-		int weaponIndex = pThis->SelectWeapon(pThis->Target);
-
-		if (auto const pWeapon = pThis->GetWeapon(weaponIndex)->WeaponType)
-		{
-			int extraDistance = static_cast<int>(pExt->TypeExtData->KeepTargetOnMove_ExtraDistance.Get());
-			int range = pWeapon->Range;
-			pWeapon->Range += extraDistance; // Temporarily adjust weapon range based on the extra distance.
-
-			if (!pThis->IsCloseEnough(pThis->Target, weaponIndex))
-				pThis->SetTarget(nullptr);
-
-			pWeapon->Range = range;
-		}
-	}
-
-	return 0;
-}
-
-#pragma endregion
 
 #pragma region BuildingTypeSelectable
 
@@ -717,3 +724,4 @@ DEFINE_HOOK(0x465D40, BuildingClass_Is1x1AndUndeployable_BuildingMassSelectable,
 }
 
 #pragma endregion
+

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -37,6 +37,7 @@ DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
 		pExt->UpdateTypeData_Foot(pExt->PreviousType);
 
 	pExt->UpdateLaserTrails();
+	pExt->UpdateWarpInDelay();
 
 	return 0;
 }

--- a/src/Ext/TechnoType/Hooks.Teleport.cpp
+++ b/src/Ext/TechnoType/Hooks.Teleport.cpp
@@ -152,26 +152,3 @@ DEFINE_HOOK(0x719BD9, TeleportLocomotionClass_Process_ChronosphereDelay2, 0x6)
 
 	return 0;
 }
-
-DEFINE_HOOK(0x4DA53E, FootClass_Update_WarpInDelay, 0x6)
-{
-	GET(FootClass*, pThis, ESI);
-
-	auto const pExt = TechnoExt::ExtMap.Find(pThis);
-
-	if (pExt->HasRemainingWarpInDelay)
-	{
-		if (pExt->LastWarpInDelay)
-		{
-			pExt->LastWarpInDelay--;
-		}
-		else
-		{
-			pExt->HasRemainingWarpInDelay = false;
-			pExt->IsBeingChronoSphered = false;
-			pThis->WarpingOut = false;
-		}
-	}
-
-	return 0;
-}


### PR DESCRIPTION
Splits functionality away from `TechnoClass_AI` / `TechnoExt::OnEarlyUpdate()` that does not need to be processed for all types of technos.

- Splits logic concerning `FootClass` only from `TechnoExt::UpdateTypeData()` to `TechnoExt::UpdateTypeData_Foot()` called from `FootClass_AI`. While `OpenTopped` is read for all technos, it does not work correctly for buildings so it was also moved.
- Moves tunnel enter / exit processing and relevant hooks entirely to appropriate update functions instead of general ones.
- `TechnoExt::DepletedAmmoActions()` is now called from `UnitClass_AI` (not a new hook - was repurposed/generalized from `KeepTargetOnMove` feature which was split into its own function too).
- `TechnoExt::UpdateGattlingRateDownReset()` is now called from `UnitClass_AI` and `BuildingClass_AI`.

Some notes:
- `TechnoExt::EatPassengers()` was kept in `TechnoExt::OnEarlyUpdate()` because it does work with passenger logic used on buildings such as Bio Reactor.
- Theoretically under current circumstances the entire  `TechnoExt::UpdateTypeData()` could've been moved to be processed for `FootClass` only as there are no building type changes in the game, but I suppose this is the future-proofed approach.