### PR TITLE
Allow using <Player @ X> as trigger owner in skirmish/MP

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -280,7 +280,7 @@ This page lists all the individual contributions to the project by their author.
   - Build area customizations
   - `Scorch` / `Flamer` fire animation customization
   - EM Pulse cannon logic improvements
-  - `<Player @ X>` as owner for pre-placed objects
+  - `<Player @ X>` as owner for pre-placed objects and triggers
   - Custom exit cell for infantry factory
   - Vehicles keeping target on move command
   - `IsSonic` wave drawing crash fix

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -4,6 +4,7 @@ This page describes all AI scripting and mapping related additions and changes i
 
 ## Bugfixes and Miscellanous
 
+- `<Player @ X>` can now be used as owner for pre-placed objects as well as owner for triggers on skirmish and multiplayer maps. Triggers with owners that are not present in the game are destroyed and never sprung.
 - Script action `Move to cell` now obeys YR cell calculation now. Using `1000 * Y + X` as its cell value. (was `128 * Y + X` as it's a RA1 leftover)
 - The game now can reads waypoints ranges in [0, 2147483647]. (was [0,701])
 - Map trigger action `41 Play Animation At...` can now create 'non-inert' animations which can play sounds, deal damage and apply `TiberiumChainReaction` if a parameter is set (needs [following changes to `fadata.ini`](Whats-New.md#for-map-editor-final-alert-2)).

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -158,7 +158,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed damaged aircraft not repairing on `UnitReload=true` docks unless they land on the dock first.
 - Certain global tileset indices (`ShorePieces`, `WaterSet`, `CliffSet`, `WaterCliffs`, `WaterBridge`, `BridgeSet` and `WoodBridgeSet`) can now be toggled to be parsed for lunar theater by setting `[General] -> ApplyLunarFixes` to true in `lunarmd.ini`. Do note that enabling this without fixing f.ex `WoodBridgeTileSet` pointing to a tileset with `TilesInSet=0` will cause issues in-game.
 - Fixed objects with ally target and `AttackFriendlies=true` having their target reset every frame, particularly AI-owned buildings.
-- `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps.
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers.
 - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
 - Stop command (`[S]` by default) behavior is now more correct:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -720,6 +720,7 @@ HideShakeEffects=false           ; boolean
 - [Disable AlphaImage during Buildup](Fixed-or-Improved-Logics.md#disable-alphaimage-during-buildup) (by Noble_Fish)
 - [Reload speed adjustment on promotion](New-or-Enhanced-Logics.md#reload-speed-adjustment-on-promotion) (by Nuke)
 - Allowed `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys (by Noble_Fish)
+- `<Player @ X>` can now be used as owner for triggers on skirmish and multiplayer maps (by Starkku)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -435,6 +435,7 @@ HideShakeEffects=false           ; boolean
 - [Cloak Enhancement](New-or-Enhanced-Logics.md#cloak-enhancement) (by NetsuNegi)
 - [`513` Set mission timer properties](AI-Scripting-and-Mapping.md#set-mission-timer-properties) (by Ollerus)
 - [Customizable infantry sequence rates](New-or-Enhanced-Logics.md#customizable-infantry-sequence-rates) (by Noble_Fish)
+- `<Player @ X>` can now be used as owner for triggers on skirmish and multiplayer maps (by Starkku)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)
@@ -720,7 +721,6 @@ HideShakeEffects=false           ; boolean
 - [Disable AlphaImage during Buildup](Fixed-or-Improved-Logics.md#disable-alphaimage-during-buildup) (by Noble_Fish)
 - [Reload speed adjustment on promotion](New-or-Enhanced-Logics.md#reload-speed-adjustment-on-promotion) (by Nuke)
 - Allowed `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys (by Noble_Fish)
-- `<Player @ X>` can now be used as owner for triggers on skirmish and multiplayer maps (by Starkku)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Scenario/Body.cpp
+++ b/src/Ext/Scenario/Body.cpp
@@ -187,6 +187,7 @@ void ScenarioExt::ExtData::Serialize(T& Stm)
 		.Process(this->DefaultLS800BkgdName)
 		.Process(this->DefaultLS800BkgdPal)
 		.Process(this->LimboLaunchers)
+		.Process(this->TriggerTypePlayerAtXOwners)
 		.Process(this->UndergroundTracker)
 		.Process(this->SpecialTracker)
 		.Process(this->FallingDownTracker)
@@ -224,6 +225,7 @@ DEFINE_HOOK(0x683549, ScenarioClass_CTOR, 0x9)
 	ScenarioExt::Global()->Waypoints.clear();
 	ScenarioExt::Global()->Variables[0].clear();
 	ScenarioExt::Global()->Variables[1].clear();
+	ScenarioExt::Global()->TriggerTypePlayerAtXOwners.clear();
 
 	return 0;
 }

--- a/src/Ext/Scenario/Body.h
+++ b/src/Ext/Scenario/Body.h
@@ -44,6 +44,8 @@ public:
 
 		std::vector<TechnoExt*> LimboLaunchers;
 
+		std::map<int, int> TriggerTypePlayerAtXOwners; // TriggerTypeClass ArrayIndex -> Player slot index
+
 		DynamicVectorClass<TechnoClass*> UndergroundTracker; // Technos that are underground.
 		DynamicVectorClass<TechnoClass*> SpecialTracker; // For special purposes, like tracking technos that are forced moving. Currently unused.
 		DynamicVectorClass<TechnoClass*> FallingDownTracker; // Technos that are falling down, parachutes and land technos falling from bridge.
@@ -70,6 +72,7 @@ public:
 			, DefaultLS800BkgdName {}
 			, DefaultLS800BkgdPal {}
 			, LimboLaunchers {}
+			, TriggerTypePlayerAtXOwners {}
 			, UndergroundTracker {}
 			, SpecialTracker {}
 			, FallingDownTracker {}

--- a/src/Ext/Trigger/Hooks.cpp
+++ b/src/Ext/Trigger/Hooks.cpp
@@ -1,3 +1,5 @@
+#include <TriggerTypeClass.h>
+#include <Ext/Scenario/Body.h>
 #include <Ext/TEvent/Body.h>
 
 DEFINE_HOOK(0x727064, TriggerTypeClass_HasLocalSetOrClearedEvent, 0x5)
@@ -23,3 +25,93 @@ DEFINE_HOOK(0x727024, TriggerTypeClass_HasGlobalSetOrClearedEvent, 0x5)
 		? 0x72702E
 		: 0x727029;
 }
+
+#pragma region PlayerAtX
+
+// Store player slot index for trigger type if such value is used in scenario INI.
+DEFINE_HOOK(0x727292, TriggerTypeClass_ReadINI_PlayerAtX, 0x5)
+{
+	GET(TriggerTypeClass*, pThis, EBP);
+	GET(const char*, pID, ESI);
+
+	// Bail out early in campaign mode or if the name does not start with <
+	if (SessionClass::IsCampaign() || *pID != '<')
+		return 0;
+
+	const int playerAtIndex = HouseClass::GetPlayerAtFromString(pID);
+
+	if (playerAtIndex != -1)
+	{
+		ScenarioExt::Global()->TriggerTypePlayerAtXOwners.emplace(pThis->ArrayIndex, playerAtIndex);
+
+		// Override the name to prevent Ares whining about non-existing HouseType names.
+		R->ESI(NONE_STR);
+	}
+
+	return 0;
+}
+
+// Handle mapping player slot index for trigger to HouseClass pointer in logic.
+DEFINE_HOOK_AGAIN(0x7265F7, TriggerClass_Logic_PlayerAtX, 0x6)
+DEFINE_HOOK(0x72652D, TriggerClass_Logic_PlayerAtX, 0x6)
+{
+	enum { SkipGameCode1 = 0x726538, SkipGameCode2 = 0x726602};
+
+	GET(TriggerTypeClass*, pType, EDX);
+
+	if (SessionClass::IsCampaign())
+		return 0;
+
+	auto const& triggerOwners = ScenarioExt::Global()->TriggerTypePlayerAtXOwners;
+	auto it = triggerOwners.find(pType->ArrayIndex);
+
+	if (it != triggerOwners.end())
+	{
+		if (auto const pHouse = HouseClass::FindByPlayerAt(it->second))
+		{
+			R->EAX(pHouse);
+			return R->Origin() == 0x72652D ? SkipGameCode1 : SkipGameCode2;
+		}
+	}
+	
+	return 0;
+}
+
+// Destroy triggers with Player @ X owners if they are not present in scenario.
+DEFINE_HOOK(0x725FC7, TriggerClass_CTOR_PlayerAtX, 0x7)
+{
+	GET(TriggerClass*, pThis, ESI);
+
+	if (SessionClass::IsCampaign())
+		return 0;
+
+	auto& triggerOwners = ScenarioExt::Global()->TriggerTypePlayerAtXOwners;
+	auto it = triggerOwners.find(pThis->Type->ArrayIndex);
+
+	if (it != triggerOwners.end())
+	{
+		if (!HouseClass::FindByPlayerAt(it->second))
+			pThis->Destroy();
+	}
+
+	return 0;
+}
+
+// Remove destroyed triggers from the map.
+DEFINE_HOOK(0x726727, TriggerClass_Destroy_PlayerAtX, 0x5)
+{
+	GET(TriggerClass*, pThis, ESI);
+
+	if (SessionClass::IsCampaign())
+		return 0;
+
+	auto& triggerOwners = ScenarioExt::Global()->TriggerTypePlayerAtXOwners;
+	auto it = triggerOwners.find(pThis->Type->ArrayIndex);
+
+	if (it != triggerOwners.end())
+		triggerOwners.erase(it);
+
+	return 0;
+}
+
+#pragma endregion


### PR DESCRIPTION
Skirmish / multiplayer maps can now use <Player @ X> as trigger owner. If the player is not present in game, the trigger is destroyed and never sprung.