### PR TITLE
[Vanilla Fix] 2 bugfixes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -366,6 +366,8 @@ This page lists all the individual contributions to the project by their author.
    - Allow voxel projectiles to use `AnimPalette` and `FirersPalette`
    - Customize damaged speed ratio of drive/ship loco
    - Customize overpower logic
+   - Fix the bug that `EnterBioReactorSound` on technotype does not used
+   - Fix the bug that harvester dont stop unloading and cannot unload cargos anymore when lifting by `IsLocomotor=yes` warhead
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
    - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -366,7 +366,7 @@ This page lists all the individual contributions to the project by their author.
    - Allow voxel projectiles to use `AnimPalette` and `FirersPalette`
    - Customize damaged speed ratio of drive/ship loco
    - Customize overpower logic
-   - Fix the bug that `EnterBioReactorSound` on technotype does not used
+   - Fix the bug that `EnterBioReactorSound` and `LeaveBioReactorSound` on technotype does not used
    - Fix the bug that harvester dont stop unloading and cannot unload cargos anymore when lifting by `IsLocomotor=yes` warhead
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -207,6 +207,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that healing weapons could not automatically acquire aerial targets.
 - Allow voxel projectiles to use `AnimPalette` and `FirersPalette`.
 - Fixed an issue where AI would select unreachable buildings and get stuck when looking for buildings like tank bunkers, bio reactors, etc.
+- Fix the bug that `EnterBioReactorSound` on technotype does not used.
+- Fix the bug that harvester dont stop unloading and cannot unload cargos anymore when lifting by `IsLocomotor=yes` warhead.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -207,7 +207,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that healing weapons could not automatically acquire aerial targets.
 - Allow voxel projectiles to use `AnimPalette` and `FirersPalette`.
 - Fixed an issue where AI would select unreachable buildings and get stuck when looking for buildings like tank bunkers, bio reactors, etc.
-- Fix the bug that `EnterBioReactorSound` on technotype does not used.
+- Fix the bug that `EnterBioReactorSound` and `LeaveBioReactorSound` on technotype does not used.
 - Fix the bug that harvester dont stop unloading and cannot unload cargos anymore when lifting by `IsLocomotor=yes` warhead.
 
 ## Fixes / interactions with other extensions

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -356,6 +356,8 @@ New:
 - [Customize damaged speed ratio of drive/ship loco](Fixed-or-Improved-Logics.md#damaged-speed-customization) (by NetsuNegi)
 - [Customize overpower logic](Fixed-or-Improved-Logics.md#customize-overpower-logic) (by NetsuNegi)
 - Promotion animation deglobalization (by Ollerus)
+- Fix the bug that `EnterBioReactorSound` on technotype does not used (by NetsuNegi)
+- Fix the bug that harvester dont stop unloading and cannot unload cargos anymore when lifting by `IsLocomotor=yes` warhead (by NetsuNegi)
 
 Vanilla fixes:
 - Prevent the units with locomotors that cause problems from entering the tank bunker (by TaranDahl)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -356,7 +356,7 @@ New:
 - [Customize damaged speed ratio of drive/ship loco](Fixed-or-Improved-Logics.md#damaged-speed-customization) (by NetsuNegi)
 - [Customize overpower logic](Fixed-or-Improved-Logics.md#customize-overpower-logic) (by NetsuNegi)
 - Promotion animation deglobalization (by Ollerus)
-- Fix the bug that `EnterBioReactorSound` on technotype does not used (by NetsuNegi)
+- Fix the bug that `EnterBioReactorSound` and `LeaveBioReactorSound` on technotype does not used (by NetsuNegi)
 - Fix the bug that harvester dont stop unloading and cannot unload cargos anymore when lifting by `IsLocomotor=yes` warhead (by NetsuNegi)
 
 Vanilla fixes:

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1763,3 +1763,29 @@ DEFINE_HOOK(0x4DFB28, FootClass_FindGrinder_CheckValid, 0x8)
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x51A304, InfantryClass_UpdatePosition_EnterBioReactorSound, 0x6)
+{
+	enum { SkipGameCode = 0x51A30A };
+
+	GET(BuildingClass*, pThis, EDI);
+	const int enterSound = pThis->Type->EnterBioReactorSound;
+
+	if (enterSound >= 0)
+	{
+		R->ECX(enterSound);
+		return SkipGameCode;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x710352, FootClass_ImbueLocomotor_ResetUnloadingHarvester, 0x7)
+{
+	GET(FootClass*, pTarget, ESI);
+
+	if (const auto pUnit = abstract_cast<UnitClass*>(pTarget))
+		pUnit->Unloading = false;
+
+	return 0;
+}

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1780,6 +1780,22 @@ DEFINE_HOOK(0x51A304, InfantryClass_UpdatePosition_EnterBioReactorSound, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x44DBCF, BuildingClass_Mission_Unload_LeaveBioReactorSound, 0x6)
+{
+	enum { SkipGameCode = 0x44DBD5 };
+
+	GET(BuildingClass*, pThis, EBP);
+	const int leaveSound = pThis->Type->LeaveBioReactorSound;
+
+	if (leaveSound >= 0)
+	{
+		R->ECX(leaveSound);
+		return SkipGameCode;
+	}
+
+	return 0;
+}
+
 DEFINE_HOOK(0x710352, FootClass_ImbueLocomotor_ResetUnloadingHarvester, 0x7)
 {
 	GET(FootClass*, pTarget, ESI);


### PR DESCRIPTION
- Fix the bug that `EnterBioReactorSound` and `LeaveBioReactorSound` on technotype does not used.
- Fix the bug that harvester dont stop unloading and cannot unload cargos anymore when lifting by `IsLocomotor=yes` warhead.