### PR TITLE
[Dehardcode] Make harvesters do addtional scan after unload

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -493,6 +493,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue where AI would select unreachable buildings and get stuck when looking for buildings like tank bunkers, bio reactors, etc
   - Prone speed customization
   - RadarInvisible for non-enemy house
+  - Make harvesters do addtional scan after unload
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1428,6 +1428,17 @@ DeployingAnim.ReverseForUndeploy=true  ; boolean
 DeployingAnim.UseUnitDrawer=true       ; boolean
 ```
 
+### Make harvesters do addtional scan after unload
+
+- In vanilla, miners will remember their current location when they reach full load and move to that location after unloading. This makes miners to gradually move deeper into the mine and ignore the closer minerals.
+- Now you can have the miner search for the nearest mineral again after unloading. If a closer mineral is found, the miner will go to that location instead of the previously recorded location.
+
+In `rulesmd.ini`:
+```ini
+[General]
+HarvesterScanAfterUnload=false     ; boolean
+```
+
 ### Preserve Iron Curtain / Force Shield status on type conversion
 
 ![image](_static/images/preserve-ic.gif)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1437,6 +1437,9 @@ In `rulesmd.ini`:
 ```ini
 [General]
 HarvesterScanAfterUnload=false     ; boolean
+
+[SOMEVEHICLE]
+HarvesterScanAfterUnload=          ; boolean, default to [General] -> HarvesterScanAfterUnload
 ```
 
 ### Preserve Iron Curtain / Force Shield status on type conversion

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -366,6 +366,7 @@ New:
 - Select box logic (by NetsuNegi)
 - Customize airstrike targets (by NetsuNegi)
 - Aggressive attack move mission (by CrimRecya)
+- Make harvesters do addtional scan after unload (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -260,6 +260,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
   	this->DamagedSpeed.Read(exINI, GameStrings::General, "DamagedSpeed");
 
+	this->HarvesterScanAfterUnload.Read(exINI, GameStrings::General, "HarvesterScanAfterUnload");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -478,6 +480,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ProneSpeed_Crawls)
 		.Process(this->ProneSpeed_NoCrawls)
     	.Process(this->DamagedSpeed)
+		.Process(this->HarvesterScanAfterUnload)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -215,6 +215,8 @@ public:
 
     	Valueable<double> DamagedSpeed;
 
+		Valueable<bool> HarvesterScanAfterUnload;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -375,6 +377,8 @@ public:
 			, ProneSpeed_NoCrawls { 1.5 }
 
       		, DamagedSpeed { 0.75 }
+			
+			, HarvesterScanAfterUnload { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -547,6 +547,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Overload_ParticleSys.Read(exINI, pSection, "Overload.ParticleSys");
 	this->Overload_ParticleSysCount.Read(exINI, pSection, "Overload.ParticleSysCount");
 
+	this->HarvesterScanAfterUnload.Read(exINI, pSection, "HarvesterScanAfterUnload");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1012,6 +1014,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Overload_DeathSound)
 		.Process(this->Overload_ParticleSys)
 		.Process(this->Overload_ParticleSysCount)
+
+		.Process(this->HarvesterScanAfterUnload)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -342,6 +342,8 @@ public:
 		Nullable<ParticleSystemTypeClass*> Overload_ParticleSys;
 		Valueable<int> Overload_ParticleSysCount;
 
+		Nullable<bool> HarvesterScanAfterUnload;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, UIDescription {}
@@ -637,6 +639,8 @@ public:
 			, Overload_DeathSound {}
 			, Overload_ParticleSys {}
 			, Overload_ParticleSysCount { 5 }
+
+			, HarvesterScanAfterUnload {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -20,30 +20,32 @@ DEFINE_HOOK(0x73E411, UnitClass_Mission_Unload_DumpAmount, 0x7)
 	return SkipGameCode;
 }
 
+#pragma region HarvesterScanAfterUnload
+
 DEFINE_HOOK(0x73E730, UnitClass_MissionHarvest_HarvesterScanAfterUnload, 0x5)
 {
 	GET(UnitClass* const, pThis, EBP);
 	GET(AbstractClass* const, pFocus, EAX);
 
 	// Focus is set when the harvester is fully loaded and go home.
-	if (pFocus)
+	if (pFocus && TechnoTypeExt::ExtMap.Find(pThis->Type)->HarvesterScanAfterUnload.Get(RulesExt::Global()->HarvesterScanAfterUnload))
 	{
-		CellStruct* pCellBuffer;
-		CellStruct* pCellStru = pThis->ScanForTiberium(pCellBuffer, RulesClass::Instance->TiberiumLongScan / 256, 0);
+		auto cellBuffer = CellStruct::Empty;
+		const auto pCellStru = pThis->ScanForTiberium(&cellBuffer, RulesClass::Instance->TiberiumLongScan / 256, 0);
 
 		if (*pCellStru != CellStruct::Empty)
 		{
-			auto pCell = MapClass::Instance.GetCellAt(*pCellStru);
-			int distFromTiberium = pCell ? pThis->DistanceFrom(pCell) : -1;
-			int distFromFocus = pThis->DistanceFrom(pFocus);
+			const auto pCell = MapClass::Instance.TryGetCellAt(*pCellStru);
+			const auto distFromTiberium = pCell ? pThis->DistanceFrom(pCell) : -1;
+			const auto distFromFocus = pThis->DistanceFrom(pFocus);
 
 			// Check if pCell is better than focus.
 			if (distFromTiberium > 0 && distFromTiberium < distFromFocus)
-			{
 				R->EAX(pCell);
-			}
 		}
 	}
 
 	return 0;
 }
+
+#pragma endregion

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -19,3 +19,31 @@ DEFINE_HOOK(0x73E411, UnitClass_Mission_Unload_DumpAmount, 0x7)
 
 	return SkipGameCode;
 }
+
+DEFINE_HOOK(0x73E730, UnitClass_MissionHarvest_HarvesterScanAfterUnload, 0x5)
+{
+	GET(UnitClass* const, pThis, EBP);
+	GET(AbstractClass* const, pFocus, EAX);
+
+	// Focus is set when the harvester is fully loaded and go home.
+	if (pFocus)
+	{
+		CellStruct* pCellBuffer;
+		CellStruct* pCellStru = pThis->ScanForTiberium(pCellBuffer, RulesClass::Instance->TiberiumLongScan / 256, 0);
+
+		if (*pCellStru != CellStruct::Empty)
+		{
+			auto pCell = MapClass::Instance.GetCellAt(*pCellStru);
+			int distFromTiberium = pCell ? pThis->DistanceFrom(pCell) : -1;
+			int distFromFocus = pThis->DistanceFrom(pFocus);
+
+			// Check if pCell is better than focus.
+			if (distFromTiberium > 0 && distFromTiberium < distFromFocus)
+			{
+				R->EAX(pCell);
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -31,7 +31,7 @@ DEFINE_HOOK(0x73E730, UnitClass_MissionHarvest_HarvesterScanAfterUnload, 0x5)
 	if (pFocus && TechnoTypeExt::ExtMap.Find(pThis->Type)->HarvesterScanAfterUnload.Get(RulesExt::Global()->HarvesterScanAfterUnload))
 	{
 		auto cellBuffer = CellStruct::Empty;
-		const auto pCellStru = pThis->ScanForTiberium(&cellBuffer, RulesClass::Instance->TiberiumLongScan / 256, 0);
+		const auto pCellStru = pThis->ScanForTiberium(&cellBuffer, RulesClass::Instance->TiberiumLongScan / Unsorted::LeptonsPerCell, 0);
 
 		if (*pCellStru != CellStruct::Empty)
 		{


### PR DESCRIPTION
### Make harvesters do addtional scan after unload

- In vanilla, miners will remember their current location when they reach full load and move to that location after unloading. This makes miners to gradually move deeper into the mine and ignore the closer minerals.
- Now you can have the miner search for the nearest mineral again after unloading. If a closer mineral is found, the miner will go to that location instead of the previously recorded location.

In `rulesmd.ini`:
```ini
[General]
HarvesterScanAfterUnload=false     ; boolean

[SOMEVEHICLE]
HarvesterScanAfterUnload=          ; boolean, default to [General] -> HarvesterScanAfterUnload
```