### PR TITLE
[Minor] Speed=0 extension 2

### DIFF
--- a/src/Ext/Script/Mission.Attack.cpp
+++ b/src/Ext/Script/Mission.Attack.cpp
@@ -233,6 +233,14 @@ void ScriptExt::Mission_Attack(TeamClass* pTeam, int calcThreatMode, bool repeat
 
 						const auto whatAmI = pFoot->WhatAmI();
 
+						// If the vehicle cannot be moved, perhaps it is better this way.
+						if (whatAmI == AbstractType::Unit
+							&& TechnoExt::CannotMove(static_cast<UnitClass*>(pFoot))
+							&& !pFoot->IsCloseEnough(pSelectedTarget, pFoot->SelectWeapon(pSelectedTarget)))
+						{
+							continue;
+						}
+
 						// Aircraft hack. I hate how this game auto-manages the aircraft missions.
 						if (whatAmI == AbstractType::Aircraft
 							&& pFoot->Ammo > 0

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1234,7 +1234,7 @@ DEFINE_HOOK(0x708FC0, TechnoClass_ResponseMove_Pickup, 0x5)
 	{
 		auto const pUnit = static_cast<UnitClass*>(pThis);
 
-		if (TechnoExt::TechnoExt::CannotMove(pUnit))
+		if (TechnoExt::CannotMove(pUnit))
 			return SkipResponse;
 	}
 

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -157,13 +157,13 @@ DEFINE_HOOK(0x6F7CE2, TechnoClass_CanAutoTargetObject_DisallowMoving, 0x6)
 {
 	GET(TechnoClass* const, pThis, EDI);
 	GET(AbstractClass* const, pTarget, ESI);
-	GET(const int, WeaponIndex, EBX);
+	GET(const int, weaponIndex, EBX);
 
 	if (const auto pUnit = abstract_cast<UnitClass*, true>(pThis))
 	{
 		if (TechnoExt::CannotMove(pUnit))
 		{
-			R->EAX(pUnit->GetFireError(pTarget, WeaponIndex, true));
+			R->EAX(pUnit->GetFireError(pTarget, weaponIndex, true));
 			return 0x6F7CEE;
 		}
 	}
@@ -175,14 +175,14 @@ DEFINE_HOOK(0x7088E3, TechnoClass_ShouldRetaliate_DisallowMoving, 0x6)
 {
 	GET(TechnoClass* const, pThis, EDI);
 	GET(AbstractClass* const, pTarget, EBP);
-	GET(const int, WeaponIndex, EBX);
+	GET(const int, weaponIndex, EBX);
 
 	if (const auto pUnit = abstract_cast<UnitClass*, true>(pThis))
 	{
 		if (TechnoExt::CannotMove(pUnit))
 		{
-			R->Stack(STACK_OFFSET(0x18, 0x4), WeaponIndex);
-			R->EAX(pUnit->GetFireError(pTarget, WeaponIndex, true));
+			R->Stack(STACK_OFFSET(0x18, 0x4), weaponIndex);
+			R->EAX(pUnit->GetFireError(pTarget, weaponIndex, true));
 			return 0x7088F3;
 		}
 	}

--- a/src/Ext/Unit/Hooks.DisallowMoving.cpp
+++ b/src/Ext/Unit/Hooks.DisallowMoving.cpp
@@ -10,7 +10,7 @@ DEFINE_HOOK(0x740A93, UnitClass_Mission_Move_DisallowMoving, 0x6)
 {
 	GET(UnitClass*, pThis, ESI);
 
-	return TechnoExt::TechnoExt::CannotMove(pThis) ? 0x740AEF : 0;
+	return TechnoExt::CannotMove(pThis) ? 0x740AEF : 0;
 }
 
 DEFINE_HOOK(0x741AA7, UnitClass_Assign_Destination_DisallowMoving, 0x6)


### PR DESCRIPTION
Team attack scripts no longer affect vehicles that cannot move and are beyond weapon range.
- 作战小队攻击脚本不再对无法移动且超出武器射程的载具生效。
