### PR TITLE
Fix the issue where Ares'  "Flash.Duration" cannot override the weapon's repair flash effect.

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -279,7 +279,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - 1000 save files are supported, from `SVGM_000.NET` to `SVGM_999.NET`. When the limit is reached, the game will overwrite the latest save file.
   - The previous `SVGM_XXX.NET` files are cleaned up before first copy if it's a new game, otherwise the highest numbered `SVGM_XXX.NET` file is found and the index is incremented, if possible.
   - The game also automatically copies `spawn.ini` to the save folder as `spawnSG.ini` when saving a game.
-
+- Fix the issue where Ares' `Flash.Duration` cannot override the weapon's repair flash effect.
 
 ```{note}
 The described behavior is a replica of and is compliant with XNA CnCNet Client's multiplayer save game support.

--- a/src/Ext/TechnoType/Hooks.cpp
+++ b/src/Ext/TechnoType/Hooks.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
 #include <Ext/House/Body.h>
 #include <Ext/AnimType/Body.h>
+#include <Ext/WarheadType/Body.h>
 
 DEFINE_HOOK(0x73D223, UnitClass_DrawIt_OreGath, 0x6)
 {
@@ -126,4 +127,31 @@ DEFINE_HOOK(0x71464A, TechnoTypeClass_ReadINI_Speed, 0x7)
 	exINI.ReadSpeed(pSection, "Speed", &pThis->Speed);
 
 	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x5F547E, ObjectClass_ReceiveDamage_FlashDuration, 0x6)
+{
+    	GET(ObjectClass*, pThis, ESI);
+    	GET(int, nNewHealth, EDX);
+		LEA_STACK(args_ReceiveDamage*, pArgs, STACK_OFFSET(0x24, 0x4));
+		enum { SkipGameCode = 0x5F545C };
+
+		if (pThis->Health == nNewHealth)
+            return SkipGameCode;
+
+		int nFlashDuration = 7;
+		if (auto pWH = pArgs->WH)
+		{
+			if (auto pWHEXT = WarheadTypeExt::ExtMap.Find(pWH))
+			{
+				nFlashDuration = pWHEXT->Flash_Duration.Get(nFlashDuration);
+			}
+		}
+
+		if (nFlashDuration > 0)
+		{
+			pThis->Flash(nFlashDuration);
+		}
+
+		return SkipGameCode;
 }

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -134,6 +134,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	INI_EX exINI(pINI);
 
 	// Miscs
+	this->Flash_Duration.Read(exINI, pSection, "Flash.Duration");
 	this->Reveal.Read(exINI, pSection, "Reveal");
 	this->CreateGap.Read(exINI, pSection, "CreateGap");
 	this->TransactMoney.Read(exINI, pSection, "TransactMoney");
@@ -401,6 +402,7 @@ template <typename T>
 void WarheadTypeExt::ExtData::Serialize(T& Stm)
 {
 	Stm
+		.Process(this->Flash_Duration)
 		.Process(this->Reveal)
 		.Process(this->CreateGap)
 		.Process(this->TransactMoney)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -21,6 +21,7 @@ public:
 	{
 	public:
 
+		Nullable<int> Flash_Duration;
 		Valueable<int> Reveal;
 		Valueable<int> CreateGap;
 		Valueable<int> TransactMoney;
@@ -214,6 +215,7 @@ public:
 
 	public:
 		ExtData(WarheadTypeClass* OwnerObject) : Extension<WarheadTypeClass>(OwnerObject)
+			, Flash_Duration { 0 }
 			, Reveal { 0 }
 			, CreateGap { 0 }
 			, TransactMoney { 0 }


### PR DESCRIPTION
I had to submit this pull request again because the previous two were accidentally closed due to my mistakes. As the Chinese saying goes, 'Third time’s the charm' (or literally 'Things should not be attempted more than three times'). I hope I won’t make the same silly mistake again this time.