### PR TITLE
[Minor] SWSidebar allows multiple additions of the same super weapon type

### DIFF
--- a/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWColumnClass.cpp
@@ -108,8 +108,13 @@ bool SWColumnClass::AddButton(int superIdx)
 		sidebar.DisableEntry = false;
 	}
 
+	int currentID = SWButtonClass::StartID;
+
+	for (const auto column : sidebar.Columns)
+		currentID += static_cast<int>(column->Buttons.size());
+
 	const int cameoWidth = 60, cameoHeight = 48;
-	const auto button = GameCreate<SWButtonClass>(SWButtonClass::StartID + superIdx, superIdx, 0, 0, cameoWidth, cameoHeight);
+	const auto button = GameCreate<SWButtonClass>(currentID, superIdx, 0, 0, cameoWidth, cameoHeight);
 
 	if (!button)
 		return false;

--- a/src/Ext/Sidebar/SWSidebar/SWColumnClass.h
+++ b/src/Ext/Sidebar/SWSidebar/SWColumnClass.h
@@ -23,6 +23,8 @@ public:
 
 	void SetHeight(int height);
 
+	static constexpr int StartID = 2101;
+
 	std::vector<SWButtonClass*> Buttons {};
 	int MaxButtons { 0 };
 };

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -109,7 +109,7 @@ void SWSidebarClass::InitIO()
 
 		if (width > 0 && height > 0)
 		{
-			if (const auto toggleButton = GameCreate<ToggleSWButtonClass>(2100, 0, 0, width, height))
+			if (const auto toggleButton = GameCreate<ToggleSWButtonClass>(SWColumnClass::StartID - 1, 0, 0, width, height))
 			{
 				toggleButton->Zap();
 				GScreenClass::Instance.AddButton(toggleButton);

--- a/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
+++ b/src/Ext/Sidebar/SWSidebar/SWSidebarClass.cpp
@@ -26,7 +26,7 @@ bool SWSidebarClass::AddColumn()
 		return false;
 
 	const int cameoWidth = 60;
-	const auto column = GameCreate<SWColumnClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array.Count + 1 + columnsCount, maxButtons, 0, 0, cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval, Phobos::UI::SuperWeaponSidebar_CameoHeight);
+	const auto column = GameCreate<SWColumnClass>(SWColumnClass::StartID + columnsCount, maxButtons, 0, 0, cameoWidth + Phobos::UI::SuperWeaponSidebar_Interval, Phobos::UI::SuperWeaponSidebar_CameoHeight);
 
 	if (!column)
 		return false;
@@ -109,7 +109,7 @@ void SWSidebarClass::InitIO()
 
 		if (width > 0 && height > 0)
 		{
-			if (const auto toggleButton = GameCreate<ToggleSWButtonClass>(SWButtonClass::StartID + SuperWeaponTypeClass::Array.Count, 0, 0, width, height))
+			if (const auto toggleButton = GameCreate<ToggleSWButtonClass>(2100, 0, 0, width, height))
 			{
 				toggleButton->Zap();
 				GScreenClass::Instance.AddButton(toggleButton);
@@ -150,9 +150,6 @@ bool SWSidebarClass::AddButton(int superIdx)
 
 	if (columns.empty() && !this->AddColumn())
 		return false;
-
-	if (std::any_of(columns.begin(), columns.end(), [superIdx](SWColumnClass* column) { return std::any_of(column->Buttons.begin(), column->Buttons.end(), [superIdx](SWButtonClass* button) { return button->SuperIndex == superIdx; }); }))
-		return true;
 
 	return columns.back()->AddButton(superIdx);
 }


### PR DESCRIPTION
Currently, when attempting add a super weapon into sw sidebar, it will check if any button has same type of sw. If it exist, the attempt will be droped; Now it will add normally.