### PR TITLE
Customize whether the animation with `Crater=yes` would destroy tiberium

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -525,7 +525,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow miners do area guard
   - Make harvesters do addtional scan after unload
   - Customize the scatter caused by aircraft attack mission
-  - Customize whether the animation with `Crater=yes` would destroy tiberium
+  - Customize whether `Crater=yes` animation would destroy tiberium
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -361,20 +361,20 @@ SplashAnims.PickRandom=false  ; boolean
 ExtraShadow=true              ; boolean
 ```
 
-### Customize whether the animation with `Crater=yes` would destroy tiberium
+### Customize whether `Crater=yes` animation would destroy tiberium
 
 - In vanilla, the anim with `Crater=yes` is hardcoded to destroy the tiberium in its cell. Now you can disable this behavior by setting the following tags to `false`.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-AnimCraterReduceTiberium=true  ; boolean
+AnimCraterDestroyTiberium=true  ; boolean
 ```
 
 In `artmd.ini`:
 ```ini
-[SOMEANIM]                     ; AnimationType
-Crater.ReduceTiberium=         ; boolean, default to [General]->AnimCraterReduceTiberium
+[SOMEANIM]                      ; AnimationType
+Crater.DestroyTiberium=         ; boolean, default to [General]->AnimCraterDestroyTiberium
 ```
 
 ### Fire animations spawned by Scorch & Flamer

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -385,8 +385,8 @@ New:
 - Customize the scatter caused by aircraft attack mission (by TaranDahl)
 - [Customizable garrison and bunker properties](Fixed-or-Improved-Logics.md#customizable-garrison-and-bunker-properties) (by Otamaa)
 - [Disable DamageSound for buildings](Fixed-or-Improved-Logics.md#disable-damagesound) (by Otamaa)
-- [Power plant damage factor](New-or-Enhanced-Logics.md#power-plant-damage-factor) (by Otamaa and Ollerus)
-- Customize whether the animation with `Crater=yes` would destroy tiberium (by TaranDahl)
+- [Power plant damage factor](Fixed-or-Improved-Logics#power-plant-damage-factor) (by Otamaa and Ollerus)
+- Customize whether `Crater=yes` animation would destroy tiberium (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -25,7 +25,7 @@ DEFINE_HOOK(0x423B95, AnimClass_AI_HideIfNoOre_Threshold, 0x8)
 
 	if (pType->HideIfNoOre)
 	{
-		auto nThreshold = abs(AnimTypeExt::ExtMap.Find(pThis->Type)->HideIfNoOre_Threshold.Get());
+		const int nThreshold = abs(AnimTypeExt::ExtMap.Find(pThis->Type)->HideIfNoOre_Threshold.Get());
 		pThis->Invisible = pThis->GetCell()->GetContainedTiberiumValue() <= nThreshold;
 	}
 
@@ -42,8 +42,8 @@ DEFINE_HOOK(0x42453E, AnimClass_AI_Damage, 0x6)
 
 	GET(AnimClass*, pThis, ESI);
 
-	auto const pTypeExt = AnimTypeExt::ExtMap.Find(pThis->Type);
-	int delay = pTypeExt->Damage_Delay.Get();
+	const auto pTypeExt = AnimTypeExt::ExtMap.Find(pThis->Type);
+	const int delay = pTypeExt->Damage_Delay.Get();
 	int damageMultiplier = 1;
 	double damage = 0;
 	int appliedDamage = 0;
@@ -483,10 +483,10 @@ DEFINE_HOOK(0x425060, AnimClass_Expire_ScorchFlamer, 0x6)
 
 #pragma endregion
 
-DEFINE_HOOK(0x4250E1, AnimClass_Middle_CraterReduceTiberium, 0x6)
+DEFINE_HOOK(0x4250E1, AnimClass_Middle_CraterDestroyTiberium, 0x6)
 {
-	enum { SkipReduceTiberium = 0x4250EC };
+	enum { SkipDestroyTiberium = 0x4250EC };
 	GET(AnimTypeClass*, pType, EDX);
-	return AnimTypeExt::ExtMap.Find(pType)->Crater_ReduceTiberium.Get(RulesExt::Global()->AnimCraterReduceTiberium) ? 0 : SkipReduceTiberium;
+	return AnimTypeExt::ExtMap.Find(pType)->Crater_DestroyTiberium.Get(RulesExt::Global()->AnimCraterDestroyTiberium) ? 0 : SkipDestroyTiberium;
 }
 

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -17,8 +17,6 @@ void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)
 	if (!pThis)
 		return;
 
-	HouseClass* pInvoker = pKiller ? pKiller->Owner : nullptr;
-
 	if (pThis->Type->DestroyAnim.Count > 0)
 	{
 		auto const facing = pThis->PrimaryFacing.Current().GetDir();
@@ -49,6 +47,7 @@ void AnimTypeExt::ProcessDestroyAnims(UnitClass* pThis, TechnoClass* pKiller)
 		if (pAnimType)
 		{
 			auto const pAnim = GameCreate<AnimClass>(pAnimType, pThis->Location);
+			auto const pInvoker = pKiller ? pKiller->Owner : nullptr;
 
 			//auto VictimOwner = pThis->IsMindControlled() && pThis->GetOriginalOwner()
 			//	? pThis->GetOriginalOwner() : pThis->Owner;
@@ -119,7 +118,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->LargeFireAnims.Read(exINI, pID, "LargeFireAnims");
 	this->LargeFireChances.Read(exINI, pID, "LargeFireChances");
 	this->LargeFireDistances.Read(exINI, pID, "LargeFireDistances");
-	this->Crater_ReduceTiberium.Read(exINI, pID, "Crater.ReduceTiberium");
+	this->Crater_DestroyTiberium.Read(exINI, pID, "Crater.DestroyTiberium");
 
 	// Parasitic types
 	Nullable<TechnoTypeClass*> createUnit;
@@ -177,7 +176,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->LargeFireAnims)
 		.Process(this->LargeFireChances)
 		.Process(this->LargeFireDistances)
-		.Process(this->Crater_ReduceTiberium)
+		.Process(this->Crater_DestroyTiberium)
 		;
 }
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -54,7 +54,7 @@ public:
 		ValueableVector<AnimTypeClass*> LargeFireAnims;
 		ValueableVector<double> LargeFireChances;
 		ValueableVector<double> LargeFireDistances;
-		Nullable<bool> Crater_ReduceTiberium;
+		Nullable<bool> Crater_DestroyTiberium;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -92,7 +92,7 @@ public:
 			, LargeFireAnims {}
 			, LargeFireChances {}
 			, LargeFireDistances {}
-			, Crater_ReduceTiberium {}
+			, Crater_DestroyTiberium {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -272,7 +272,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->HarvesterScanAfterUnload.Read(exINI, GameStrings::General, "HarvesterScanAfterUnload");
 
-	this->AnimCraterReduceTiberium.Read(exINI, GameStrings::General, "AnimCraterReduceTiberium");
+	this->AnimCraterDestroyTiberium.Read(exINI, GameStrings::General, "AnimCraterDestroyTiberium");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -500,7 +500,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ProneSpeed_NoCrawls)
 		.Process(this->DamagedSpeed)
 		.Process(this->HarvesterScanAfterUnload)
-		.Process(this->AnimCraterReduceTiberium)
+		.Process(this->AnimCraterDestroyTiberium)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -225,7 +225,7 @@ public:
 
 		Valueable<bool> HarvesterScanAfterUnload;
 
-		Valueable<bool> AnimCraterReduceTiberium;
+		Valueable<bool> AnimCraterDestroyTiberium;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -398,7 +398,7 @@ public:
 
 			, HarvesterScanAfterUnload { false }
 
-			, AnimCraterReduceTiberium { true }
+			, AnimCraterDestroyTiberium { true }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Customize whether `Crater=yes` animation would destroy tiberium

- In vanilla, the anim with `Crater=yes` is hardcoded to destroy the tiberium in its cell. Now you can disable this behavior by setting the following tags to `false`.

In `rulesmd.ini`:
```ini
[General]
AnimCraterDestroyTiberium=true  ; boolean
```

In `artmd.ini`:
```ini
[SOMEANIM]                      ; AnimationType
Crater.DestroyTiberium=         ; boolean, default to [General]->AnimCraterDestroyTiberium
```