### PR TITLE
[Vanilla Fix] Fix interaction issue between aircraft carriers and elevated bridges

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -414,6 +414,8 @@ This page lists all the individual contributions to the project by their author.
   - Technos can maintain a suitable distance after firing
   - Projectile subject to ground check before firing
   - Delay automatic attack on the controlled unit
+  - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own.
+  - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude
@@ -443,6 +445,7 @@ This page lists all the individual contributions to the project by their author.
   - Recycle the spawner on other FLH
   - Fixed the bug that spawned can not return to buildings with foundation bigger than 1x1
   - `BombParachute` deglobalization
+  - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -416,6 +416,7 @@ This page lists all the individual contributions to the project by their author.
   - Delay automatic attack on the controlled unit
   - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own
   - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges
+  - Fixed an issue that Spawner cannot retract its spawned aircraft when on the bridge
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -416,7 +416,7 @@ This page lists all the individual contributions to the project by their author.
   - Delay automatic attack on the controlled unit
   - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own
   - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges
-  - Fixed an issue that Spawner cannot retract its spawned aircraft when on the bridge
+  - Fixed an issue that aircraft carriers cannot retract its spawned aircraft when on the bridge
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -414,8 +414,8 @@ This page lists all the individual contributions to the project by their author.
   - Technos can maintain a suitable distance after firing
   - Projectile subject to ground check before firing
   - Delay automatic attack on the controlled unit
-  - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own.
-  - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
+  - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own
+  - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude
@@ -445,7 +445,7 @@ This page lists all the individual contributions to the project by their author.
   - Recycle the spawner on other FLH
   - Fixed the bug that spawned can not return to buildings with foundation bigger than 1x1
   - `BombParachute` deglobalization
-  - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
+  - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -197,7 +197,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Electric bolts that are supposed to update their position based on units current firing coords (by default, those fired by vehicles) now do so correctly for more than one concurrent electric bolt.
 - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own.
 - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
-- Fixed an issue that Spawner cannot retract its spawned aircraft when on the bridge.
+- Fixed an issue that aircraft carriers cannot retract its spawned aircraft when on the bridge.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -197,6 +197,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Electric bolts that are supposed to update their position based on units current firing coords (by default, those fired by vehicles) now do so correctly for more than one concurrent electric bolt.
 - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own.
 - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
+- Fixed an issue that Spawner cannot retract its spawned aircraft when on the bridge.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -195,6 +195,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that caused `IsSonic=true` wave drawing to crash the game if the wave traveled over a certain distance.
 - Buildings with foundation bigger than 1x1 can now recycle spawner correctly.
 - Electric bolts that are supposed to update their position based on units current firing coords (by default, those fired by vehicles) now do so correctly for more than one concurrent electric bolt.
+- Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own.
+- Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -352,8 +352,8 @@ Vanilla fixes:
 - Fixed an issue that harvesters with amphibious movement zone can not automatically return to refineries with `WaterBound` on water surface (by NetsuNegi)
 - Buildings with foundation bigger than 1x1 can now recycle spawned correctly (by TaranDahl)
 - Electric bolts that are supposed to update their position based on units current firing coords (by default, those fired by vehicles) now do so correctly for more than one concurrent electric bolt (by Starkku)
-- Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own. (by CrimRecya)
-- Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges. (by CrimRecya & TaranDahl)
+- Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own (by CrimRecya)
+- Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges (by CrimRecya & TaranDahl)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -353,7 +353,7 @@ Vanilla fixes:
 - Buildings with foundation bigger than 1x1 can now recycle spawned correctly (by TaranDahl)
 - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own (by CrimRecya)
 - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges (by CrimRecya & TaranDahl)
-- Fixed an issue that Spawner cannot retract its spawned aircraft when on the bridge (by CrimRecya)
+- Fixed an issue that aircraft carriers cannot retract its spawned aircraft when on the bridge (by CrimRecya)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -354,6 +354,7 @@ Vanilla fixes:
 - Electric bolts that are supposed to update their position based on units current firing coords (by default, those fired by vehicles) now do so correctly for more than one concurrent electric bolt (by Starkku)
 - Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own (by CrimRecya)
 - Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges (by CrimRecya & TaranDahl)
+- Fixed an issue that Spawner cannot retract its spawned aircraft when on the bridge (by CrimRecya)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -352,6 +352,8 @@ Vanilla fixes:
 - Fixed an issue that harvesters with amphibious movement zone can not automatically return to refineries with `WaterBound` on water surface (by NetsuNegi)
 - Buildings with foundation bigger than 1x1 can now recycle spawned correctly (by TaranDahl)
 - Electric bolts that are supposed to update their position based on units current firing coords (by default, those fired by vehicles) now do so correctly for more than one concurrent electric bolt (by Starkku)
+- Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own. (by CrimRecya)
+- Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges. (by CrimRecya & TaranDahl)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/src/Ext/Bullet/Hooks.Obstacles.cpp
+++ b/src/Ext/Bullet/Hooks.Obstacles.cpp
@@ -227,6 +227,18 @@ DEFINE_HOOK(0x6F7647, TechnoClass_InRange_Obstacles, 0x5)
 		pObstacleCell = BulletObstacleHelper::FindFirstImpenetrableObstacle(newSourceCoords, targetCoords, pTechno, pTarget, pTechno->Owner, pWeapon, true, subjectToGround);
 	}
 
+	// Enable aircraft carriers to search for suitable attack positions on their own
+	if (!pObstacleCell && pTechno->SpawnManager && (pTechno->AbstractFlags & AbstractFlags::Foot) && !pTechno->IsInAir())
+	{
+		const auto coords = pTechno->Location;
+		pTechno->Location = *pSourceCoords; // Temporarily adjust the coordinates based on the path finding.
+
+		if (reinterpret_cast<bool(__thiscall*)(const TechnoClass*)>(0x703B10)(pTechno)) // Near by elevated bridge
+			pObstacleCell = MapClass::Instance.GetCellAt(*pSourceCoords);
+
+		pTechno->Location = coords;
+	}
+
 	InRangeTemp::Techno = nullptr;
 
 	R->EAX(pObstacleCell);

--- a/src/Ext/Bullet/Hooks.Obstacles.cpp
+++ b/src/Ext/Bullet/Hooks.Obstacles.cpp
@@ -231,7 +231,7 @@ DEFINE_HOOK(0x6F7647, TechnoClass_InRange_Obstacles, 0x5)
 	if (!pObstacleCell && pTechno->SpawnManager && (pTechno->AbstractFlags & AbstractFlags::Foot) && !pTechno->IsInAir())
 	{
 		const auto coords = pTechno->Location;
-		pTechno->Location = *pSourceCoords; // Temporarily adjust the coordinates based on the path finding.
+		pTechno->Location = *pSourceCoords; // Temporarily adjust the coordinates based on the path finding
 
 		if (reinterpret_cast<bool(__thiscall*)(const TechnoClass*)>(0x703B10)(pTechno)) // Near by elevated bridge
 			pObstacleCell = MapClass::Instance.GetCellAt(*pSourceCoords);

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1245,6 +1245,20 @@ DEFINE_HOOK(0x6F4BB3, TechnoClass_ReceiveCommand_NotifyUnlink, 0x7)
 
 #pragma endregion
 
+#pragma region SpawnerFireFix
+
+DEFINE_HOOK(0x6FC617, TechnoClass_GetFireError_AirCarrierSkipCheckNearBridge, 0x8)
+{
+	enum { ContinueCheck = 0x6FC61F, CannotFire = 0x6FCD29 };
+
+	GET(TechnoClass* const, pThis, ESI);
+	GET(const bool, nearBridge, EAX);
+
+	return (nearBridge && !pThis->IsInAir()) ? CannotFire : ContinueCheck;
+}
+
+#pragma endregion
+
 #pragma region TeamCloseRangeFix
 
 int __fastcall Check2DDistanceInsteadOf3D(ObjectClass* pSource, void* _, AbstractClass* pTarget)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1245,9 +1245,10 @@ DEFINE_HOOK(0x6F4BB3, TechnoClass_ReceiveCommand_NotifyUnlink, 0x7)
 
 #pragma endregion
 
-#pragma region SpawnerFireFix
+#pragma region SpawnerFix
 
-DEFINE_HOOK(0x6FC617, TechnoClass_GetFireError_AirCarrierSkipCheckNearBridge, 0x8)
+// Let in air aircraft carrier ignore nearby elevated bridge check
+DEFINE_HOOK(0x6FC617, TechnoClass_GetFireError_Spawner, 0x8)
 {
 	enum { ContinueCheck = 0x6FC61F, TemporaryCannotFire = 0x6FCD0E };
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1249,12 +1249,12 @@ DEFINE_HOOK(0x6F4BB3, TechnoClass_ReceiveCommand_NotifyUnlink, 0x7)
 
 DEFINE_HOOK(0x6FC617, TechnoClass_GetFireError_AirCarrierSkipCheckNearBridge, 0x8)
 {
-	enum { ContinueCheck = 0x6FC61F, CannotFire = 0x6FCD29 };
+	enum { ContinueCheck = 0x6FC61F, TemporaryCannotFire = 0x6FCD0E };
 
 	GET(TechnoClass* const, pThis, ESI);
 	GET(const bool, nearBridge, EAX);
 
-	return (nearBridge && !pThis->IsInAir()) ? CannotFire : ContinueCheck;
+	return (nearBridge && !pThis->IsInAir()) ? TemporaryCannotFire : ContinueCheck;
 }
 
 #pragma endregion

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1247,15 +1247,36 @@ DEFINE_HOOK(0x6F4BB3, TechnoClass_ReceiveCommand_NotifyUnlink, 0x7)
 
 #pragma region SpawnerFix
 
+// Enable the carrier on the bridge to retrieve the aircraft normally
+DEFINE_HOOK(0x4CF3F9, FlyLocomotionClass_FlightUpdate_FixFlightLevel, 0x5)
+{
+	enum { SkipGameCode = 0x4CF4D2 };
+
+	GET(FlyLocomotionClass* const, pThis, EBP);
+
+	const auto pFoot = pThis->LinkedTo;
+
+	if (pFoot->GetMapCoords() == CellClass::Coord2Cell(pThis->MovingDestination) // Maintain height until on same cell to prevent poor visual display
+		&& MapClass::Instance.GetCellAt(pFoot->Location)->ContainsBridge() // Only effective when on the bridge
+		&& pThis->FlightLevel >= CellClass::BridgeHeight) // Not lower than the ground level
+	{
+		// Subtract the excess bridge height to allow the aircraft to return to the correct altitude
+		pThis->FlightLevel -= CellClass::BridgeHeight;
+	}
+
+	return SkipGameCode;
+}
+
 // Let in air aircraft carrier ignore nearby elevated bridge check
 DEFINE_HOOK(0x6FC617, TechnoClass_GetFireError_Spawner, 0x8)
 {
 	enum { ContinueCheck = 0x6FC61F, TemporaryCannotFire = 0x6FCD0E };
 
 	GET(TechnoClass* const, pThis, ESI);
-	GET(const bool, nearBridge, EAX);
+	GET(const bool, nearElevatedBridge, EAX);
 
-	return (nearBridge && !pThis->IsInAir()) ? TemporaryCannotFire : ContinueCheck;
+	// In addition, the return value of the function has been changed to allow the aircraft carrier to retain the current target
+	return (nearElevatedBridge && !pThis->IsInAir()) ? TemporaryCannotFire : ContinueCheck;
 }
 
 #pragma endregion


### PR DESCRIPTION
- Fixed an issue that aircraft carriers can not find suitable locations for attacks when under elevated bridges on their own.
- Fixed an issue that in air aircraft carriers being unable to attack when it is near by elevated bridges.
- Fixed an issue that aircraft carriers cannot retract its spawned aircraft when on the bridge.