### PR TITLE
[Vanilla Fix] Fixed an issue where `FireAngle` would not work properly under certain circumstances.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -443,6 +443,7 @@ This page lists all the individual contributions to the project by their author.
   - Recycle the spawner on other FLH
   - Fixed the bug that spawned can not return to buildings with foundation bigger than 1x1
   - `BombParachute` deglobalization
+  - Fixed an issue where `FireAngle` would not work properly under certain circumstances.
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -195,6 +195,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that caused `IsSonic=true` wave drawing to crash the game if the wave traveled over a certain distance.
 - Buildings with foundation bigger than 1x1 can now recycle spawner correctly.
 - Electric bolts that are supposed to update their position based on units current firing coords (by default, those fired by vehicles) now do so correctly for more than one concurrent electric bolt.
+- Fixed an issue where `FireAngle` would not work properly under certain circumstances.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -346,6 +346,7 @@ New:
 - Projectile subject to ground check before firing (by CrimRecya)
 - Delay automatic attack on the controlled unit (by CrimRecya)
 - `BombParachute` deglobalization (by TaranDahl)
+- Fixed an issue where `FireAngle` would not work properly under certain circumstances (by TaranDahl)
 
 Vanilla fixes:
 - Prevent the units with locomotors that cause problems from entering the tank bunker (by TaranDahl)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1563,3 +1563,16 @@ DEFINE_HOOK(0x75EE49, WaveClass_DrawSonic_CrashFix, 0x7)
 
 	return 0;
 }
+
+// WW used SetDesired here, causing the barrel drawn incorrectly.
+DEFINE_HOOK(0x6F6DEE, TechnoClass_Unlimbo_BarrelFacingBugFix, 0x7)
+{
+	enum { SkipGameCode = 0x6F6DFA };
+
+	GET(DirStruct*, pDir, ECX);
+	GET(TechnoClass*, pThis, ESI);
+
+	pThis->BarrelFacing.SetCurrent(*pDir);
+
+	return SkipGameCode;
+}


### PR DESCRIPTION
WW uses `SetDesired` on `BarrelFacing`, which causes the barrel image cache to be incorrectly initialized.