### PR TITLE
[Minor] Update on Arcing.AllowElevationInaccuracy

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -68,7 +68,7 @@ This page lists all the individual contributions to the project by their author.
   - Wall-Gate links
   - Ability for deployed infantry to use both weapons
   - Observer PCX loading screen
-  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
+  - Original `Arcing` elevation inaccuracy fix
   - Official CN docs for Build#29 and previous versions
 - **secsome (SEC-SOME)**:
   - Debug info dump hotkey
@@ -96,7 +96,7 @@ This page lists all the individual contributions to the project by their author.
   - Vanilla map preview reading bugfix
   - Customizable tooltip background
   - Parts of Ares calling code
-  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
+  - Original `Arcing` elevation inaccuracy fix
 - **Otamaa (Fahroni, BoredEXE)**:
   - Help with CellSpread
   - Ported and fixed custom RadType code
@@ -219,7 +219,7 @@ This page lists all the individual contributions to the project by their author.
   - `PipScale` pip size & ammo pip frame customization
   - Extension class optimization
   - Additional sync logging
-  - `Arcing` elevation inaccuracy fix
+  - Original `Arcing` elevation inaccuracy fix
   - `EMPulseCannon` projectile gravity fix
   - Custom palette support for wall overlays
   - Warhead animation improvements
@@ -392,6 +392,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it
   - Fix the bug that infantry ignored `Passengers` and `SizeLimit` when entering buildings
   - Tiberium eater logic
+  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons
@@ -466,7 +467,6 @@ This page lists all the individual contributions to the project by their author.
   - Aggressive attack move mission
   - Amphibious access vehicle
   - Fix an issue that spawned `Strafe` aircraft on aircraft carriers may not be able to return normally if aircraft carriers moved a short distance when the aircraft is landing
-  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -68,6 +68,7 @@ This page lists all the individual contributions to the project by their author.
   - Wall-Gate links
   - Ability for deployed infantry to use both weapons
   - Observer PCX loading screen
+  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
   - Official CN docs for Build#29 and previous versions
 - **secsome (SEC-SOME)**:
   - Debug info dump hotkey
@@ -95,6 +96,7 @@ This page lists all the individual contributions to the project by their author.
   - Vanilla map preview reading bugfix
   - Customizable tooltip background
   - Parts of Ares calling code
+  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
 - **Otamaa (Fahroni, BoredEXE)**:
   - Help with CellSpread
   - Ported and fixed custom RadType code
@@ -464,6 +466,7 @@ This page lists all the individual contributions to the project by their author.
   - Aggressive attack move mission
   - Amphibious access vehicle
   - Fix an issue that spawned `Strafe` aircraft on aircraft carriers may not be able to return normally if aircraft carriers moved a short distance when the aircraft is landing
+  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -393,7 +393,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug that infantry ignored `Passengers` and `SizeLimit` when entering buildings
   - Tiberium eater logic
   - Fix the bug that ships can travel on elevated bridges
-  - `Arcing` elevation inaccuracy fix and `Inaccurate` support
+  - `Arcing` elevation inaccuracy fix
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/src/Ext/Bullet/Body.cpp
+++ b/src/Ext/Bullet/Body.cpp
@@ -334,13 +334,13 @@ void BulletExt::SimulatedFiringUnlimbo(BulletClass* pBullet, HouseClass* pHouse,
 		const auto targetCoords = pBullet->Target->GetCenterCoords();
 		const auto gravity = BulletTypeExt::GetAdjustedGravity(pType);
 		const auto distanceCoords = targetCoords - sourceCoords;
-		const auto horizontalDistance = Point2D{distanceCoords.X, distanceCoords.Y}.Magnitude();
+		const auto horizontalDistance = Point2D { distanceCoords.X, distanceCoords.Y }.Magnitude();
 		const bool lobber = pWeapon->Lobber || static_cast<int>(horizontalDistance) < distanceCoords.Z; // 0x70D590
 		// The lower the horizontal velocity, the higher the trajectory
 		// WW calculates the launch angle (and limits it) before calculating the velocity
 		// Here, some magic numbers are used to directly simulate its calculation
 		const auto speedMult = (lobber ? 0.45 : (distanceCoords.Z > 0 ? 0.68 : 1.0)); // Simulated 0x48A9D0
-		const auto speed = static_cast<int>(speedMult * sqrt(horizontalDistance * gravity * 1.2)); // 0x48AB90
+		const auto speed = speedMult * sqrt(horizontalDistance * gravity * 1.2); // 0x48AB90
 
 		// Simulate firing Arcing bullet
 		if (horizontalDistance < 1e-10 || !speed)
@@ -390,49 +390,30 @@ void BulletExt::SimulatedFiringEffects(BulletClass* pBullet, HouseClass* pHouse,
 	}
 }
 
-void BulletExt::ExtData::ApplyArcingFix()
+void BulletExt::ApplyArcingFix(BulletClass* pThis, const CoordStruct& sourceCoords, const CoordStruct& targetCoords, BulletVelocity& velocity)
 {
-	auto pThis = this->OwnerObject();
-	auto const pType = pThis->Type;
-	bool inaccutate = pType->Inaccurate;
-	bool elevationFix = !this->TypeExtData->Arcing_AllowElevationInaccuracy;
-
-	if (!inaccutate && !elevationFix)
-		return;
-	
-	auto theSourceCoords = pThis->SourceCoords;
-	auto theTargetCoords = pThis->TargetCoords;
-	const auto pWeapon = pThis->WeaponType;
-
-	if (inaccutate)
-	{
-		const auto distance = theSourceCoords.DistanceFrom(theTargetCoords);
-		const auto pTypeExt = BulletTypeExt::ExtMap.Find(pType);
-		// Don't know whether the weapon is correctly set, if not, a fixed value of 10 will be used
-		const auto offsetMult = distance / (pWeapon ? pWeapon->Range : (10.0 * Unsorted::LeptonsPerCell));
-		const auto offsetMin = static_cast<int>(offsetMult * pTypeExt->BallisticScatter_Min.Get(Leptons(0)));
-		const auto offsetMax = static_cast<int>(offsetMult * pTypeExt->BallisticScatter_Max.Get(Leptons(RulesClass::Instance->BallisticScatter)));
-		const auto offsetDistance = ScenarioClass::Instance->Random.RandomRanged(offsetMin, offsetMax);
-		// Substitute to calculate random coordinates
-		theTargetCoords = MapClass::GetRandomCoordsNear(theTargetCoords, offsetDistance, false);
-	}
-
-	const auto distanceCoords = theTargetCoords - theSourceCoords;
+	const auto distanceCoords = targetCoords - sourceCoords;
 	const auto horizontalDistance = Point2D { distanceCoords.X, distanceCoords.Y }.Magnitude();
-	const bool lobber = pWeapon->Lobber || static_cast<int>(horizontalDistance) < distanceCoords.Z; // 0x70D590
+	const bool lobber = pThis->WeaponType->Lobber || static_cast<int>(horizontalDistance) < distanceCoords.Z; // 0x70D590
 	// The lower the horizontal velocity, the higher the trajectory
 	// WW calculates the launch angle (and limits it) before calculating the velocity
 	// Here, some magic numbers are used to directly simulate its calculation
 	const auto speedMult = (lobber ? 0.45 : (distanceCoords.Z > 0 ? 0.68 : 1.0)); // Simulated 0x48A9D0
-	const double gravity = BulletTypeExt::GetAdjustedGravity(pType);
+	const double gravity = BulletTypeExt::GetAdjustedGravity(pThis->Type);
 	const double speed = speedMult * sqrt(horizontalDistance * gravity * 1.2); // 0x48AB90
 
-	const auto mult = speed / horizontalDistance;
-	const auto zDelta = elevationFix ? distanceCoords.Z : 0;
-	pThis->Velocity.X = distanceCoords.X * mult;
-	pThis->Velocity.Y = distanceCoords.Y * mult;
-	pThis->Velocity.Z = zDelta * mult + (gravity * horizontalDistance) / (2 * speed);
-	pThis->Speed = static_cast<int>(speed);
+	if (horizontalDistance < 1e-10 || !speed)
+	{
+		// No solution
+		velocity.Z = speed;
+	}
+	else
+	{
+		const auto mult = speed / horizontalDistance;
+		velocity.X = static_cast<double>(distanceCoords.X) * mult;
+		velocity.Y = static_cast<double>(distanceCoords.Y) * mult;
+		velocity.Z = static_cast<double>(distanceCoords.Z) * mult + (gravity * horizontalDistance) / (2 * speed);
+	}
 }
 
 // =============================

--- a/src/Ext/Bullet/Body.cpp
+++ b/src/Ext/Bullet/Body.cpp
@@ -143,14 +143,13 @@ void BulletExt::ExtData::InitializeLaserTrails()
 
 	auto pThis = this->OwnerObject();
 
-	if (auto pTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type))
-	{
-		auto pOwner = pThis->Owner ? pThis->Owner->Owner : nullptr;
+	auto pTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type);
+	auto pOwner = pThis->Owner ? pThis->Owner->Owner : nullptr;
+	this->LaserTrails.reserve(pTypeExt->LaserTrail_Types.size());
 
-		for (auto const& idxTrail : pTypeExt->LaserTrail_Types)
-		{
-			this->LaserTrails.emplace_back(LaserTrailTypeClass::Array[idxTrail].get(), pOwner);
-		}
+	for (auto const& idxTrail : pTypeExt->LaserTrail_Types)
+	{
+		this->LaserTrails.emplace_back(LaserTrailTypeClass::Array[idxTrail].get(), pOwner);
 	}
 }
 
@@ -196,8 +195,8 @@ inline void BulletExt::SimulatedFiringAnim(BulletClass* pBullet, HouseClass* pHo
 
 	if (pAttach)
 	{
-		if (pAttach->WhatAmI() == AbstractType::Building)
-			pAnim->ZAdjust = SetBuildingFireAnimZAdjust(static_cast<BuildingClass*>(pAttach), pBullet->SourceCoords.Y);
+		if (const auto pBuilding = abstract_cast<BuildingClass*, true>(pAttach))
+			pAnim->ZAdjust = SetBuildingFireAnimZAdjust(pBuilding, pBullet->SourceCoords.Y);
 		else
 			pAnim->SetOwnerObject(pAttach);
 	}

--- a/src/Ext/Bullet/Body.h
+++ b/src/Ext/Bullet/Body.h
@@ -54,7 +54,6 @@ public:
 		void InterceptBullet(TechnoClass* pSource, WeaponTypeClass* pWeapon);
 		void ApplyRadiationToCell(CellStruct Cell, int Spread, int RadLevel);
 		void InitializeLaserTrails();
-		void ApplyArcingFix();
 
 	private:
 		template <typename T>
@@ -69,6 +68,8 @@ public:
 	};
 
 	static ExtContainer ExtMap;
+
+	static void ApplyArcingFix(BulletClass* pThis, const CoordStruct& sourceCoords, const CoordStruct& targetCoords, BulletVelocity& velocity);
 
 	static void SimulatedFiringUnlimbo(BulletClass* pBullet, HouseClass* pHouse, WeaponTypeClass* pWeapon, const CoordStruct& sourceCoords, bool randomVelocity);
 	static void SimulatedFiringEffects(BulletClass* pBullet, HouseClass* pHouse, ObjectClass* pAttach, bool firingEffect, bool visualEffect);

--- a/src/Ext/Bullet/Body.h
+++ b/src/Ext/Bullet/Body.h
@@ -54,6 +54,7 @@ public:
 		void InterceptBullet(TechnoClass* pSource, WeaponTypeClass* pWeapon);
 		void ApplyRadiationToCell(CellStruct Cell, int Spread, int RadLevel);
 		void InitializeLaserTrails();
+		void ApplyArcingFix();
 
 	private:
 		template <typename T>

--- a/src/Ext/Bullet/Hooks.DetonateLogics.cpp
+++ b/src/Ext/Bullet/Hooks.DetonateLogics.cpp
@@ -69,6 +69,7 @@ DEFINE_HOOK(0x4690C1, BulletClass_Logics_DetonateOnAllMapObjects, 0x8)
 		auto const originalLocation = pThis->Location;
 		auto const pOriginalTarget = pThis->Target;
 		auto const pExt = BulletExt::ExtMap.Find(pThis);
+		auto const isFull = pWHExt->DetonateOnAllMapObjects_Full;
 		auto pOwner = pThis->Owner ? pThis->Owner->Owner : pExt->FirerHouse;
 
 		auto copy_dvc = []<typename T>(const DynamicVectorClass<T>&dvc)
@@ -78,23 +79,21 @@ DEFINE_HOOK(0x4690C1, BulletClass_Logics_DetonateOnAllMapObjects, 0x8)
 			return vec;
 		};
 
-		std::function<void(TechnoClass*)> tryDetonate = [pThis, pWHExt, pOwner](TechnoClass* pTechno)
+		auto tryDetonate = [pThis, pWHExt, pOwner, isFull](TechnoClass* pTechno)
 			{
 				if (pWHExt->EligibleForFullMapDetonation(pTechno, pOwner))
 				{
-					pThis->Target = pTechno;
-					pThis->Location = pTechno->GetCoords();
-					pThis->Detonate(pTechno->GetCoords());
-				}
-			};
-
-		if (!pWHExt->DetonateOnAllMapObjects_Full)
-			tryDetonate = [pThis, pWHExt, pOwner](TechnoClass* pTechno)
-			{
-				if (pWHExt->EligibleForFullMapDetonation(pTechno, pOwner))
-				{
-					int damage = (pThis->Health * pThis->DamageMultiplier) >> 8;
-					pWHExt->DamageAreaWithTarget(pTechno->GetCoords(), damage, pThis->Owner, pThis->WH, true, pOwner, pTechno);
+					if (isFull)
+					{
+						pThis->Target = pTechno;
+						pThis->Location = pTechno->GetCoords();
+						pThis->Detonate(pTechno->GetCoords());
+					}
+					else
+					{
+						int damage = (pThis->Health * pThis->DamageMultiplier) >> 8;
+						pWHExt->DamageAreaWithTarget(pTechno->GetCoords(), damage, pThis->Owner, pThis->WH, true, pOwner, pTechno);
+					}
 				}
 			};
 
@@ -164,13 +163,14 @@ DEFINE_HOOK(0x469E34, BulletClass_Logics_DebrisAnims, 0x5)
 	enum { SkipGameCode = 0x469EBA };
 
 	GET(BulletClass*, pThis, ESI);
-	GET(int, debrisCount, EBX);
 
 	auto const pWHExt = WarheadTypeExt::ExtMap.Find(pThis->WH);
 	auto const debrisAnims = pWHExt->DebrisAnims.GetElements(RulesClass::Instance->MetallicDebris);
 
 	if (debrisAnims.size() < 1)
 		return SkipGameCode;
+
+	GET(int, debrisCount, EBX);
 
 	while (debrisCount > 0)
 	{
@@ -204,19 +204,20 @@ DEFINE_HOOK(0x469C46, BulletClass_Logics_DamageAnimSelected, 0x8)
 {
 	enum { SkipGameCode = 0x469C98 };
 
-	GET(BulletClass*, pThis, ESI);
 	GET(AnimTypeClass*, pAnimType, EBX);
-	LEA_STACK(CoordStruct*, coords, STACK_OFFSET(0xA4, -0x40));
 
 	bool createdAnim = false;
 
 	if (pAnimType)
 	{
+		GET(BulletClass*, pThis, ESI);
+		LEA_STACK(CoordStruct*, coords, STACK_OFFSET(0xA4, -0x40));
 		auto const pWHExt = WarheadTypeExt::ExtMap.Find(pThis->WH);
-		int creationInterval = pWHExt->Splashed ? pWHExt->SplashList_CreationInterval : pWHExt->AnimList_CreationInterval;
+		const bool splashed = pWHExt->Splashed;
+		int creationInterval = splashed ? pWHExt->SplashList_CreationInterval : pWHExt->AnimList_CreationInterval;
 		int* remainingInterval = &pWHExt->RemainingAnimCreationInterval;
-		int scatterMin = pWHExt->Splashed ? pWHExt->SplashList_ScatterMin.Get() : pWHExt->AnimList_ScatterMin.Get();
-		int scatterMax = pWHExt->Splashed ? pWHExt->SplashList_ScatterMax.Get() : pWHExt->AnimList_ScatterMax.Get();
+		int scatterMin = splashed ? pWHExt->SplashList_ScatterMin.Get() : pWHExt->AnimList_ScatterMin.Get();
+		int scatterMax = splashed ? pWHExt->SplashList_ScatterMax.Get() : pWHExt->AnimList_ScatterMax.Get();
 		bool allowScatter = scatterMax != 0 || scatterMin != 0;
 
 		if (creationInterval > 0 && pThis->Owner)
@@ -229,16 +230,16 @@ DEFINE_HOOK(0x469C46, BulletClass_Logics_DamageAnimSelected, 0x8)
 			HouseClass* pInvoker = pThis->Owner ? pThis->Owner->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
 			HouseClass* pVictim = nullptr;
 
-			if (TechnoClass* Target = generic_cast<TechnoClass*>(pThis->Target))
+			if (auto const Target = abstract_cast<TechnoClass*>(pThis->Target))
 				pVictim = Target->Owner;
 
 			auto types = make_iterator_single(pAnimType);
 
-			if (pWHExt->SplashList_CreateAll && pWHExt->Splashed)
+			if (pWHExt->SplashList_CreateAll && splashed)
 			{
 				types = pWHExt->SplashList.GetElements(RulesClass::Instance->SplashList);
 			}
-			else if (!pWHExt->Splashed)
+			else if (!splashed)
 			{
 				bool createAll = pWHExt->AnimList_CreateAll;
 
@@ -295,13 +296,13 @@ DEFINE_HOOK(0x469C46, BulletClass_Logics_DamageAnimSelected, 0x8)
 DEFINE_HOOK(0x469AA4, BulletClass_Logics_Extras, 0x5)
 {
 	GET(BulletClass*, pThis, ESI);
-	GET_BASE(CoordStruct*, coords, 0x8);
 
 	auto const pOwner = pThis->Owner ? pThis->Owner->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
 
 	// Extra warheads
 	if (pThis->WeaponType)
 	{
+		GET_BASE(CoordStruct*, coords, 0x8);
 		auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pThis->WeaponType);
 		int defaultDamage = pThis->WeaponType->Damage;
 

--- a/src/Ext/Bullet/Hooks.Obstacles.cpp
+++ b/src/Ext/Bullet/Hooks.Obstacles.cpp
@@ -161,15 +161,16 @@ DEFINE_HOOK(0x468C86, BulletClass_ShouldExplode_Obstacles, 0xA)
 
 	GET(BulletClass*, pThis, ESI);
 
-	BulletTypeExt::ExtData* pBulletTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type);
+	auto const pType = pThis->Type;
+	auto pBulletTypeExt = BulletTypeExt::ExtMap.Find(pType);
 
-	if (BulletObstacleHelper::SubjectToObstacles(pThis->Type, pBulletTypeExt))
+	if (BulletObstacleHelper::SubjectToObstacles(pType, pBulletTypeExt))
 	{
 		auto const pCellSource = MapClass::Instance.GetCellAt(pThis->SourceCoords);
 		auto const pCellTarget = MapClass::Instance.GetCellAt(pThis->TargetCoords);
 		auto const pCellCurrent = MapClass::Instance.GetCellAt(pThis->LastMapCoords);
 		auto const pOwner = pThis->Owner ? pThis->Owner->Owner : BulletExt::ExtMap.Find(pThis)->FirerHouse;
-		const auto pObstacleCell = BulletObstacleHelper::GetObstacle(pCellSource, pCellTarget, pCellCurrent, pThis->Location, pThis->Owner, pThis->Target, pOwner, pThis->Type, pBulletTypeExt, false);
+		auto const pObstacleCell = BulletObstacleHelper::GetObstacle(pCellSource, pCellTarget, pCellCurrent, pThis->Location, pThis->Owner, pThis->Target, pOwner, pType, pBulletTypeExt, false);
 
 		if (pObstacleCell)
 			return Explode;
@@ -212,17 +213,17 @@ DEFINE_HOOK(0x6F737F, TechnoClass_InRange_WeaponMinimumRange, 0x6)
 
 DEFINE_HOOK(0x6F7647, TechnoClass_InRange_Obstacles, 0x5)
 {
-	GET_BASE(WeaponTypeClass*, pWeapon, 0x10);
-	GET(CoordStruct const* const, pSourceCoords, ESI);
-	REF_STACK(CoordStruct const, targetCoords, STACK_OFFSET(0x3C, -0x1C));
-	GET_BASE(AbstractClass* const, pTarget, 0xC);
 	GET(CellClass*, pResult, EAX);
+	GET(CoordStruct const* const, pSourceCoords, ESI);
 
 	auto pObstacleCell = pResult;
 	auto pTechno = InRangeTemp::Techno;
 
 	if (!pObstacleCell)
 	{
+		GET_BASE(WeaponTypeClass*, pWeapon, 0x10);
+		REF_STACK(CoordStruct const, targetCoords, STACK_OFFSET(0x3C, -0x1C));
+		GET_BASE(AbstractClass* const, pTarget, 0xC);
 		auto subjectToGround = BulletTypeExt::ExtMap.Find(pWeapon->Projectile)->SubjectToGround.Get();
 		const auto newSourceCoords = subjectToGround ? BulletObstacleHelper::AddFLHToSourceCoords(*pSourceCoords, targetCoords, pTechno, pTarget, pWeapon, subjectToGround) : *pSourceCoords;
 		pObstacleCell = BulletObstacleHelper::FindFirstImpenetrableObstacle(newSourceCoords, targetCoords, pTechno, pTarget, pTechno->Owner, pWeapon, true, subjectToGround);

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -417,38 +417,12 @@ DEFINE_HOOK(0x4687F8, BulletClass_Unlimbo_FlakScatter, 0x6)
 // Skip a forced detonation check for Level=true projectiles that is now handled in Hooks.Obstacles.cpp.
 DEFINE_JUMP(LJMP, 0x468D08, 0x468D2F);
 
-DEFINE_HOOK(0x6FE657, TechnoClass_FireAt_ArcingFix, 0x6)
+DEFINE_HOOK(0x468B72, BulletClass_Unlimbo_ArcingFix, 0x5)
 {
-	GET_STACK(BulletTypeClass*, pBulletType, STACK_OFFSET(0xB0, -0x48));
-	GET(int, targetHeight, EDI);
-	GET(int, fireHeight, EAX);
+	GET(BulletClass*, pThis, EBX);
 
-	if (pBulletType->Arcing && targetHeight > fireHeight)
-	{
-		auto const pBulletTypeExt = BulletTypeExt::ExtMap.Find(pBulletType);
-
-		if (!pBulletTypeExt->Arcing_AllowElevationInaccuracy)
-			R->EAX(targetHeight);
-	}
-
-	return 0;
-}
-
-DEFINE_HOOK(0x44D23C, BuildingClass_Mission_Missile_ArcingFix, 0x7)
-{
-	GET(WeaponTypeClass*, pWeapon, EBP);
-	GET(int, targetHeight, EBX);
-	GET(int, fireHeight, EAX);
-
-	auto const pBulletType = pWeapon->Projectile;
-
-	if (pBulletType->Arcing && targetHeight > fireHeight)
-	{
-		auto const pBulletTypeExt = BulletTypeExt::ExtMap.Find(pBulletType);
-
-		if (!pBulletTypeExt->Arcing_AllowElevationInaccuracy)
-			R->EAX(targetHeight);
-	}
+	if (pThis->Type->Arcing)
+		BulletExt::ExtMap.Find(pThis)->ApplyArcingFix();
 
 	return 0;
 }

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -396,19 +396,17 @@ DEFINE_HOOK(0x468D3F, BulletClass_ShouldExplode_AirTarget, 0x6)
 DEFINE_HOOK(0x4687F8, BulletClass_Unlimbo_FlakScatter, 0x6)
 {
 	GET(BulletClass*, pThis, EBX);
-	GET_STACK(float, mult, STACK_OFFSET(0x5C, -0x44));
 
 	if (pThis->WeaponType)
 	{
-		if (auto const pTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type))
-		{
-			int defaultValue = RulesClass::Instance->BallisticScatter;
-			int min = pTypeExt->BallisticScatter_Min.Get(Leptons(0));
-			int max = pTypeExt->BallisticScatter_Max.Get(Leptons(defaultValue));
+		GET_STACK(float, mult, STACK_OFFSET(0x5C, -0x44));
+		auto const pTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type);
+		int defaultValue = RulesClass::Instance->BallisticScatter;
+		int min = pTypeExt->BallisticScatter_Min.Get(Leptons(0));
+		int max = pTypeExt->BallisticScatter_Max.Get(Leptons(defaultValue));
 
-			int result = (int)((mult * ScenarioClass::Instance->Random.RandomRanged(2 * min, 2 * max)) / pThis->WeaponType->Range);
-			R->EAX(result);
-		}
+		int result = (int)((mult * ScenarioClass::Instance->Random.RandomRanged(2 * min, 2 * max)) / pThis->WeaponType->Range);
+		R->EAX(result);
 	}
 
 	return 0;

--- a/src/Ext/Techno/Body.Internal.cpp
+++ b/src/Ext/Techno/Body.Internal.cpp
@@ -11,12 +11,12 @@ void TechnoExt::ExtData::InitializeLaserTrails()
 	if (this->LaserTrails.size())
 		return;
 
-	if (auto pTypeExt = this->TypeExtData)
+	auto pTypeExt = this->TypeExtData;
+	this->LaserTrails.reserve(pTypeExt->LaserTrailData.size());
+
+	for (auto const& entry : pTypeExt->LaserTrailData)
 	{
-		for (auto const& entry : pTypeExt->LaserTrailData)
-		{
-			this->LaserTrails.emplace_back(entry.GetType(), this->OwnerObject()->Owner, entry.FLH, entry.IsOnTurret);
-		}
+		this->LaserTrails.emplace_back(entry.GetType(), this->OwnerObject()->Owner, entry.FLH, entry.IsOnTurret);
 	}
 }
 

--- a/src/Ext/Techno/Hooks.Airstrike.cpp
+++ b/src/Ext/Techno/Hooks.Airstrike.cpp
@@ -95,11 +95,11 @@ DEFINE_HOOK(0x41DBD4, AirstrikeClass_Stop_ResetForTarget, 0x7)
 {
 	enum { SkipGameCode = 0x41DC3A };
 
-	GET(AirstrikeClass*, pThis, EBP);
 	GET(ObjectClass*, pTarget, ESI);
 
 	if (const auto pTargetTechno = abstract_cast<TechnoClass*>(pTarget))
 	{
+		GET(AirstrikeClass*, pThis, EBP);
 		const auto& array = Make_Global<DynamicVectorClass<AirstrikeClass*>>(0x889FB8);
 		AirstrikeClass* pLastTargetingMe = nullptr;
 
@@ -186,10 +186,12 @@ DEFINE_HOOK(0x51EAE0, TechnoClass_WhatAction_AllowAirstrike, 0x7)
 DEFINE_HOOK(0x70782D, TechnoClass_PointerGotInvalid_Airstrike, 0x6)
 {
 	GET(TechnoClass*, pThis, ESI);
-	GET(AbstractClass*, pAbstract, EBP);
 
 	if (const auto pExt = TechnoExt::ExtMap.Find(pThis)) // It's necessary
+	{
+		GET(AbstractClass*, pAbstract, EBP);
 		AnnounceInvalidPointer(pExt->AirstrikeTargetingMe, pAbstract);
+	}
 
 	return 0;
 }

--- a/src/Ext/VoxelAnim/Body.cpp
+++ b/src/Ext/VoxelAnim/Body.cpp
@@ -13,6 +13,8 @@ void VoxelAnimExt::InitializeLaserTrails(VoxelAnimClass* pThis)
 	if (pThisExt->LaserTrails.size())
 		return;
 
+	pThisExt->LaserTrails.reserve(pTypeExt->LaserTrail_Types.size());
+
 	for (auto const& idxTrail : pTypeExt->LaserTrail_Types)
 	{
 		pThisExt->LaserTrails.emplace_back(LaserTrailTypeClass::Array[idxTrail].get(), pThis->OwnerHouse);


### PR DESCRIPTION
The previous `Arcing.AllowElevationInaccuracy` fix will make the projectile fall and detonate at different positions, which looks awkward in many times
![a9e84132490cddd7bd7a04df3833a55a](https://github.com/user-attachments/assets/ceccddc4-e303-44f2-9f71-d59221b827d3)

This fix is based on https://github.com/Phobos-developers/Phobos/pull/269 and https://github.com/Phobos-developers/Phobos/pull/270, which will adjust the projectile's trace to make them fall and detonate at the same elevated position, also enabled by setting `Arcing.AllowElevationInaccuracy=false`.

Also includes some bullet optimizations from https://github.com/Phobos-developers/Phobos/pull/1568