### PR TITLE
[Minor] Fix selling bio reactor crash in dev

### DIFF
--- a/src/Ext/Techno/Hooks.Transport.cpp
+++ b/src/Ext/Techno/Hooks.Transport.cpp
@@ -259,9 +259,9 @@ static inline bool CanEnterNow(UnitClass* pTransport, FootClass* pPassenger)
 		return false;
 
 	const bool bySize = TechnoTypeExt::ExtMap.Find(pTransportType)->Passengers_BySize;
-	const int passengerSize = Game::F2I(pPassenger->GetTechnoType()->Size);
+	const int passengerSize = static_cast<int>(pPassenger->GetTechnoType()->Size);
 
-	if (passengerSize > Game::F2I(pTransportType->SizeLimit))
+	if (passengerSize > static_cast<int>(pTransportType->SizeLimit))
 		return false;
 
 	const int maxSize = pTransportType->Passengers;
@@ -273,9 +273,9 @@ static inline bool CanEnterNow(UnitClass* pTransport, FootClass* pPassenger)
 	if (needCalculate)
 	{
 		if (IsCloseEnoughToEnter(pTransport, pLink))
-			return (predictSize <= (maxSize - (bySize ? Game::F2I(pLink->GetTechnoType()->Size) : 1)));
+			return (predictSize <= (maxSize - (bySize ? static_cast<int>(pLink->GetTechnoType()->Size) : 1)));
 
-		if (predictSize > (maxSize - (bySize ? Game::F2I(pLink->GetTechnoType()->Size) : 1)))
+		if (predictSize > (maxSize - (bySize ? static_cast<int>(pLink->GetTechnoType()->Size) : 1)))
 		{
 			pLink->QueueMission(Mission::None, false);
 			pLink->SetDestination(nullptr, true);

--- a/src/Ext/Techno/Hooks.Transport.cpp
+++ b/src/Ext/Techno/Hooks.Transport.cpp
@@ -258,16 +258,16 @@ static inline bool CanEnterNow(UnitClass* pTransport, FootClass* pPassenger)
 	if (pTransport->GetCell()->LandType == LandType::Water && !TechnoTypeExt::ExtMap.Find(pTransportType)->AmphibiousEnter.Get(RulesExt::Global()->AmphibiousEnter))
 		return false;
 
-	const auto bySize = TechnoTypeExt::ExtMap.Find(pTransportType)->Passengers_BySize;
-	const auto passengerSize = bySize ? Game::F2I(pPassenger->GetTechnoType()->Size) : 1;
+	const bool bySize = TechnoTypeExt::ExtMap.Find(pTransportType)->Passengers_BySize;
+	const int passengerSize = Game::F2I(pPassenger->GetTechnoType()->Size);
 
 	if (passengerSize > Game::F2I(pTransportType->SizeLimit))
 		return false;
 
-	const auto maxSize = pTransportType->Passengers;
-	const auto predictSize = (bySize ? pTransport->Passengers.GetTotalSize() : pTransport->Passengers.NumPassengers) + passengerSize;
+	const int maxSize = pTransportType->Passengers;
+	const int predictSize = bySize ? (pTransport->Passengers.GetTotalSize() + passengerSize) : (pTransport->Passengers.NumPassengers + 1);
 	const auto pLink = abstract_cast<FootClass*>(pTransport->GetNthLink());
-	const auto needCalculate = pLink && pLink != pPassenger && pLink->Destination == pTransport;
+	const bool needCalculate = pLink && pLink != pPassenger && pLink->Destination == pTransport;
 
 	// When the most important passenger is close, need to prevent overlap
 	if (needCalculate)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1913,7 +1913,7 @@ DEFINE_HOOK(0x44DBCF, BuildingClass_Mission_Unload_LeaveBioReactor, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x51A2AD, InfantryClass_UpdatePosition_EnterBuilding_CheckSize, 0x9)
+DEFINE_HOOK(0x51A298, InfantryClass_UpdatePosition_EnterBuilding_CheckSize, 0x6)
 {
 	enum { CannotEnter = 0x51A4BF };
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1929,16 +1929,11 @@ static inline bool CanInfantryEnterBuildingFix(BuildingClass* pTransport, Infant
 	if (pTransport->GetCell()->LandType == LandType::Water && !TechnoTypeExt::ExtMap.Find(pTransportType)->AmphibiousEnter.Get(RulesExt::Global()->AmphibiousEnter))
 		return false;
 
-	const bool bySize = TechnoTypeExt::ExtMap.Find(pTransportType)->Passengers_BySize;
-	const int passengerSize = Game::F2I(pPassenger->GetTechnoType()->Size);
-
-	if (passengerSize > Game::F2I(pTransportType->SizeLimit))
+	// Infantry entering the building ignoring Passengers.BySize and is always regarded as 1
+	if (static_cast<int>(pPassenger->GetTechnoType()->Size) > static_cast<int>(pTransportType->SizeLimit))
 		return false;
 
-	const int maxSize = pTransportType->Passengers;
-	const int predictSize = bySize ? (pTransport->Passengers.GetTotalSize() + passengerSize) : (pTransport->Passengers.NumPassengers + 1);
-
-	return predictSize <= maxSize;
+	return (pTransport->Passengers.NumPassengers + 1) <= pTransportType->Passengers;
 }
 
 DEFINE_HOOK(0x51A2AD, InfantryClass_UpdatePosition_EnterBuilding_CheckSize, 0x9)


### PR DESCRIPTION
- In commit 0fc6584, the `Transporter` pointer of the techno was set to point to the bio reactor it is located in, but it was not correctly removed during reactor's selling mission or when reactor has destroyed by C4, resulting in a wild pointer.
  > 在提交 0fc6584 中，`Transporter` 指针被设置为能够指向单位所处的生化反应炉，但它在反应炉被售卖或被 C4 摧毁时并未正确移除，导致了野指针。
- It is best to conduct specialized testing on the original repair content and `UnitAbsorb` related things.
  > 最好对原修复内容以及 `UnitAbsorb` 再进行专项测试。
- Have not conducted a complete test yet, so I pull this request.
  > 还未进行完整测试，所以提交了这个请求。

---

- Also fix a minor issue with `Size` calculation in `NoQueueUpToEnter`.
  > 还修复了有关 `NoQueueUpToEnter` 中 `Size` 计算的问题。
- Replace the repair content in `InfantryEnterBuildingFix` with the same function used in other types.
  > 将原本 `InfantryEnterBuildingFix` 中的修复内容替换为使用其他类型相同的函数。
- Fixed the previously unresolved issue when `UnitAbsorb` and `AutoDeath` were used together.
  > 修复了之前 `UnitAbsorb` 和 `AutoDeath` 共同使用时未被解决的问题。