### PR TITLE
[Minor] Fix several issues

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -542,6 +542,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue that barrel anim data will be incorrectly overwritten by turret anim data if the techno's section exists in the map file
   - Jumpjet Climbing Logic Enhancement
   - Fix for pathfinding crashes on big maps due to too small pathfinding node buffer
+  - Fix an issue that units' `LaserTrails` will always lags behind by one frame
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -604,6 +604,7 @@ This page lists all the individual contributions to the project by their author.
   - Force techno targeting in distributed frames to improve performance
   - Use `SkipCrushSlowdown=true` to avoid the bug related to `Accelerates=true` and `MovementZone=CrushAll`
   - Auto deploy for GI-like infantry
+  - Fix an issue that Ares' Type Conversion not resetting barrel's direction by `FireAngle`
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -261,6 +261,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `DeployingAnim` now supports both `Normalized=true` and `Reverse=true`. Keep in mind `Reverse` uses `LoopEnd` for frame amount instead of `End` even without `LoopCount` > 1.
 - `DeployingAnim` using unit drawer now also tint accordingly with the unit.
 - Fixed the bug that armor multiplier of new attacheffect will have extra take effect once if restricted warheads.
+- Fixed an issue that units' `LaserTrails` will always lags behind by one frame
 
 ## Fixes / interactions with other extensions
 
@@ -287,7 +288,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
   - 1000 save files are supported, from `SVGM_000.NET` to `SVGM_999.NET`. When the limit is reached, the game will overwrite the latest save file.
   - The previous `SVGM_XXX.NET` files are cleaned up before first copy if it's a new game, otherwise the highest numbered `SVGM_XXX.NET` file is found and the index is incremented, if possible.
   - The game also automatically copies `spawn.ini` to the save folder as `spawnSG.ini` when saving a game.
-
+- Fixed an issue that Ares' Type Conversion not resetting barrel's direction by `FireAngle`.
 
 ```{note}
 The described behavior is a replica of and is compliant with XNA CnCNet Client's multiplayer save game support.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -43,6 +43,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 - `AnimList.ShowOnZeroDamage` has been renamed to `CreateAnimsOnZeroDamage` to make it more clear it applies to both `AnimList` and splash animations.
 - INI inclusion and inheritance are now turned off by default and need to be turned on via command line flags `-Include` and `-Inheritance`.
 - `Level=true` projectiles no longer attempt to do reposition against targets that are behind non-water tiles by default. Use `SubjectToLand=true` to re-enable this behaviour.
+- Units' `LaserTrails` will no longer lags behind by one frame, So it needs to be repositioned (Previously, units with faster speeds may need to be positioned further ahead).
 
 #### From 0.3
 
@@ -464,6 +465,7 @@ Phobos fixes:
 - Fixed an issue that `FireAngle` was not taken into account when drawing barrel in `TurretShadow` (by CrimRecya)
 - Fixed a bug that sometimes caused weapon/warhead detonations from features such as `ExtraWarheads`, animation damage or `Crit.Warhead` to unintentionally move from its intended position (by Starkku)
 - Fixed the bug that armor multiplier of new attacheffect will have extra take effect once if restricted warheads (by NetsuNegi)
+- Fixed an issue that units' `LaserTrails` will always lags behind by one frame (by CrimRecya)
 
 Fixes / interactions with other extensions:
 - `Convert.Deploy` displays 'no deploy' cursor if the new type is not allowed to move to the cell due to `SpeedType` etc. (by Starkku)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -471,6 +471,7 @@ Fixes / interactions with other extensions:
 - `Convert.Deploy` displays 'no deploy' cursor if the new type is not allowed to move to the cell due to `SpeedType` etc. (by Starkku)
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)
 - Taking over Ares' AlphaImage respawn logic to reduce lags from it (by NetsuNegi)
+- Fixed an issue that Ares' Type Conversion not resetting barrel's direction by `FireAngle` (by TaranDahl)
 ```
 
 ### 0.4

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -537,6 +537,9 @@ DEFINE_HOOK(0x4DDD66, FootClass_IsLandZoneClear_ReplaceHardcode, 0x6) // To avoi
 	return SkipGameCode;
 }
 
+// Skip duplicated aircraft check
+DEFINE_PATCH(0x4CF033, 0x8B, 0x06, 0xEB, 0x18); // mov eax, [esi] ; jmp short loc_4CF04F ;
+
 DEFINE_HOOK(0x4CF190, FlyLocomotionClass_FlightUpdate_SetPrimaryFacing, 0x6) // Make aircraft not to fly directly to the airport before starting to land
 {
 	enum { SkipGameCode = 0x4CF29A };

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -18,12 +18,15 @@ DEFINE_HOOK(0x43FE69, BuildingClass_AI, 0xA)
 {
 	GET(BuildingClass*, pThis, ESI);
 
-	auto const pExt = BuildingExt::ExtMap.Find(pThis);
-	pExt->DisplayIncomeString();
-	pExt->ApplyPoweredKillSpawns();
+	const auto pBuildingExt = BuildingExt::ExtMap.Find(pThis);
+	pBuildingExt->DisplayIncomeString();
+	pBuildingExt->ApplyPoweredKillSpawns();
+
+	const auto pTechnoExt = pBuildingExt->TechnoExtData;
+	pTechnoExt->UpdateLaserTrails(); // Mainly for on turret trails
 
 	// Force airstrike targets to redraw every frame to account for tint intensity fluctuations.
-	if (TechnoExt::ExtMap.Find(pThis)->AirstrikeTargetingMe)
+	if (pTechnoExt->AirstrikeTargetingMe)
 		pThis->Mark(MarkType::Change);
 
 	return 0;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -36,7 +36,6 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 
 	this->UpdateShield();
 	this->UpdateAttachEffects();
-	this->UpdateLaserTrails();
 	this->ApplyInterceptor();
 	this->EatPassengers();
 	this->ApplySpawnLimitRange();
@@ -640,6 +639,13 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 		for (auto& pTrail : addition)
 			this->LaserTrails.emplace_back(std::move(pTrail));
 	}
+	else if (const size_t trailSize = pNewTypeExt->LaserTrailData.size())
+	{
+		this->LaserTrails.reserve(trailSize);
+
+		for (const auto& entry : pNewTypeExt->LaserTrailData)
+			this->LaserTrails.emplace_back(std::make_unique<LaserTrailClass>(entry.GetType(), pOwner, entry.FLH, entry.IsOnTurret));
+	}
 
 	// Reset AutoDeath Timer
 	if (this->AutoDeathTimer.HasStarted())
@@ -994,6 +1000,25 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 		pThis->ReleaseLocomotor(pThis->Target == pThis->LocomotorTarget);
 		pThis->LocomotorTarget->LocomotorSource = nullptr;
 		pThis->LocomotorTarget = nullptr;
+	}
+
+	// FireAngle
+	pThis->BarrelFacing.SetCurrent(DirStruct(0x4000 - (pCurrentType->FireAngle << 8)));
+
+	// Reset recoil data
+	{
+		auto& turretRecoil = pThis->TurretRecoil.Turret;
+		const auto& turretAnimData = pCurrentType->TurretAnimData;
+		turretRecoil.Travel = turretAnimData.Travel;
+		turretRecoil.CompressFrames = turretAnimData.CompressFrames;
+		turretRecoil.RecoverFrames = turretAnimData.RecoverFrames;
+		turretRecoil.HoldFrames = turretAnimData.HoldFrames;
+		auto& barrelRecoil = pThis->BarrelRecoil.Turret;
+		const auto& barrelAnimData = pCurrentType->BarrelAnimData;
+		barrelRecoil.Travel = barrelAnimData.Travel;
+		barrelRecoil.CompressFrames = barrelAnimData.CompressFrames;
+		barrelRecoil.RecoverFrames = barrelAnimData.RecoverFrames;
+		barrelRecoil.HoldFrames = barrelAnimData.HoldFrames;
 	}
 
 	// Only FootClass* can use this.

--- a/src/Ext/Techno/Hooks.Transport.cpp
+++ b/src/Ext/Techno/Hooks.Transport.cpp
@@ -316,11 +316,15 @@ static inline void DoEnterNow(UnitClass* pTransport, FootClass* pPassenger)
 	pPassenger->Undiscover();
 }
 
-// The core part of the fast enter action
-DEFINE_HOOK(0x4DA8A0, FootClass_Update_FastEnter, 0x6)
+// Update after unit location update
+DEFINE_HOOK(0x4DA8A0, FootClass_Update_AfterLocomotorProcess, 0x6)
 {
 	GET(FootClass* const, pThis, ESI);
 
+	// Update laser trails after locomotor process, to ensure that the updated position is not the previous frame's position
+	TechnoExt::ExtMap.Find(pThis)->UpdateLaserTrails();
+
+	// The core part of the fast enter action
 	if (const auto pDest = abstract_cast<UnitClass*>(pThis->CurrentMission == Mission::Enter ? pThis->GetNthLink() : pThis->QueueUpToEnter))
 	{
 		const auto pType = pDest->Type;


### PR DESCRIPTION
- Units' `LaserTrails` will no longer lags behind by one frame.
  > 单位的 `LaserTrails` 将不再延迟在单位后面一帧。
- Units' `LaserTrails` will no longer be lost when they're transformed from ones without `LaserTrails` into ones with `LaserTrails`.
  > 单位的 `LaserTrails` 将不再会在从无 `LaserTrails` 到有 `LaserTrails` 的变形时丢失。
- The transformed units can be reset to the correct `FireAngle` and `TurretRecoil`.
  > 单位变形后能够正确重置到正确的 `FireAngle` 和 `TurretRecoil` 。