### PR TITLE
[Minor] Fixed attack mouse action

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -382,6 +382,7 @@ This page lists all the individual contributions to the project by their author.
   - Player-controlled spies are not forced to perform other tasks while attacking buildings
   - If `BombDisarm=yes` is not present for all weapon warheads, then the engineer will no longer use the appropriate mouse action
   - Fix an unusual use of DeployFireWeapon for InfantryType
+  - Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -252,6 +252,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that `IsLocomotor=yes` warhead rendering hover units unselectable and undamageable on elevated bridge.
 - Fixed the bug that Locomotor warhead won't stop working when firer (except for vehicle) stop firing.
 - Fixed the bug that hover vehicle will sink if destroyed on bridge.
+- Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -438,6 +438,7 @@ Vanilla fixes:
 - Fixed an issue where airstrike flare line drawn to target at lower elevation would clip (by Starkku)
 - Fixed the bug that damaged particle dont disappear after building has repaired by engineer (by NetsuNegi)
 - Projectiles with `Vertical=true` now drop straight down if fired off by AircraftTypes instead of behaving erratically (by Starkku)
+- Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target (by FlyStar)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2440,7 +2440,7 @@ namespace WhatActionObjectTemp
 	bool Skip = false;
 }
 
-DEFINE_HOOK(0x700536, TechnoClass_WhatAction_ObjectObject_AllowAttack, 0x6)
+DEFINE_HOOK(0x700536, TechnoClass_WhatAction_Object_AllowAttack, 0x6)
 {
 	enum { CanAttack = 0x70055D, Continue = 0x700548 };
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2440,14 +2440,17 @@ namespace MouseOverROFTemp
 	bool Skip = false;
 }
 
-DEFINE_HOOK(0x700536, TechnoClass_MouseOverObject_AllowEnter, 0x6)
+DEFINE_HOOK(0x700536, TechnoClass_MouseOverObject_AllowAttack, 0x6)
 {
 	GET_STACK(bool, canEnter, STACK_OFFSET(0x1C, 0x4));
 	GET_STACK(bool, ignoreForce, STACK_OFFSET(0x1C, 0x8));
 	enum { CanAttack = 0x70055D };
 
+	if (canEnter || ignoreForce)
+		return CanAttack;
+
 	MouseOverROFTemp::Skip = true;
-	return (canEnter || ignoreForce) ? CanAttack : 0;
+	return 0;
 }
 
 DEFINE_HOOK(0x6FC8F5, TechnoClass_CanFire_SkipROF, 0x6)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2429,3 +2429,36 @@ DEFINE_PATCH(0x501504, 0x01); // HouseClass::All_To_Hunt
 DEFINE_PATCH(0x6DF77A, 0x01); // TActionClass::Execute
 
 #pragma endregion
+
+#pragma region MouseOverObjectROF
+
+// canEnter and ignoreForce should come before GetFireError().
+DEFINE_JUMP(LJMP, 0x70054D, 0x70056C)
+
+namespace MouseOverROFTemp
+{
+	bool Skip = false;
+}
+
+DEFINE_HOOK(0x700536, TechnoClass_MouseOverObject_AllowEnter, 0x6)
+{
+	GET_STACK(bool, canEnter, STACK_OFFSET(0x1C, 0x4));
+	GET_STACK(bool, ignoreForce, STACK_OFFSET(0x1C, 0x8));
+	enum { CanAttack = 0x70055D };
+
+	MouseOverROFTemp::Skip = true;
+	return (canEnter || ignoreForce) ? CanAttack : 0;
+}
+
+DEFINE_HOOK(0x6FC8F5, TechnoClass_CanFire_SkipROF, 0x6)
+{
+	if (MouseOverROFTemp::Skip)
+	{
+		MouseOverROFTemp::Skip = false;
+		return 0x6FC981;
+	}
+
+	return 0;
+}
+
+#pragma endregion

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2444,14 +2444,15 @@ DEFINE_HOOK(0x700536, TechnoClass_WhatAction_Object_AllowAttack, 0x6)
 {
 	enum { CanAttack = 0x70055D, Continue = 0x700548 };
 
-	GET(TechnoClass*, pThis, ESI);
-	GET(ObjectClass*, pObject, EDI);
 	GET_STACK(bool, canEnter, STACK_OFFSET(0x1C, 0x4));
 	GET_STACK(bool, ignoreForce, STACK_OFFSET(0x1C, 0x8));
-	GET_STACK(int, WeaponIndex, STACK_OFFSET(0x1C, -0x8));
 
 	if (canEnter || ignoreForce)
 		return CanAttack;
+
+	GET(TechnoClass*, pThis, ESI);
+	GET(ObjectClass*, pObject, EDI);
+	GET_STACK(int, WeaponIndex, STACK_OFFSET(0x1C, -0x8));
 
 	WhatActionObjectTemp::Skip = true;
 	R->EAX(pThis->GetFireError(pObject, WeaponIndex, true));


### PR DESCRIPTION
Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target.
- 修正了当选定的单位处于重新武装状态时可以无条件对目标使用攻击鼠标的问题。

