### PR TITLE
[Customized] Customized bib & impassable rows & weapons factory direction

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -530,6 +530,7 @@ This page lists all the individual contributions to the project by their author.
   - Burst without delay
   - Fix an issue that if the garrison unload occupants when there is no open space around it would result in the disappearance of the occupants
   - Fix an issue where Ares' `Convert.Deploy` triggers repeatedly when the unit is turning or moving
+  - Customized bib & impassable rows & weapons factory direction
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -586,6 +586,29 @@ Adjacent.Disallowed=        ; List of BuildingTypes
 NoBuildAreaOnBuildup=false  ; boolean
 ```
 
+### Customized bib & impassable rows & weapons factory direction
+
+- Now you can use `ExtendedWeaponsFactory` to remove the hard coding of `WeaponsFactory` position and direction, and adjust the position of the generated unit and the direction of the unit's exit separately through the original `ExitCoord` and the newly added `WeaponsFactory.Dir`. Similarly, the directions of `Bib` and `NumberImpassableRows` can also be modified through `Bib.Dir` and `NumberImpassableRows.Dir` respectively.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ExtendedWeaponsFactory=false  ; boolean
+
+[SOMEBUILDING]                ; BuildingType
+Bib.Dir=2                     ; integer
+NumberImpassableRows.Dir=2    ; integer
+WeaponsFactory.Dir=2          ; integer
+```
+
+```{note}
+- The available directions are:
+  - 0 - North (top right)
+  - 2 - East (bottom right)
+  - 4 - South (bottom left)
+  - 6 - West (top left)
+```
+
 ### Destroyable pathfinding obstacles
 
 - It is possible to make buildings be considered pathfinding obstacles that can be destroyed by setting `IsDestroyableBlockage` to true. What this does is make the building be considered impassable and impenetrable pathfinding obstacle to every unit that is not flying or have appropriate `MovementZone` (ones that allow destroyable obstacles to be overcome, e.g `(Infantry|Amphibious)Destroyer`) akin to wall overlays and TerrainTypes.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -428,6 +428,7 @@ New:
 - [Units can customize the attack voice that plays when using more weapons](New-or-Enhanced-Logics.md#multi-voiceattack) (by FlyStar)
 - Customize squid grapple animation (by NetsuNegi)
 - [Auto deploy for GI-like infantry](Fixed-or-Improved-Logics.md#auto-deploy-for-gi-like-infantry) (by TaranDahl)
+- Customized bib & impassable rows & weapons factory direction (by CrimRecya)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -219,6 +219,13 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Refinery_UseNormalActiveAnim.Read(exArtINI, pArtSection, "Refinery.UseNormalActiveAnim");
 
+	this->Bib_Dir.Read(exINI, pSection, "Bib.Dir");
+	this->Bib_Dir = Math::max(0, this->Bib_Dir) & 6; // Only accept 0,2,4,6
+	this->NumberImpassableRows_Dir.Read(exINI, pSection, "NumberImpassableRows.Dir");
+	this->NumberImpassableRows_Dir = Math::max(0, this->NumberImpassableRows_Dir) & 6; // Only accept 0,2,4,6
+	this->WeaponsFactory_Dir.Read(exINI, pSection, "WeaponsFactory.Dir");
+	this->WeaponsFactory_Dir = Math::max(0, this->WeaponsFactory_Dir) & 6; // Only accept 0,2,4,6
+
 	// Ares tag
 	this->SpyEffect_Custom.Read(exINI, pSection, "SpyEffect.Custom");
 	if (SuperWeaponTypeClass::Array.Count > 0)
@@ -334,6 +341,9 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BuildingRepairedSound)
 		.Process(this->Refinery_UseNormalActiveAnim)
 		.Process(this->HasPowerUpAnim)
+		.Process(this->Bib_Dir)
+		.Process(this->NumberImpassableRows_Dir)
+		.Process(this->WeaponsFactory_Dir)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -99,6 +99,10 @@ public:
 
 		ValueableVector<bool> HasPowerUpAnim;
 
+		Valueable<int> Bib_Dir;
+		Valueable<int> NumberImpassableRows_Dir;
+		Valueable<int> WeaponsFactory_Dir;
+
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
 			, PowersUp_Buildings {}
@@ -161,6 +165,9 @@ public:
 			, BuildingRepairedSound {}
 			, Refinery_UseNormalActiveAnim { false }
 			, HasPowerUpAnim {}
+			, Bib_Dir { 2 }
+			, NumberImpassableRows_Dir { 2 }
+			, WeaponsFactory_Dir { 2 }
 		{ }
 
 		// Ares 0.A functions

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -301,6 +301,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->InfantryAutoDeploy.Read(exINI, GameStrings::General, "InfantryAutoDeploy");
 
+	this->ExtendedWeaponsFactory.Read(exINI, GameStrings::General, "ExtendedWeaponsFactory");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -554,6 +556,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttackMove_StopWhenTargetAcquired)
 		.Process(this->Parasite_GrappleAnim)
 		.Process(this->InfantryAutoDeploy)
+		.Process(this->ExtendedWeaponsFactory)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -247,12 +247,14 @@ public:
 
 		NullableIdx<AnimTypeClass> Parasite_GrappleAnim;
 
+		Valueable<bool> InfantryAutoDeploy;
+
+		Valueable<bool> ExtendedWeaponsFactory;
+
 		// cache tint color
 		int TintColorIronCurtain;
 		int TintColorForceShield;
 		int TintColorBerserk;
-
-		Valueable<bool> InfantryAutoDeploy;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -449,7 +451,10 @@ public:
 			, AttackMove_StopWhenTargetAcquired { }
 
 			, Parasite_GrappleAnim {}
+
 			, InfantryAutoDeploy { false }
+
+			, ExtendedWeaponsFactory { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- Now you can use `ExtendedWeaponsFactory` to remove the hard coding of `WeaponsFactory` position and direction, and adjust the position of the generated unit and the direction of the unit's exit separately through the original `ExitCoord` and the newly added `WeaponsFactory.Dir`. Similarly, the directions of `Bib` and `NumberImpassableRows` can also be modified through `Bib.Dir` and `NumberImpassableRows.Dir` respectively.

In `rulesmd.ini`:
```ini
[General]
ExtendedWeaponsFactory=false  ; boolean

[SOMEBUILDING]                ; BuildingType
Bib.Dir=2                     ; integer
NumberImpassableRows.Dir=2    ; integer
WeaponsFactory.Dir=2          ; integer
```

```{note}
- The available directions are:
  - 0 - North (top right)
  - 2 - East (bottom right)
  - 4 - South (bottom left)
  - 6 - West (top left)
```

![重工](https://github.com/user-attachments/assets/30a03c78-5afa-4c2f-9a1a-48b7fc335ef2)
In combination with AAA #1479 