### PR TITLE
Auto deploy for GI-like infantry

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -587,6 +587,7 @@ This page lists all the individual contributions to the project by their author.
   - Skip target scanning function calling for unarmed technos (code)
   - Force techno targeting in distributed frames to improve performance
   - Use `SkipCrushSlowdown=true` to avoid the bug related to `Accelerates=true` and `MovementZone=CrushAll`
+  - Auto deploy for GI-like infantry
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -691,6 +691,19 @@ BuildingWaypoints=false  ; boolean
 
 ## Infantry
 
+### Auto deploy for GI-like infantry
+
+- In RA2, the GI-like infantry controlled by the AI will automatically deploy to use their more powerful secondary weapons when engaging the enemy. This feature was broken in Yuri’s Revenge. Now you can use the following flags to re-enable this feature.
+
+In `rulesmd.ini`:
+```ini
+[General]                     ; InfantryType
+InfantryAutoDeploy=false      ; boolean
+
+[SOMEINFANTRY]                ; InfantryType
+InfantryAutoDeploy=           ; boolean, default to [General] -> InfantryAutoDeploy
+```
+
 ### Prone speed customization
 
 - In vanilla, infantry has hardcoded prone speed. Now you can customize it.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -697,7 +697,7 @@ BuildingWaypoints=false  ; boolean
 
 In `rulesmd.ini`:
 ```ini
-[General]                     ; InfantryType
+[General]
 InfantryAutoDeploy=false      ; boolean
 
 [SOMEINFANTRY]                ; InfantryType

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -426,6 +426,7 @@ New:
 - [Additional attached animation position customizations](Fixed-or-Improved-Logics.md#attached-animation-position-customization) (by Starkku)
 - Use `SkipCrushSlowdown=true` to avoid the bug related to `Accelerates=true` and `MovementZone=CrushAll` (by TaranDahl)
 - Units can customize the attack voice that plays when using more weapons (by FlyStar)
+- Auto deploy for GI-like infantry (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Infantry/Hooks.cpp
+++ b/src/Ext/Infantry/Hooks.cpp
@@ -5,6 +5,8 @@
 #include <InputManagerClass.h>
 #include <WarheadTypeClass.h>
 
+#include <Ext/TechnoType/Body.h>
+
 DEFINE_HOOK(0x51B2BD, InfantryClass_UpdateTarget_IsControlledByHuman, 0x6)
 {
 	GET(InfantryClass*, pThis, ESI);
@@ -127,4 +129,12 @@ DEFINE_HOOK(0x7093F8, TechnoClass_709290_DeployWeapon, 0x5)
 	}
 
 	return ReturnTrue;
+}
+
+// Skip incorrect retn to restore the auto deploy behavior of infantry
+DEFINE_HOOK(0x522373, InfantryClass_ApproachTarget_InfantryAutoDeploy, 0x5)
+{
+	enum { Deploy = 0x522378 };
+	GET(InfantryClass*, pThis, ESI);
+	return TechnoTypeExt::ExtMap.Find(pThis->Type)->InfantryAutoDeploy.Get(RulesExt::Global()->InfantryAutoDeploy) ? Deploy : 0;
 }

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -297,6 +297,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DistributeTargetingFrame.Read(exINI, GameStrings::General, "DistributeTargetingFrame");
 	this->DistributeTargetingFrame_AIOnly.Read(exINI, GameStrings::General, "DistributeTargetingFrame.AIOnly");
 
+	this->InfantryAutoDeploy.Read(exINI, GameStrings::General, "InfantryAutoDeploy");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -548,6 +550,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->TintColorBerserk)
 		.Process(this->AttackMove_IgnoreWeaponCheck)
 		.Process(this->AttackMove_StopWhenTargetAcquired)
+		.Process(this->InfantryAutoDeploy)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -250,6 +250,8 @@ public:
 		int TintColorForceShield;
 		int TintColorBerserk;
 
+		Valueable<bool> InfantryAutoDeploy;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -443,6 +445,8 @@ public:
 
 			, AttackMove_IgnoreWeaponCheck { false }
 			, AttackMove_StopWhenTargetAcquired { }
+
+			, InfantryAutoDeploy { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -955,6 +955,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttackMove_StopWhenTargetAcquired.Read(exINI, pSection, "AttackMove.StopWhenTargetAcquired");
 	this->AttackMove_PursuitTarget.Read(exINI, pSection, "AttackMove.PursuitTarget");
 
+	this->InfantryAutoDeploy.Read(exINI, pSection, "InfantryAutoDeploy");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1587,6 +1589,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->VoiceIFVRepair)
 		.Process(this->VoiceWeaponAttacks)
 		.Process(this->VoiceEliteWeaponAttacks)
+
+		.Process(this->InfantryAutoDeploy)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -416,6 +416,8 @@ public:
 		ValueableVector<int> VoiceWeaponAttacks;
 		ValueableVector<int> VoiceEliteWeaponAttacks;
 
+		Nullable<bool> InfantryAutoDeploy;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, UIDescription {}
@@ -781,6 +783,8 @@ public:
 			, VoiceIFVRepair { -1 }
 			, VoiceWeaponAttacks {}
 			, VoiceEliteWeaponAttacks {}
+
+			, InfantryAutoDeploy {}
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION

### Auto deploy for GI-like infantry

- In RA2, the GI-like infantry controlled by the AI will automatically deploy to use their more powerful secondary weapons when engaging the enemy. This feature was broken in Yuri’s Revenge. Now you can use the following flags to re-enable this feature.

In `rulesmd.ini`:
```ini
[General]
InfantryAutoDeploy=false      ; boolean

[SOMEINFANTRY]                ; InfantryType
InfantryAutoDeploy=           ; boolean, default to [General] -> InfantryAutoDeploy
```
