### PR TITLE
[minor] Fix the AddAnger conflict with Ares.dll

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -354,6 +354,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix `Hospital=yes` building can't kick out infantry after loading a save
   - `Edit/Clear Hate-Value` Trigger Action
   - `Set Force Enemy` Trigger Action
+  - Fixed the issue where computer players did not search for new enemies after defeating them or forming alliances with them
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -222,6 +222,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Separated the AirstrikeClass pointer between the attacker/aircraft and the target to avoid erroneous overwriting issues.
 - Fixed the bug that buildings will always be tinted as airstrike owner.
 - Fixed the bug that 'AllowAirstrike=no' cannot completely prevent air strikes from being launched against it.
+- Fixed the issue where computer players did not search for new enemies after defeating them or forming alliances with them.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -676,6 +676,7 @@ Vanilla fixes:
 - Fixed an issue where the shadow of jumpjet remained on the ground when it was above the elevated bridge (by CrimRecya)
 - Fixed an issue where AI would select unreachable buildings and get stuck when looking for buildings like tank bunkers, bio reactors, etc. (by TaranDahl)
 - Fixed the bug that a unit can overlap with `Teleport` units after it's been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads (by NetsuNegi)
+- Fixed the issue where computer players did not search for new enemies after defeating them or forming alliances with them (by FlyStar)
 
 Phobos fixes:
 - Fixed a few errors of calling for superweapon launch by `LaunchSW` or building infiltration (by Trsdy)

--- a/src/Ext/House/Hooks.ForceEnemy.cpp
+++ b/src/Ext/House/Hooks.ForceEnemy.cpp
@@ -32,7 +32,8 @@ DEFINE_HOOK(0x4FD772, HouseClass_ClearForceEnemy, 0xA)			// HouseClass_UpdateAI
 	if (pThis)
 	{
 		HouseExt::ExtMap.Find(pThis)->SetForceEnemyIndex(-1);
-		pThis->UpdateAngerNodes(0, nullptr);
+		pThis->UpdateAngerNodes(0, pThis);
+		return R->Origin() + 0xA;
 	}
 
 	return 0;

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -426,7 +426,7 @@ bool TActionExt::EditAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectCl
 			HouseClass::FindByCountryIndex(pThis->Value);
 
 		setValue(pTargetHouse);
-		pHouse->UpdateAngerNodes(0, nullptr);
+		pHouse->UpdateAngerNodes(0, pHouse);
 	}
 	else if (pThis->Value == -1)
 	{
@@ -435,7 +435,7 @@ bool TActionExt::EditAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectCl
 			setValue(pTargetHouse);
 		}
 
-		pHouse->UpdateAngerNodes(0, nullptr);
+		pHouse->UpdateAngerNodes(0, pHouse);
 	}
 
 	return true;
@@ -460,7 +460,7 @@ bool TActionExt::ClearAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectC
 					continue;
 
 				pAngerNode.AngerLevel = 0;
-				pHouse->UpdateAngerNodes(0, nullptr);
+				pHouse->UpdateAngerNodes(0, pHouse);
 				break;
 			}
 		}
@@ -472,7 +472,7 @@ bool TActionExt::ClearAngerNode(TActionClass* pThis, HouseClass* pHouse, ObjectC
 			pAngerNode.AngerLevel = 0;
 		}
 
-		pHouse->UpdateAngerNodes(0, nullptr);
+		pHouse->UpdateAngerNodes(0, pHouse);
 	}
 
 	return true;
@@ -494,19 +494,19 @@ bool TActionExt::SetForceEnemy(TActionClass* pThis, HouseClass* pHouse, ObjectCl
 				!pHouse->IsAlliedWith(pTargetHouse))
 			{
 				pHouseExt->SetForceEnemyIndex(pTargetHouse->GetArrayIndex());
-				pHouse->UpdateAngerNodes(0, nullptr);
+				pHouse->UpdateAngerNodes(0, pHouse);
 			}
 		}
 		else
 		{
 			pHouseExt->SetForceEnemyIndex(-2);
-			pHouse->UpdateAngerNodes(0, nullptr);
+			pHouse->UpdateAngerNodes(0, pHouse);
 		}
 	}
 	else if (pThis->Param3 == -1)
 	{
 		pHouseExt->SetForceEnemyIndex(-1);
-		pHouse->UpdateAngerNodes(0, nullptr);
+		pHouse->UpdateAngerNodes(0, pHouse);
 	}
 
 	return true;


### PR DESCRIPTION
when a certain house was defeated, the Ares.dll crashed due to writing incorrect parameters. now I'm trying to solve this problem.
---------
由于写入了错误的参数导致某个所属方战败时Ares.dll崩溃了，我正在尝试解决这个问题。
