### PR TITLE
[Ares Fix] Fix `Convert.Deploy` triggers repeatedly

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -520,6 +520,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue that `Spawned` aircraft will fly towards the edge of the map when its `Spawner` is under EMP
   - Burst without delay
   - Fix an issue that if the garrison unload occupants when there is no open space around it would result in the disappearance of the occupants
+  - Fix an issue where Ares' `Convert.Deploy` triggers repeatedly when the unit is turning or moving
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -269,6 +269,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue where a portion of Ares's trigger event 75/77 was determined unsuccessfully.
 - Fixed an issue where some units crashed after the deployment transformation.
 - Fixed the bug that AlphaImage remained after unit entered tunnel.
+- Fixed an issue where Ares' `Convert.Deploy` triggers repeatedly when the unit is turning or moving.
 
 ## Aircraft
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -445,6 +445,7 @@ Phobos fixes:
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)
 - Taking over Ares' AlphaImage respawn logic to reduce lags from it (by NetsuNegi)
+- Fixed an issue where Ares' `Convert.Deploy` triggers repeatedly when the unit is turning or moving (by CrimRecya)
 ```
 
 ### 0.4

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -67,18 +67,24 @@ void Apply_Ares3_0_Patches()
 	// Replace the TemporalClass::Detach call by LetGo in convert function:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x436DA, &LetGo);
 
-	// SuperClass_Launch_SkipRelatedTags
+	// SuperClass_Launch_SkipRelatedTags:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x3207C, AresHelper::AresBaseAddress + 0x320DF);
 
-	// Convert ManagerFix
+	// Convert ManagerFix:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x039DAE, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x046C6D, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x04B397, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x04C099, &ConvertToType);
 
+	// EBolt reimpl:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x550A0, GET_OFFSET(CreateEBolt));
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x550F0, GET_OFFSET(CreateEBolt2));
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x561F0, GET_OFFSET(EBoltExt::_EBolt_Draw_Colors));
+
+	// Unit simple deployer fix:
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4C0C6, { 0x5E }); // pop esi
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4C0C7, { 0x33, 0xC0 }); // xor eax, eax
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x4C0A9, AresHelper::AresBaseAddress + 0x4C0C6);
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -105,16 +111,22 @@ void Apply_Ares3_0p1_Patches()
 	// Replace the TemporalClass::Detach call by LetGo in convert function:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x441BA, &LetGo);
 
-	// SuperClass_Launch_SkipRelatedTags
+	// SuperClass_Launch_SkipRelatedTags:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x32A5C, AresHelper::AresBaseAddress + 0x32ABF);
 
-	// Convert ManagerFix
+	// Convert ManagerFix:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x3A82E, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4780D, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4BFF7, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4CCF9, &ConvertToType);
 
+	// EBolt reimpl:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x55D50, GET_OFFSET(CreateEBolt));
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x55DA0, GET_OFFSET(CreateEBolt2));
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x56EA0, GET_OFFSET(EBoltExt::_EBolt_Draw_Colors));
+
+	// Unit simple deployer fix:
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4CD26, { 0x5E }); // pop esi
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4CD27, { 0x33, 0xC0 }); // xor eax, eax
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x4CD09, AresHelper::AresBaseAddress + 0x4CD26);
 }


### PR DESCRIPTION
- Fix an issue where Ares' `Convert.Deploy` triggers repeatedly when the unit is turning or moving.
  > 修复在单位进行转向或移动时，Ares的 `Convert.Deploy` 会重复触发的问题。

---

- I'm not entirely sure why Ares specifically checked the movement status, so I think it may need to be tested more.
  > 我不是特别清楚为什么Ares特别地判断了移动状态，所以我觉得可能需要多测试一下。