### PR TITLE
Attached animation draw offset customizations

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -308,6 +308,7 @@ This page lists all the individual contributions to the project by their author.
   - Tank Bunker improvements
   - `ProjectileRange` weapon range modifiers interaction fix
   - Berzerk duration stacking behaviour customization
+  - Attached animation draw offset customizations
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -52,7 +52,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 
 - Vehicle to building deployers now keep their target when deploying with `DeployToFire`.
 - Effects like lasers are no longer drawn from wrong firing offset on weapons that use Burst.
-- Animations can now be offset on the X axis with `XDrawOffset`.
 - `IsSimpleDeployer` units now only play `DeploySound` and `UndeploySound` once, when done with (un)deploying instead of repeating it over duration of turning and/or `DeployingAnim`.
 - AITrigger can now recognize Building Upgrades as legal condition.
 - Fixed interaction of `UnitAbsorb` & `InfantryAbsorb` with `Grinding` buildings. The keys will now make the building only accept appropriate types of objects.
@@ -1078,6 +1077,28 @@ In `artmd.ini`:
 ```ini
 [SOMEANIM]                      ; AnimationType
 Crater.DestroyTiberium=         ; boolean, default to [General] -> AnimCraterDestroyTiberium
+```
+
+### Draw offset customization
+
+- `XDrawOffset` can be used to adjust horizontal/X axis position of the animation.
+- `X/YDrawOffset.ApplyBracketHeight` makes X/Y axis position follow it's owner object's selection bracket width/height (for buildings, this is based on `Height` and `Foundation`, for others it is influenced by `PixelSelectionBracketDelta` for Y axis and hardcoded bracket width for X axis) if it is attached to one.
+  - By default Y axis shift will only apply if the bracket position is negative e.g it is moved upwards from the object center. If `YDrawOffset.InvertBracketShift` is set to true, the opposite is true and negative shift is ignored.
+  - For X axis the shift direction can also be switched by setting `XDrawOffset.InvertBracketShift=true`. The default is positive shift, towards right-hand side of the screen.
+  - The bracket-based shift can be further adjusted with offset from `X/YDrawOffset.BracketAdjust`, overridden by `X/YDrawOffset.BracketAdjust.Buildings` for buildings only.
+ 
+In `artmd.ini`:
+```ini
+[SOMEANIM]                            ; AnimationType
+XDrawOffset=0                         ; integer, pixels relative to default
+XDrawOffset.ApplyBracketHeight=false  ; boolean
+XDrawOffset.InvertBracketShift=false  ; boolean
+XDrawOffset.BracketAdjust=0           ; integer, pixels relative to default
+XDrawOffset.BracketAdjust.Buildings=  ; integer, pixels relative to default
+YDrawOffset.ApplyBracketHeight=false  ; boolean
+YDrawOffset.InvertBracketShift=false  ; boolean
+YDrawOffset.BracketAdjust=0           ; integer, pixels relative to default
+YDrawOffset.BracketAdjust.Buildings=  ; integer, pixels relative to default
 ```
 
 ### Fire animations spawned by Scorch & Flamer

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -46,6 +46,8 @@ This page describes all the engine features that are either new and introduced b
     - `Animation.TemporalAction` determines what happens to the animation when the attached object is under effect of `Temporal=true` Warhead.
     - `Animation.UseInvokerAsOwner` can be used to set the house and TechnoType that created the effect (e.g firer of the weapon that applied it) as the animation's owner & invoker instead of the object the effect is attached to.
     - `Animation.HideIfAttachedWith` contains list of other AttachEffectTypes that if attached to same techno as the current one, will hide this effect's animation.
+    - `Animation.DrawOffsetN` (where N is integer starting from 0) can be used to define draw offset rules for the animation. These are parsed starting from index 0 until offset with value 0,0 is encountered.
+      - `Animation.DrawOffsetN.RequiredTypes` contains list other AttachEffectTypes that need to be attached on the same techno as the current one for the draw offset rule to apply. Note that this does not currently work correctly together with `Animation.HideIfAttachedWith`, animations hidden by this may not cause drawing offset rules to be updated even if they should.
   - `CumulativeAnimations` can be used to declare a list of animations used for `Cumulative=true` types instead of `Animation`. An animation is picked from the list in order matching the number of active instances of the type on the object, with last listed animation used if number is higher than the number of listed animations. This animation is only displayed once and is transferred from the effect to another of same type (specifically one with longest remaining duration), if such exists, upon expiration or removal. Note that because `Cumulative.MaxCount` limits the number of effects of same type that can be applied this can cause animations to 'flicker' here as effects expire before new ones can be applied in some circumstances.
     - `CumulativeAnimations.RestartOnChange` determines if the animation playback is restarted when the type of animation changes, if not then playback resumes at frame at same position relative to the animation's length.
   - Attached effect can fire off a weapon when expired / removed / object dies by setting `ExpireWeapon`.
@@ -149,6 +151,8 @@ Animation.OfflineAction=Hides                      ; AttachedAnimFlag (None, Hid
 Animation.TemporalAction=None                      ; AttachedAnimFlag (None, Hides, Temporal, Paused or PausedTemporal)
 Animation.UseInvokerAsOwner=false                  ; boolean
 Animation.HideIfAttachedWith=                      ; List of AttachEffectTypes
+Animation.DrawOffsetN=0,0                          ; X,Y, pixels relative to default
+Animation.DrawOffsetN.RequiredTypes=               ; List of AttachEffectTypes
 CumulativeAnimations=                              ; List of AnimationTypes
 CumulativeAnimations.RestartOnChange=true          ; boolean
 ExpireWeapon=                                      ; WeaponType

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -438,6 +438,8 @@ HideShakeEffects=false           ; boolean
 - [Customizable infantry sequence rates](New-or-Enhanced-Logics.md#customizable-infantry-sequence-rates) (by Noble_Fish)
 - `<Player @ X>` can now be used as owner for triggers on skirmish and multiplayer maps (by Starkku)
 - More veteran and elite abilities (by Ollerus)
+- [Attached animation draw offset customizations](Fixed-or-Improved-Logics.md#draw-offset-customization) (by Starkku)
+- [Draw offset rules for AttachEffect animations](New-or-Enhanced-Logics.md#attached-effects) by (Starkku)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -456,6 +456,7 @@ void AnimExt::Serialize(T& Stm)
 		.Process(this->FiringAnim_LastFacing)
 		.Process(this->FiringAnim_LastCoords)
 		.Process(this->FirepowerMult)
+		.Process(this->AEDrawOffset)
 		;
 }
 

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -39,6 +39,7 @@ public:
 	DirStruct FiringAnim_LastFacing;
 	CoordStruct FiringAnim_LastCoords;
 	double FirepowerMult;
+		Point2D AEDrawOffset;
 
 	AnimExt(AnimClass* OwnerObject) : ObjectExt(OwnerObject)
 		, DeathUnitFacing { 0 }
@@ -59,6 +60,7 @@ public:
 		, FiringAnim_LastFacing {}
 		, FiringAnim_LastCoords {}
 		, FirepowerMult { 1.0 }
+			, AEDrawOffset { Point2D::Empty }
 	{ }
 
 	void SetInvoker(TechnoClass* pInvoker);

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -279,14 +279,70 @@ DEFINE_HOOK(0x424CF1, AnimClass_Start_DetachedReport, 0x6)
 }
 
 // 0x422CD8 is in an alternate code path only used by anims with ID RING1, unused normally but covering it just because
-DEFINE_HOOK_AGAIN(0x422CD8, AnimClass_DrawIt_XDrawOffset, 0x6)
-DEFINE_HOOK(0x423122, AnimClass_DrawIt_XDrawOffset, 0x6)
+DEFINE_HOOK_AGAIN(0x422CD8, AnimClass_DrawIt_DrawOffset, 0x6)
+DEFINE_HOOK(0x423122, AnimClass_DrawIt_DrawOffset, 0x6)
 {
 	GET(AnimClass* const, pThis, ESI);
 	GET_STACK(Point2D*, pLocation, STACK_OFFSET(0x110, 0x4));
 
-	if (auto const pTypeExt = AnimTypeExt::TryFetch(pThis->Type))
-		pLocation->X += pTypeExt->XDrawOffset;
+	auto const pTypeExt = AnimTypeExt::Fetch(pThis->Type);
+	pLocation->X += pTypeExt->XDrawOffset;
+
+	bool const applyX = pTypeExt->XDrawOffset_ApplyBracketWidth;
+	bool const applyY = pTypeExt->YDrawOffset_ApplyBracketHeight;
+
+	if ((applyX || applyY) && pThis->OwnerObject && pThis->OwnerObject->AbstractFlags & AbstractFlags::Techno)
+	{
+		// Hardcoded in shield healthbar code as well.
+		constexpr int SHIELD_HEALTHBAR_OFFSET = -3;
+		auto const pTechno = static_cast<TechnoClass*>(pThis->OwnerObject);
+		bool const invertX = pTypeExt->XDrawOffset_InvertBracketShift;
+		bool const invertY = pTypeExt->YDrawOffset_InvertBracketShift;
+
+		if (auto const pBuilding = abstract_cast<BuildingClass*>(pTechno))
+		{
+			auto const pType = pBuilding->Type;
+			auto const pos = TechnoExt::GetBuildingSelectBracketPosition(pBuilding, pBuilding->Type, BuildingSelectBracketPosition::Top);
+
+			if (applyY && ((pType->Height >= 0 && !invertY) || (pType->Height < 0 && invertY)))
+				pLocation->Y = pos.Y + pTypeExt->YDrawOffset_BracketAdjust_Buildings.Get(pTypeExt->YDrawOffset_BracketAdjust);
+
+			if (applyX)
+			{
+				int const width = pBuilding->Type->GetFoundationWidth();
+				int const shift = static_cast<int>(Unsorted::CellWidthInPixels * (width / 2.0) * (invertX ? -1 : 1));
+				pLocation->X = pos.X + shift + pTypeExt->XDrawOffset_BracketAdjust_Buildings.Get(pTypeExt->XDrawOffset_BracketAdjust);
+			}
+		}
+		else
+		{
+			auto const pType = pTechno->GetTechnoType();
+			auto const horizontalPos = invertX ? HorizontalPosition::Left : HorizontalPosition::Right;
+			auto const pos = TechnoExt::GetFootSelectBracketPosition(pTechno, Anchor(horizontalPos, VerticalPosition::Top), pTechno->WhatAmI() == AbstractType::Infantry);
+
+			if (applyY && ((pType->PixelSelectionBracketDelta <= 0 && !invertY) || (pType->PixelSelectionBracketDelta > 0 && invertY)))
+				pLocation->Y = pos.Y + pType->PixelSelectionBracketDelta + pTypeExt->YDrawOffset_BracketAdjust;
+
+			if (applyX)
+				pLocation->X = pos.X + pTypeExt->XDrawOffset_BracketAdjust;
+		}
+
+		if (applyY)
+		{
+			if (auto const pShield = TechnoExt::Fetch(pTechno)->Shield.get())
+			{
+				auto const pShieldType = pShield->GetType();
+
+				if (pShield->IsAvailable() && !pShield->IsBrokenAndNonRespawning() && (pShield->GetHealthRatio() > 0.0 || !pShieldType->Pips_HideIfNoStrength))
+				{
+					if ((pShieldType->BracketDelta <= 0 && !invertY) || (pShieldType->BracketDelta > 0 && invertY))
+						pLocation->Y += pShieldType->BracketDelta + SHIELD_HEALTHBAR_OFFSET;
+				}
+			}
+		}
+	}
+
+	*pLocation += AnimExt::Fetch(pThis)->AEDrawOffset;
 
 	return 0;
 }

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -80,6 +80,14 @@ void AnimTypeExt::LoadFromINIFile(CCINIClass* pINI)
 
 	this->Palette.LoadFromINI(pINI, pID, "CustomPalette");
 	this->XDrawOffset.Read(exINI, pID, "XDrawOffset");
+	this->XDrawOffset_ApplyBracketWidth.Read(exINI, pID, "XDrawOffset.ApplyBracketWidth");
+	this->XDrawOffset_InvertBracketShift.Read(exINI, pID, "XDrawOffset.InvertBracketShift");
+	this->XDrawOffset_BracketAdjust.Read(exINI, pID, "XDrawOffset.BracketAdjust");
+	this->XDrawOffset_BracketAdjust_Buildings.Read(exINI, pID, "XDrawOffset.BracketAdjust.Buildings");
+	this->YDrawOffset_ApplyBracketHeight.Read(exINI, pID, "YDrawOffset.ApplyBracketHeight");
+	this->YDrawOffset_InvertBracketShift.Read(exINI, pID, "YDrawOffset.InvertBracketShift");
+	this->YDrawOffset_BracketAdjust.Read(exINI, pID, "YDrawOffset.BracketAdjust");
+	this->YDrawOffset_BracketAdjust_Buildings.Read(exINI, pID, "YDrawOffset.BracketAdjust.Buildings");
 	this->HideIfNoOre_Threshold.Read(exINI, pID, "HideIfNoOre.Threshold");
 	this->Layer_UseObjectLayer.Read(exINI, pID, "Layer.UseObjectLayer");
 	this->AttachedAnimPosition.Read(exINI, pID, "AttachedAnimPosition");
@@ -144,6 +152,14 @@ void AnimTypeExt::Serialize(T& Stm)
 		.Process(this->Palette)
 		.Process(this->CreateUnitType)
 		.Process(this->XDrawOffset)
+		.Process(this->XDrawOffset_ApplyBracketWidth)
+		.Process(this->XDrawOffset_InvertBracketShift)
+		.Process(this->XDrawOffset_BracketAdjust)
+		.Process(this->XDrawOffset_BracketAdjust_Buildings)
+		.Process(this->YDrawOffset_ApplyBracketHeight)
+		.Process(this->YDrawOffset_InvertBracketShift)
+		.Process(this->YDrawOffset_BracketAdjust)
+		.Process(this->YDrawOffset_BracketAdjust_Buildings)
 		.Process(this->HideIfNoOre_Threshold)
 		.Process(this->Layer_UseObjectLayer)
 		.Process(this->AttachedAnimPosition)

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -35,6 +35,14 @@ public:
 	CustomPalette Palette;
 	std::unique_ptr<CreateUnitTypeClass> CreateUnitType;
 	Valueable<int> XDrawOffset;
+		Valueable<bool> XDrawOffset_ApplyBracketWidth;
+		Valueable<bool> XDrawOffset_InvertBracketShift;
+		Valueable<int> XDrawOffset_BracketAdjust;
+		Nullable<int> XDrawOffset_BracketAdjust_Buildings;
+		Valueable<bool> YDrawOffset_ApplyBracketHeight;
+		Valueable<bool> YDrawOffset_InvertBracketShift;
+		Valueable<int> YDrawOffset_BracketAdjust;
+		Nullable<int> YDrawOffset_BracketAdjust_Buildings;
 	Valueable<int> HideIfNoOre_Threshold;
 	Nullable<bool> Layer_UseObjectLayer;
 	Valueable<AttachedAnimPosition> AttachedAnimPosition;
@@ -79,6 +87,14 @@ public:
 		, Palette { CustomPalette::PaletteMode::Temperate }
 		, CreateUnitType { nullptr }
 		, XDrawOffset { 0 }
+			, XDrawOffset_ApplyBracketWidth { false }
+			, XDrawOffset_InvertBracketShift { false }
+			, XDrawOffset_BracketAdjust { 0 }
+			, XDrawOffset_BracketAdjust_Buildings {}
+			, YDrawOffset_ApplyBracketHeight { false }
+			, YDrawOffset_InvertBracketShift { false }
+			, YDrawOffset_BracketAdjust { 0 }
+			, YDrawOffset_BracketAdjust_Buildings {}
 		, HideIfNoOre_Threshold { 0 }
 		, Layer_UseObjectLayer {}
 		, AttachedAnimPosition { AttachedAnimPosition::Default }

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -965,7 +965,10 @@ void TechnoExt::UpdateAttachEffects()
 	}
 
 	if (requiresRecalc)
+	{
 		this->RecalculateStatMultipliers();
+		this->UpdateAEAnimDrawingLogic();
+	}
 
 	if (markForRedraw)
 	{
@@ -995,6 +998,7 @@ void TechnoExt::UpdateSelfOwnedAttachEffects()
 	std::vector<std::unique_ptr<AttachEffectClass>>::iterator it;
 	std::vector<AEWeaponParams> expireWeapons;
 	bool requiresRecalc = false;
+	int removeCount = 0;
 
 	// Delete ones on old type and not on current.
 	for (it = this->AttachedEffects.begin(); it != this->AttachedEffects.end(); )
@@ -1011,6 +1015,7 @@ void TechnoExt::UpdateSelfOwnedAttachEffects()
 				requiresRecalc = true;
 
 			attachEffect->AddExpireWeaponParams(ExpireWeaponCondition::Expire, expireWeapons);
+			removeCount++;
 			it = this->AttachedEffects.erase(it);
 		}
 		else
@@ -1026,11 +1031,16 @@ void TechnoExt::UpdateSelfOwnedAttachEffects()
 		WeaponTypeExt::DetonateAt(info.Weapon, coords, info.Invoker, info.InvokerHouse, pThis);
 	}
 
-	if (requiresRecalc)
-		this->RecalculateStatMultipliers();
-
 	// Add new ones.
-	AttachEffectClass::Attach(pThis, pThis->Owner, pThis, pThis, pTypeExt->AttachEffects, true);
+	const int count = AttachEffectClass::Attach(pThis, pThis->Owner, pThis, pThis, pTypeExt->AttachEffects);
+
+	if (!count && removeCount > 0)
+	{
+		if (requiresRecalc)
+			this->RecalculateStatMultipliers();
+
+		this->UpdateAEAnimDrawingLogic();
+	}
 }
 
 // Updates CumulativeAnimations AE's on techno.
@@ -1075,6 +1085,15 @@ void TechnoExt::UpdateCumulativeAttachEffects(AttachEffectTypeClass* pAttachEffe
 
 		if (createAnim)
 			pAELargestDuration->CreateAnim();
+	}
+}
+
+// Update AttachEffect animation drawing logic.
+void TechnoExt::ExtData::UpdateAEAnimDrawingLogic()
+{
+	for (auto const& attachEffect : this->AttachedEffects)
+	{
+		attachEffect->UpdateConditionalAnimDrawingLogic();
 	}
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -480,27 +480,19 @@ bool TechnoExt::IsTypeImmune(TechnoClass* pThis, TechnoTypeClass* pType, TechnoC
 	return false;
 }
 
-/// <summary>
-/// Gets whether or not techno has listed AttachEffect types active on it
-/// </summary>
-/// <param name="attachEffectTypes">Attacheffect types.</param>
-/// <param name="requireAll">Whether or not to require all listed types to be present or if only one will satisfy the check.</param>
-/// <param name="ignoreSameSource">Ignore AttachEffects that come from set invoker and source.</param>
-/// <param name="pInvoker">Invoker Techno used for same source check.</param>
-/// <param name="pSource">Source AbstractClass instance used for same source check.</param>
-/// <returns>True if techno has active AttachEffects that satisfy the source, false if not.</returns>
-bool TechnoExt::HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll, bool ignoreSameSource,
-	TechnoClass* pInvoker, AbstractClass* pSource, std::vector<int> const* minCounts, std::vector<int> const* maxCounts) const
+// Gets whether or not techno has listed AttachEffect types active on it
+bool TechnoExt::ExtData::HasAttachedEffects(std::vector<AttachEffectTypeClass*> const& attachEffectTypes, bool requireAll, bool ignoreSameSource,
+	TechnoClass* pInvoker, AbstractClass* pSource, std::vector<int> const* minCounts, std::vector<int> const* maxCounts, bool requireAnims) const
 {
 	unsigned int foundCount = 0;
 	unsigned int typeCounter = 1;
 	const bool checkSource = ignoreSameSource && pInvoker && pSource;
 
-	for (auto const& type : attachEffectTypes)
+	for (auto const& pType : attachEffectTypes)
 	{
-		if (type->Cumulative)
+		if (pType->Cumulative)
 		{
-			const int cumulativeCount = this->GetAttachedEffectCumulativeCount(type, ignoreSameSource, pInvoker, pSource);
+			const int cumulativeCount = this->GetAttachedEffectCumulativeCount(pType, ignoreSameSource, pInvoker, pSource, requireAnims);
 			bool matched = cumulativeCount > 0;
 			const unsigned int minSize = minCounts ? minCounts->size() : 0;
 			const unsigned int maxSize = maxCounts ? maxCounts->size() : 0;
@@ -530,7 +522,9 @@ bool TechnoExt::HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEff
 		{
 			for (auto const& attachEffect : this->AttachedEffects)
 			{
-				if (attachEffect->GetType() == type && attachEffect->IsActive())
+				const auto type = attachEffect->GetType();
+
+				if (type == pType && attachEffect->IsActive() && (!requireAnims || !type->HasAnim() || attachEffect->HasAnim()))
 				{
 					if (checkSource && attachEffect->IsFromSource(pInvoker, pSource))
 						continue;
@@ -558,22 +552,17 @@ bool TechnoExt::HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEff
 	return false;
 }
 
-/// <summary>
-/// Gets how many counts of same cumulative AttachEffect type instance techno has active on it.
-/// </summary>
-/// <param name="pAttachEffectType">AttachEffect type.</param>
-/// <param name="ignoreSameSource">Ignore AttachEffects that come from set invoker and source.</param>
-/// <param name="pInvoker">Invoker Techno used for same source check.</param>
-/// <param name="pSource">Source AbstractClass instance used for same source check.</param>
-/// <returns>Number of active cumulative AttachEffect type instances on the techno. 0 if the AttachEffect type is not cumulative.</returns>
-int TechnoExt::GetAttachedEffectCumulativeCount(AttachEffectTypeClass* pAttachEffectType, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource) const
+// Gets how many counts of same cumulative AttachEffect type instance techno has active on it.
+int TechnoExt::GetAttachedEffectCumulativeCount(AttachEffectTypeClass* pAttachEffectType, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource, bool requireAnims) const
 {
 	unsigned int foundCount = 0;
 	const bool checkSource = ignoreSameSource && pInvoker && pSource;
 
 	for (auto const& attachEffect : this->AttachedEffects)
 	{
-		if (attachEffect->GetType() == pAttachEffectType && attachEffect->IsActive())
+		const auto type = attachEffect->GetType();
+
+		if (type == pAttachEffectType && attachEffect->IsActive() && (!requireAnims || !type->HasAnim() || attachEffect->HasAnim()))
 		{
 			if (checkSource && attachEffect->IsFromSource(pInvoker, pSource))
 				continue;
@@ -932,7 +921,7 @@ struct DummyExtHere
 	char _pad0[0x50];
 	CDTimerClass DisableWeaponsTimer;
 	char _pad1[0x40];
-	bool DriverKilled; 
+	bool DriverKilled;
 };
 
 struct DummyTypeExtHere

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -165,6 +165,7 @@ public:
 	void UpdateAttachEffects();
 	void UpdateGattlingRateDownReset();
 	void UpdateCumulativeAttachEffects(AttachEffectTypeClass* pAttachEffectType, bool createAnim = false);
+	void UpdateAEAnimDrawingLogic();
 	bool RecalculateStatMultipliers(AttachEffectClass* pAttachEffect = nullptr);
 	void UpdateTemporal();
 	void UpdateMindControlAnim();
@@ -174,8 +175,8 @@ public:
 	void InitializeLaserTrails();
 	void InitializeAttachEffects();
 	void UpdateSelfOwnedAttachEffects();
-	bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> attachEffectTypes, bool requireAll, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource, std::vector<int> const* minCounts, std::vector<int> const* maxCounts) const;
-	int GetAttachedEffectCumulativeCount(AttachEffectTypeClass* pAttachEffectType, bool ignoreSameSource = false, TechnoClass* pInvoker = nullptr, AbstractClass* pSource = nullptr) const;
+	bool HasAttachedEffects(std::vector<AttachEffectTypeClass*> const& attachEffectTypes, bool requireAll, bool ignoreSameSource, TechnoClass* pInvoker, AbstractClass* pSource, std::vector<int> const* minCounts, std::vector<int> const* maxCounts, bool requireAnims = false) const;
+	int GetAttachedEffectCumulativeCount(AttachEffectTypeClass* pAttachEffectType, bool ignoreSameSource = false, TechnoClass* pInvoker = nullptr, AbstractClass* pSource = nullptr, bool requireAnims = false) const;
 	void InitializeDisplayInfo(TechnoTypeClass* pType);
 	void ApplyMindControlRangeLimit();
 	int ApplyForceWeaponInRange(AbstractClass* pTarget);

--- a/src/New/Entity/AttachEffectClass.cpp
+++ b/src/New/Entity/AttachEffectClass.cpp
@@ -112,7 +112,11 @@ AttachEffectClass::~AttachEffectClass()
 	if (it != AttachEffectClass::Array.end())
 		AttachEffectClass::Array.erase(it);
 
-	this->KillAnim();
+	if (this->Animation)
+	{
+		this->Animation->UnInit();
+		this->Animation = nullptr;
+	}
 
 	// the invoker may be mid-destruction with its extension already removed
 	if (this->Invoker)
@@ -325,13 +329,29 @@ void AttachEffectClass::AI_Temporal()
 
 void AttachEffectClass::AnimCheck()
 {
+	if (!this->Animation && this->CanShowAnim())
+		this->CreateAnim();
+}
+
+// Updates animation drawing logic that depends on state of other AE's on owner.
+// Called from TechnoExt::UpdateAEAnimDrawingLogic() on all AE's on owner if AE's are attached/detached/expire etc.
+// or if their animation state changes. Do not call directly.
+// Take care to to not invoke recursion - should not call any functions that call TechnoExt::UpdateAEAnimDrawingLogic() such as CreateAnim/KillAnim here.
+void AttachEffectClass::UpdateConditionalAnimDrawingLogic()
+{
 	if (this->Type->Animation_HideIfAttachedWith.size() > 0)
 	{
 		auto const pTechnoExt = TechnoExt::Fetch(this->Techno);
 
 		if (pTechnoExt->HasAttachedEffects(this->Type->Animation_HideIfAttachedWith, false, false, nullptr, nullptr, nullptr, nullptr))
 		{
-			this->KillAnim();
+			// Inlined because calling KillAnim() would cause recursive calls to this function.
+			if (this->Animation)
+			{
+				this->Animation->UnInit();
+				this->Animation = nullptr;
+			}
+
 			this->IsAnimHidden = true;
 			return;
 		}
@@ -339,8 +359,18 @@ void AttachEffectClass::AnimCheck()
 
 	this->IsAnimHidden = false;
 
-	if (!this->Animation && this->CanShowAnim())
-		this->CreateAnim();
+	if (this->Animation && this->Type->Animation_DrawOffsets.size() > 0)
+	{
+		auto const pAnimExt = AnimExt::Fetch(this->Animation);
+		auto const pTechnoExt = TechnoExt::Fetch(this->Techno);
+		pAnimExt->AEDrawOffset = Point2D::Empty;
+
+		for (auto const& drawOffset : this->Type->Animation_DrawOffsets)
+		{
+			if (drawOffset.RequiredTypes.size() < 1 || pTechnoExt->HasAttachedEffects(drawOffset.RequiredTypes, false, false, nullptr, nullptr, nullptr, nullptr, true))
+				pAnimExt->AEDrawOffset += drawOffset.Offset;
+		}
+	}
 }
 
 void AttachEffectClass::OnlineCheck()
@@ -455,6 +485,17 @@ void AttachEffectClass::CreateAnim()
 
 		pAnim->RemainingIterations = 0xFFu;
 		this->Animation = pAnim;
+		TechnoExt::Fetch(this->Techno)->UpdateAEAnimDrawingLogic();
+	}
+}
+
+void AttachEffectClass::KillAnim()
+{
+	if (this->Animation)
+	{
+		this->Animation->UnInit();
+		this->Animation = nullptr;
+		TechnoExt::Fetch(this->Techno)->UpdateAEAnimDrawingLogic();
 	}
 }
 
@@ -662,7 +703,7 @@ bool AttachEffectClass::ShouldBeDiscardedNow()
 			}
 		}
 	}
-	
+
 	if ((discardOn & DiscardCondition::Mission) != DiscardCondition::None)
 	{
 		auto const& missions = pTechno->Owner->IsControlledByHuman()
@@ -819,7 +860,7 @@ int AttachEffectClass::Attach(TechnoClass* pTarget, HouseClass* pInvokerHouse, T
 	{
 		pTargetExt->UpdateCumulativeAttachEffects(pType);
 	}
-	          
+
 	return attachedCount;
 }
 
@@ -927,6 +968,8 @@ AttachEffectClass* AttachEffectClass::CreateAndAttach(AttachEffectTypeClass* pTy
 	if (!currentTypeCount && cumulative && pType->CumulativeAnimations.size() > 0)
 		pAE->HasCumulativeAnim = true;
 
+	TechnoExt::Fetch(pTarget)->UpdateAEAnimDrawingLogic();
+
 	return pAE;
 }
 
@@ -1013,6 +1056,7 @@ int AttachEffectClass::DetachTypes(TechnoClass* pTarget, AEAttachInfoTypeClass c
 	if (detachedCount > 0)
 	{
 		const auto pExt = TechnoExt::Fetch(pTarget);
+		pExt->UpdateAEAnimDrawingLogic();
 
 		if (requiresRecalc)
 			pExt->RecalculateStatMultipliers();
@@ -1150,7 +1194,7 @@ void AttachEffectClass::TransferAttachedEffects(TechnoClass* pSource, TechnoClas
 
 			if (targetAttachEffect->GetType() == type)
 			{
-				currentTypeCount++;	
+				currentTypeCount++;
 
 				if (!cumulative)
 				{
@@ -1187,10 +1231,12 @@ void AttachEffectClass::TransferAttachedEffects(TechnoClass* pSource, TechnoClas
 
 		transferCount++;
 		it = pSourceExt->AttachedEffects.erase(it);
-	} 
+	}
 
 	if (transferCount > 0)
 	{
+		pTargetExt->UpdateAEAnimDrawingLogic();
+
 		if (requiresRecalc)
 			pTargetExt->RecalculateStatMultipliers();
 

--- a/src/New/Entity/AttachEffectClass.h
+++ b/src/New/Entity/AttachEffectClass.h
@@ -18,18 +18,15 @@ public:
 
 	void AI();
 	void AI_Temporal();
-
-	void KillAnim()
-	{
-		if (this->Animation)
-		{
-			this->Animation->UnInit();
-			this->Animation = nullptr;
-		}
-	}
-
+	void UpdateConditionalAnimDrawingLogic();
+	void KillAnim();
 	void CreateAnim();
 	void UpdateCumulativeAnim(int count);
+
+	bool HasAnim() const
+	{
+		return this->Animation != nullptr;
+	}
 
 	bool CanShowAnim() const
 	{

--- a/src/New/Type/AttachEffectTypeClass.cpp
+++ b/src/New/Type/AttachEffectTypeClass.cpp
@@ -54,6 +54,14 @@ std::vector<AttachEffectTypeClass*> AttachEffectTypeClass::GetTypesFromGroups(co
 	return std::vector<AttachEffectTypeClass*>(types.begin(), types.end());
 }
 
+bool AttachEffectTypeClass::HasAnim() const
+{
+	if (this->Cumulative)
+		return this->CumulativeAnimations.size() > 0 || this->Animation != nullptr;
+	else
+		return this->Animation != nullptr;
+}
+
 void AttachEffectTypeClass::HandleEvent(TechnoClass* pTarget)
 {
 	if (const auto pTag = pTarget->AttachedTag)
@@ -207,6 +215,17 @@ void AttachEffectTypeClass::LoadFromINI(CCINIClass* pINI)
 	exINI.ParseStringList(this->Groups, pSection, "Groups");
 	AddToGroupsMap();
 
+	// Animation draw offsets.
+	for (int i = 0; i < INT32_MAX; i++)
+	{
+		AnimationDrawOffsetClass offset;
+
+		if (offset.LoadFromINI(pINI, pSection, i))
+			this->Animation_DrawOffsets.emplace_back(offset);
+		else
+			break;
+	}
+
 	// RequiresRecalculation
 	if (this->FirepowerMultiplier != 1.0 || this->ArmorMultiplier != 1.0 || this->SpeedMultiplier != 1.0 || this->ROFMultiplier != 1.0
 		|| this->WeaponRange_Multiplier != 1.0 || this->WeaponRange_ExtraRange != 0.0 || this->Crit_Multiplier != 1.0 || this->Crit_ExtraChance != 0.0
@@ -309,6 +328,7 @@ void AttachEffectTypeClass::Serialize(T& Stm)
 		.Process(this->Unkillable)
 		.Process(this->LaserTrail_Type)
 		.Process(this->Groups)
+		.Process(this->Animation_DrawOffsets)
 		.Process(this->RequiresRecalculation)
 		;
 }
@@ -554,6 +574,48 @@ bool AEAttachInfoTypeClass::Load(PhobosStreamReader& stm, bool registerForChange
 bool AEAttachInfoTypeClass::Save(PhobosStreamWriter& stm) const
 {
 	return const_cast<AEAttachInfoTypeClass*>(this)->Serialize(stm);
+}
+
+#pragma endregion(save/load)
+
+// AnimationDrawOffsetClass
+
+bool AnimationDrawOffsetClass::LoadFromINI(CCINIClass* pINI, const char* pSection, int index)
+{
+	INI_EX exINI(pINI);
+	char tempBuffer[48];
+
+	_snprintf_s(tempBuffer, sizeof(tempBuffer), "Animation.DrawOffset%d", index);
+	this->Offset.Read(exINI, pSection, tempBuffer);
+
+	if (this->Offset.Get() == Point2D::Empty)
+		return false;
+
+	_snprintf_s(tempBuffer, sizeof(tempBuffer), "Animation.DrawOffset%d.RequiredTypes", index);
+	this->RequiredTypes.Read(exINI, pSection, tempBuffer);
+
+	return true;
+}
+
+#pragma region(save/load)
+
+template <class T>
+bool AnimationDrawOffsetClass::Serialize(T& stm)
+{
+	return stm
+		.Process(this->Offset)
+		.Process(this->RequiredTypes)
+		.Success();
+}
+
+bool AnimationDrawOffsetClass::Load(PhobosStreamReader& stm, bool registerForChange)
+{
+	return this->Serialize(stm);
+}
+
+bool AnimationDrawOffsetClass::Save(PhobosStreamWriter& stm) const
+{
+	return const_cast<AnimationDrawOffsetClass*>(this)->Serialize(stm);
 }
 
 #pragma endregion(save/load)

--- a/src/New/Type/AttachEffectTypeClass.h
+++ b/src/New/Type/AttachEffectTypeClass.h
@@ -46,6 +46,8 @@ enum class ExpireWeaponCondition : unsigned char
 
 MAKE_ENUM_FLAGS(ExpireWeaponCondition);
 
+class AnimationDrawOffsetClass;
+
 class AttachEffectTypeClass final : public Enumerable<AttachEffectTypeClass>
 {
 	static std::unordered_map<std::string, std::set<AttachEffectTypeClass*>> GroupsMap;
@@ -129,6 +131,7 @@ public:
 	ValueableIdx<LaserTrailTypeClass> LaserTrail_Type;
 
 	std::vector<std::string> Groups;
+	std::vector<AnimationDrawOffsetClass> Animation_DrawOffsets;
 	bool RequiresRecalculation;
 	bool RestrictedArmorMultiplier;
 
@@ -210,6 +213,7 @@ public:
 		, Unkillable { false }
 		, LaserTrail_Type { -1 }
 		, Groups {}
+		, Animation_DrawOffsets {}
 		, RequiresRecalculation { false }
 		, RestrictedArmorMultiplier { false }
 	{};
@@ -221,6 +225,7 @@ public:
 
 	bool HasGroup(const std::string& groupID) const;
 	bool HasGroups(const std::vector<std::string>& groupIDs, bool requireAll) const;
+	bool HasAnim() const;
 
 	AnimTypeClass* GetCumulativeAnimation(int cumulativeCount) const
 	{
@@ -342,3 +347,25 @@ struct AEWeaponParams
 	{
 	}
 };
+
+// Container for AttachEffect animation draw offset info.
+class AnimationDrawOffsetClass
+{
+public:
+	Valueable<Point2D> Offset;
+	ValueableVector<AttachEffectTypeClass*> RequiredTypes;
+
+	bool LoadFromINI(CCINIClass* pINI, const char* pSection, int index);
+	bool Load(PhobosStreamReader& stm, bool registerForChange);
+	bool Save(PhobosStreamWriter& stm) const;
+
+	AnimationDrawOffsetClass() :
+		Offset { Point2D::Empty}
+		, RequiredTypes {}
+	{ }
+
+private:
+	template <typename T>
+	bool Serialize(T& stm);
+};
+


### PR DESCRIPTION
### Draw offset customization

- `YDrawOffset.ApplyBracketHeight` makes Y axis position follow it's owner object's selection bracket height (for buildings, this is based on `Height` and `Foundation`, for others it is influenced by `PixelSelectionBracketDelta`) if it is attached to one.
  - By default this will only apply if the bracket position is negative e.g it is moved upwards from the object center. If `YDrawOffset.InvertBracketShift` is set to true, the opposite is true and negative shift is ignored.
  - The bracket-based shift can be further adjusted with offset from `YDrawOffset.BracketAdjust`, overridden by `YDrawOffset.BracketAdjust.Buildings` for buildings only.
 
In `artmd.ini`:
```ini
[SOMEANIM]                            ; AnimationType
YDrawOffset.ApplyBracketHeight=false  ; boolean
YDrawOffset.InvertBracketShift=false  ; boolean
YDrawOffset.BracketAdjust=0,0         ; X,Y, pixels relative to default
YDrawOffset.BracketAdjust.Buildings=  ; X,Y, pixels relative to default
```

### AttachEffect animation-specific

 - `Animation.DrawOffsetN` (where N is integer starting from 0) can be used to define draw offset rules for the animation. These are parsed starting from index 0 until offset with value 0,0 is encountered.
   - `Animation.DrawOffsetN.RequiredTypes` contains list other AttachEffectTypes that need to be attached on the same techno as the current one for the draw offset rule to apply.

In `rulesmd.ini`:
```ini
[SOMEATTACHEFFECT]                                 ; AttachEffectType
Animation.DrawOffsetN=0,0                          ; X,Y, pixels relative to default
Animation.DrawOffsetN.RequiredTypes=               ; List of AttachEffectTypes
```


