### PR TITLE
TriggerEvent 75/77 fixes、GetFlags extension

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -362,7 +362,6 @@ This page lists all the individual contributions to the project by their author.
   - Fix the issue where computer players did not search for new enemies after defeating them or forming alliances with them
   - Customize the damage taken when falling from a bridge
   - `600 The shield of the attached object is broken` bug fix for the triggered event
-  - Extends TEventClass_GetFlags for classification
   - Fixed an issue where a portion of Ares's trigger event 75/77 was determined unsuccessfully
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -362,6 +362,8 @@ This page lists all the individual contributions to the project by their author.
   - Fix the issue where computer players did not search for new enemies after defeating them or forming alliances with them
   - Customize the damage taken when falling from a bridge
   - `600 The shield of the attached object is broken` bug fix for the triggered event
+  - Extends TEventClass_GetFlags for classification
+  - Fixed an issue where a portion of Ares's trigger event 75/77 was determined unsuccessfully
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -244,7 +244,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed Ares' InitialPayload not being created for vehicles spawned by trigger actions.
 - Allowed Ares' `SW.AuxBuildings` and `SW.NegBuildings` to count building upgrades.
 - Taking over Ares' AlphaImage respawn logic to make it not recreate in every frame for buildings, static techno and techno without turret, in order to reduce lags from it.
-- Fixed an issue where a portion of Ares's trigger event 75/77 was determined unsuccessfully
+- Fixed an issue where a portion of Ares's trigger event 75/77 was determined unsuccessfully.
 
 ## Aircraft
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -244,6 +244,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed Ares' InitialPayload not being created for vehicles spawned by trigger actions.
 - Allowed Ares' `SW.AuxBuildings` and `SW.NegBuildings` to count building upgrades.
 - Taking over Ares' AlphaImage respawn logic to make it not recreate in every frame for buildings, static techno and techno without turret, in order to reduce lags from it.
+- Fixed an issue where a portion of Ares's trigger event 75/77 was determined unsuccessfully
 
 ## Aircraft
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -406,10 +406,12 @@ Vanilla fixes:
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)
 - `600 The shield of the attached object is broken` bug fix for the triggered event (by FlyStar)
+- Extends TEventClass_GetFlags for classification (by FlyStar)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)
 - Taking over Ares' AlphaImage respawn logic to reduce lags from it (by NetsuNegi)
+- Fixed an issue where a portion of Ares's trigger event 75/77 was determined unsuccessfully (by FlyStar)
 
 ```
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -406,7 +406,6 @@ Vanilla fixes:
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)
 - `600 The shield of the attached object is broken` bug fix for the triggered event (by FlyStar)
-- Extends TEventClass_GetFlags for classification (by FlyStar)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -17,16 +17,18 @@
 
 void SWTypeExt::FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell)
 {
-	auto const pTypeExt = SWTypeExt::ExtMap.Find(pSW->Type);
+	const auto pHouse = pSW->Owner;
+	const auto pType = pSW->Type;
+	auto const pTypeExt = SWTypeExt::ExtMap.Find(pType);
 
 	if (pTypeExt->LimboDelivery_Types.size() > 0)
-		pTypeExt->ApplyLimboDelivery(pSW->Owner);
+		pTypeExt->ApplyLimboDelivery(pHouse);
 
 	if (pTypeExt->LimboKill_IDs.size() > 0)
-		pTypeExt->ApplyLimboKill(pSW->Owner);
+		pTypeExt->ApplyLimboKill(pHouse);
 
 	if (pTypeExt->Detonate_Warhead || pTypeExt->Detonate_Weapon)
-		pTypeExt->ApplyDetonation(pSW->Owner, cell);
+		pTypeExt->ApplyDetonation(pHouse, cell);
 
 	if (pTypeExt->SW_Next.size() > 0)
 		pTypeExt->ApplySWNext(pSW, cell);
@@ -34,11 +36,39 @@ void SWTypeExt::FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell)
 	if (pTypeExt->Convert_Pairs.size() > 0)
 		pTypeExt->ApplyTypeConversion(pSW);
 
-	if (static_cast<int>(pSW->Type->Type) == 28 && !pTypeExt->EMPulse_TargetSelf) // Ares' Type=EMPulse SW
+	if (static_cast<int>(pType->Type) == 28 && !pTypeExt->EMPulse_TargetSelf) // Ares' Type=EMPulse SW
 		pTypeExt->HandleEMPulseLaunch(pSW, cell);
 
-	auto& sw_ext = HouseExt::ExtMap.Find(pSW->Owner)->SuperExts[pSW->Type->ArrayIndex];
+	auto& sw_ext = HouseExt::ExtMap.Find(pHouse)->SuperExts[pType->ArrayIndex];
 	sw_ext.ShotCount++;
+
+	const auto pTags = &pHouse->RelatedTags;
+	if (pTags->Count > 0)
+	{
+		int index = 0;
+		int TagCount = pTags->Count;
+
+		while (true)
+		{
+			if (TagCount <= 0 || index >= TagCount)
+				break;
+
+			const auto pTag = pTags->GetItem(index);
+
+			// don't be confused as to why (TechnoClass*)(pSW) is there, it's something very much needed..
+			if (pTag->RaiseEvent(static_cast<TriggerEvent>(77), nullptr, CellStruct::Empty, false, (TechnoClass*)(pSW)) ||
+				pTag->RaiseEvent(static_cast<TriggerEvent>(75), nullptr, CellStruct::Empty, false, (TechnoClass*)(pSW)))
+			{
+				if (TagCount != pTags->Count)
+				{
+					TagCount = pTags->Count;
+					continue;
+				}
+			}
+
+			++index;
+		}
+	}
 }
 
 // ====================================================

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -56,8 +56,8 @@ void SWTypeExt::FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell)
 			const auto pTag = pTags->GetItem(index);
 
 			// don't be confused as to why (TechnoClass*)(pSW) is there, it's something very much needed..
-			if (pTag->RaiseEvent(static_cast<TriggerEvent>(77), nullptr, CellStruct::Empty, false, (TechnoClass*)(pSW)) ||
-				pTag->RaiseEvent(static_cast<TriggerEvent>(75), nullptr, CellStruct::Empty, false, (TechnoClass*)(pSW)))
+			if (pTag->RaiseEvent(static_cast<TriggerEvent>(77), nullptr, CellStruct::Empty, false, (TechnoClass*)(pSW))
+				|| pTag->RaiseEvent(static_cast<TriggerEvent>(75), nullptr, CellStruct::Empty, false, (TechnoClass*)(pSW)))
 			{
 				if (TagCount != pTags->Count)
 				{

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -33,7 +33,7 @@ void TEventExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 	this->Serialize(Stm);
 }
 
-int TEventExt::GetFlags(const int& iEvent)
+int TEventExt::GetFlags(int iEvent)
 {
 	// 0x4 : In MapClass, ZoneEntryBy uses it.
 	// 0x8 : In HouseClass, It will be added to the RelatedTags of the specified house. Ares' TriggerEvent 75/77 uses it.

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -36,9 +36,9 @@ void TEventExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 // by Fly-Star
 int TEventExt::GetFlags(int iEvent)
 {
-	// 0x4 : In MapClass, ZoneEntryBy uses it.
-	// 0x8 : In HouseClass, It will be added to the RelatedTags of the specified house. Ares' TriggerEvent 75/77 uses it.
-	// 0x10 : In LogicClass.
+	// 0x4 : In MapClass, ZoneEntryBy uses it. borrowed from 0x684D61.
+	// 0x8 : In HouseClass, It will be added to the RelatedTags of the specified house. Ares' TriggerEvent 75/77 uses it. borrowed from 0x684E34.
+	// 0x10 : In LogicClass. borrowed from 0x684DCA.
 	switch (static_cast<PhobosTriggerEvent>(iEvent))
 	{
 	case PhobosTriggerEvent::ShieldBroken:

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -33,6 +33,24 @@ void TEventExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 	this->Serialize(Stm);
 }
 
+int TEventExt::GetFlags(const int& iEvent)
+{
+	// 0x4 : In MapClass, ZoneEntryBy uses it.
+	// 0x8 : In HouseClass, Ares' TriggerEvent 75/77 uses it.
+	// 0x10 : In LogicClass.
+	switch (static_cast<PhobosTriggerEvent>(iEvent))
+	{
+	case PhobosTriggerEvent::ShieldBroken:
+		return 0;
+	//case
+	//	return 0x4;
+	//case
+	//	return 0x8;
+	default:
+		return 0x10;
+	}
+}
+
 std::optional<bool> TEventExt::Execute(TEventClass* pThis, int iEvent, HouseClass* pHouse,
 	ObjectClass* pObject, CDTimerClass* pTimer, bool* isPersitant, TechnoClass* pSource)
 {

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -33,6 +33,7 @@ void TEventExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 	this->Serialize(Stm);
 }
 
+// by Fly-Star
 int TEventExt::GetFlags(int iEvent)
 {
 	// 0x4 : In MapClass, ZoneEntryBy uses it.

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -36,6 +36,7 @@ void TEventExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 // by Fly-Star
 int TEventExt::GetFlags(int iEvent)
 {
+	// 0x0 : If it has to have an AttachedObject in order to use it, then let it return 0.
 	// 0x4 : In MapClass, ZoneEntryBy uses it. borrowed from 0x684D61.
 	// 0x8 : In HouseClass, It will be added to the RelatedTags of the specified house. Ares' TriggerEvent 75/77 uses it. borrowed from 0x684E34.
 	// 0x10 : In LogicClass. borrowed from 0x684DCA.

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -36,7 +36,7 @@ void TEventExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
 int TEventExt::GetFlags(const int& iEvent)
 {
 	// 0x4 : In MapClass, ZoneEntryBy uses it.
-	// 0x8 : In HouseClass, Ares' TriggerEvent 75/77 uses it.
+	// 0x8 : In HouseClass, It will be added to the RelatedTags of the specified house. Ares' TriggerEvent 75/77 uses it.
 	// 0x10 : In LogicClass.
 	switch (static_cast<PhobosTriggerEvent>(iEvent))
 	{

--- a/src/Ext/TEvent/Body.h
+++ b/src/Ext/TEvent/Body.h
@@ -83,6 +83,8 @@ public:
 		void Serialize(T& Stm);
 	};
 
+	static int GetFlags(const int& iEvent);
+
 	static std::optional<bool> Execute(TEventClass* pThis, int iEvent, HouseClass* pHouse,
 		ObjectClass* pObject, CDTimerClass* pTimer, bool* isPersitant, TechnoClass* pSource);
 

--- a/src/Ext/TEvent/Body.h
+++ b/src/Ext/TEvent/Body.h
@@ -83,7 +83,7 @@ public:
 		void Serialize(T& Stm);
 	};
 
-	static int GetFlags(const int& iEvent);
+	static int GetFlags(int iEvent);
 
 	static std::optional<bool> Execute(TEventClass* pThis, int iEvent, HouseClass* pHouse,
 		ObjectClass* pObject, CDTimerClass* pTimer, bool* isPersitant, TechnoClass* pSource);

--- a/src/Ext/TEvent/Hooks.cpp
+++ b/src/Ext/TEvent/Hooks.cpp
@@ -36,7 +36,9 @@ DEFINE_HOOK(0x7271F9, TEventClass_GetFlags, 0x5)
 
 	int nEvent = static_cast<int>(pThis->EventKind);
 	if (nEvent >= PhobosTriggerEvent::LocalVariableGreaterThan && nEvent < PhobosTriggerEvent::_DummyMaximum)
-		eAttach |= 0x10; // LOGIC
+	{
+		eAttach |= TEventExt::GetFlags(nEvent);
+	}
 
 	R->EAX(eAttach);
 

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -46,6 +46,9 @@ void Apply_Ares3_0_Patches()
 
 	// Replace the TemporalClass::Detach call by LetGo in convert function:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x436DA, &LetGo);
+
+	// SuperClass_Launch_SkipRelatedTags
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x3207C, AresHelper::AresBaseAddress + 0x320DF);
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -71,4 +74,7 @@ void Apply_Ares3_0p1_Patches()
 
 	// Replace the TemporalClass::Detach call by LetGo in convert function:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x441BA, &LetGo);
+
+	// SuperClass_Launch_SkipRelatedTags
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x32A5C, AresHelper::AresBaseAddress + 0x32ABF);
 }


### PR DESCRIPTION
Fixed an issue where a portion of Ares's **trigger event 75/77** was determined unsuccessfully.
Extends TEventClass_GetFlags for classification.

---------
修复了Ares的**触发条件75/77**有一部分判定不成功的问题。
扩展TEventClass_GetFlags以进行分类。