### PR TITLE
[Minor] Damage.DealtByInvoker tweak & Damage.ApplyFIrepowerMult

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -330,15 +330,17 @@ LandingDir=     ; Direction type (integers from 0-255). Accepts negative values 
 - `Weapon` can be set to a WeaponType, to create a projectile and immediately detonate it instead of simply dealing `Damage` by `Warhead`. This allows weapon effects to be applied.
 - `Damage.Delay` determines delay between two applications of `Damage`. Requires `Damage` to be set to 1.0 or above. Value of 0 disables the delay. Keep in mind that this is measured in animation frames, not game frames. Depending on `Rate`, animation may or may not advance animation frames on every game frame.
 - `Damage.DealtByInvoker`, if set to true, makes any `Damage` dealt to be considered as coming from the animation's invoker (f.ex, firer of the weapon if it is Warhead `AnimList/SplashList` animation, the destroyed vehicle if it is `DestroyAnim` animation or the object the animation is attached to). If invoker has died or does not exist, the house the invoker belonged to is still used to deal damage and apply Phobos-introduced Warhead effects. Does not affect which house the `Damage` dealt by `Warhead` is dealt by.
+  - `Damage.ApplyFirepowerMult` determines whether or not firepower modifiers from the animation's invoker are applied on the damage dealt from this animation, if exists.
 - `Damage.ApplyOncePerLoop`, if set to true, makes `Damage` be dealt only once per animation loop (on single loop animations, only once, period) instead of on every frame or intervals defined by `Damage.Delay`. The frame on which it is dealt is determined by `Damage.Delay`, defaulting to after the first animation frame.
 
 In `artmd.ini`:
 ```ini
-[SOMEANIM]                     ; AnimationType
-Weapon=                        ; WeaponType
-Damage.Delay=0                 ; integer, animation frames
-Damage.DealtByInvoker=false    ; boolean
-Damage.ApplyOncePerLoop=false  ; boolean
+[SOMEANIM]                      ; AnimationType
+Weapon=                         ; WeaponType
+Damage.Delay=0                  ; integer, animation frames
+Damage.DealtByInvoker=false     ; boolean
+Damage.ApplyOncePerLoop=false   ; boolean
+Damage.ApplyFirepowerMult=false ; boolean
 ```
 
 ```{note}

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -51,9 +51,6 @@ DEFINE_HOOK(0x42453E, AnimClass_AI_Damage, 0x6)
 	const int damageMultiplier = isTerrain ? 5 : 1;
 	const double baseDamage = pThis->Type->Damage;
 
-	if (baseDamage < 1.0 && delay <= 0)
-		return SkipDamage;
-
 	int appliedDamage = 0;
 
 	if (pTypeExt->Damage_ApplyOncePerLoop) // If damage is to be applied only once per animation loop
@@ -111,7 +108,7 @@ DEFINE_HOOK(0x42453E, AnimClass_AI_Damage, 0x6)
 			if (pThis->OwnerObject)
 				pInvoker = abstract_cast<TechnoClass*, true>(pThis->OwnerObject);
 			else if (pThis->IsBuildingAnim)
-				pInvoker = AnimExt::ExtMap.Find(pThis)->ParentBuilding;
+				pInvoker = pExt->ParentBuilding;
 		}
 
 		if (pInvoker)

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -93,6 +93,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->Damage_Delay.Read(exINI, pID, "Damage.Delay");
 	this->Damage_DealtByInvoker.Read(exINI, pID, "Damage.DealtByInvoker");
 	this->Damage_ApplyOncePerLoop.Read(exINI, pID, "Damage.ApplyOncePerLoop");
+	this->Damage_ApplyFirepowerMult.Read(exINI, pID, "Damage.ApplyFirepowerMult");
 	this->ExplodeOnWater.Read(exINI, pID, "ExplodeOnWater");
 	this->Warhead_Detonate.Read(exINI, pID, "Warhead.Detonate");
 	this->WakeAnim.Read(exINI, pID, "WakeAnim");
@@ -151,6 +152,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Damage_Delay)
 		.Process(this->Damage_DealtByInvoker)
 		.Process(this->Damage_ApplyOncePerLoop)
+		.Process(this->Damage_ApplyFirepowerMult)
 		.Process(this->ExplodeOnWater)
 		.Process(this->Warhead_Detonate)
 		.Process(this->WakeAnim)

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -29,6 +29,7 @@ public:
 		Valueable<int> Damage_Delay;
 		Valueable<bool> Damage_DealtByInvoker;
 		Valueable<bool> Damage_ApplyOncePerLoop;
+		Valueable<bool> Damage_ApplyFirepowerMult;
 		Valueable<bool> ExplodeOnWater;
 		Valueable<bool> Warhead_Detonate;
 		Valueable<AnimTypeClass*> WakeAnim;
@@ -67,6 +68,7 @@ public:
 			, Damage_Delay { 0 }
 			, Damage_DealtByInvoker { false }
 			, Damage_ApplyOncePerLoop { false }
+			, Damage_ApplyFirepowerMult { false }
 			, ExplodeOnWater { false }
 			, Warhead_Detonate { false }
 			, WakeAnim {}


### PR DESCRIPTION
previous `Damage.DealtByInvoker` doesn't really apply to anim warhead, this PR makes it inline with anim weapon. Notice that this might change the behavior of anim weapon and warhead a bit, but I think this should be the correct way. Any other feedbacks and reviews are welcome

`Damage.ApplyFirepowerMult` determines whether or not firepower modifiers from the animation's invoker are applied on the damage dealt from this animation, if exists