### PR TITLE
Map Action 606-608

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -349,6 +349,8 @@ This page lists all the individual contributions to the project by their author.
    - New condition for automatic self-destruction logic when TechnoTypes exist/don't exist
    - Fix `AltNextScenario` not taking effect
    - Fix `Hospital=yes` building can't kick out infantry after loading a save
+   - `Edit/Clear Hate-Value` Trigger Action
+   - `Set Force Enemy` Trigger Action
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ClCompile Include="src\Blowfish\blowfish.cpp" />
     <ClCompile Include="src\Blowfish\Hooks.Blowfish.cpp" />
+    <ClCompile Include="src\Ext\House\Hooks.ForceEnemy.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Hooks.MatrixOp.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Sinking.cpp" />
     <ClCompile Include="src\Misc\Hooks.AlphaImage.cpp" />

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -611,6 +611,61 @@ ID=ActionCount,[Action1],510,0,0,[MCVRedeploy],0,0,0,A,[ActionX]
 ...
 ```
 
+### `606` Edit Hate-Value
+
+- Edit the hate-value that trigger houses to other houses.
+- -1 works for all houses.
+
+In `mycampaign.map`:
+```ini
+[Actions]
+...
+ID=ActionCount,[Action1],606,0,[HouseIndex],[Operation],[Number],0,0,A,[ActionX]
+...
+```
+
+| *Operation* | *Description*                                 |
+|------------:|:----------------------------------------------|
+| 0           | CurrentValue = Number                         |
+| 1           | CurrentValue = CurrentValue + Number          |
+| 2           | CurrentValue = CurrentValue - Number          |
+| 3           | CurrentValue = CurrentValue * Number          |
+| 4           | CurrentValue = CurrentValue / Number          |
+| 5           | CurrentValue = CurrentValue % Number          |
+| 6           | CurrentValue = CurrentValue leftshift Number  |
+| 7           | CurrentValue = CurrentValue rightshift Number |
+| 8           | CurrentValue = ~CurrentValue                  |
+| 9           | CurrentValue = CurrentValue xor Number        |
+| 10          | CurrentValue = CurrentValue or Number         |
+| 11          | CurrentValue = CurrentValue and Number        |
+
+### `607` Clear Hate-Value
+
+- Clear the hate-value that trigger houses to other houses.
+- -1 works for all houses.
+
+In `mycampaign.map`:
+```ini
+[Actions]
+...
+ID=ActionCount,[Action1],607,0,[HouseIndex],0,0,0,0,A,[ActionX]
+...
+```
+
+### `608` Set Force Enemy
+
+- Force an enemy, it will not change with the change of hate-value.
+- -1 will remove the forced enemy.
+- -2 will never have any enemies.
+
+In `mycampaign.map`:
+```ini
+[Actions]
+...
+ID=ActionCount,[Action1],608,0,0,[HouseIndex],0,0,0,A,[ActionX]
+...
+```
+
 ## Trigger events
 
 ### `500-511` Variable comparation

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -170,6 +170,9 @@ HideLightFlashEffects=false      ; boolean
   505=Fire Super Weapon at specified location (Phobos),0,0,20,2,21,22,0,0,0,Launch a Super Weapon from [SuperWeaponTypes] list at a specified location. House=-1 means random target that isn't neutral. House=-2 means the first neutral house. House=-3 means random human target. Coordinate X=-1 means random. Coordinate Y=-1 means random,0,1,505
   506=Fire Super Weapon at specified waypoint (Phobos),0,0,20,2,30,0,0,0,0,Launch a Super Weapon from [SuperWeaponTypes] list at a specified waypoint. House=-1 means random target that isn't neutral. House=-2 means the first neutral house. House=-3 means random human target. Coordinate X=-1 means random. Coordinate Y=-1 means random,0,1,506
   510=Toggle MCV Redeployablility (Phobos),0,0,15,0,0,0,0,0,0, Set MCVRedeploys to the given value,0,1,510
+  606=Edit hate-value (Phobos),0,2,55,6,0,0,0,0,0, Edit the hate-value that trigger houses to other houses. -1 works for all houses.,0,1,606
+  607=Clear hate-value (Phobos),0,2,0,0,0,0,0,0,0, Clear the hate-value that trigger houses to other houses. -1 works for all houses.,0,1,607
+  608=Set force enemy (Phobos),0,0,2,0,0,0,0,0,0, Force an enemy, it will not change with the change of hate-value. -1 will remove the forced enemy, -2 will never have any enemies.,0,1,608
 
   ; FOLLOWING ENTRIES REQUIRE FA2SP.DLL (by secsome)
   [ScriptTypeLists]

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -658,6 +658,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 		.Process(this->AIFireSaleDelayTimer)
 		.Process(this->SuspendedEMPulseSWs)
 		.Process(this->SuperExts)
+		.Process(this->ForceEnemyIndex)
 		;
 }
 

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -604,9 +604,6 @@ void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 int HouseExt::ExtData::GetForceEnemyIndex()
 {
-	if (!this)
-		return -1;
-
 	auto const pHouse = this->OwnerObject();
 	if (!pHouse)
 		return -1;
@@ -614,11 +611,8 @@ int HouseExt::ExtData::GetForceEnemyIndex()
 	return this->ForceEnemyIndex;
 }
 
-void HouseExt::ExtData::SetForceEnemy(int EnemyIndex)
+void HouseExt::ExtData::SetForceEnemyIndex(int EnemyIndex)
 {
-	if (!this)
-		return;
-
 	if (EnemyIndex < 0 && EnemyIndex != -2)
 		this->ForceEnemyIndex = -1;
 	else

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -602,6 +602,29 @@ void HouseExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	}
 }
 
+int HouseExt::ExtData::GetForceEnemyIndex()
+{
+	if (!this)
+		return -1;
+
+	auto const pHouse = this->OwnerObject();
+	if (!pHouse)
+		return -1;
+
+	return this->ForceEnemyIndex;
+}
+
+void HouseExt::ExtData::SetForceEnemy(int EnemyIndex)
+{
+	if (!this)
+		return;
+
+	if (EnemyIndex < 0 && EnemyIndex != -2)
+		this->ForceEnemyIndex = -1;
+	else
+		this->ForceEnemyIndex = EnemyIndex;
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -64,6 +64,8 @@ public:
 		};
 		std::vector<SWExt> SuperExts;
 
+		int ForceEnemyIndex;
+
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, PowerPlantEnhancers {}
 			, OwnedLimboDeliveredBuildings {}
@@ -91,6 +93,7 @@ public:
 			, AIFireSaleDelayTimer {}
 			, SuspendedEMPulseSWs {}
 			, SuperExts(SuperWeaponTypeClass::Array.Count)
+			, ForceEnemyIndex(-1)
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding);
@@ -100,6 +103,9 @@ public:
 		void UpdateNonMFBFactoryCounts(AbstractType rtti, bool remove, bool isNaval);
 		int GetFactoryCountWithoutNonMFB(AbstractType rtti, bool isNaval);
 		float GetRestrictedFactoryPlantMult(TechnoTypeClass* pTechnoType) const;
+
+		int GetForceEnemyIndex();
+		void SetForceEnemy(int EnemyIndex);
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -105,7 +105,7 @@ public:
 		float GetRestrictedFactoryPlantMult(TechnoTypeClass* pTechnoType) const;
 
 		int GetForceEnemyIndex();
-		void SetForceEnemy(int EnemyIndex);
+		void SetForceEnemyIndex(int EnemyIndex);
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/House/Hooks.ForceEnemy.cpp
+++ b/src/Ext/House/Hooks.ForceEnemy.cpp
@@ -5,12 +5,15 @@ DEFINE_HOOK(0x5047D0, HouseClass_UpdateAngerNodes_SetForceEnemy, 0x6)
 	GET(HouseClass*, pThis, EAX);
 	enum { ReturnValue = 0x50483F };
 
-	int forceIndex = HouseExt::ExtMap.Find(pThis)->GetForceEnemyIndex();
-
-	if (forceIndex >= 0 || forceIndex == -2)
+	if (pThis)
 	{
-		R->EDX(forceIndex == -2 ? -1 : forceIndex);
-		return ReturnValue;
+		int forceIndex = HouseExt::ExtMap.Find(pThis)->GetForceEnemyIndex();
+
+		if (forceIndex >= 0 || forceIndex == -2)
+		{
+			R->EDX(forceIndex == -2 ? -1 : forceIndex);
+			return ReturnValue;
+		}
 	}
 
 	return 0;
@@ -28,7 +31,7 @@ DEFINE_HOOK(0x4FD772, HouseClass_ClearForceEnemy, 0xA)			// HouseClass_UpdateAI
 
 	if (pThis)
 	{
-		HouseExt::ExtMap.Find(pThis)->SetForceEnemy(-1);
+		HouseExt::ExtMap.Find(pThis)->SetForceEnemyIndex(-1);
 		pThis->UpdateAngerNodes(0, nullptr);
 	}
 

--- a/src/Ext/House/Hooks.ForceEnemy.cpp
+++ b/src/Ext/House/Hooks.ForceEnemy.cpp
@@ -1,0 +1,36 @@
+#include "Body.h"
+
+DEFINE_HOOK(0x5047D0, HouseClass_UpdateAngerNodes_SetForceEnemy, 0x6)
+{
+	GET(HouseClass*, pThis, EAX);
+	enum { ReturnValue = 0x50483F };
+
+	int forceIndex = HouseExt::ExtMap.Find(pThis)->GetForceEnemyIndex();
+
+	if (forceIndex >= 0 || forceIndex == -2)
+	{
+		R->EDX(forceIndex == -2 ? -1 : forceIndex);
+		return ReturnValue;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x4F9BFC, HouseClass_ClearForceEnemy, 0xA)	// HouseClass_MakeAlly
+DEFINE_HOOK(0x4FD772, HouseClass_ClearForceEnemy, 0xA)			// HouseClass_UpdateAI
+{
+	HouseClass* pThis = nullptr;
+
+	if (R->Origin() == 0x4FD772)
+		pThis = R->EBX<HouseClass*>();
+	else
+		pThis = R->ESI<HouseClass*>();
+
+	if (pThis)
+	{
+		HouseExt::ExtMap.Find(pThis)->SetForceEnemy(-1);
+		pThis->UpdateAngerNodes(0, nullptr);
+	}
+
+	return 0;
+}

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -426,7 +426,7 @@ bool TActionExt::EditAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectCl
 
 			setValue(pTargetHouse);
 		}
-		else
+		else if (pThis->Value == -1)
 		{
 			for (auto pTargetHouse : HouseClass::Array)
 			{
@@ -452,7 +452,7 @@ bool TActionExt::ClearAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectC
 				pAngerNode.AngerLevel = 0;
 		}
 	}
-	else
+	else  if (pThis->Value == -1)
 	{
 		for (auto pTargetHouse : HouseClass::Array)
 		{
@@ -493,7 +493,7 @@ bool TActionExt::SetForceEnemy(TActionClass* pThis, HouseClass* pHouse, ObjectCl
 			pHouse->EnemyHouseIndex = -1;
 		}
 	}
-	else
+	else if (pThis->Param3 == -1)
 	{
 		pHouseExt->SetForceEnemy(-1);
 		pHouse->UpdateAngerNodes(0, nullptr);

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -431,7 +431,9 @@ bool TActionExt::EditAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectCl
 	else if (pThis->Value == -1)
 	{
 		for (auto pTargetHouse : HouseClass::Array)
+		{
 			setValue(pTargetHouse);
+		}
 
 		pHouse->UpdateAngerNodes(0, nullptr);
 	}
@@ -466,7 +468,9 @@ bool TActionExt::ClearAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectC
 	else if (pThis->Value == -1)
 	{
 		for (auto& pAngerNode : pHouse->AngerNodes)
+		{
 			pAngerNode.AngerLevel = 0;
+		}
 
 		pHouse->UpdateAngerNodes(0, nullptr);
 	}
@@ -477,8 +481,6 @@ bool TActionExt::ClearAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectC
 bool TActionExt::SetForceEnemy(TActionClass* pThis, HouseClass* pHouse, ObjectClass* pObject, TriggerClass* pTrigger, CellStruct const& location)
 {
 	auto const pHouseExt = HouseExt::ExtMap.Find(pHouse);
-	if (!pHouseExt)
-		return true;
 
 	if (pThis->Param3 >= 0 || pThis->Param3 == -2)
 	{
@@ -491,19 +493,19 @@ bool TActionExt::SetForceEnemy(TActionClass* pThis, HouseClass* pHouse, ObjectCl
 			if (pTargetHouse && pHouse != pTargetHouse &&
 				!pHouse->IsAlliedWith(pTargetHouse))
 			{
-				pHouseExt->SetForceEnemy(pTargetHouse->GetArrayIndex());
+				pHouseExt->SetForceEnemyIndex(pTargetHouse->GetArrayIndex());
 				pHouse->UpdateAngerNodes(0, nullptr);
 			}
 		}
 		else
 		{
-			pHouseExt->SetForceEnemy(-2);
+			pHouseExt->SetForceEnemyIndex(-2);
 			pHouse->UpdateAngerNodes(0, nullptr);
 		}
 	}
 	else if (pThis->Param3 == -1)
 	{
-		pHouseExt->SetForceEnemy(-1);
+		pHouseExt->SetForceEnemyIndex(-1);
 		pHouse->UpdateAngerNodes(0, nullptr);
 	}
 

--- a/src/Ext/TAction/Body.h
+++ b/src/Ext/TAction/Body.h
@@ -19,6 +19,10 @@ enum class PhobosTriggerAction : unsigned int
 	RunSuperWeaponAtLocation = 505,
 	RunSuperWeaponAtWaypoint = 506,
 	ToggleMCVRedeploy = 510,
+
+	EditAngerNode = 606,
+	ClearAngerNode = 607,
+	SetForceEnemy = 608,
 };
 
 class TActionExt
@@ -63,6 +67,10 @@ public:
 	ACTION_FUNC(RunSuperWeaponAtLocation);
 	ACTION_FUNC(RunSuperWeaponAtWaypoint);
 	ACTION_FUNC(ToggleMCVRedeploy);
+
+	ACTION_FUNC(EditAngerNode);
+	ACTION_FUNC(ClearAngerNode);
+	ACTION_FUNC(SetForceEnemy);
 
 	static bool RunSuperWeaponAt(TActionClass* pThis, int X, int Y);
 


### PR DESCRIPTION
This is the third time it's been pushed, and I don't know why every forced merge causes PR to shut down.

Function for three trigger actions 606-608:

- 606: Edit the hate-value that triggers houses against specified house. -1 for all houses.
- 607: Clear the hate-value that triggers houses against specified house. -1 for all houses
- 608: Set a forced enemy that is not affected by hate-value. -1 will remove forced enemies, -2 will force no enemies.

----------------------
这是第三次推送它了，我不知道为什么每次强制合并都会导致PR关闭。

功能为三个触发动作 606-608：

- 606 : 编辑触发所属方对指定所属方的仇恨值。-1为全部所属方。
- 607 : 清除触发所属方对指定所属方的仇恨值。-1为全部所属方。
- 608 : 设置一个不会被仇恨值影响的强制敌人。-1删除强制敌人，-2强制没有敌人。