### PR TITLE
[Minor] Speed=0 extension

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -386,7 +386,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an unusual use of DeployFireWeapon for InfantryType
   - Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target
   - Units can customize the attack voice that plays when using more weapons
-  - `Speed = 0` will disable the vehicle's `Area Guard` or `Hunt` task
+  - When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTod`, the vehicle's `AreaGuard` and `Hunting` task will be disabled, and it will be prevented from attacking targets outside its range
   - When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -386,6 +386,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an unusual use of DeployFireWeapon for InfantryType
   - Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target
   - Units can customize the attack voice that plays when using more weapons
+  - `Speed = 0` will disable the vehicle's `Area Guard` or `Hunt` task
   - When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -386,7 +386,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an unusual use of DeployFireWeapon for InfantryType
   - Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target
   - Units can customize the attack voice that plays when using more weapons
-  - Allow turret response when custom vehicle loses target
+  - When the vehicle loses its target, customize whether its turret is allowed to rotate
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -386,6 +386,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an unusual use of DeployFireWeapon for InfantryType
   - Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target
   - Units can customize the attack voice that plays when using more weapons
+  - Allow turret response when custom vehicle loses target
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -386,7 +386,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an unusual use of DeployFireWeapon for InfantryType
   - Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target
   - Units can customize the attack voice that plays when using more weapons
-  - When the vehicle loses its target, customize whether its turret is allowed to rotate
+  - When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -386,7 +386,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an unusual use of DeployFireWeapon for InfantryType
   - Fix the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target
   - Units can customize the attack voice that plays when using more weapons
-  - When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTod`, the vehicle's `AreaGuard` and `Hunting` task will be disabled, and it will be prevented from attacking targets outside its range
+  - When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTo`, vehicles cannot attack targets beyond the weapon's range. `Area Guard` and `Hunt` missions will also become ineffective
   - When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -253,6 +253,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that Locomotor warhead won't stop working when firer (except for vehicle) stop firing.
 - Fixed the bug that hover vehicle will sink if destroyed on bridge.
 - Fixed the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target.
+- `Speed = 0` will disable the vehicle's `Area Guard` or `Hunt` task.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -253,7 +253,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that Locomotor warhead won't stop working when firer (except for vehicle) stop firing.
 - Fixed the bug that hover vehicle will sink if destroyed on bridge.
 - Fixed the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target.
-- When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTod`, the vehicle's `AreaGuard` and `Hunting` task will be disabled, and it will be prevented from attacking targets outside its range.
+- When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTo`, vehicles cannot attack targets beyond the weapon's range. `Area Guard` and `Hunt` missions will also become ineffective.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -253,7 +253,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that Locomotor warhead won't stop working when firer (except for vehicle) stop firing.
 - Fixed the bug that hover vehicle will sink if destroyed on bridge.
 - Fixed the fact that when the selected unit is in a rearmed state, it can unconditionally use attack mouse on the target.
-- `Speed = 0` will disable the vehicle's `Area Guard` or `Hunt` task.
+- When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTod`, the vehicle's `AreaGuard` and `Hunting` task will be disabled, and it will be prevented from attacking targets outside its range.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2077,7 +2077,7 @@ FireUp.ResetInRetarget=true     ; boolean
 
 ### Turret Response
 
-- When the vehicle loses its target, customize whether its turret is allowed to rotate.
+- When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body.
   - When `Speed=0` or TechnoTypes cells cannot move due to `MovementRestrictedTod`, the default value is no; in other cases, it is yes.
 
 In `rulesmd.ini`:

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2078,7 +2078,7 @@ FireUp.ResetInRetarget=true     ; boolean
 ### Turret Response
 
 - When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body.
-  - When `Speed=0` or TechnoTypes cells cannot move due to `MovementRestrictedTod`, the default value is no; in other cases, it is yes.
+  - When `Speed=0` or TechnoTypes cells cannot move due to `MovementRestrictedTo`, the default value is no; in other cases, it is yes.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2075,6 +2075,16 @@ FireUp=                         ; integer
 FireUp.ResetInRetarget=true     ; boolean
 ```
 
+### Turret Response
+
+- Allow turret response when custom vehicle loses target. when `Speed=0`, the default value is no; in other cases, it is yes.
+
+In `rulesmd.ini`:
+```ini
+[SOMEVEHICLE]       ; VehicleType
+TurretResponse=     ; boolean
+```
+
 ## Warheads
 
 ```{hint}

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2077,7 +2077,8 @@ FireUp.ResetInRetarget=true     ; boolean
 
 ### Turret Response
 
-- When the vehicle loses its target, customize whether its turret is allowed to rotate. when `Speed=0`, the default value is no; in other cases, it is yes.
+- When the vehicle loses its target, customize whether its turret is allowed to rotate.
+  - When `Speed=0` or TechnoTypes cells cannot move due to `MovementRestrictedTod`, the default value is no; in other cases, it is yes.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2077,7 +2077,7 @@ FireUp.ResetInRetarget=true     ; boolean
 
 ### Turret Response
 
-- Allow turret response when custom vehicle loses target. when `Speed=0`, the default value is no; in other cases, it is yes.
+- When the vehicle loses its target, customize whether its turret is allowed to rotate. when `Speed=0`, the default value is no; in other cases, it is yes.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -445,7 +445,7 @@ Vanilla fixes:
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)
-- When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTod`, the vehicle's `AreaGuard` and `Hunting` task will be disabled, and it will be prevented from attacking targets outside its range (by FlyStar)
+- When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTo`, vehicles cannot attack targets beyond the weapon's range. `Area Guard` and `Hunt` missions will also become ineffective (by FlyStar)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -428,7 +428,7 @@ New:
 - [Units can customize the attack voice that plays when using more weapons](New-or-Enhanced-Logics.md#multi-voiceattack) (by FlyStar)
 - Customize squid grapple animation (by NetsuNegi)
 - [Auto deploy for GI-like infantry](Fixed-or-Improved-Logics.md#auto-deploy-for-gi-like-infantry) (by TaranDahl)
-- Allow turret response when custom vehicle loses target (by FlyStar)
+- When the vehicle loses its target, customize whether its turret is allowed to rotate (by FlyStar)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -445,7 +445,7 @@ Vanilla fixes:
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)
-- `Speed = 0` will disable the vehicle's `Area Guard` or `Hunt` task (by FlyStar)
+- When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTod`, the vehicle's `AreaGuard` and `Hunting` task will be disabled, and it will be prevented from attacking targets outside its range (by FlyStar)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -445,6 +445,7 @@ Vanilla fixes:
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)
+- `Speed = 0` will disable the vehicle's `Area Guard` or `Hunt` task (by FlyStar)
 
 Fixes / interactions with other extensions:
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -428,7 +428,7 @@ New:
 - [Units can customize the attack voice that plays when using more weapons](New-or-Enhanced-Logics.md#multi-voiceattack) (by FlyStar)
 - Customize squid grapple animation (by NetsuNegi)
 - [Auto deploy for GI-like infantry](Fixed-or-Improved-Logics.md#auto-deploy-for-gi-like-infantry) (by TaranDahl)
-- When the vehicle loses its target, customize whether its turret is allowed to rotate (by FlyStar)
+- When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body (by FlyStar)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -428,6 +428,7 @@ New:
 - [Units can customize the attack voice that plays when using more weapons](New-or-Enhanced-Logics.md#multi-voiceattack) (by FlyStar)
 - Customize squid grapple animation (by NetsuNegi)
 - [Auto deploy for GI-like infantry](Fixed-or-Improved-Logics.md#auto-deploy-for-gi-like-infantry) (by TaranDahl)
+- Allow turret response when custom vehicle loses target (by FlyStar)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -824,32 +824,3 @@ DEFINE_HOOK(0x4157EB, AircraftClass_Mission_SpyPlaneOverfly_MaxCount, 0x6)
 
 	return 0;
 }
-
-DEFINE_HOOK(0x708FC0, TechnoClass_ResponseMove_Pickup, 0x5)
-{
-	enum { SkipResponse = 0x709015 };
-
-	GET(TechnoClass*, pThis, ECX);
-
-	if (auto const pAircraft = abstract_cast<AircraftClass*>(pThis))
-	{
-		auto const pType = pAircraft->Type;
-
-		if (pType->Carryall
-			&& pAircraft->HasAnyLink()
-			&& generic_cast<FootClass*>(pAircraft->Destination))
-		{
-			auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-
-			if (pTypeExt->VoicePickup.isset())
-			{
-				pThis->QueueVoice(pTypeExt->VoicePickup.Get());
-
-				R->EAX(1);
-				return SkipResponse;
-			}
-		}
-	}
-
-	return 0;
-}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -731,6 +731,35 @@ bool TechnoExt::IsHealthInThreshold(TechnoClass* pObject, double min, double max
 	return hp <= max && hp >= min;
 }
 
+bool TechnoExt::CannotMove(UnitClass* pThis)
+{
+	const auto pType = pThis->Type;
+
+	if (pType->Speed == 0)
+		return true;
+
+	if (!pThis->IsInAir())
+	{
+		LandType landType = pThis->GetCell()->LandType;
+		const LandType movementRestrictedTo = pType->MovementRestrictedTo;
+
+		if (pThis->OnBridge
+			&& (landType == LandType::Water || landType == LandType::Beach))
+		{
+			landType = LandType::Road;
+		}
+
+		if (movementRestrictedTo != LandType::None &&
+			movementRestrictedTo != landType &&
+			landType != LandType::Tunnel)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -265,6 +265,7 @@ public:
 	static bool IsHealthInThreshold(TechnoClass* pObject, double min, double max);
 	static UnitTypeClass* GetUnitTypeExtra(UnitClass* pUnit);
 	static AircraftTypeClass* GetAircraftTypeExtra(AircraftClass* pAircraft);
+	static bool CannotMove(UnitClass* pThis);
 
 	// WeaponHelpers.cpp
 	static int PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, AbstractClass* pTarget, int weaponIndexOne, int weaponIndexTwo, bool allowFallback = true, bool allowAAFallback = true);

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1234,7 +1234,7 @@ DEFINE_HOOK(0x708FC0, TechnoClass_ResponseMove_Pickup, 0x5)
 	{
 		auto const pUnit = static_cast<UnitClass*>(pThis);
 
-		if (pUnit->Type->Speed == 0)
+		if (TechnoExt::TechnoExt::CannotMove(pUnit))
 			return SkipResponse;
 	}
 

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1202,3 +1202,41 @@ DEFINE_HOOK(0x4DF3A6, FootClass_UpdateAttackMove_Follow, 0x6)
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x708FC0, TechnoClass_ResponseMove_Pickup, 0x5)
+{
+	enum { SkipResponse = 0x709015 };
+
+	GET(TechnoClass*, pThis, ECX);
+
+	const AbstractType rtti = pThis->WhatAmI();
+
+	if (rtti == AbstractType::Aircraft)
+	{
+		auto const pAircraft = static_cast<AircraftClass*>(pThis);
+		auto const pType = pAircraft->Type;
+
+		if (pType->Carryall && pAircraft->HasAnyLink()
+			&& generic_cast<FootClass*>(pAircraft->Destination))
+		{
+			auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+			if (pTypeExt->VoicePickup.isset())
+			{
+				pThis->QueueVoice(pTypeExt->VoicePickup.Get());
+
+				R->EAX(1);
+				return SkipResponse;
+			}
+		}
+	}
+	else if (rtti == AbstractType::Unit)
+	{
+		auto const pUnit = static_cast<UnitClass*>(pThis);
+
+		if (pUnit->Type->Speed == 0)
+			return SkipResponse;
+	}
+
+	return 0;
+}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -956,7 +956,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttackMove_PursuitTarget.Read(exINI, pSection, "AttackMove.PursuitTarget");
 
 	this->InfantryAutoDeploy.Read(exINI, pSection, "InfantryAutoDeploy");
-
+	
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1190,14 +1190,14 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	if (GeneralUtils::IsValidString(pThis->PaletteFile) && !pThis->Palette)
 		Debug::Log("[Developer warning] [%s] has Palette=%s set but no palette file was loaded (missing file or wrong filename). Missing palettes cause issues with lighting recalculations.\n", pArtSection, pThis->PaletteFile);
 
-	this->LoadFromINIByWhatAmI(exArtINI, pArtSection);
+	this->LoadFromINIByWhatAmI(exINI, pSection, exArtINI, pArtSection);
 
 	// VoiceIFVRepair from Ares 0.2
 	this->VoiceIFVRepair.Read(exINI, pSection, "VoiceIFVRepair");
 	this->ParseVoiceWeaponAttacks(exINI, pSection, this->VoiceWeaponAttacks, this->VoiceEliteWeaponAttacks);
 }
 
-void TechnoTypeExt::ExtData::LoadFromINIByWhatAmI(INI_EX& exArtINI, const char* pArtSection)
+void TechnoTypeExt::ExtData::LoadFromINIByWhatAmI(INI_EX& exINI, const char* pSection, INI_EX& exArtINI, const char* pArtSection)
 {
 	AbstractType abs = this->OwnerObject()->WhatAmI();
 
@@ -1207,6 +1207,7 @@ void TechnoTypeExt::ExtData::LoadFromINIByWhatAmI(INI_EX& exArtINI, const char* 
 	{
 		this->FireUp.Read(exArtINI, pArtSection, "FireUp");
 		this->FireUp_ResetInRetarget.Read(exArtINI, pArtSection, "FireUp.ResetInRetarget");
+		this->TurretResponse.Read(exINI, pSection, "TurretResponse");
 		//this->SecondaryFire.Read(exArtINI, pArtSection, "SecondaryFire");
 		break;
 	}
@@ -1591,6 +1592,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->VoiceEliteWeaponAttacks)
 
 		.Process(this->InfantryAutoDeploy)
+
+		.Process(this->TurretResponse)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -418,6 +418,8 @@ public:
 
 		Nullable<bool> InfantryAutoDeploy;
 
+		Nullable<bool> TurretResponse;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, UIDescription {}
@@ -785,6 +787,8 @@ public:
 			, VoiceEliteWeaponAttacks {}
 
 			, InfantryAutoDeploy {}
+
+			, TurretResponse {}
 		{ }
 
 		virtual ~ExtData() = default;
@@ -796,7 +800,7 @@ public:
 		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 
-		void LoadFromINIByWhatAmI(INI_EX& exArtINI, const char* pArtSection);
+		void LoadFromINIByWhatAmI(INI_EX& exINI, const char* pSection, INI_EX& exArtINI, const char* pArtSection);
 
 		void ApplyTurretOffset(Matrix3D* mtx, double factor = 1.0);
 		void CalculateSpawnerRange();

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -72,7 +72,7 @@ DEFINE_HOOK(0x736B60, UnitClass_Rotation_AI_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return !TechnoTypeExt::ExtMap.Find(pThis->Type)->TurretResponse.Get(pThis->Type->Speed != 0) ? 0x736AFB : 0;
+	return !TechnoTypeExt::ExtMap.Find(pThis->Type)->TurretResponse.Get(!TechnoExt::CannotMove(pThis)) ? 0x736AFB : 0;
 }
 
 DEFINE_HOOK(0x73891D, UnitClass_Active_Click_With_DisallowMoving, 0x6)

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -81,3 +81,40 @@ DEFINE_HOOK(0x73891D, UnitClass_Active_Click_With_DisallowMoving, 0x6)
 
 	return pThis->Type->Speed == 0 ? 0x738927 : 0;
 }
+
+DEFINE_HOOK_AGAIN(0x73F08A, UnitClass_Mission_DisallowMoving, 0x7)	//UnitClass::Mission_Hunt
+DEFINE_HOOK(0x74416C, UnitClass_Mission_DisallowMoving, 0x7)		//UnitClass::Mission_AreaGuard
+{
+	GET(UnitClass*, pThis, ESI);
+
+	DWORD address = R->Origin();
+
+	if (pThis->Type->Speed == 0)
+	{
+		pThis->QueueMission(Mission::Guard, false);
+		pThis->NextMission();
+
+		R->EAX(pThis->FootClass::Mission_Guard());
+	}
+	else if (address == 0x74416C)
+	{
+		R->EAX(pThis->FootClass::Mission_AreaGuard());
+	}
+	else
+	{
+		R->EAX(pThis->FootClass::Mission_Hunt());
+	}
+
+	return R->Origin() + 0x7;
+}
+
+DEFINE_HOOK(0x74132B, UnitClass_GetFireError_DisallowMoving, 0x7)
+{
+	GET(UnitClass*, pThis, ESI);
+	GET(FireError, result, EAX);
+
+	if (result == FireError::RANGE && pThis->Type->Speed == 0)
+		R->EAX(FireError::ILLEGAL);
+
+	return 0;
+}

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -107,7 +107,8 @@ DEFINE_HOOK(0x73891D, UnitClass_Active_Click_With_DisallowMoving, 0x6)
 	return CannotMove(pThis) ? 0x738927 : 0;
 }
 
-DEFINE_HOOK(0x744103, UnitClass_Mission_AreaGuard_DisallowMoving, 0x6)
+DEFINE_HOOK_AGAIN(0x744103, UnitClass_Mission_DisallowMoving, 0x6)	// UnitClass::Mission_AreaGuard
+DEFINE_HOOK(0x73EFC4, UnitClass_Mission_DisallowMoving, 0x6)		// UnitClass::Mission_Hunt
 {
 	GET(UnitClass*, pThis, ESI);
 
@@ -116,24 +117,8 @@ DEFINE_HOOK(0x744103, UnitClass_Mission_AreaGuard_DisallowMoving, 0x6)
 		pThis->QueueMission(Mission::Guard, false);
 		pThis->NextMission();
 
-		R->EAX(pThis->FootClass::Mission_Guard());
-		return 0x744173;
-	}
-
-	return 0;
-}
-
-DEFINE_HOOK(0x73EFC4, UnitClass_Mission_Hunt_DisallowMoving, 0x6)
-{
-	GET(UnitClass*, pThis, ESI);
-
-	if (CannotMove(pThis))
-	{
-		pThis->QueueMission(Mission::Guard, false);
-		pThis->NextMission();
-
-		R->EAX(pThis->FootClass::Mission_Guard());
-		return 0x73F091;
+		R->EAX(pThis->Mission_Guard());
+		return R->Origin() == 0x744103 ? 0x744173 : 0x73F091;
 	}
 
 	return 0;

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -15,17 +15,17 @@ bool CannotMove(UnitClass* pThis)
 
 	if (!pThis->IsInAir())
 	{
-		const auto pCell = pThis->GetCell();
-		const LandType Land = pCell->LandType;
-		const LandType MovementRestrictedTo = pType->MovementRestrictedTo;
+		LandType landType = pThis->GetCell()->LandType;
+		const LandType movementRestrictedTo = pType->MovementRestrictedTo;
 
-		if (MovementRestrictedTo != LandType::None && MovementRestrictedTo != Land && Land != LandType::Tunnel)
+		if (pThis->OnBridge
+			&& (landType == LandType::Water || landType == LandType::Beach))
 		{
-			const int OverlayTypeIndex = pCell->OverlayTypeIndex;
-
-			if (OverlayTypeIndex < 237 || OverlayTypeIndex > 238)
-				return true;
+			landType = LandType::Road;
 		}
+
+		if (movementRestrictedTo != LandType::None && movementRestrictedTo != landType && landType != LandType::Tunnel)
+			return true;
 	}
 
 	return false;
@@ -97,7 +97,7 @@ DEFINE_HOOK(0x736B60, UnitClass_Rotation_AI_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return CannotMove(pThis) ? 0x736AFB : 0;
+	return !TechnoTypeExt::ExtMap.Find(pThis->Type)->TurretResponse.Get(pThis->Type->Speed != 0) ? 0x736AFB : 0;
 }
 
 DEFINE_HOOK(0x73891D, UnitClass_Active_Click_With_DisallowMoving, 0x6)

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -153,21 +153,21 @@ DEFINE_HOOK(0x7414E0, UnitClass_ApproachTarget_DisallowMoving, 0xA)
 {
 	GET(UnitClass*, pThis, ECX);
 
-	int WeaponIndex = -1;
+	int weaponIndex = -1;
 
 	if (CannotMove(pThis))
 	{
 		const auto pTarget = pThis->Target;
-		WeaponIndex = pThis->SelectWeapon(pTarget);
+		weaponIndex = pThis->SelectWeapon(pTarget);
 
-		if (!pThis->IsCloseEnough(pTarget, WeaponIndex))
+		if (!pThis->IsCloseEnough(pTarget, weaponIndex))
 		{
 			pThis->SetTarget(nullptr);
 			return 0x741690;
 		}
 	}
 
-	UnitApproachTargetTemp::WeaponIndex = WeaponIndex;
+	UnitApproachTargetTemp::WeaponIndex = weaponIndex;
 	return 0;
 }
 

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -4,73 +4,48 @@
 #include "UnitClass.h"
 
 #include <Utilities/GeneralUtils.h>
-#include <Ext/TechnoType/Body.h>
-
-bool CannotMove(UnitClass* pThis)
-{
-	const auto pType = pThis->Type;
-
-	if (pType->Speed == 0)
-		return true;
-
-	if (!pThis->IsInAir())
-	{
-		LandType landType = pThis->GetCell()->LandType;
-		const LandType movementRestrictedTo = pType->MovementRestrictedTo;
-
-		if (pThis->OnBridge
-			&& (landType == LandType::Water || landType == LandType::Beach))
-		{
-			landType = LandType::Road;
-		}
-
-		if (movementRestrictedTo != LandType::None && movementRestrictedTo != landType && landType != LandType::Tunnel)
-			return true;
-	}
-
-	return false;
-}
+#include <Ext/Techno/Body.h>
 
 DEFINE_HOOK(0x740A93, UnitClass_Mission_Move_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return CannotMove(pThis) ? 0x740AEF : 0;
+	return TechnoExt::TechnoExt::CannotMove(pThis) ? 0x740AEF : 0;
 }
 
 DEFINE_HOOK(0x741AA7, UnitClass_Assign_Destination_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, EBP);
 
-	return CannotMove(pThis) ? 0x743173 : 0;
+	return TechnoExt::CannotMove(pThis) ? 0x743173 : 0;
 }
 
 DEFINE_HOOK(0x743B4B, UnitClass_Scatter_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, EBP);
 
-	return CannotMove(pThis) ? 0x74408E : 0;
+	return TechnoExt::CannotMove(pThis) ? 0x74408E : 0;
 }
 
 DEFINE_HOOK(0x74038F, UnitClass_What_Action_ObjectClass_DisallowMoving_1, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return CannotMove(pThis) ? 0x7403A3 : 0;
+	return TechnoExt::CannotMove(pThis) ? 0x7403A3 : 0;
 }
 
 DEFINE_HOOK(0x7403B7, UnitClass_What_Action_ObjectClass_DisallowMoving_2, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return CannotMove(pThis) ? 0x7403C1 : 0;
+	return TechnoExt::CannotMove(pThis) ? 0x7403C1 : 0;
 }
 
 DEFINE_HOOK(0x740709, UnitClass_What_Action_DisallowMoving_1, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return CannotMove(pThis) ? 0x740727 : 0;
+	return TechnoExt::CannotMove(pThis) ? 0x740727 : 0;
 }
 
 DEFINE_HOOK(0x740744, UnitClass_What_Action_DisallowMoving_2, 0x6)
@@ -80,7 +55,7 @@ DEFINE_HOOK(0x740744, UnitClass_What_Action_DisallowMoving_2, 0x6)
 	GET(UnitClass*, pThis, ESI);
 	GET_STACK(Action, result, 0x30);
 
-	if (CannotMove(pThis))
+	if (TechnoExt::CannotMove(pThis))
 	{
 		if (result == Action::Move)
 			return ReturnNoMove;
@@ -104,7 +79,7 @@ DEFINE_HOOK(0x73891D, UnitClass_Active_Click_With_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return CannotMove(pThis) ? 0x738927 : 0;
+	return TechnoExt::CannotMove(pThis) ? 0x738927 : 0;
 }
 
 DEFINE_HOOK_AGAIN(0x744103, UnitClass_Mission_DisallowMoving, 0x6)	// UnitClass::Mission_AreaGuard
@@ -112,7 +87,7 @@ DEFINE_HOOK(0x73EFC4, UnitClass_Mission_DisallowMoving, 0x6)		// UnitClass::Miss
 {
 	GET(UnitClass*, pThis, ESI);
 
-	if (CannotMove(pThis))
+	if (TechnoExt::CannotMove(pThis))
 	{
 		pThis->QueueMission(Mission::Guard, false);
 		pThis->NextMission();
@@ -129,7 +104,7 @@ DEFINE_HOOK(0x74132B, UnitClass_GetFireError_DisallowMoving, 0x7)
 	GET(UnitClass*, pThis, ESI);
 	GET(FireError, result, EAX);
 
-	if (result == FireError::RANGE && CannotMove(pThis))
+	if (result == FireError::RANGE && TechnoExt::CannotMove(pThis))
 		R->EAX(FireError::ILLEGAL);
 
 	return 0;
@@ -146,7 +121,7 @@ DEFINE_HOOK(0x7414E0, UnitClass_ApproachTarget_DisallowMoving, 0xA)
 
 	int weaponIndex = -1;
 
-	if (CannotMove(pThis))
+	if (TechnoExt::CannotMove(pThis))
 	{
 		const auto pTarget = pThis->Target;
 		weaponIndex = pThis->SelectWeapon(pTarget);

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -118,3 +118,31 @@ DEFINE_HOOK(0x74132B, UnitClass_GetFireError_DisallowMoving, 0x7)
 
 	return 0;
 }
+
+DEFINE_HOOK(0x736E34, UnitClass_UpdateFiring_DisallowMoving, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+	GET(AbstractClass*, pTarget, EAX);
+	GET(int, nWeaponIndex, EDI);
+
+	const auto pType = pThis->Type;
+
+	if (pType->Speed == 0)
+	{
+		if (!pThis->IsCloseEnough(pTarget, nWeaponIndex))
+		{
+			if (pType->IsGattling)
+				pThis->GattlingRateDown(1);
+
+			pThis->SetTarget(nullptr);
+			return 0x737140;
+		}
+		else
+		{
+			R->EAX(pThis->GetFireError(pTarget, nWeaponIndex, false));
+			return 0x736E40;
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -107,12 +107,9 @@ DEFINE_HOOK(0x73891D, UnitClass_Active_Click_With_DisallowMoving, 0x6)
 	return CannotMove(pThis) ? 0x738927 : 0;
 }
 
-DEFINE_HOOK_AGAIN(0x73F08A, UnitClass_Mission_DisallowMoving, 0x7)	//UnitClass::Mission_Hunt
-DEFINE_HOOK(0x74416C, UnitClass_Mission_DisallowMoving, 0x7)		//UnitClass::Mission_AreaGuard
+DEFINE_HOOK(0x744103, UnitClass_Mission_AreaGuard_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
-
-	DWORD address = R->Origin();
 
 	if (CannotMove(pThis))
 	{
@@ -120,17 +117,26 @@ DEFINE_HOOK(0x74416C, UnitClass_Mission_DisallowMoving, 0x7)		//UnitClass::Missi
 		pThis->NextMission();
 
 		R->EAX(pThis->FootClass::Mission_Guard());
-	}
-	else if (address == 0x74416C)
-	{
-		R->EAX(pThis->FootClass::Mission_AreaGuard());
-	}
-	else
-	{
-		R->EAX(pThis->FootClass::Mission_Hunt());
+		return 0x744173;
 	}
 
-	return R->Origin() + 0x7;
+	return 0;
+}
+
+DEFINE_HOOK(0x73EFC4, UnitClass_Mission_Hunt_DisallowMoving, 0x6)
+{
+	GET(UnitClass*, pThis, ESI);
+
+	if (CannotMove(pThis))
+	{
+		pThis->QueueMission(Mission::Guard, false);
+		pThis->NextMission();
+
+		R->EAX(pThis->FootClass::Mission_Guard());
+		return 0x73F091;
+	}
+
+	return 0;
 }
 
 DEFINE_HOOK(0x74132B, UnitClass_GetFireError_DisallowMoving, 0x7)


### PR DESCRIPTION
When `Speed=0` or the TechnoTypes cell cannot move due to `MovementRestrictedTo`, vehicles cannot attack targets beyond the weapon's range. `Area Guard` and `Hunt` missions will also become ineffective.
- `Speed=0`或`MovementRestrictedTo`导致单元格无法移动时载具无法攻击超出武器射程的目标。`区域守卫（AreaGuard）`和`猎杀（Hunt）`任务也会失效。

- When the vehicle loses its target, you can customize whether to align the turret direction with the vehicle body.
  - When `Speed=0` or TechnoTypes cells cannot move due to `MovementRestrictedTo`, the default value is no; in other cases, it is yes.
- 当载具失去目标时可以自定义炮塔朝向和本体对齐。
  - `Speed=0`或者`MovementRestrictedTo`导致单元格无法移动时默认值为no，其他情况为yes。

In `rulesmd.ini`:
```ini
[SOMEVEHICLE]       ; VehicleType
TurretResponse=     ; boolean
```

