### PR TITLE
Skip drawing frame to improve performance

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -586,6 +586,7 @@ This page lists all the individual contributions to the project by their author.
   - Skip target scanning function calling for unarmed technos (code)
   - Force techno targeting in distributed frames to improve performance
   - Use `SkipCrushSlowdown=true` to avoid the bug related to `Accelerates=true` and `MovementZone=CrushAll`
+  - Skip drawing frame to improve performance
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -358,6 +358,17 @@ In `RA2MD.INI`:
 ShowDesignatorRange=false             ; boolean
 ```
 
+### Skip drawing frame to improve performance
+
+- Now you can make the game skip the drawing by 1 frame every `SkipFrameDelay` when the frame rate is lower than the vanilla defined `DetailMinFrameRateNormal`. This helps alleviate the frame rate drop caused by drawing.
+  - This logic only takes effect when `SkipFrameDelay` is greater than or equal to 2.
+
+In `RA2MD.INI`:
+```ini
+[Phobos]
+SkipFrameDelay=0  ; integer
+```
+
 ### SuperWeapon ShowTimer sorting
 
 - You can now sort the timers of superweapons in ascending order from top to bottom according to a given priority value.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -438,6 +438,7 @@ Vanilla fixes:
 - Fixed an issue where airstrike flare line drawn to target at lower elevation would clip (by Starkku)
 - Fixed the bug that damaged particle dont disappear after building has repaired by engineer (by NetsuNegi)
 - Projectiles with `Vertical=true` now drop straight down if fired off by AircraftTypes instead of behaving erratically (by Starkku)
+- Skip drawing frame to improve performance (by TaranDahl)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -4,6 +4,7 @@
 #include <PreviewClass.h>
 #include <Surface.h>
 #include <ThemeClass.h>
+#include <FPSCounter.h>
 
 #include <Ext/House/Body.h>
 #include <Ext/Side/Body.h>
@@ -427,4 +428,11 @@ DEFINE_HOOK(0x69A317, SessionClass_PlayerColorIndexToColorSchemeIndex, 0x0)
 	R->EAX(index);
 
 	return 0x69A325;
+}
+
+DEFINE_HOOK(0x4F4480, GScreenClass_DrawOnTop_Start, 0x8)
+{
+	enum { retn = 0x4F45A8 };
+	int delay = Phobos::Config::SkipFrameDelay;
+	return delay && FPSCounter::CurrentFrameRate < RulesClass::Instance->DetailMinFrameRateNormal && !(Unsorted::CurrentFrame % delay) ? retn : 0;
 }

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -430,7 +430,7 @@ DEFINE_HOOK(0x69A317, SessionClass_PlayerColorIndexToColorSchemeIndex, 0x0)
 	return 0x69A325;
 }
 
-DEFINE_HOOK(0x4F4480, GScreenClass_DrawOnTop_Start, 0x8)
+DEFINE_HOOK(0x4F4480, GScreenClass_Render_FrameSkip, 0x8)
 {
 	enum { retn = 0x4F45A8 };
 	int delay = Phobos::Config::SkipFrameDelay;

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -70,6 +70,7 @@ bool Phobos::Config::HideLightFlashEffects = true;
 bool Phobos::Config::ShowFlashOnSelecting = false;
 bool Phobos::Config::UnitPowerDrain = false;
 int Phobos::Config::SuperWeaponSidebar_RequiredSignificance = 0;
+int Phobos::Config::SkipFrameDelay = 0;
 
 bool Phobos::Misc::CustomGS = false;
 int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
@@ -98,6 +99,9 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::HideLightFlashEffects = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "HideLightFlashEffects", false);
 	Phobos::Config::ShowFlashOnSelecting = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "ShowFlashOnSelecting", false);
 	Phobos::Config::SuperWeaponSidebar_RequiredSignificance = CCINIClass::INI_RA2MD.ReadInteger(phobosSection, "SuperWeaponSidebar.RequiredSignificance", 0);
+	Phobos::Config::SkipFrameDelay = CCINIClass::INI_RA2MD.ReadInteger("Phobos", "SkipFrameDelay", 0);
+	if (Phobos::Config::SkipFrameDelay < 2)
+		Phobos::Config::SkipFrameDelay = 0;
 
 	// Custom game speeds, 6 - i so that GS6 is index 0, just like in the engine
 	Phobos::Config::CampaignDefaultGameSpeed = 6 - CCINIClass::INI_RA2MD.ReadInteger(phobosSection, "CampaignDefaultGameSpeed", 4);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -105,6 +105,7 @@ public:
 		static bool ShowFlashOnSelecting;
 		static bool UnitPowerDrain;
 		static int SuperWeaponSidebar_RequiredSignificance;
+		static int SkipFrameDelay;
 	};
 
 	class Misc


### PR DESCRIPTION
### Skip drawing frame to improve performance

- Now you can make the game skip the drawing by 1 frame every `SkipFrameDelay` when the frame rate is lower than the vanilla defined `DetailMinFrameRateNormal`. This helps alleviate the frame rate drop caused by drawing.
  - This logic only takes effect when `SkipFrameDelay` is greater than or equal to 2.

In `RA2MD.INI`:
```ini
[Phobos]
SkipFrameDelay=0  ; integer
```
