### PR TITLE
KeepRange.EarlyStopFrame

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2542,7 +2542,7 @@ In `rulesmd.ini`:
 KeepRange=0                       ; floating point value
 KeepRange.AllowAI=false           ; boolean
 KeepRange.AllowPlayer=false       ; boolean
-KeepRange.MaxRearmTimerAllowed=0  ; boolean
+KeepRange.MaxRearmTimerAllowed=0  ; integer
 ```
 
 ### Make units try turning to target when firing with `OmniFire=yes`

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2534,15 +2534,15 @@ FeedbackWeapon=  ; WeaponType
   - `KeepRange` controls how long the distance to maintain when the techno's ROF timer is ticking. What is actually read is its absolute value. If it is a positive value, it will be stayed outside this distance, just like it has a special `MinimumRange` after firing. If it is a negative value, it will be kept as close as possible to this distance, just like it has a special `Range` after firing. In addition, if the effective range section is too small, it will be considered unable to fire. It is best to have an effective range of 1.0, and 2.0 is best for Infantry.
     - `KeepRange.AllowAI` controls whether this function is effective for computer.
     - `KeepRange.AllowPlayer` controls whether this function is effective for human.
-    - The function won't take effect if the techno's rearm time left is shorter than `KeepRange.MaxRearmTimerAllowed`.
+    - The function won't take effect if the techno's rearm time left is shorter than `KeepRange.EarlyStopFrame`.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWEAPON]                      ; WeaponType
-KeepRange=0                       ; floating point value
-KeepRange.AllowAI=false           ; boolean
-KeepRange.AllowPlayer=false       ; boolean
-KeepRange.MaxRearmTimerAllowed=0  ; integer
+[SOMEWEAPON]                  ; WeaponType
+KeepRange=0                   ; floating point value
+KeepRange.AllowAI=false       ; boolean
+KeepRange.AllowPlayer=false   ; boolean
+KeepRange.EarlyStopFrame=0    ; integer
 ```
 
 ### Make units try turning to target when firing with `OmniFire=yes`

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2534,13 +2534,15 @@ FeedbackWeapon=  ; WeaponType
   - `KeepRange` controls how long the distance to maintain when the techno's ROF timer is ticking. What is actually read is its absolute value. If it is a positive value, it will be stayed outside this distance, just like it has a special `MinimumRange` after firing. If it is a negative value, it will be kept as close as possible to this distance, just like it has a special `Range` after firing. In addition, if the effective range section is too small, it will be considered unable to fire. It is best to have an effective range of 1.0, and 2.0 is best for Infantry.
     - `KeepRange.AllowAI` controls whether this function is effective for computer.
     - `KeepRange.AllowPlayer` controls whether this function is effective for human.
+    - The function won't take effect if the techno's rearm time left is shorter than `KeepRange.MaxRearmTimerAllowed`.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWEAPON]                 ; WeaponType
-KeepRange=0                  ; floating point value
-KeepRange.AllowAI=false      ; boolean
-KeepRange.AllowPlayer=false  ; boolean
+[SOMEWEAPON]                      ; WeaponType
+KeepRange=0                       ; floating point value
+KeepRange.AllowAI=false           ; boolean
+KeepRange.AllowPlayer=false       ; boolean
+KeepRange.MaxRearmTimerAllowed=0  ; boolean
 ```
 
 ### Make units try turning to target when firing with `OmniFire=yes`

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -133,7 +133,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->KeepRange.Read(exINI, pSection, "KeepRange");
 	this->KeepRange_AllowAI.Read(exINI, pSection, "KeepRange.AllowAI");
 	this->KeepRange_AllowPlayer.Read(exINI, pSection, "KeepRange.AllowPlayer");
-	this->KeepRange_MaxRearmTimerAllowed.Read(exINI, pSection, "KeepRange.MaxRearmTimerAllowed");
+	this->KeepRange_EarlyStopFrame.Read(exINI, pSection, "KeepRange.EarlyStopFrame");
 	this->KickOutPassengers.Read(exINI, pSection, "KickOutPassengers");
 	this->Beam_Color.Read(exINI, pSection, "Beam.Color");
 	this->Beam_Duration.Read(exINI, pSection, "Beam.Duration");
@@ -214,7 +214,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->KeepRange)
 		.Process(this->KeepRange_AllowAI)
 		.Process(this->KeepRange_AllowPlayer)
-		.Process(this->KeepRange_MaxRearmTimerAllowed)
+		.Process(this->KeepRange_EarlyStopFrame)
 		.Process(this->KickOutPassengers)
 		.Process(this->Beam_Color)
 		.Process(this->Beam_Duration)
@@ -393,7 +393,7 @@ int WeaponTypeExt::GetTechnoKeepRange(WeaponTypeClass* pThis, TechnoClass* pFire
 		return 0;
 	}
 
-	if (pFirer->RearmTimer.GetTimeLeft() < pExt->KeepRange_MaxRearmTimerAllowed)
+	if (pFirer->RearmTimer.GetTimeLeft() < pExt->KeepRange_EarlyStopFrame)
 		return 0;
 
 	if (!pFirer->RearmTimer.InProgress())

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -133,6 +133,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->KeepRange.Read(exINI, pSection, "KeepRange");
 	this->KeepRange_AllowAI.Read(exINI, pSection, "KeepRange.AllowAI");
 	this->KeepRange_AllowPlayer.Read(exINI, pSection, "KeepRange.AllowPlayer");
+	this->KeepRange_MaxRearmTimerAllowed.Read(exINI, pSection, "KeepRange.MaxRearmTimerAllowed");
 	this->KickOutPassengers.Read(exINI, pSection, "KickOutPassengers");
 	this->Beam_Color.Read(exINI, pSection, "Beam.Color");
 	this->Beam_Duration.Read(exINI, pSection, "Beam.Duration");
@@ -213,6 +214,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->KeepRange)
 		.Process(this->KeepRange_AllowAI)
 		.Process(this->KeepRange_AllowPlayer)
+		.Process(this->KeepRange_MaxRearmTimerAllowed)
 		.Process(this->KickOutPassengers)
 		.Process(this->Beam_Color)
 		.Process(this->Beam_Duration)
@@ -390,6 +392,9 @@ int WeaponTypeExt::GetTechnoKeepRange(WeaponTypeClass* pThis, TechnoClass* pFire
 	{
 		return 0;
 	}
+
+	if (pFirer->RearmTimer.GetTimeLeft() < pExt->KeepRange_MaxRearmTimerAllowed)
+		return 0;
 
 	if (!pFirer->RearmTimer.InProgress())
 	{

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -71,7 +71,7 @@ public:
 		Valueable<Leptons> KeepRange;
 		Valueable<bool> KeepRange_AllowAI;
 		Valueable<bool> KeepRange_AllowPlayer;
-		Valueable<int> KeepRange_MaxRearmTimerAllowed;
+		Valueable<int> KeepRange_EarlyStopFrame;
 		Valueable<bool> KickOutPassengers;
 		Nullable<ColorStruct> Beam_Color;
 		Valueable<int> Beam_Duration;
@@ -141,7 +141,7 @@ public:
 			, KeepRange { Leptons(0) }
 			, KeepRange_AllowAI { false }
 			, KeepRange_AllowPlayer { false }
-			, KeepRange_MaxRearmTimerAllowed { 0 }
+			, KeepRange_EarlyStopFrame { 0 }
 			, KickOutPassengers { true }
 			, Beam_Color {}
 			, Beam_Duration { 15 }

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -71,6 +71,7 @@ public:
 		Valueable<Leptons> KeepRange;
 		Valueable<bool> KeepRange_AllowAI;
 		Valueable<bool> KeepRange_AllowPlayer;
+		Valueable<int> KeepRange_MaxRearmTimerAllowed;
 		Valueable<bool> KickOutPassengers;
 		Nullable<ColorStruct> Beam_Color;
 		Valueable<int> Beam_Duration;
@@ -140,6 +141,7 @@ public:
 			, KeepRange { Leptons(0) }
 			, KeepRange_AllowAI { false }
 			, KeepRange_AllowPlayer { false }
+			, KeepRange_MaxRearmTimerAllowed { 0 }
 			, KickOutPassengers { true }
 			, Beam_Color {}
 			, Beam_Duration { 15 }


### PR DESCRIPTION
  - `KeepRange` controls how long the distance to maintain when the techno's ROF timer is ticking. What is actually read is its absolute value. If it is a positive value, it will be stayed outside this distance, just like it has a special `MinimumRange` after firing. If it is a negative value, it will be kept as close as possible to this distance, just like it has a special `Range` after firing. In addition, if the effective range section is too small, it will be considered unable to fire. It is best to have an effective range of 1.0, and 2.0 is best for Infantry.
    - `KeepRange.AllowAI` controls whether this function is effective for computer.
    - `KeepRange.AllowPlayer` controls whether this function is effective for human.
    - The function won't take effect if the techno's rearm time left is shorter than `KeepRange.EarlyStopFrame`.
