### PR TITLE
[Minor] Shield armor fix

### DIFF
--- a/src/Ext/Bullet/Hooks.DetonateLogics.cpp
+++ b/src/Ext/Bullet/Hooks.DetonateLogics.cpp
@@ -378,7 +378,7 @@ static bool IsAllowedSplitsTarget(TechnoClass* pSource, HouseClass* pOwner, Weap
 	{
 		auto const pType = pTarget->GetTechnoType();
 
-		if (!pType->LegalTarget || GeneralUtils::GetWarheadVersusArmor(pWH, pType->Armor) == 0.0)
+		if (!pType->LegalTarget || GeneralUtils::GetWarheadVersusArmor(pWH, pTarget, pType) == 0.0)
 			return false;
 
 		auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -255,10 +255,10 @@ DEFINE_HOOK(0x46A4FB, BulletClass_Shrapnel_Targeting, 0x6)
 			if (!pWeaponExt->HasRequiredAttachedEffects(pTechno, pSource))
 				return SkipObject;
 
-			auto const pExt = TechnoExt::ExtMap.Find(pTechno);
+			auto const pShield = TechnoExt::ExtMap.Find(pTechno)->Shield.get();
 
-			if (pExt->Shield && pExt->Shield->IsActive() && !pExt->Shield->CanBePenetrated(pWH))
-				armorType = pExt->Shield->GetArmorType();
+			if (pShield && pShield->IsActive() && !pShield->CanBePenetrated(pWH))
+				armorType = pShield->GetArmorType();
 		}
 
 		if (GeneralUtils::GetWarheadVersusArmor(pWH, armorType) == 0.0)

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -1,5 +1,6 @@
 #include "Body.h"
 #include <Ext/Anim/Body.h>
+#include <Ext/Techno/Body.h>
 #include <Ext/BulletType/Body.h>
 #include <Ext/WeaponType/Body.h>
 #include <Utilities/EnumFunctions.h>
@@ -237,13 +238,13 @@ DEFINE_HOOK(0x46A4FB, BulletClass_Shrapnel_Targeting, 0x6)
 	{
 		auto const pWeaponExt = WeaponTypeExt::ExtMap.Find(pShrapnelWeapon);
 		auto const pType = pObject->GetType();
+		auto const pWH = pShrapnelWeapon->Warhead;
+		auto armorType = pType->Armor;
 
-		if (!pType->LegalTarget || GeneralUtils::GetWarheadVersusArmor(pShrapnelWeapon->Warhead, pType->Armor) == 0.0)
-			return SkipObject;
-		else if (!EnumFunctions::IsCellEligible(pObject->GetCell(), pWeaponExt->CanTarget, true, true))
+		if (!pType->LegalTarget || !EnumFunctions::IsCellEligible(pObject->GetCell(), pWeaponExt->CanTarget, true, true))
 			return SkipObject;
 
-		if (auto const pTechno = abstract_cast<TechnoClass*>(pObject))
+		if (auto const pTechno = abstract_cast<TechnoClass*, true>(pObject))
 		{
 			if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pOwner, pTechno->Owner))
 				return SkipObject;
@@ -253,8 +254,15 @@ DEFINE_HOOK(0x46A4FB, BulletClass_Shrapnel_Targeting, 0x6)
 
 			if (!pWeaponExt->HasRequiredAttachedEffects(pTechno, pSource))
 				return SkipObject;
+
+			auto const pExt = TechnoExt::ExtMap.Find(pTechno);
+
+			if (pExt->Shield && pExt->Shield->IsActive() && !pExt->Shield->CanBePenetrated(pWH))
+				armorType = pExt->Shield->GetArmorType();
 		}
 
+		if (GeneralUtils::GetWarheadVersusArmor(pWH, armorType) == 0.0)
+			return SkipObject;
 	}
 	else if (pOwner->IsAlliedWith(pObject))
 	{

--- a/src/Ext/Script/Mission.Attack.cpp
+++ b/src/Ext/Script/Mission.Attack.cpp
@@ -413,7 +413,7 @@ TechnoClass* ScriptExt::GreatestThreat(TechnoClass* pTechno, int method, int cal
 
 		if (!agentMode)
 		{
-			if (weaponType && GeneralUtils::GetWarheadVersusArmor(weaponType->Warhead, pTargetType->Armor) == 0.0)
+			if (weaponType && GeneralUtils::GetWarheadVersusArmor(weaponType->Warhead, pTarget, pTargetType) == 0.0)
 				continue;
 
 			if (pTarget->IsInAir() && !unitWeaponsHaveAA)

--- a/src/Ext/Techno/Body.Internal.cpp
+++ b/src/Ext/Techno/Body.Internal.cpp
@@ -197,8 +197,9 @@ void TechnoExt::ApplyCustomTintValues(TechnoClass* pThis, int& color, int& inten
 {
 	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
 	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	auto const pShield = pExt->Shield.get();
 	bool hasTechnoTint = pTypeExt->Tint_Color.isset() || pTypeExt->Tint_Intensity;
-	bool hasShieldTint = pExt->Shield && pExt->Shield->IsActive() && pExt->Shield->GetType()->HasTint();
+	bool hasShieldTint = pShield && pShield->IsActive() && pShield->GetType()->HasTint();
 
 	// Bail out early if no custom tint is applied.
 	if (!hasTechnoTint && !pExt->AE.HasTint && !hasShieldTint)
@@ -229,7 +230,7 @@ void TechnoExt::ApplyCustomTintValues(TechnoClass* pThis, int& color, int& inten
 
 	if (hasShieldTint)
 	{
-		auto const pShieldType = pExt->Shield->GetType();
+		auto const pShieldType = pShield->GetType();
 
 		if (!EnumFunctions::CanTargetHouse(pShieldType->Tint_VisibleToHouses, pThis->Owner, HouseClass::CurrentPlayer))
 			return;

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -208,29 +208,43 @@ DEFINE_HOOK(0x6F3432, TechnoClass_WhatWeaponShouldIUse_Gattling, 0xA)
 	}
 	else if (pTargetTechno)
 	{
+		auto const pTargetExt = TechnoExt::ExtMap.Find(pTargetTechno);
 		auto const pWeaponOdd = pThis->GetWeapon(oddWeaponIndex)->WeaponType;
 		auto const pWeaponEven = pThis->GetWeapon(evenWeaponIndex)->WeaponType;
+		bool skipRemainingChecks = false;
 
-		if (GeneralUtils::GetWarheadVersusArmor(pWeaponOdd->Warhead, pTargetTechno) == 0.0)
+		if (const auto pShield = pTargetExt->Shield.get())
 		{
-			chosenWeaponIndex = evenWeaponIndex;
-		}
-		else
-		{
-			auto const pCell = pTargetTechno->GetCell();
-			bool isOnWater = (pCell->LandType == LandType::Water || pCell->LandType == LandType::Beach) && !pTargetTechno->IsInAir();
-
-			if (!pTargetTechno->OnBridge && isOnWater)
-			{
-				int navalTargetWeapon = pThis->SelectNavalTargeting(pTargetTechno);
-
-				if (navalTargetWeapon == 2)
-					chosenWeaponIndex = evenWeaponIndex;
-			}
-			else if ((pTargetTechno->IsInAir() && !pWeaponOdd->Projectile->AA && pWeaponEven->Projectile->AA) ||
-				!pTargetTechno->IsInAir() && pThis->GetTechnoType()->LandTargeting == LandTargetingType::Land_Secondary)
+			if (pShield->IsActive() && !pShield->CanBeTargeted(pWeaponOdd))
 			{
 				chosenWeaponIndex = evenWeaponIndex;
+				skipRemainingChecks = true;
+			}
+		}
+
+		if (!skipRemainingChecks)
+		{
+			if (GeneralUtils::GetWarheadVersusArmor(pWeaponOdd->Warhead, pTargetTechno->GetTechnoType()->Armor) == 0.0)
+			{
+				chosenWeaponIndex = evenWeaponIndex;
+			}
+			else
+			{
+				auto const pCell = pTargetTechno->GetCell();
+				bool isOnWater = (pCell->LandType == LandType::Water || pCell->LandType == LandType::Beach) && !pTargetTechno->IsInAir();
+
+				if (!pTargetTechno->OnBridge && isOnWater)
+				{
+					int navalTargetWeapon = pThis->SelectNavalTargeting(pTargetTechno);
+
+					if (navalTargetWeapon == 2)
+						chosenWeaponIndex = evenWeaponIndex;
+				}
+				else if ((pTargetTechno->IsInAir() && !pWeaponOdd->Projectile->AA && pWeaponEven->Projectile->AA) ||
+					!pTargetTechno->IsInAir() && pThis->GetTechnoType()->LandTargeting == LandTargetingType::Land_Secondary)
+				{
+					chosenWeaponIndex = evenWeaponIndex;
+				}
 			}
 		}
 	}

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -250,7 +250,7 @@ double __fastcall HealthRatio_Wrapper(TechnoClass* pTechno)
 					const auto pFoot = abstract_cast<FootClass*>(pTechno);
 
 					if (!pShieldData->CanBePenetrated(pWH) || ((pFoot && pFoot->ParasiteEatingMe)))
-						result = pExt->Shield->GetHealthRatio();
+						result = pShieldData->GetHealthRatio();
 				}
 			}
 		}

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -30,7 +30,7 @@ bool WarheadTypeExt::ExtData::CanTargetHouse(HouseClass* pHouse, TechnoClass* pT
 	return true;
 }
 
-bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt = nullptr) const
+bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget) const
 {
 	if (!pTarget)
 		return false;
@@ -38,24 +38,7 @@ bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget, TechnoExt::E
 	if (!this->EffectsRequireVerses)
 		return true;
 
-	auto armorType = pTarget->GetTechnoType()->Armor;
-
-	if (!pTargetExt)
-		pTargetExt = TechnoExt::ExtMap.Find(pTarget);
-
-	if (pTargetExt)
-	{
-		if (const auto pShieldData = pTargetExt->Shield.get())
-		{
-			if (pShieldData->IsActive())
-			{
-				if (!pShieldData->CanBePenetrated(this->OwnerObject()))
-					armorType = pShieldData->GetArmorType();
-			}
-		}
-	}
-
-	return GeneralUtils::GetWarheadVersusArmor(this->OwnerObject(), armorType) != 0.0;
+	return GeneralUtils::GetWarheadVersusArmor(this->OwnerObject(), pTarget) != 0.0;
 }
 
 // Checks if Warhead can affect target that might or might be currently invulnerable.
@@ -109,13 +92,7 @@ bool WarheadTypeExt::ExtData::EligibleForFullMapDetonation(TechnoClass* pTechno,
 
 	if (this->DetonateOnAllMapObjects_RequireVerses)
 	{
-		auto const pExt = TechnoExt::ExtMap.Find(pTechno);
-		auto armorType = pTechno->GetTechnoType()->Armor;
-
-		if (pExt->Shield && pExt->Shield->IsActive() && !pExt->Shield->CanBePenetrated(this->OwnerObject()))
-			armorType = pExt->Shield->GetArmorType();
-
-		if (GeneralUtils::GetWarheadVersusArmor(this->OwnerObject(), armorType) == 0.0)
+		if (GeneralUtils::GetWarheadVersusArmor(this->OwnerObject(), pTechno) == 0.0)
 			return false;
 	}
 

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -406,8 +406,8 @@ public:
 		void DetonateOnOneUnit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* pOwner = nullptr, bool bulletWasIntercepted = false);
 		void ApplyRemoveDisguise(HouseClass* pHouse, TechnoClass* pTarget);
 		void ApplyRemoveMindControl(TechnoClass* pTarget);
-		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner, TechnoExt::ExtData* pTargetExt);
-		void ApplyShieldModifiers(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt);
+		void ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget, TechnoClass* Owner);
+		void ApplyShieldModifiers(TechnoClass* pTarget);
 		void ApplyAttachEffects(TechnoClass* pTarget, HouseClass* pInvokerHouse, TechnoClass* pInvoker);
 		void ApplyBuildingUndeploy(TechnoClass* pTarget);
 		double GetCritChance(TechnoClass* pFirer) const;

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -383,7 +383,7 @@ public:
 		void ApplyLocomotorInflictionReset(TechnoClass* pTarget);
 	public:
 		bool CanTargetHouse(HouseClass* pHouse, TechnoClass* pTechno) const;
-		bool CanAffectTarget(TechnoClass* pTarget, TechnoExt::ExtData* pTargetExt) const;
+		bool CanAffectTarget(TechnoClass* pTarget) const;
 		bool CanAffectInvulnerable(TechnoClass* pTarget) const;
 		bool EligibleForFullMapDetonation(TechnoClass* pTechno, HouseClass* pOwner) const;
 

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -450,9 +450,8 @@ void WarheadTypeExt::ExtData::ApplyCrit(HouseClass* pHouse, TechnoClass* pTarget
 		return;
 
 	auto const pTargetExt = TechnoExt::ExtMap.Find(pTarget);
-	auto const pTypeExt = pTargetExt->TypeExtData;
 
-	if (pTypeExt->ImmuneToCrit)
+	if (pTargetExt->TypeExtData->ImmuneToCrit)
 		return;
 
 	auto pSld = pTargetExt->Shield.get();

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -197,9 +197,7 @@ void WarheadTypeExt::ExtData::DetonateOnOneUnit(HouseClass* pHouse, TechnoClass*
 	if (!pTarget || pTarget->InLimbo || !pTarget->IsAlive || !pTarget->Health || pTarget->IsSinking || pTarget->BeingWarpedOut)
 		return;
 
-	TechnoExt::ExtData* pTargetExt = nullptr;
-
-	if (!this->CanTargetHouse(pHouse, pTarget) || !this->CanAffectTarget(pTarget, pTargetExt))
+	if (!this->CanTargetHouse(pHouse, pTarget) || !this->CanAffectTarget(pTarget))
 		return;
 
 	this->ApplyShieldModifiers(pTarget, pTargetExt);

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -81,10 +81,10 @@ const double GeneralUtils::GetWarheadVersusArmor(WarheadTypeClass* pWH, TechnoCl
 		pType = pThis->GetTechnoType();
 
 	auto ArmorType = pType->Armor;
-	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	auto const pShield = TechnoExt::ExtMap.Find(pThis)->Shield.get();
 
-	if (pExt->Shield && pExt->Shield->IsActive() && !pExt->Shield->CanBePenetrated(pWH))
-		ArmorType = pExt->Shield->GetArmorType();
+	if (pShield && pShield->IsActive() && !pShield->CanBePenetrated(pWH))
+		ArmorType = pShield->GetArmorType();
 
 	return double(MapClass::GetTotalDamage(100, pWH, ArmorType, 0)) / 100.0;
 }

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -5,6 +5,7 @@
 #include <BitFont.h>
 
 #include <Ext/Rules/Body.h>
+#include <Ext/Techno/Body.h>
 #include <Misc/FlyingStrings.h>
 #include <Utilities/Constructs.h>
 
@@ -79,13 +80,13 @@ const double GeneralUtils::GetWarheadVersusArmor(WarheadTypeClass* pWH, TechnoCl
 	if (!pType)
 		pType = pThis->GetTechnoType();
 
-	auto armorType = pType->Armor;
+	auto ArmorType = pType->Armor;
 	auto const pExt = TechnoExt::ExtMap.Find(pThis);
 
 	if (pExt->Shield && pExt->Shield->IsActive() && !pExt->Shield->CanBePenetrated(pWH))
-		armorType = pExt->Shield->GetArmorType();
+		ArmorType = pExt->Shield->GetArmorType();
 
-	return GeneralUtils::GetWarheadVersusArmor(WarheadTypeClass* pWH, Armor armorType);
+	return double(MapClass::GetTotalDamage(100, pWH, ArmorType, 0)) / 100.0;
 }
 
 // Weighted random element choice (weight) - roll for one.

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -74,6 +74,20 @@ const double GeneralUtils::GetWarheadVersusArmor(WarheadTypeClass* pWH, Armor Ar
 	return double(MapClass::GetTotalDamage(100, pWH, ArmorType, 0)) / 100.0;
 }
 
+const double GeneralUtils::GetWarheadVersusArmor(WarheadTypeClass* pWH, TechnoClass* pThis, TechnoTypeClass* pType)
+{
+	if (!pType)
+		pType = pThis->GetTechnoType();
+
+	auto armorType = pType->Armor;
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+
+	if (pExt->Shield && pExt->Shield->IsActive() && !pExt->Shield->CanBePenetrated(pWH))
+		armorType = pExt->Shield->GetArmorType();
+
+	return GeneralUtils::GetWarheadVersusArmor(WarheadTypeClass* pWH, Armor armorType);
+}
+
 // Weighted random element choice (weight) - roll for one.
 // Takes a vector of integer type weights, which are then summed to calculate the chances.
 // Returns chosen index or -1 if nothing is chosen.

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -29,6 +29,7 @@ public:
 	static const int GetRangedRandomOrSingleValue(PartialVector2D<int> range);
 	static const double GetRangedRandomOrSingleValue(PartialVector2D<double> range);
 	static const double GetWarheadVersusArmor(WarheadTypeClass* pWH, Armor ArmorType);
+	static const double GetWarheadVersusArmor(WarheadTypeClass* pWH, TechnoClass* pThis, TechnoTypeClass* pType = nullptr);
 	static int ChooseOneWeighted(const double dice, const std::vector<int>* weights);
 	static bool HasHealthRatioThresholdChanged(double oldRatio, double newRatio);
 	static bool ApplyTheaterSuffixToString(char* str);


### PR DESCRIPTION
currently there're several armor checks that haven't taken shield's armor into account, this pull request made a generic function for that

also made some simplification on Detonate.cpp during editing it, removing a seemingly redundant TechnoExt pointer which is always nullptr. Not sure if it'll accidentally break something tho, so review and test is needed