### PR TITLE
[Minor] Repair the manager after unit conversion

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -529,6 +529,7 @@ This page lists all the individual contributions to the project by their author.
   - AI vehicle production update code
   - parts of TechnoType conversion placeholder code
 - **ststl, FlyStar, NaotoYuuki, Saigyouji, JunJacobYoung** - Digital Display
+- **ststl, FlyStar** - Fixed the issue where some units crashed after the deployment transformation
 - **SukaHati (Erzoid)** - Minimum interceptor guard range
 - **E1 Elite** - TileSet 255 and above bridge repair fix
 - **AutoGavy** - interceptor logic, Warhead critical hit logic

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1751,6 +1751,17 @@ WarpInWeapon.UseDistanceAsDamage=false  ; boolean
 WarpOutWeapon=                          ; WeaponType
 ```
 
+### Reset MindControl after transformation
+
+- After the unit conversion is completed, its mind control can be reset.
+ - If `Convert.ResetMindControl=no` and there are no warheads in the unit that use `MindControl=yes`, then the controlled units that exceed the maximum value will be released.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                            ; TechnoType
+Convert.ResetMindControl=               ; boolean, default to false
+```
+
 ## Terrain
 
 ### Destroy animation & sound

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -381,6 +381,7 @@ New:
 - Dehardcoded 255 limit of `OverlayType` (by secsome)
 - [Customizable airstrike flare colors](Fixed-or-Improved-Logics.md#airstrike-flare-customizations) (by Starkku)
 - Allowed player's self-healing effects to be benefited by allied or `PlayerControl=true` houses (by Ollerus)
+- Fixed the issue where some units crashed after the deployment transformation (by ststl, FlyStar)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -5,6 +5,11 @@
 #include <SpawnManagerClass.h>
 #include <ParticleSystemClass.h>
 #include <Conversions.h>
+#include <SlaveManagerClass.h>
+#include <AirstrikeClass.h>
+#include <Kamikaze.h>
+#include <JumpjetLocomotionClass.h>
+#include <FlyLocomotionClass.h>
 
 #include <Ext/Anim/Body.h>
 #include <Ext/Bullet/Body.h>
@@ -526,6 +531,7 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 	this->TypeExtData = TechnoTypeExt::ExtMap.Find(pCurrentType);
 
 	this->UpdateSelfOwnedAttachEffects();
+	this->UpdateTypeExtData_FixOther(pOldTypeExt);
 
 	// Recreate Laser Trails
 	if (this->LaserTrails.size())
@@ -654,6 +660,535 @@ void TechnoExt::ExtData::UpdateTypeData_Foot()
 	}
 
 	this->PreviousType = nullptr;
+}
+
+// Powered by ststl-s、Fly-Star
+void TechnoExt::ExtData::UpdateTypeExtData_FixOther(TechnoTypeExt::ExtData* pOldTypeExt)
+{
+	TechnoClass* const pThis = this->OwnerObject();
+	TechnoTypeClass* const pType = pThis->GetTechnoType();
+	FootClass* pFoot = nullptr;
+	AbstractType abs = pThis->WhatAmI();
+
+	if (abs != AbstractType::Building)
+	{
+		pFoot = static_cast<FootClass*>(pThis);
+
+		if (!pType->CanDisguise || (!pFoot->Disguise && pType->PermaDisguise))
+		{
+			// When it can't disguise or has lost its disguise, update its disguise.
+			pFoot->ClearDisguise();
+		}
+
+		if (pFoot->Passengers.NumPassengers > 0)
+		{
+			FootClass* pFirstPassenger = pFoot->Passengers.GetFirstPassenger();
+
+			while (true)
+			{
+				if (pType->OpenTopped)
+				{
+					// Add passengers to the logic layer.
+					pFoot->EnteredOpenTopped(pFirstPassenger);
+				}
+				else
+				{
+					// Lose target & destination
+					pFirstPassenger->SetTarget(nullptr);
+					pFirstPassenger->SetCurrentWeaponStage(0);
+					pFirstPassenger->AbortMotion();
+					pFoot->ExitedOpenTopped(pFirstPassenger);
+
+					// OpenTopped adds passengers to logic layer when enabled. Under normal conditions this does not need to be removed since
+					// OpenTopped state does not change while passengers are still in transport but in case of type conversion that can happen.
+					LogicClass::Instance.RemoveObject(pFirstPassenger);
+				}
+
+				pFirstPassenger->Transporter = pFoot;
+
+				if (const auto pNextPassenger = abstract_cast<FootClass*>(pFirstPassenger->NextObject))
+				{
+					pFirstPassenger = pNextPassenger;
+				}
+				else
+				{
+					break;
+				}
+			}
+
+			if (pType->Gunner)
+			{
+				pFoot->ReceiveGunner(pFirstPassenger);
+			}
+		}
+		else if (pType->Gunner)
+		{
+			pFoot->RemoveGunner(nullptr);
+		}
+
+		if (abs == AbstractType::Infantry || abs == AbstractType::Unit)
+		{
+			const auto pOldType = pOldTypeExt->OwnerObject();
+
+			if (pFoot->IsInAir() && !pFoot->LocomotorSource)
+			{
+				auto pLocomotorType = pType->Locomotor;
+
+				// The Hover movement pattern allows for self-landing.
+				if (pLocomotorType != LocomotionClass::CLSIDs::Fly &&
+					pLocomotorType != LocomotionClass::CLSIDs::Hover)
+				{
+					if (auto const pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor))
+					{
+						pJJLoco->LocomotionFacing.SetCurrent(pFoot->PrimaryFacing.Current());
+						pJJLoco->LocomotionFacing.SetROT(pType->JumpjetTurnRate);
+
+						// Modify the flight height.
+						if (pType->BalloonHover)
+						{
+							pJJLoco->State = JumpjetLocomotionClass::State::Hovering;
+							pJJLoco->IsMoving = true;
+							pJJLoco->DestinationCoords = pFoot->Location;
+							pJJLoco->CurrentHeight = pType->JumpjetHeight;
+							pJJLoco->Height = pType->JumpjetHeight;
+						}
+						else
+						{
+							pJJLoco->Move_To(pFoot->Location);
+						}
+					}
+					else
+					{
+						// Let it go into free fall.
+						pFoot->FallRate = 0;
+						pFoot->IsFallingDown = true;
+
+						const auto pCell = MapClass::Instance.TryGetCellAt(pFoot->Location);
+
+						if (pCell && !pCell->IsClearToMove(pType->SpeedType, true, true,
+							-1, pType->MovementZone, pCell->GetLevel(), pCell->ContainsBridge()))
+						{
+							// If it's landing position cannot be moved, then it is granted a crash death.
+							pFoot->IsABomb = true;
+						}
+						else
+						{
+							// If it's gonna land on the bridge, then it needs this.
+							pFoot->OnBridge = pCell ? pCell->ContainsBridge() : false;
+						}
+
+						if (abs == AbstractType::Infantry)
+						{
+							// Infantry changed to parachute status (not required).
+							static_cast<InfantryClass*>(pFoot)->PlayAnim(Sequence::Paradrop, true, false);
+						}
+					}
+				}
+			}
+
+			if (abs == AbstractType::Unit)
+			{
+				// Yes, synchronize its turret facing or it will turn strangely.
+				if (pOldType->Turret != pType->Turret)
+				{
+					const auto primaryFacing = pFoot->PrimaryFacing.Current();
+					auto& secondaryFacing = pFoot->SecondaryFacing;
+
+					secondaryFacing.SetCurrent(primaryFacing);
+					secondaryFacing.SetDesired(primaryFacing);
+				}
+			}
+		}
+	}
+
+	const auto pOwner = pThis->Owner;
+	auto& pSlaveManager = pThis->SlaveManager;
+
+	if (pType->Enslaves && pType->SlavesNumber > 0)
+	{
+		// SlaveManager does not exist or they have different slaves.
+		if (!pSlaveManager || pSlaveManager->SlaveType != pType->Enslaves)
+		{
+			if (pSlaveManager)
+			{
+				// Slaves are not the same, so clear out.
+				pSlaveManager->Killed(nullptr);
+				GameDelete(pSlaveManager);
+				pSlaveManager = nullptr;
+			}
+
+			pSlaveManager = GameCreate<SlaveManagerClass>(pThis, pType->Enslaves, pType->SlavesNumber, pType->SlaveRegenRate, pType->SlaveReloadRate);
+		}
+		else if (pSlaveManager->SlaveCount != pType->SlavesNumber)
+		{
+			// Additions/deletions made when quantities are inconsistent.
+			if (pSlaveManager->SlaveCount < pType->SlavesNumber)
+			{
+				// There are too few slaves here. More are needed.
+				int count = pType->SlavesNumber - pSlaveManager->SlaveCount;
+
+				for (int index = 0; index < count; index++)
+				{
+					if (auto pSlaveNode = GameCreate<SlaveManagerClass::SlaveControl>())
+					{
+						pSlaveNode->Slave = nullptr;
+						pSlaveNode->State = SlaveControlStatus::Dead;
+						pSlaveNode->RespawnTimer.Start(pType->SlaveRegenRate);
+						pSlaveManager->SlaveNodes.AddItem(pSlaveNode);
+					}
+				}
+			}
+			else
+			{
+				for (int index = pSlaveManager->SlaveCount - 1; index >= pType->SlavesNumber; --index)
+				{
+					// I guess you have so many slaves you're overflowing. Clean it up.
+					if (auto pSlaveNode = pSlaveManager->SlaveNodes.GetItem(index))
+					{
+						const auto pSlave = pSlaveNode->Slave;
+
+						if (pSlave)
+						{
+							if (pSlave->InLimbo)
+							{
+								// He wasn't killed, just erased.
+								pSlave->RegisterDestruction(pThis);
+								pSlave->UnInit();
+							}
+							else
+							{
+								// Oh, my God, he's been killed.
+								pSlave->ReceiveDamage(&pSlave->Health, 0, RulesClass::Instance->C4Warhead, nullptr, true, false, pOwner);
+							}
+						}
+
+						// Unlink
+						pSlaveNode->Slave = nullptr;
+						pSlaveNode->State = SlaveControlStatus::Dead;
+						GameDelete(pSlaveNode);
+					}
+
+					// Remove it
+					pSlaveManager->SlaveNodes.RemoveItem(index);
+				}
+			}
+
+			pSlaveManager->SlaveCount = pType->SlavesNumber;
+		}
+	}
+	else if (pSlaveManager)
+	{
+		pSlaveManager->Killed(nullptr);
+		GameDelete(pSlaveManager);
+		pSlaveManager = nullptr;
+	}
+
+	auto& pSpawnManager = pThis->SpawnManager;
+
+	if (pType->Spawns && pType->SpawnsNumber > 0)
+	{
+		// No SpawnManager exists, or their SpawnType is inconsistent.
+		if (!pSpawnManager || pType->Spawns != pSpawnManager->SpawnType)
+		{
+			if (pSpawnManager)
+			{
+				// It may be odd that AircraftType is different, I chose to reset it.
+				pSpawnManager->KillNodes();
+				GameDelete(pSpawnManager);
+				pSpawnManager = nullptr;
+			}
+
+			pSpawnManager = GameCreate<SpawnManagerClass>(pThis, pType->Spawns, pType->SpawnsNumber, pType->SpawnRegenRate, pType->SpawnReloadRate);
+		}
+		else if (pSpawnManager->SpawnCount != pType->SpawnsNumber)
+		{
+			// Additions/deletions made when quantities are inconsistent.
+			if (pSpawnManager->SpawnCount < pType->SpawnsNumber)
+			{
+				int count = pType->SpawnsNumber - pSpawnManager->SpawnCount;
+
+				// Add the missing Spawns, but don't intend for them to be born right away.
+				for (int index = 0; index < count; index++)
+				{
+					if (auto pSpawnNode = GameCreate<SpawnControl>())
+					{
+						pSpawnNode->Unit = nullptr;
+						pSpawnNode->Status = SpawnNodeStatus::Dead;
+						pSpawnNode->SpawnTimer.Start(pType->SpawnRegenRate);
+						pSpawnNode->IsSpawnMissile = false;
+						pSpawnManager->SpawnedNodes.AddItem(pSpawnNode);
+					}
+				}
+			}
+			else
+			{
+				for (int index = pSpawnManager->SpawnCount - 1; index >= pType->SpawnsNumber; --index)
+				{
+					// Excess Spawns will be eliminated.
+					if (auto pSpawnNode = pSpawnManager->SpawnedNodes.GetItem(index))
+					{
+						const auto pAircraft = pSpawnNode->Unit;
+						auto& pStatus = pSpawnNode->Status;
+
+						// Spawns that don't die get killed.
+						if (pAircraft)
+						{
+							pAircraft->SpawnOwner = nullptr;
+
+							if (pAircraft->InLimbo || pStatus == SpawnNodeStatus::Idle ||
+								pStatus == SpawnNodeStatus::Reloading || pStatus == SpawnNodeStatus::TakeOff)
+							{
+								if (pStatus == SpawnNodeStatus::TakeOff)
+								{
+									Kamikaze::Instance.Remove(pAircraft);
+								}
+
+								pAircraft->UnInit();
+							}
+							else if (pSpawnNode->IsSpawnMissile)
+							{
+								pAircraft->ReceiveDamage(&pAircraft->Health, 0, RulesClass::Instance->C4Warhead, nullptr, true, false, pOwner);
+							}
+							else
+							{
+								pAircraft->Crash(nullptr);
+							}
+						}
+
+						// Unlink
+						pSpawnNode->Unit = nullptr;
+						pStatus = SpawnNodeStatus::Dead;
+						GameDelete(pSpawnNode);
+					}
+
+					// Remove it
+					pSpawnManager->SpawnedNodes.RemoveItem(index);
+				}
+			}
+
+			pSpawnManager->SpawnCount = pType->SpawnsNumber;
+		}
+	}
+	else if (pSpawnManager)
+	{
+		// Reset the target.
+		pSpawnManager->ResetTarget();
+
+		// pSpawnManager->KillNodes() kills all Spawns, but it is not necessary to kill the parts that are not performing tasks.
+		for (auto pSpawnNode : pSpawnManager->SpawnedNodes)
+		{
+			const auto pAircraft = pSpawnNode->Unit;
+			auto& Status = pSpawnNode->Status;
+
+			// A dead or idle Spawn is not killed.
+			if (!pAircraft || Status == SpawnNodeStatus::Dead ||
+				Status == SpawnNodeStatus::Idle || Status == SpawnNodeStatus::Reloading)
+			{
+				continue;
+			}
+
+			pAircraft->SpawnOwner = nullptr;
+
+			if (Status == SpawnNodeStatus::TakeOff)
+			{
+				Kamikaze::Instance.Remove(pAircraft);
+				pAircraft->UnInit();
+			}
+			else if (pSpawnNode->IsSpawnMissile)
+			{
+				pAircraft->ReceiveDamage(&pAircraft->Health, 0, RulesClass::Instance->C4Warhead, nullptr, true, false, pOwner);
+			}
+			else
+			{
+				pAircraft->Crash(nullptr);
+			}
+
+			pSpawnNode->Unit = nullptr;
+			Status = SpawnNodeStatus::Dead;
+			pSpawnNode->IsSpawnMissile = false;
+			pSpawnNode->SpawnTimer.Start(pSpawnManager->RegenRate);
+		}
+	}
+
+	std::vector<WeaponTypeClass*> vWeapons;
+
+	// Get all its weapons.
+	for (int index = 0; index < TechnoTypeClass::MaxWeapons; index++)
+	{
+		const auto pWeaponType = pType->GetWeapon(index, pThis->Veterancy.IsElite()).WeaponType;
+
+		if (pWeaponType)
+		{
+			vWeapons.push_back(pWeaponType);
+		}
+	}
+
+	// Prepare the variables.
+	int maxCapture = 0;
+	bool infiniteCapture = false;
+	bool hasTemporal = false;
+	bool hasAirstrike = false;
+	bool hasParasite = false;
+
+	if (!vWeapons.empty())
+	{
+		for (const auto pWeaponType : vWeapons)
+		{
+			const auto pWH = pWeaponType->Warhead;
+
+			if (pWH->MindControl)
+			{
+				if (pWeaponType->Damage > maxCapture)
+				{
+					// Wow, it can be mind controlled.
+					maxCapture = pWeaponType->Damage;
+				}
+
+				if (pWeaponType->InfiniteMindControl)
+				{
+					// You can overload, right?
+					infiniteCapture = true;
+				}
+			}
+
+			if (pWH->Temporal)
+			{
+				// Wow, it has a temporal device.
+				hasTemporal = true;
+			}
+
+			if (pWH->Airstrike)
+			{
+				// Look at me. I can call in an air strike.
+				hasAirstrike = true;
+			}
+
+			if (pWH->Parasite && pFoot)
+			{
+				// Oh, this is gonna be fun.
+				hasParasite = true;
+			}
+		}
+	}
+
+	auto& pCaptureManager = pThis->CaptureManager;
+	auto clearMindControlNode = [pCaptureManager](const int& maxCapture)
+	{
+		// If not exceeded, then stop.
+		if (pCaptureManager->ControlNodes.Count <= maxCapture)
+			return;
+
+		// Remove excess nodes.
+		for (int index = pCaptureManager->ControlNodes.Count - 1; index >= maxCapture; --index)
+		{
+			auto pControlNode = pCaptureManager->ControlNodes.GetItem(index);
+			pCaptureManager->FreeUnit(pControlNode->Unit);
+		}
+	};
+
+	if (maxCapture > 0)
+	{
+		if (!pCaptureManager)
+		{
+			// Rebuild a CaptureManager
+			pCaptureManager = GameCreate<CaptureManagerClass>(pThis, maxCapture, infiniteCapture);
+		}
+		else
+		{
+			if (!infiniteCapture)
+			{
+				// It can't be overloaded, so remove the excess nodes.
+				clearMindControlNode(maxCapture);
+			}
+
+			pCaptureManager->MaxControlNodes = maxCapture;
+			pCaptureManager->InfiniteMindControl = infiniteCapture;
+		}
+	}
+	else if (pCaptureManager)
+	{
+		if (pOldTypeExt && pOldTypeExt->Convert_ResetMindControl.Get())
+		{
+			// Remove CaptureManager completely
+			pCaptureManager->FreeAll();
+			GameDelete(pCaptureManager);
+			pCaptureManager = nullptr;
+		}
+		else
+		{
+			// Remove excess mind control node.
+			clearMindControlNode(pCaptureManager->MaxControlNodes);
+			pCaptureManager->InfiniteMindControl = false;
+		}
+	}
+
+	auto& pTemporalImUsing = pThis->TemporalImUsing;
+	if (hasTemporal)
+	{
+		if (!pTemporalImUsing)
+		{
+			// Rebuild a TemporalClass
+			pTemporalImUsing = GameCreate<TemporalClass>(pThis);
+		}
+	}
+	else if (pTemporalImUsing)
+	{
+		if (pTemporalImUsing->Target)
+		{
+			// Free this afflicted man.
+			pTemporalImUsing->LetGo();
+		}
+
+		// Delete it
+		GameDelete(pTemporalImUsing);
+		pTemporalImUsing = nullptr;
+	}
+
+	auto& pAirstrike = pThis->Airstrike;
+	if (hasAirstrike && pType->AirstrikeTeam > 0)
+	{
+		if (!pAirstrike)
+		{
+			// Rebuild a AirstrikeClass
+			pAirstrike = GameCreate<AirstrikeClass>(pThis);
+		}
+		else
+		{
+			// Modify the parameters of AirstrikeClass.
+			pAirstrike->AirstrikeTeam = pType->AirstrikeTeam;
+			pAirstrike->EliteAirstrikeTeam = pType->EliteAirstrikeTeam;
+			pAirstrike->AirstrikeTeamType = pType->AirstrikeTeamType;
+			pAirstrike->EliteAirstrikeTeamType = pType->EliteAirstrikeTeamType;
+			pAirstrike->AirstrikeRechargeTime = pType->AirstrikeRechargeTime;
+			pAirstrike->EliteAirstrikeRechargeTime = pType->EliteAirstrikeRechargeTime;
+		}
+	}
+
+	// Only FootClass* can use this.
+	if (pFoot)
+	{
+		auto& pParasiteImUsing = pFoot->ParasiteImUsing;
+		if (hasParasite)
+		{
+			if (!pParasiteImUsing)
+			{
+				// Rebuild a ParasiteClass
+				pParasiteImUsing = GameCreate<ParasiteClass>(pFoot);
+			}
+		}
+		else if (pParasiteImUsing)
+		{
+			if (pParasiteImUsing->Victim)
+			{
+				// Release of victims.
+				pParasiteImUsing->ExitUnit();
+			}
+
+			// Delete it
+			GameDelete(pParasiteImUsing);
+			pParasiteImUsing = nullptr;
+		}
+	}
 }
 
 void TechnoExt::ExtData::UpdateLaserTrails()

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -130,6 +130,7 @@ public:
 		void ApplySpawnLimitRange();
 		void UpdateTypeData(TechnoTypeClass* pCurrentType);
 		void UpdateTypeData_Foot();
+		void UpdateTypeExtData_FixOther(TechnoTypeExt::ExtData* pOldTypeExt);
 		void UpdateLaserTrails();
 		void UpdateAttachEffects();
 		void UpdateGattlingRateDownReset();

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -487,6 +487,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Convert_HumanToComputer.Read(exINI, pSection, "Convert.HumanToComputer");
 	this->Convert_ComputerToHuman.Read(exINI, pSection, "Convert.ComputerToHuman");
+	this->Convert_ResetMindControl.Read(exINI, pSection, "Convert.ResetMindControl");
 
 	this->CrateGoodie_RerollChance.Read(exINI, pSection, "CrateGoodie.RerollChance");
 
@@ -1031,6 +1032,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->Convert_HumanToComputer)
 		.Process(this->Convert_ComputerToHuman)
+			.Process(this->Convert_ResetMindControl)
 
 		.Process(this->CrateGoodie_RerollChance)
 

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -241,6 +241,7 @@ public:
 
 		Valueable<TechnoTypeClass*> Convert_HumanToComputer;
 		Valueable<TechnoTypeClass*> Convert_ComputerToHuman;
+		Valueable<bool> Convert_ResetMindControl;
 
 		Valueable<double> CrateGoodie_RerollChance;
 
@@ -570,6 +571,7 @@ public:
 
 			, Convert_HumanToComputer { }
 			, Convert_ComputerToHuman { }
+			, Convert_ResetMindControl { false }
 
 			, CrateGoodie_RerollChance { 0.0 }
 

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -6,6 +6,7 @@
 #include <Utilities/Helpers.Alex.h>
 
 #include <Ext/Sidebar/Body.h>
+#include <Ext/Techno/Body.h>
 
 // Remember that we still don't fix Ares "issues" a priori. Extensions as well.
 // Patches presented here are exceptions rather that the rule. They must be short, concise and correct.
@@ -23,6 +24,14 @@ ObjectClass* __fastcall CreateInitialPayload(TechnoTypeClass* type, void*, House
 void __fastcall LetGo(TemporalClass* pTemporal)
 {
 	pTemporal->LetGo();
+}
+
+bool  _stdcall ConvertToType(TechnoClass* pThis, TechnoTypeClass* pToType)
+{
+	if (pThis->WhatAmI() == AbstractType::Building)
+		return false;
+
+	return TechnoExt::ConvertToType(static_cast<FootClass*>(pThis), pToType);
 }
 
 void Apply_Ares3_0_Patches()
@@ -46,6 +55,12 @@ void Apply_Ares3_0_Patches()
 
 	// Replace the TemporalClass::Detach call by LetGo in convert function:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x436DA, &LetGo);
+
+	// Convert ManagerFix
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x039DAE, &ConvertToType);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x046C6D, &ConvertToType);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x04B397, &ConvertToType);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x04C099, &ConvertToType);
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -71,4 +86,10 @@ void Apply_Ares3_0p1_Patches()
 
 	// Replace the TemporalClass::Detach call by LetGo in convert function:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x441BA, &LetGo);
+
+	// Convert ManagerFix
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x3A82E, &ConvertToType);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4780D, &ConvertToType);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4BFF7, &ConvertToType);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4CCF9, &ConvertToType);
 }


### PR DESCRIPTION

![convertfix](https://github.com/user-attachments/assets/1eabbaba-8d7d-4135-89ca-495c559089e6)
After the conversion, the unit may lose the manager or retain some unnecessary ones. now they have been repaired.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                            ; TechnoType
Convert.ResetMindControl=               ; boolean, default to false
```

- After the unit conversion is completed, its mind control can be reset.
 - If `Convert.ResetMindControl=no` and there are no warheads in the unit that use `MindControl=yes`, then the controlled units that exceed the maximum value will be released.
---------
单位在变形后会丢失管理器或是留下一些不需要的管理器，现在它们被修复了。

In `rulesmd.ini`:
```ini
[SOMETECHNO]                            ; TechnoType
Convert.ResetMindControl=               ; boolean, default to false
```

- 单位变形结束后可以重置其心灵控制。
- 如果`Convert.ResetMindControl=no`且单位没有任何使用了`MindControl=yes`的弹头，那么超出最大值的被控制单位会得到解放。