### PR TITLE
[Minor] Add rectangular arrangement for SWSidebar

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -620,8 +620,9 @@ Default position for weeds counter overlaps with [harvester counter](#harvester-
 ![image](_static/images/sw_sidebar.png)
 *SuperWeapon Sidebar used with vanilla-like assets for from [Phobos supplementaries](https://github.com/Phobos-developers/PhobosSupplementaries)*
 
-- It is possible to put superweapon cameos on the left of screen like C&C3 when `SuperWeaponSidebar` is true. Cameos are arranged in a pyramid shape.
+- It is possible to put superweapon cameos on the left of screen like C&C3 when `SuperWeaponSidebar` is true.
   - Superweapon Sidebar is compatible with Ares superweapons.
+  - `SuperWeaponSidebar.Pyramid` controls whether cameos are arranged in a pyramid or rectangle.
   - `SuperWeaponSidebar.Interval` controls the distance between two column cameos (excluding the background). When you need to make a background, the width of the background should be (`SuperWeaponSidebar.Interval` + cameo fixed width 60).
   - `SuperWeaponSidebar.LeftOffset` controls the distance between the left side of cameo and the left side of its column (background). This should not be greater than `SuperWeaponSidebar.Interval`.
   - `SuperWeaponSidebar.CameoHeight` controls the distance from the top of the previous cameo to the top of the next cameo. That is, the space between the upper and lower cameos is (`SuperWeaponSidebar.CameoHeight` - cameo fixed height 48). This should not be less than 48. When you need to make a background, this is the height of the background.
@@ -648,6 +649,7 @@ In `uimd.ini`:
 ```ini
 [Sidebar]
 SuperWeaponSidebar=false              ; boolean
+SuperWeaponSidebar.Pyramid=true      ; boolean
 SuperWeaponSidebar.Interval=0         ; integer, pixels
 SuperWeaponSidebar.LeftOffset=0       ; integer, pixels
 SuperWeaponSidebar.CameoHeight=48     ; integer, pixels

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -14,17 +14,19 @@ CommandClass* SWSidebarClass::Commands[10];
 bool SWSidebarClass::AddColumn()
 {
 	auto& columns = this->Columns;
+	const int columnsCount = static_cast<int>(columns.size());
 
-	if (static_cast<int>(columns.size()) >= Phobos::UI::SuperWeaponSidebar_MaxColumns)
+	if (columnsCount >= Phobos::UI::SuperWeaponSidebar_MaxColumns)
 		return false;
 
-	const int maxButtons = Phobos::UI::SuperWeaponSidebar_Max - static_cast<int>(columns.size());
+	const int firstColumn = Phobos::UI::SuperWeaponSidebar_Max;
+	const int maxButtons = Phobos::UI::SuperWeaponSidebar_Pyramid ? firstColumn - columnsCount : firstColumn;
 
 	if (maxButtons <= 0)
 		return false;
 
 	const int cameoWidth = 60;
-	const auto column = GameCreate<SWColumnClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array.Count + 1 + static_cast<int>(columns.size()), maxButtons, 0, 0, cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval, Phobos::UI::SuperWeaponSidebar_CameoHeight);
+	const auto column = GameCreate<SWColumnClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array.Count + 1 + columnsCount, maxButtons, 0, 0, cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval, Phobos::UI::SuperWeaponSidebar_CameoHeight);
 
 	if (!column)
 		return false;
@@ -196,9 +198,9 @@ void SWSidebarClass::SortButtons()
 
 	const int buttonCount = static_cast<int>(vec_Buttons.size());
 	const int cameoWidth = 60, cameoHeight = 48;
-	const int maximum = Phobos::UI::SuperWeaponSidebar_Max;
+	const int firstColumn = Phobos::UI::SuperWeaponSidebar_Max;
 	const int cameoHarfInterval = (Phobos::UI::SuperWeaponSidebar_CameoHeight - cameoHeight) / 2;
-	int location_Y = (DSurface::ViewBounds.Height - std::min(buttonCount, maximum) * Phobos::UI::SuperWeaponSidebar_CameoHeight) / 2;
+	int location_Y = (DSurface::ViewBounds.Height - std::min(buttonCount, firstColumn) * Phobos::UI::SuperWeaponSidebar_CameoHeight) / 2;
 	Point2D location = { Phobos::UI::SuperWeaponSidebar_LeftOffset, location_Y + cameoHarfInterval };
 	int rowIdx = 0, columnIdx = 0;
 
@@ -217,11 +219,16 @@ void SWSidebarClass::SortButtons()
 		button->SetPosition(location.X, location.Y);
 		rowIdx++;
 
-		if (rowIdx >= maximum - columnIdx)
+		const int currentCapacity = Phobos::UI::SuperWeaponSidebar_Pyramid ? firstColumn - columnIdx : firstColumn;
+
+		if (rowIdx >= currentCapacity)
 		{
 			rowIdx = 0;
 			columnIdx++;
-			location_Y += Phobos::UI::SuperWeaponSidebar_CameoHeight / 2;
+
+			if (Phobos::UI::SuperWeaponSidebar_Pyramid)
+				location_Y += Phobos::UI::SuperWeaponSidebar_CameoHeight / 2;
+
 			location.X += cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval;
 			location.Y = location_Y + cameoHarfInterval;
 		}
@@ -238,8 +245,14 @@ void SWSidebarClass::SortButtons()
 int SWSidebarClass::GetMaximumButtonCount()
 {
 	const int firstColumn = Phobos::UI::SuperWeaponSidebar_Max;
-	const int columns = std::min(firstColumn, Phobos::UI::SuperWeaponSidebar_MaxColumns);
-	return (firstColumn + (firstColumn - (columns - 1))) * columns / 2;
+
+	if (Phobos::UI::SuperWeaponSidebar_Pyramid)
+	{
+		const int columns = std::min(firstColumn, Phobos::UI::SuperWeaponSidebar_MaxColumns);
+		return (firstColumn + (firstColumn - (columns - 1))) * columns / 2;
+	}
+
+	return firstColumn * Phobos::UI::SuperWeaponSidebar_MaxColumns;
 }
 
 bool SWSidebarClass::IsEnabled()

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -34,6 +34,7 @@ double Phobos::UI::PowerDelta_ConditionYellow = 0.75;
 double Phobos::UI::PowerDelta_ConditionRed = 1.0;
 bool Phobos::UI::CenterPauseMenuBackground = false;
 bool Phobos::UI::SuperWeaponSidebar = false;
+bool Phobos::UI::SuperWeaponSidebar_Pyramid = true;
 int Phobos::UI::SuperWeaponSidebar_Interval = 0;
 int Phobos::UI::SuperWeaponSidebar_LeftOffset = 0;
 int Phobos::UI::SuperWeaponSidebar_CameoHeight = 48;
@@ -180,6 +181,9 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 
 		Phobos::UI::SuperWeaponSidebar =
 			ini_uimd.ReadBool(SIDEBAR_SECTION, "SuperWeaponSidebar", Phobos::UI::SuperWeaponSidebar);
+
+		Phobos::UI::SuperWeaponSidebar_Pyramid =
+			ini_uimd.ReadBool(SIDEBAR_SECTION, "SuperWeaponSidebar.Pyramid", Phobos::UI::SuperWeaponSidebar_Pyramid);
 
 		Phobos::UI::SuperWeaponSidebar_Interval =
 			ini_uimd.ReadInteger(SIDEBAR_SECTION, "SuperWeaponSidebar.Interval", Phobos::UI::SuperWeaponSidebar_Interval);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -55,6 +55,7 @@ public:
 		static double PowerDelta_ConditionRed;
 		static bool CenterPauseMenuBackground;
 		static bool SuperWeaponSidebar;
+		static bool SuperWeaponSidebar_Pyramid;
 		static int SuperWeaponSidebar_Interval;
 		static int SuperWeaponSidebar_LeftOffset;
 		static int SuperWeaponSidebar_CameoHeight;


### PR DESCRIPTION
- `SuperWeaponSidebar.Pyramid` controls whether cameos are arranged in a pyramid or rectangle.
- `SuperWeaponSidebar.Pyramid` 控制图标按照金字塔形状排列，否则按照矩形排列。

In `uimd.ini`:
```ini
[Sidebar]
SuperWeaponSidebar.Pyramid=true      ; boolean
```