### PR TITLE
[Vanilla Enhancement]Customize palette of rubble

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -435,6 +435,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug that `IsLocomotor=yes` warhead rendering hover units unselectable and undamageable on elevated bridge
   - Fix the bug that Locomotor warhead won't stop working when firer (except for vehicle) stop firing
   - Fix the bug that hover vehicle will sink if destroyed on bridge
+  - Customize palette of rubble
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -689,6 +689,16 @@ In `rulesmd.ini`:
 BuildingWaypoints=false  ; boolean
 ```
 
+### Customize palette of rubble
+
+- In vanilla, rubble overlay is hardcoded to use cell's palette. Now you can choose it.
+
+In `artmd.ini`
+```
+[SOMEBUILDING]        ; BuildingType
+RubblePalette=           ; filename - excluding .pal extension and three-character theater-specific suffix
+```
+
 ## Infantry
 
 ### Prone speed customization

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -425,6 +425,7 @@ New:
 - [Damaged aircraft image changes](New-or-Enhanced-Logics.md#damaged-aircraft-image-changes) (by Fryone)
 - [Additional attached animation position customizations](Fixed-or-Improved-Logics.md#attached-animation-position-customization) (by Starkku)
 - Use `SkipCrushSlowdown=true` to avoid the bug related to `Accelerates=true` and `MovementZone=CrushAll` (by TaranDahl)
+- Customize palette of rubble (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -263,6 +263,8 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// Art
 	this->IsAnimDelayedBurst.Read(exArtINI, pArtSection, "IsAnimDelayedBurst");
 	this->ZShapePointMove_OnBuildup.Read(exArtINI, pArtSection, "ZShapePointMove.OnBuildup");
+
+	this->RubblePalette.LoadFromINI(pArtINI, pArtSection, "RubblePalette");
 }
 
 void BuildingTypeExt::ExtData::CompleteInitialization()
@@ -336,6 +338,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BunkerWallsDownSound)
 		.Process(this->BuildingRepairedSound)
 		.Process(this->Refinery_UseNormalActiveAnim)
+		.Process(this->RubblePalette)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -97,6 +97,8 @@ public:
 
 		Valueable<bool> Refinery_UseNormalActiveAnim;
 
+		CustomPalette RubblePalette;
+
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
 			, PowersUp_Buildings {}
@@ -158,6 +160,7 @@ public:
 			, BunkerWallsDownSound {}
 			, BuildingRepairedSound {}
 			, Refinery_UseNormalActiveAnim { false }
+			, RubblePalette { CustomPalette::PaletteMode::Temperate }
 		{ }
 
 		// Ares 0.A functions

--- a/src/Ext/OverlayType/Hooks.cpp
+++ b/src/Ext/OverlayType/Hooks.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
-
 #include <HouseClass.h>
+
+#include <Ext/BuildingType/Body.h>
 
 DEFINE_HOOK(0x47F71D, CellClass_DrawOverlay_ZAdjust, 0x5)
 {
@@ -25,7 +26,7 @@ DEFINE_HOOK(0x47F974, CellClass_DrawOverlay_Walls, 0x5)
 	GET(RectangleStruct*, pBounds, EBP);
 	GET(int, zAdjust, EDI);
 	GET_STACK(OverlayTypeClass*, pOverlayType, STACK_OFFSET(0x24, -0x14));
-	REF_STACK(Point2D, pLocation, STACK_OFFSET(0x24, -0x10));
+	REF_STACK(Point2D, location, STACK_OFFSET(0x24, -0x10));
 
 	int wallOwnerIndex = pThis->WallOwnerIndex;
 	int colorSchemeIndex = HouseClass::CurrentPlayer->ColorSchemeIndex;
@@ -41,8 +42,29 @@ DEFINE_HOOK(0x47F974, CellClass_DrawOverlay_Walls, 0x5)
 	else
 		pConvert = ColorScheme::Array[colorSchemeIndex]->LightConvert;
 
-	DSurface::Temp->DrawSHP(pConvert, pShape, pThis->OverlayData, &pLocation, pBounds,
+	DSurface::Temp->DrawSHP(pConvert, pShape, pThis->OverlayData, &location, pBounds,
 		BlitterFlags(0x4E00), 0, -2 - zAdjust, ZGradient::Deg90, pThis->Intensity_Normal, 0, 0, 0, 0, 0);
 
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x47FAFD, CellClass_DrawOverlay_Rubble, 0x5)
+{
+	enum { SkipGameCode = 0x47FB86 };
+
+	GET(CellClass*, pCell, ESI);
+	GET(RectangleStruct*, pBounds, EBP);
+	GET_STACK(SHPStruct*, pRubbleShape, STACK_OFFSET(0x24, -0x14));
+	GET_STACK(int, frameIdx, STACK_OFFSET(0x24, 0x8));
+	REF_STACK(const Point2D, location, STACK_OFFSET(0x24, -0x10));
+
+	const auto pRubbleTypeExt = BuildingTypeExt::ExtMap.Find(pCell->Rubble);
+	const auto pRubblePalette = pRubbleTypeExt->RubblePalette.GetOrDefaultConvert(pCell->LightConvert);
+
+	const auto blitterFlags = BlitterFlags::ZReadWrite | BlitterFlags::Alpha | BlitterFlags::bf_400 | BlitterFlags::Centered;
+	const int zAdjust = R->EDI<int>() - R->Stack<int>(STACK_OFFSET(0x24, 0x4)) - 2;
+	const auto zGradient = R->BL() ? ZGradient::Ground : ZGradient::Deg90;
+
+	DSurface::Temp->DrawSHP(pRubblePalette, pRubbleShape, frameIdx, &location, pBounds, blitterFlags, 0, zAdjust, zGradient, pCell->Intensity_Terrain, 0, nullptr, 0, 0, 0);
 	return SkipGameCode;
 }


### PR DESCRIPTION
- In vanilla, rubble overlay is hardcoded to use cell's palette. Now you can choose it.
- 在原版游戏中，废墟覆盖物硬编码为使用所在格子的调色盘. 现在你可以选择了.

In `artmd.ini`
```
[SOMEBUILDING]        ; BuildingType
RubblePalette=           ; filename - excluding .pal extension and three-character theater-specific suffix
```