### PR TITLE
[minor] Fix `OmniFire.TurnToTarget=true` not working when the unit is rearming

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1558,7 +1558,7 @@ Sinkable.SquidGrab=true    ; boolean
 
 ### Unit Without Turret Always Turn To Target
 
-- Now vehicles (exclude jumpjets) without turret will attempt to turn to the target while the weapon is cooling down, rather than after the weapon has cooled down, by setting `NoTurret.TrackTarget` to true.
+- Now vehicles without turret will attempt to turn to the target while the weapon is cooling down, rather than after the weapon has cooled down, by setting `NoTurret.TrackTarget` to true.
 
 In `rulesmd.ini`:
 ```ini
@@ -1567,6 +1567,10 @@ NoTurret.TrackTarget=false   ; boolean
 
 [SOMEVEHICLE]                ; VehicleType
 NoTurret.TrackTarget=        ; boolean, defaults to [General] -> NoTurret.TrackTarget
+```
+
+```{note}
+Jumpjet can also be affected by this if firing an `OmniFire` weapon with `OmniFire.TurnToTarget` set to true.
 ```
 
 ### Voxel turret shadow

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -64,6 +64,9 @@ DEFINE_HOOK(0x736E6E, UnitClass_UpdateFiring_OmniFireTurnToTarget, 0x9)
 	if ((pType->DeployFire || pType->DeployFireWeapon == wpIdx) && pThis->CurrentMission == Mission::Unload)
 		return 0;
 
+	if (err == FireError::REARM && !TechnoTypeExt::ExtMap.Find(pType)->NoTurret_TrackTarget.Get(RulesExt::Global()->NoTurret_TrackTarget))
+		return 0;
+
 	auto const pWpn = pThis->GetWeapon(wpIdx)->WeaponType;
 	if (pWpn->OmniFire)
 	{

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -47,10 +47,15 @@ DEFINE_HOOK(0x736F78, UnitClass_UpdateFiring_FireErrorIsFACING, 0x6)
 }
 
 // For compatibility with previous builds
-DEFINE_HOOK(0x736EE9, UnitClass_UpdateFiring_FireErrorIsOK, 0x6)
+DEFINE_HOOK(0x736E6E, UnitClass_UpdateFiring_OmniFireTurnToTarget, 0x9)
 {
+	GET(FireError, err, EBP);
 	GET(UnitClass* const, pThis, ESI);
 	GET(int const, wpIdx, EDI);
+
+	if (err != FireError::OK && err != FireError::REARM)
+		return 0;
+
 	auto pType = pThis->Type;
 
 	if ((pType->Turret && !pType->HasTurret) || pType->TurretSpins)

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -53,7 +53,7 @@ DEFINE_HOOK(0x736E6E, UnitClass_UpdateFiring_OmniFireTurnToTarget, 0x9)
 	GET(UnitClass* const, pThis, ESI);
 	GET(int const, wpIdx, EDI);
 
-	if (err != FireError::OK && err != FireError::REARM)
+	if (pThis->IsWarpingIn() || err != FireError::OK && err != FireError::REARM)
 		return 0;
 
 	auto pType = pThis->Type;

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -50,16 +50,21 @@ DEFINE_HOOK(0x736F78, UnitClass_UpdateFiring_FireErrorIsFACING, 0x6)
 DEFINE_HOOK(0x736E6E, UnitClass_UpdateFiring_OmniFireTurnToTarget, 0x9)
 {
 	GET(FireError, err, EBP);
-	GET(UnitClass* const, pThis, ESI);
-	GET(int const, wpIdx, EDI);
 
-	if (pThis->IsWarpingIn() || err != FireError::OK && err != FireError::REARM)
+	if (err != FireError::OK && err != FireError::REARM)
+		return 0;
+
+	GET(UnitClass* const, pThis, ESI);
+
+	if (pThis->IsWarpingIn())
 		return 0;
 
 	auto pType = pThis->Type;
 
 	if ((pType->Turret && !pType->HasTurret) || pType->TurretSpins)
 		return 0;
+
+	GET(int const, wpIdx, EDI);
 
 	if ((pType->DeployFire || pType->DeployFireWeapon == wpIdx) && pThis->CurrentMission == Mission::Unload)
 		return 0;
@@ -68,10 +73,10 @@ DEFINE_HOOK(0x736E6E, UnitClass_UpdateFiring_OmniFireTurnToTarget, 0x9)
 		return 0;
 
 	auto const pWpn = pThis->GetWeapon(wpIdx)->WeaponType;
+
 	if (pWpn->OmniFire)
 	{
-		const auto pTypeExt = WeaponTypeExt::ExtMap.Find(pWpn);
-		if (pTypeExt->OmniFire_TurnToTarget.Get() && !pThis->Locomotor->Is_Moving_Now())
+		if (WeaponTypeExt::ExtMap.Find(pWpn)->OmniFire_TurnToTarget.Get() && !pThis->Locomotor->Is_Moving_Now())
 		{
 			CoordStruct& source = pThis->Location;
 			CoordStruct target = pThis->Target->GetCoords();


### PR DESCRIPTION
<!-- Please add [Minor] to the title or the description if this change should not be mentioned in documentation, what's new and no credit needs to be given.
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches. -->
