### PR TITLE
[Minor] Optimize Interceptor

### DIFF
--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -50,7 +50,7 @@ void TechnoExt::ExtData::ApplyInterceptor()
 	auto const pThis = this->OwnerObject();
 	auto const pTypeExt = this->TypeExtData;
 
-	if (pTypeExt->InterceptorType && !pThis->Target && !this->IsBurrowed)
+	if (pTypeExt->InterceptorType && !pThis->Target && pThis->RearmTimer.Expired() && !this->IsBurrowed)
 	{
 		BulletClass* pTargetBullet = nullptr;
 		const auto pInterceptorType = pTypeExt->InterceptorType.get();
@@ -58,6 +58,8 @@ void TechnoExt::ExtData::ApplyInterceptor()
 		const double guardRangeSq = guardRange * guardRange;
 		const double minguardRange = pInterceptorType->MinimumGuardRange.Get(pThis);
 		const double minguardRangeSq = minguardRange * minguardRange;
+		// Interceptor weapon is always fixed
+		const auto pWeapon = pThis->GetWeapon(pInterceptorType->Weapon)->WeaponType;
 
 		// DO NOT iterate BulletExt::ExtMap here, the order of items is not deterministic
 		// so it can differ across players throwing target management out of sync.
@@ -76,8 +78,6 @@ void TechnoExt::ExtData::ApplyInterceptor()
 
 			if (pBulletTypeExt->Armor.isset())
 			{
-				const int weaponIndex = pThis->SelectWeapon(pBullet);
-				const auto pWeapon = pThis->GetWeapon(weaponIndex)->WeaponType;
 				const double versus = GeneralUtils::GetWarheadVersusArmor(pWeapon->Warhead, pBulletTypeExt->Armor.Get());
 
 				if (versus == 0.0)

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -50,7 +50,7 @@ void TechnoExt::ExtData::ApplyInterceptor()
 	auto const pThis = this->OwnerObject();
 	auto const pTypeExt = this->TypeExtData;
 
-	if (pTypeExt->InterceptorType && !pThis->Target && pThis->RearmTimer.Expired() && !this->IsBurrowed)
+	if (pTypeExt->InterceptorType && !pThis->Target && !this->IsBurrowed)
 	{
 		BulletClass* pTargetBullet = nullptr;
 		const auto pInterceptorType = pTypeExt->InterceptorType.get();

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -12,6 +12,32 @@
 
 #pragma region TechnoClass_SelectWeapon
 
+DEFINE_HOOK(0x6F3339, TechnoClass_WhatWeaponShouldIUse_Interceptor, 0x8)
+{
+	enum { SkipGameCode = 0x6F3341, ReturnValue = 0x6F3406 };
+
+	GET(TechnoClass*, pThis, ESI);
+	GET_STACK(AbstractClass*, pTarget, STACK_OFFSET(0x18, 0x4));
+
+	auto const pType = pThis->GetTechnoType();
+
+	if (pTarget && pTarget->WhatAmI() == AbstractType::Bullet)
+	{
+		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+		if (pTypeExt->InterceptorType)
+		{
+			R->EAX(pTypeExt->InterceptorType->Weapon);
+			return ReturnValue;
+		}
+	}
+
+	// Restore overridden instructions.
+	R->EAX(pType);
+
+	return SkipGameCode;
+}
+
 DEFINE_HOOK(0x6F33CD, TechnoClass_WhatWeaponShouldIUse_ForceFire, 0x6)
 {
 	enum { ReturnWeaponIndex = 0x6F37AF };

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -12,32 +12,6 @@
 
 #pragma region TechnoClass_SelectWeapon
 
-DEFINE_HOOK(0x6F3339, TechnoClass_WhatWeaponShouldIUse_Interceptor, 0x8)
-{
-	enum { SkipGameCode = 0x6F3341, ReturnValue = 0x6F3406 };
-
-	GET(TechnoClass*, pThis, ESI);
-	GET_STACK(AbstractClass*, pTarget, STACK_OFFSET(0x18, 0x4));
-
-	auto const pType = pThis->GetTechnoType();
-
-	if (pTarget && pTarget->WhatAmI() == AbstractType::Bullet)
-	{
-		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-
-		if (pTypeExt->InterceptorType)
-		{
-			R->EAX(pTypeExt->InterceptorType->Weapon);
-			return ReturnValue;
-		}
-	}
-
-	// Restore overridden instructions.
-	R->EAX(pType);
-
-	return SkipGameCode;
-}
-
 DEFINE_HOOK(0x6F33CD, TechnoClass_WhatWeaponShouldIUse_ForceFire, 0x6)
 {
 	enum { ReturnWeaponIndex = 0x6F37AF };


### PR DESCRIPTION
split from https://github.com/Phobos-developers/Phobos/pull/1568. This one is a bit controversial so I'd pull this alone for test and review
- instead of selecting weapon for every bullet, used the fixed value from `Interceptor.Weapon` once and for all
- added a RearmTimer check for the interceptor process