### PR TITLE
[Vanilla Fix] Fix an issue related to `Spawned` aircraft

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -504,6 +504,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue that `MovementZone=Fly` harvesters can not be able to enter refinery buildings manually
   - Fix an issue that jumpjet harvester cannot automatically go mining when leaving the weapons factory
   - Fix an issue that jumpjet harvester will overlap when manually entering refinery buildings and cause game crashes
+  - Fix an issue that `Spawned` aircraft will fly towards the edge of the map when its `Spawner` is under EMP
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -236,6 +236,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that `MovementZone=Fly` harvesters can not be able to enter refinery buildings manually.
 - Fixed an issue that jumpjet harvester cannot automatically go mining when leaving the weapons factory.
 - Fixed an issue that jumpjet harvester will overlap when manually entering refinery buildings and cause game crashes.
+- Fixed an issue that `Spawned` aircraft will fly towards the edge of the map when its `Spawner` is under EMP.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -443,6 +443,7 @@ Vanilla fixes:
 - Fixed an issue that `MovementZone=Fly` harvesters can not be able to enter refinery buildings manually (by CrimRecya)
 - Fixed an issue that jumpjet harvester cannot automatically go mining when leaving the weapons factory (by CrimRecya)
 - Fixed an issue that jumpjet harvester will overlap when manually entering refinery buildings and cause game crashes (by CrimRecya)
+- Fixed an issue that `Spawned` aircraft will fly towards the edge of the map when its `Spawner` is under EMP (by CrimRecya)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -275,6 +275,23 @@ DEFINE_HOOK(0x6B74F0, SpawnManagerClass_AI_UseTurretFacing, 0x5)
 	return 0;
 }
 
+DEFINE_HOOK(0x418CF3, AircraftClass_Mission_Attack_ReturnToSpawnOwner, 0x5)
+{
+	enum { SkipGameCode = 0x418D00 };
+
+	GET(AircraftClass* const, pThis, ESI);
+
+	const auto pSpawnOwner = pThis->SpawnOwner;
+
+	if (!pSpawnOwner)
+		return 0;
+
+	pThis->SetDestination(pSpawnOwner, true);
+	pThis->QueueMission(Mission::Move, false);
+
+	return SkipGameCode;
+}
+
 #pragma endregion
 
 #pragma region WakeAnims


### PR DESCRIPTION
- Fixed an issue that `Spawned` aircraft will fly towards the edge of the map when its `Spawner` is under EMP.

---

If continuously under EMP, the aircraft will stop at the position of the carrier.