### PR TITLE
[Vanillia Enhancement] Customize harvester dump amount

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -375,6 +375,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead
   - Fix the bug that a unit can overlap with `Teleport` units after it's been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads
   - Customize parasite culling targets
+  - Customize harvester dump amount
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -21,6 +21,7 @@
     <ClCompile Include="src\Blowfish\blowfish.cpp" />
     <ClCompile Include="src\Blowfish\Hooks.Blowfish.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Hooks.MatrixOp.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.Harvester.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Sinking.cpp" />
     <ClCompile Include="src\Misc\Hooks.AlphaImage.cpp" />
     <ClCompile Include="src\New\Entity\AttachEffectClass.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1478,7 +1478,7 @@ TurretShadow=   ; boolean
 ### Customize harvester dump amount
 
 - Now you can limit how much ore the harvester can dump out per time, like it in Tiberium Sun.
-- Equal or less 0 means no limit, it will always dump out all at one time.
+- Less than or equal to 0 means no limit, it will always dump out all at one time.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1475,6 +1475,20 @@ In `artmd.ini`:
 TurretShadow=   ; boolean
 ```
 
+### Customize harvester dump amount
+
+- Now you can limit how much ore the harvester can dump out per time, like it in Tiberium Sun.
+- Equal or less 0 means no limit, it will always dump out all at one time.
+
+In `rulesmd.ini`:
+```ini
+[General]
+HarvesterDumpAmount=0.0f              ; float point value
+
+[SOMEVEHICLE]
+HarvesterDumpAmount=                  ; float point value
+```
+
 ## Veinholes & Weeds
 
 ### Veinholes

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1483,7 +1483,7 @@ TurretShadow=   ; boolean
 In `rulesmd.ini`:
 ```ini
 [General]
-HarvesterDumpAmount=0.0f              ; float point value
+HarvesterDumpAmount=0.0               ; float point value
 
 [SOMEVEHICLE]
 HarvesterDumpAmount=                  ; float point value

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -360,6 +360,7 @@ New:
 - [Removed dependency on `blowfish.dll`](Miscellanous.md#blowfish-dependency) (by ZivDero)
 - [Warhead that can not kill](New-or-Enhanced-Logics.md#warhead-that-cannot-kill) (by FS-21)
 - [Customize parasite culling targets](Fixed-or-Improved-Logics.md#customizing-parasite-culling-targets) (by NetsuNegi)
+- Customize harvester dump amount (by NetsuNegi)
 
 Vanilla fixes:
 - Prevent the units with locomotors that cause problems from entering the tank bunker (by TaranDahl)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -68,6 +68,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	INI_EX exINI(pINI);
 
 	this->Storage_TiberiumIndex.Read(exINI, GameStrings::General, "Storage.TiberiumIndex");
+	this->HarvesterDumpAmount.Read(exINI, GameStrings::General, "HarvesterDumpAmount");
 	this->InfantryGainSelfHealCap.Read(exINI, GameStrings::General, "InfantryGainSelfHealCap");
 	this->UnitsGainSelfHealCap.Read(exINI, GameStrings::General, "UnitsGainSelfHealCap");
 	this->GainSelfHealAllowMultiplayPassive.Read(exINI, GameStrings::General, "GainSelfHealAllowMultiplayPassive");
@@ -319,6 +320,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AITargetTypesLists)
 		.Process(this->AIScriptsLists)
 		.Process(this->Storage_TiberiumIndex)
+		.Process(this->HarvesterDumpAmount)
 		.Process(this->InfantryGainSelfHealCap)
 		.Process(this->UnitsGainSelfHealCap)
 		.Process(this->GainSelfHealAllowMultiplayPassive)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -32,6 +32,7 @@ public:
 		std::vector<std::vector<ScriptTypeClass*>> AIScriptsLists;
 
 		Valueable<int> Storage_TiberiumIndex;
+		Valueable<float> HarvesterDumpAmount;
 		Nullable<int> InfantryGainSelfHealCap;
 		Nullable<int> UnitsGainSelfHealCap;
 		Valueable<bool> GainSelfHealAllowMultiplayPassive;
@@ -209,6 +210,7 @@ public:
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
+			, HarvesterDumpAmount { 0.0f }
 			, InfantryGainSelfHealCap {}
 			, UnitsGainSelfHealCap {}
 			, GainSelfHealAllowMultiplayPassive { true }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -299,6 +299,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ForbidParallelAIQueues.Read(exINI, pSection, "ForbidParallelAIQueues");
 	this->ShieldType.Read<true>(exINI, pSection, "ShieldType");
 
+	this->HarvesterDumpAmount.Read(exINI, pSection, "HarvesterDumpAmount");
+
 	this->Ammo_AddOnDeploy.Read(exINI, pSection, "Ammo.AddOnDeploy");
 	this->Ammo_AutoDeployMinimumAmount.Read(exINI, pSection, "Ammo.AutoDeployMinimumAmount");
 	this->Ammo_AutoDeployMaximumAmount.Read(exINI, pSection, "Ammo.AutoDeployMaximumAmount");
@@ -727,6 +729,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ForbidParallelAIQueues)
 		.Process(this->ShieldType)
 		.Process(this->PassengerDeletionType)
+
+		.Process(this->HarvesterDumpAmount)
 
 		.Process(this->Ammo_AddOnDeploy)
 		.Process(this->Ammo_AutoDeployMinimumAmount)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -61,6 +61,8 @@ public:
 		std::unique_ptr<PassengerDeletionTypeClass> PassengerDeletionType;
 		std::unique_ptr<DroppodTypeClass> DroppodType;
 
+		Nullable<float> HarvesterDumpAmount;
+
 		Valueable<int> Ammo_AddOnDeploy;
 		Valueable<int> Ammo_AutoDeployMinimumAmount;
 		Valueable<int> Ammo_AutoDeployMaximumAmount;
@@ -406,6 +408,8 @@ public:
 			, DeployingAnim_KeepUnitVisible { false }
 			, DeployingAnim_ReverseForUndeploy { true }
 			, DeployingAnim_UseUnitDrawer { true }
+
+			, HarvesterDumpAmount {}
 
 			, Ammo_AddOnDeploy { 0 }
 			, Ammo_AutoDeployMinimumAmount { -1 }

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -1,0 +1,23 @@
+#include <UnitClass.h>
+
+#include <Ext/TechnoType/Body.h>
+
+DEFINE_HOOK(0x73E411, UnitClass_Mission_Unload_DumpAmount, 0x7)
+{
+	enum { SkipGameCode = 0x73E41D };
+
+	GET(UnitClass*, pThis, ESI);
+	GET(int, tiberiumIdx, EBP);
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
+	const float totalAmount = pThis->Tiberium.GetAmount(tiberiumIdx);
+	float dumpAmount = pTypeExt->HarvesterDumpAmount.Get(RulesExt::Global()->HarvesterDumpAmount);
+
+	if (dumpAmount > 0)
+		dumpAmount = std::min(dumpAmount, totalAmount);
+	else
+		dumpAmount = totalAmount;
+
+	__asm fld dumpAmount;
+
+	return SkipGameCode;
+}

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -12,9 +12,7 @@ DEFINE_HOOK(0x73E411, UnitClass_Mission_Unload_DumpAmount, 0x7)
 	const float totalAmount = pThis->Tiberium.GetAmount(tiberiumIdx);
 	float dumpAmount = pTypeExt->HarvesterDumpAmount.Get(RulesExt::Global()->HarvesterDumpAmount);
 
-	if (dumpAmount > 0)
-		dumpAmount = std::min(dumpAmount, totalAmount);
-	else
+	if (dumpAmount <= 0.0f || totalAmount < dumpAmount)
 		dumpAmount = totalAmount;
 
 	__asm fld dumpAmount;


### PR DESCRIPTION
- Now you can limit how much ore the harvester can dump out per time, like it in Tiberium Sun.
- 现在你可以限制矿车每次能倾倒出多少矿石，就像《泰伯利亚之日》中的那样。
- Less than or equal to 0 means no limit, it will always dump out all at one time.
- 小于等于0意味着没有限制，它总是一次性倒光全部矿石。

In `rulesmd.ini`:
```ini
[General]
HarvesterDumpAmount=0.0               ; float point value

[SOMEVEHICLE]
HarvesterDumpAmount=                  ; float point value
```