### PR TITLE
Allows refineries to use multiple ActiveAnim simultaneously

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -526,6 +526,7 @@ This page lists all the individual contributions to the project by their author.
   - Make harvesters do addtional scan after unload
   - Customize the scatter caused by aircraft attack mission
   - Customize whether `Crater=yes` animation would destroy tiberium
+  - Allows refineries to use multiple ActiveAnim simultaneously
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -444,6 +444,16 @@ In `rulesmd.ini`:
 AircraftDockingDir(N)=  ; Direction type (integers from 0-255)
 ```
 
+### Allows refineries to use multiple ActiveAnim simultaneously
+
+- In vanilla, the refinery uses different ActiveAnims depending on the storage. You can now make it use multiple ActiveAnims simultaneously like any other building.
+
+In `artmd.ini`:
+```ini
+[SOMEBUILDING]                         ; BuildingType
+Refinery.UseNormalActiveAnim=false     ; boolean
+```
+
 ### Allowed / disallowed types for FactoryPlant
 
 - It is now possible to customize which TechnoTypes benefit from bonuses of a `FactoryPlant=true` building by listing them on `FactoryPlant.AllowTypes` and/or `FactoryPlant.DisallowTypes`.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -387,6 +387,7 @@ New:
 - [Disable DamageSound for buildings](Fixed-or-Improved-Logics.md#disable-damagesound) (by Otamaa)
 - [Power plant damage factor](Fixed-or-Improved-Logics#power-plant-damage-factor) (by Otamaa and Ollerus)
 - Customize whether `Crater=yes` animation would destroy tiberium (by TaranDahl)
+- Allows refineries to use multiple ActiveAnim simultaneously (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Building/Hooks.Refinery.cpp
+++ b/src/Ext/Building/Hooks.Refinery.cpp
@@ -57,3 +57,17 @@ DEFINE_HOOK(0x522E4F, InfantryClass_SlaveGiveMoney_CheckBalanceAfter, 0x6)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x445FD6, BuildingClass_Place_RefineryActiveAnim, 0x6)
+{
+	GET(BuildingTypeClass*, pType, ESI);
+
+	return BuildingTypeExt::ExtMap.Find(pType)->Refinery_UseNormalActiveAnim ? 0x446183 : 0;
+}
+
+DEFINE_HOOK(0x450D9C, BuildingClass_UpdateAnimations_RefineryActiveAnim, 0x6)
+{
+	GET(BuildingTypeClass*, pType, EDX);
+
+	return BuildingTypeExt::ExtMap.Find(pType)->Refinery_UseNormalActiveAnim ? 0x450F9E : 0;
+}

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -223,6 +223,8 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		}
 	}
 
+	this->Refinery_UseNormalActiveAnim.Read(exArtINI, pArtSection, "Refinery.UseNormalActiveAnim");
+	
 	// Ares tag
 	this->SpyEffect_Custom.Read(exINI, pSection, "SpyEffect.Custom");
 	if (SuperWeaponTypeClass::Array.Count > 0)
@@ -333,6 +335,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BuildingOccupyROFMult)
 		.Process(this->BuildingBunkerDamageMult)
 		.Process(this->BuildingBunkerROFMult)
+		.Process(this->Refinery_UseNormalActiveAnim)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -92,6 +92,8 @@ public:
 		Nullable<float> BuildingBunkerROFMult;
 		NullableIdx<VocClass> BunkerWallsUpSound;
 		NullableIdx<VocClass> BunkerWallsDownSound;
+		
+		Valueable<bool> Refinery_UseNormalActiveAnim;
 
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
@@ -152,6 +154,7 @@ public:
 			, BuildingBunkerROFMult {}
 			, BunkerWallsUpSound {}
 			, BunkerWallsDownSound {}
+			, Refinery_UseNormalActiveAnim { false }
 		{ }
 
 		// Ares 0.A functions


### PR DESCRIPTION

### Allows refineries to use multiple ActiveAnim simultaneously

- In vanilla, the refinery uses different ActiveAnims depending on the storage. You can now make it use multiple ActiveAnims simultaneously like any other building.

In `artmd.ini`:
```ini
[SOMEBUILDING]                         ; BuildingType
Refinery.UseNormalActiveAnim=false     ; boolean
```
