### PR TITLE
Fix functions that return structs to return structs, not pointers

### DIFF
--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -364,8 +364,7 @@ void BuildingExt::KickOutStuckUnits(BuildingClass* pThis)
 		}
 	}
 
-	auto buffer = CoordStruct::Empty;
-	auto pCell = MapClass::Instance.GetCellAt(*pThis->GetExitCoords(&buffer, 0));
+	auto pCell = MapClass::Instance.GetCellAt(pThis->GetExitCoords(0));
 	int i = 0;
 
 	while (true)

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -172,11 +172,11 @@ DEFINE_HOOK(0x44CEEC, BuildingClass_Mission_Missile_EMPulseSelectWeapon, 0x6)
 	return SkipGameCode;
 }
 
-CoordStruct* __fastcall BuildingClass_GetFireCoords_Wrapper(BuildingClass* pThis, void* _, CoordStruct* pCrd, int weaponIndex)
+CoordStruct* __fastcall BuildingClass_GetFireCoords_Wrapper(BuildingClass* pThis, CoordStruct* buffer, CoordStruct* pCrd, int weaponIndex)
 {
 	auto coords = MapClass::Instance.GetCellAt(pThis->Owner->EMPTarget)->GetCellCoords();
-	pCrd = pThis->GetFLH(&coords, EMPulseCannonTemp::weaponIndex, *pCrd);
-	return pCrd;
+	*buffer = pThis->GetFLH(EMPulseCannonTemp::weaponIndex, coords);
+	return buffer;
 }
 
 DEFINE_FUNCTION_JUMP(CALL6, 0x44D1F9, BuildingClass_GetFireCoords_Wrapper);

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -172,11 +172,10 @@ DEFINE_HOOK(0x44CEEC, BuildingClass_Mission_Missile_EMPulseSelectWeapon, 0x6)
 	return SkipGameCode;
 }
 
-CoordStruct* __fastcall BuildingClass_GetFireCoords_Wrapper(BuildingClass* pThis, CoordStruct* buffer, CoordStruct* pCrd, int weaponIndex)
+CoordStruct* __fastcall BuildingClass_GetFireCoords_Wrapper(BuildingClass* pThis, void* _, CoordStruct* pCrd, int weaponIndex)
 {
-	auto coords = MapClass::Instance.GetCellAt(pThis->Owner->EMPTarget)->GetCellCoords();
-	*buffer = pThis->GetFLH(EMPulseCannonTemp::weaponIndex, coords);
-	return buffer;
+	*pCrd = pThis->GetFLH(EMPulseCannonTemp::weaponIndex);
+	return pCrd;
 }
 
 DEFINE_FUNCTION_JUMP(CALL6, 0x44D1F9, BuildingClass_GetFireCoords_Wrapper);

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -43,12 +43,11 @@ DEFINE_HOOK(0x73E730, UnitClass_MissionHarvest_HarvesterScanAfterUnload, 0x5)
 	// Focus is set when the harvester is fully loaded and go home.
 	if (pFocus && !pType->Weeder && TechnoTypeExt::ExtMap.Find(pType)->HarvesterScanAfterUnload.Get(RulesExt::Global()->HarvesterScanAfterUnload))
 	{
-		auto cellBuffer = CellStruct::Empty;
-		const auto pCellStru = pThis->ScanForTiberium(&cellBuffer, RulesClass::Instance->TiberiumLongScan / Unsorted::LeptonsPerCell, 0);
+		const auto pCellStru = pThis->ScanForTiberium(RulesClass::Instance->TiberiumLongScan / Unsorted::LeptonsPerCell, 0);
 
-		if (*pCellStru != CellStruct::Empty)
+		if (pCellStru != CellStruct::Empty)
 		{
-			const auto pCell = MapClass::Instance.TryGetCellAt(*pCellStru);
+			const auto pCell = MapClass::Instance.TryGetCellAt(pCellStru);
 			const auto distFromTiberium = pCell ? pThis->DistanceFrom(pCell) : -1;
 			const auto distFromFocus = pThis->DistanceFrom(pFocus);
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1528,7 +1528,8 @@ DEFINE_HOOK(0x446BF4, BuildingClass_Place_FreeUnit_NearByLocation, 0x6)
 	const auto movementZone = pFreeUnit->Type->MovementZone;
 	const auto currentZone = MapClass::Instance.GetMovementZoneType(mapCoords, movementZone, false);
 
-	R->EAX(MapClass::Instance.NearByLocation(*outBuffer, mapCoords, pFreeUnit->Type->SpeedType, currentZone, movementZone, false, 1, 1, true, true, false, false, CellStruct::Empty, false, false));
+	*outBuffer = MapClass::Instance.NearByLocation(mapCoords, pFreeUnit->Type->SpeedType, currentZone, movementZone, false, 1, 1, true, true, false, false, CellStruct::Empty, false, false);
+	R->EAX(outBuffer);
 	return SkipGameCode;
 }
 
@@ -1543,7 +1544,8 @@ DEFINE_HOOK(0x446D42, BuildingClass_Place_FreeUnit_NearByLocation2, 0x6)
 	const auto movementZone = pFreeUnit->Type->MovementZone;
 	const auto currentZone = MapClass::Instance.GetMovementZoneType(mapCoords, movementZone, false);
 
-	R->EAX(MapClass::Instance.NearByLocation(*outBuffer, mapCoords, pFreeUnit->Type->SpeedType, currentZone, movementZone, false, 1, 1, false, true, false, false, CellStruct::Empty, false, false));
+	*outBuffer = MapClass::Instance.NearByLocation(mapCoords, pFreeUnit->Type->SpeedType, currentZone, movementZone, false, 1, 1, false, true, false, false, CellStruct::Empty, false, false);
+	R->EAX(outBuffer);
 	return SkipGameCode;
 }
 


### PR DESCRIPTION
Fixes functions that return CoordStruct, CellStruct or Matrix3D by value to actually do that, and dump the wrappers.
Needs to be tested, also `BuildingClass_GetFireCoords_Wrapper` is weird.