### PR TITLE
[Vanilla Fix] Two fixes related to abnormal deaths

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -446,7 +446,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue that MCV will self-destruct when using trigger 107 to teleport
   - Fix an issue that moving MCV with Teleport locomotion will cause reconnection error
   - Jumpjet Tilts While Moving
-  - Fix an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupable building that has been removed and is not real dead
+  - Fix an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -446,6 +446,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue that MCV will self-destruct when using trigger 107 to teleport
   - Fix an issue that moving MCV with Teleport locomotion will cause reconnection error
   - Jumpjet Tilts While Moving
+  - Fix an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupable building that has been removed and is not real dead
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -447,6 +447,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue that moving MCV with Teleport locomotion will cause reconnection error
   - Jumpjet Tilts While Moving
   - Fix an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead
+  - Fix an issue that game crashes when spawnee has been removed and is not real dead
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -218,6 +218,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead.
 - Fixed the bug that a unit can overlap with `Teleport` units after it's been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads.
 - Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead.
+- Fixed an issue that game crashes when spawnee has been removed and is not real dead.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -216,8 +216,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that MCV will self-destruct when using trigger 107 to teleport.
 - Fixed an issue that moving MCV with Teleport locomotion will cause reconnection error.
 - Fixed wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead.
-- Fixed the bug that a unit can overlap with `Teleport` units after it's been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads
-- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupable building that has been removed and is not real dead.
+- Fixed the bug that a unit can overlap with `Teleport` units after it's been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads.
+- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -217,6 +217,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that moving MCV with Teleport locomotion will cause reconnection error.
 - Fixed wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead.
 - Fixed the bug that a unit can overlap with `Teleport` units after it's been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads
+- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupable building that has been removed and is not real dead.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -380,6 +380,7 @@ Vanilla fixes:
 - Fixed an issue that moving MCV with Teleport locomotion will cause reconnection error (by CrimRecya)
 - Fixed wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead (by NetsuNegi)
 - Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead (by CrimRecya)
+- Fixed an issue that game crashes when spawnee has been removed and is not real dead (by CrimRecya)
 
 Phobos fixes:
 - Fixed an issue that MCV will self-destruct when using trigger 107 to teleport (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -379,7 +379,7 @@ Vanilla fixes:
 - Fixed an issue that teleport units board transport vehicles on the bridge will create an impassable invisible barrier, which may cause the game to freeze or even crash (by NetsuNegi)
 - Fixed an issue that moving MCV with Teleport locomotion will cause reconnection error (by CrimRecya)
 - Fixed wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead (by NetsuNegi)
-- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead.
+- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead (by CrimRecya)
 
 Phobos fixes:
 - Fixed an issue that MCV will self-destruct when using trigger 107 to teleport (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -379,6 +379,7 @@ Vanilla fixes:
 - Fixed an issue that teleport units board transport vehicles on the bridge will create an impassable invisible barrier, which may cause the game to freeze or even crash (by NetsuNegi)
 - Fixed an issue that moving MCV with Teleport locomotion will cause reconnection error (by CrimRecya)
 - Fixed wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead (by NetsuNegi)
+- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupable building that has been removed and is not real dead.
 
 Phobos fixes:
 - Fixed an issue that MCV will self-destruct when using trigger 107 to teleport (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -379,7 +379,7 @@ Vanilla fixes:
 - Fixed an issue that teleport units board transport vehicles on the bridge will create an impassable invisible barrier, which may cause the game to freeze or even crash (by NetsuNegi)
 - Fixed an issue that moving MCV with Teleport locomotion will cause reconnection error (by CrimRecya)
 - Fixed wrong shadow when a vehicle has hover locomotor and is being lifted by `IsLocomotor=yes` warhead (by NetsuNegi)
-- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupable building that has been removed and is not real dead.
+- Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead.
 
 Phobos fixes:
 - Fixed an issue that MCV will self-destruct when using trigger 107 to teleport (by CrimRecya)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1650,7 +1650,7 @@ DEFINE_HOOK(0x5F530B, ObjectClass_Disappear_AnnounceExpiredPointer, 0x6)
 // I think no one wants to see wild pointers caused by WW's negligence
 DEFINE_HOOK(0x4D9A62, FootClass_PointerExpired_RemoveDestination, 0xA)
 {
-	GET_STACK(bool, removed, STACK_OFFSET(0x8, 0x4));
+	GET_STACK(bool, removed, STACK_OFFSET(0x1C, 0x8));
 	return removed ? 0x4D9ABD : 0;
 }
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1648,10 +1648,15 @@ DEFINE_HOOK(0x5F530B, ObjectClass_Disappear_AnnounceExpiredPointer, 0x6)
 }
 
 // I think no one wants to see wild pointers caused by WW's negligence
-DEFINE_HOOK(0x4D9A62, FootClass_PointerExpired_RemoveDestination, 0xA)
+DEFINE_HOOK(0x4D9A1B, FootClass_PointerExpired_RemoveDestination, 0x6)
 {
 	GET_STACK(bool, removed, STACK_OFFSET(0x1C, 0x8));
-	return removed ? 0x4D9ABD : 0;
+
+	if (removed)
+		return 0x4D9ABD;
+
+	R->BL(true);
+	return 0x4D9A25;
 }
 
 namespace RemoveSpawneeHelper

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1647,6 +1647,13 @@ DEFINE_HOOK(0x5F530B, ObjectClass_Disappear_AnnounceExpiredPointer, 0x6)
 	return 0x5F5311;
 }
 
+// I think no one wants to see wild pointers caused by WW's negligence
+DEFINE_HOOK(0x4D9A62, FootClass_PointerExpired_RemoveDestination, 0xA)
+{
+	GET_STACK(bool, removed, STACK_OFFSET(0x8, 0x4));
+	return removed ? 0x4D9ABD : 0;
+}
+
 #pragma endregion
 
 // IsSonic wave drawing uses fixed-size arrays accessed with index that is determined based on factors like wave lifetime,

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1654,6 +1654,29 @@ DEFINE_HOOK(0x4D9A62, FootClass_PointerExpired_RemoveDestination, 0xA)
 	return removed ? 0x4D9ABD : 0;
 }
 
+namespace RemoveSpawneeHelper
+{
+	bool removed = false;
+}
+
+DEFINE_HOOK(0x707B23, TechnoClass_PointerExpired_RemoveSpawnee, 0x6)
+{
+	GET(SpawnManagerClass*, pSpawnManager, ECX);
+	GET(AbstractClass*, pRemove, EBP);
+	GET_STACK(bool, removed, STACK_OFFSET(0x20, 0x8));
+
+	RemoveSpawneeHelper::removed = removed;
+	pSpawnManager->UnlinkPointer(pRemove);
+	RemoveSpawneeHelper::removed = false;
+
+	return 0x707B29;
+}
+
+DEFINE_HOOK(0x6B7CE4, SpawnManagerClass_UnlinkPointer_RemoveSpawnee, 0x6)
+{
+	return RemoveSpawneeHelper::removed ? 0x6B7CF4 : 0;
+}
+
 #pragma endregion
 
 // IsSonic wave drawing uses fixed-size arrays accessed with index that is determined based on factors like wave lifetime,


### PR DESCRIPTION
  - Fixed an issue that game crashes (EIP:7FB178) when infantry are about to enter an occupiable building that has been removed and is not real dead.
  - Fixed an issue that game crashes when spawnee has been removed and is not real dead.

---

PS: such as sell action, vanish by auto death or removed by temporal weapon.