### PR TITLE
[Dehardcode]Customize damaged speed

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -364,6 +364,7 @@ This page lists all the individual contributions to the project by their author.
    - Fix `DefaultDisguise` showing wrong house colors for different players
    - Taking over Ares' AlphaImage respawn logic to reduce lags from it
    - Allow voxel projectiles to use AnimPalette and FirersPalette
+   - Customize damaged speed ratio of drive/ship loco
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
    - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -533,6 +533,7 @@ BuildingWaypoints=false  ; boolean
 ### Damaged speed customization
 
 - In vanilla, units using drive/ship loco will has hardcoded speed multiplier when damaged. Now you can customize it.
+- The max valuebale value is 1.0, you cannot make unit get faster on yellow condition by it.
 
 In `rulesmd.ini`
 ```ini

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -530,6 +530,19 @@ In `rulesmd.ini`:
 BuildingWaypoints=false  ; boolean
 ```
 
+### Damaged speed customization
+
+- In vanilla, units using drive/ship loco will has hardcoded speed multiplier when damaged. Now you can customize it.
+
+In `rulesmd.ini`
+```ini
+[General]
+DamagedSpeed=0.75        ; double
+
+[SOMEUNIT]
+DamagedSpeed=            ; double
+```
+
 ## Particle systems
 
 ### Fire particle target coordinate adjustment when firer rotates

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -351,6 +351,7 @@ New:
 - Laser, electric bolt and rad beam scatter (by CrimRecya)
 - [Airburst weapon firing/source coordinate customizations](Fixed-or-Improved-Logics.md#airburst--splits) (by Starkku)
 - [AlternateFLH on-turret toggle](Fixed-or-Improved-Logics.md#alternate-flh-customizations) (by Starkku)
+- Customize damaged speed ratio of drive/ship loco (by NetsuNegi)
 
 Vanilla fixes:
 - Prevent the units with locomotors that cause problems from entering the tank bunker (by TaranDahl)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -248,8 +248,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->ProneSpeed_Crawls.Read(exINI, GameStrings::General, "ProneSpeed.Crawls");
 	this->ProneSpeed_NoCrawls.Read(exINI, GameStrings::General, "ProneSpeed.NoCrawls");
-  
-  this->DamagedSpeed.Read(exINI, GameStrings::General, "DamagedSpeed");
+
+  	this->DamagedSpeed.Read(exINI, GameStrings::General, "DamagedSpeed");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -463,7 +463,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->BuildingTypeSelectable)
 		.Process(this->ProneSpeed_Crawls)
 		.Process(this->ProneSpeed_NoCrawls)
-    .Process(this->DamagedSpeed)
+    	.Process(this->DamagedSpeed)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -246,6 +246,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->BuildingTypeSelectable.Read(exINI, GameStrings::General, "BuildingTypeSelectable");
 
+	this->DamagedSpeed.Read(exINI, GameStrings::General, "DamagedSpeed");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -456,6 +458,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->CombatLightDetailLevel)
 		.Process(this->LightFlashAlphaImageDetailLevel)
 		.Process(this->BuildingTypeSelectable)
+		.Process(this->DamagedSpeed)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -204,8 +204,8 @@ public:
 
 		Valueable<double> ProneSpeed_Crawls;
 		Valueable<double> ProneSpeed_NoCrawls;
-    
-    Valueable<double> DamagedSpeed;
+
+    	Valueable<double> DamagedSpeed;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -358,11 +358,10 @@ public:
 			, LightFlashAlphaImageDetailLevel { 0 }
 			, BuildingWaypoints { false }
 			, BuildingTypeSelectable { false }
-    
 			, ProneSpeed_Crawls { 0.67 }
 			, ProneSpeed_NoCrawls { 1.5 }
-    
-      , DamagedSpeed { 0.75 }
+
+      		, DamagedSpeed { 0.75 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -202,6 +202,8 @@ public:
 		Valueable<bool> BuildingWaypoints;
 		Valueable<bool> BuildingTypeSelectable;
 
+		Valueable<double> DamagedSpeed;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -353,6 +355,8 @@ public:
 			, LightFlashAlphaImageDetailLevel { 0 }
 			, BuildingWaypoints { false }
 			, BuildingTypeSelectable { false }
+
+			, DamagedSpeed { 0.75 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -715,28 +715,14 @@ DEFINE_HOOK(0x465D40, BuildingClass_Is1x1AndUndeployable_BuildingMassSelectable,
 
 #pragma endregion
 
-DEFINE_HOOK(0x4B3DF0, DriveLocomotionClass_Sub_4B2630_DamagedSpeedMultiplier, 0x6)
+DEFINE_HOOK_AGAIN(0x6A343F, LocomotionClass_Process_DamagedSpeedMultiplier, 0x6)// Ship
+DEFINE_HOOK(0x4B3DF0, LocomotionClass_Process_DamagedSpeedMultiplier, 0x6)// Drive
 {
-	enum { SkipGameCode = 0x4B3DF6 };
-
 	GET(FootClass*, pLinkedTo, ECX);
 	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pLinkedTo->GetTechnoType());
 
 	const double multiplier = pTypeExt->DamagedSpeed.Get(RulesExt::Global()->DamagedSpeed);
 	__asm fmul multiplier;
 
-	return SkipGameCode;
-}
-
-DEFINE_HOOK(0x6A343F, ShipLocomotionClass_Sub_6A1C80_DamagedSpeedMultiplier, 0x6)
-{
-	enum { SkipGameCode = 0x6A3445 };
-
-	GET(FootClass*, pLinkedTo, ECX);
-	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pLinkedTo->GetTechnoType());
-
-	const double multiplier = pTypeExt->DamagedSpeed.Get(RulesExt::Global()->DamagedSpeed);
-	__asm fmul multiplier;
-
-	return SkipGameCode;
+	return R->Origin() + 0x6;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -715,3 +715,28 @@ DEFINE_HOOK(0x465D40, BuildingClass_Is1x1AndUndeployable_BuildingMassSelectable,
 
 #pragma endregion
 
+DEFINE_HOOK(0x4B3DF0, DriveLocomotionClass_Sub_4B2630_DamagedSpeedMultiplier, 0x6)
+{
+	enum { SkipGameCode = 0x4B3DF6 };
+
+	GET(FootClass*, pLinkedTo, ECX);
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pLinkedTo->GetTechnoType());
+
+	const double multiplier = pTypeExt->DamagedSpeed.Get(RulesExt::Global()->DamagedSpeed);
+	__asm fmul multiplier;
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x6A343F, ShipLocomotionClass_Sub_6A1C80_DamagedSpeedMultiplier, 0x6)
+{
+	enum { SkipGameCode = 0x6A3445 };
+
+	GET(FootClass*, pLinkedTo, ECX);
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pLinkedTo->GetTechnoType());
+
+	const double multiplier = pTypeExt->DamagedSpeed.Get(RulesExt::Global()->DamagedSpeed);
+	__asm fmul multiplier;
+
+	return SkipGameCode;
+}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -503,7 +503,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Sinkable.Read(exINI, pSection, "Sinkable");
 	this->Sinkable_SquidGrab.Read(exINI, pSection, "Sinkable.SquidGrab");
 	this->SinkSpeed.Read(exINI, pSection, "SinkSpeed");
-	
+
 	this->ProneSpeed.Read(exINI, pSection, "ProneSpeed");
 
 	this->DamagedSpeed.Read(exINI, pSection, "DamagedSpeed");

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -504,6 +504,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Sinkable_SquidGrab.Read(exINI, pSection, "Sinkable.SquidGrab");
 	this->SinkSpeed.Read(exINI, pSection, "SinkSpeed");
 
+	this->DamagedSpeed.Read(exINI, pSection, "DamagedSpeed");
+
 	this->SuppressKillWeapons.Read(exINI, pSection, "SuppressKillWeapons");
 	this->SuppressKillWeapons_Types.Read(exINI, pSection, "SuppressKillWeapons.Types");
 
@@ -929,6 +931,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Sinkable)
 		.Process(this->Sinkable_SquidGrab)
 		.Process(this->SinkSpeed)
+
+		.Process(this->DamagedSpeed)
 
 		.Process(this->SuppressKillWeapons)
 		.Process(this->SuppressKillWeapons_Types)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -279,6 +279,8 @@ public:
 		Valueable<bool> Sinkable_SquidGrab;
 		Valueable<int> SinkSpeed;
 
+		Nullable<double> DamagedSpeed;
+
 		struct LaserTrailDataEntry
 		{
 			ValueableIdx<LaserTrailTypeClass> idxType;
@@ -554,6 +556,8 @@ public:
 			, Sinkable { }
 			, Sinkable_SquidGrab { true }
 			, SinkSpeed { 5 }
+
+			, DamagedSpeed { }
 
 			, SuppressKillWeapons { false }
 			, SuppressKillWeapons_Types {}

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -280,8 +280,8 @@ public:
 		Valueable<int> SinkSpeed;
 
 		Nullable<double> ProneSpeed;
-    
-    Nullable<double> DamagedSpeed;
+
+    	Nullable<double> DamagedSpeed;
 
 		struct LaserTrailDataEntry
 		{


### PR DESCRIPTION
- In vanilla, units using drive/ship loco will has hardcoded speed multiplier when damaged. Now you can customize it.
- The max valuebale value is 1.0, you cannot make unit get faster on yellow condition by it.

In `rulesmd.ini`
```ini
[General]
DamagedSpeed=0.75        ; double

[SOMEUNIT]
DamagedSpeed=            ; double
```