### PR TITLE
[Minor] Allow aircraft to continuously kill targets in planning mode

### DIFF
--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -771,6 +771,15 @@ DEFINE_HOOK(0x4C72F2, EventClass_Execute_AircraftAreaGuard_Untether, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x418CF3, AircraftClass_Mission_Attack_PlanningFix, 0x5)
+{
+	enum { SkipIdle = 0x418D00 };
+
+	GET(AircraftClass*, pThis, ESI);
+
+	return pThis->Ammo <= 0 || !pThis->TryNextPlanningTokenNode() ? 0 : SkipIdle;
+}
+
 #pragma endregion
 
 static __forceinline bool CheckSpyPlaneCameraCount(AircraftClass* pThis)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2204,12 +2204,3 @@ DEFINE_HOOK(0x489E47, DamageArea_RockerItemsFix2, 0x6)
 }
 
 #pragma region
-
-DEFINE_HOOK(0x418CF3, AircraftClass_Mission_Attack_PlanningFix, 0x5)
-{
-	enum { SkipIdle = 0x418D00 };
-
-	GET(AircraftClass*, pThis, ESI);
-
-	return pThis->Ammo <= 0 || !pThis->TryNextPlanningTokenNode() ? 0 : SkipIdle;
-}


### PR DESCRIPTION
In vanilla game, aircraft will always return to airport even it still has remain ammo and planning after target has been destroyed.
For now, the aircraft will continue attack next planning target if it still has ammo.