### PR TITLE
[Minor] Make PassengerDeletion trigger UpdatePower for Bio Reactor

### DIFF
--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -76,10 +76,8 @@ inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int ID)
 		pBuilding->DiscoveredBy(pOwner);
 
 		pOwner->RegisterGain(pBuilding, false);
-		pOwner->UpdatePower();
 		pOwner->RecheckTechTree = true;
 		pOwner->RecheckPower = true;
-		pOwner->RecheckRadar = true;
 		pOwner->Buildings.AddItem(pBuilding);
 
 		// Different types of building logics

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -327,6 +327,13 @@ void TechnoExt::ExtData::EatPassengers()
 					pPassenger->KillPassengers(pSource);
 					pPassenger->RegisterDestruction(pSource);
 					pPassenger->UnInit();
+
+					// Handle extra power
+					if (auto const pBld = abstract_cast<BuildingClass*, true>(pThis))
+					{
+						if (pBld->HasExtraPowerBonus)
+							pThis->Owner->RecheckPower = true;
+					}
 				}
 
 				this->PassengerDeletionTimer.Stop();


### PR DESCRIPTION
previously using `PassengerDeletion` on Bio Reactor can't change its power output until another recheck event happens, which should be fixed now. Also removed redundant checks in `LimboCreate` since `RecheckPower` already cover them