### PR TITLE
Fixed AI bug when an UndeploysInto building undeploys

### DIFF
--- a/src/Ext/Building/Hooks.Selling.cpp
+++ b/src/Ext/Building/Hooks.Selling.cpp
@@ -44,7 +44,7 @@ bool __forceinline BuildingExt::CanUndeployOnSell(BuildingClass* pThis)
 	}
 
 	// Move ArchiveTarget check outside Conyard check to allow generic Unsellable=no buildings to be sold
-	return pThis->ArchiveTarget;
+	return pThis->ArchiveTarget || pThis->Type->Unsellable;
 }
 
 // Skip SessionClass::IsCampaign() checks, where inlined not exactly the function above but sth similar


### PR DESCRIPTION
The AI bug never created the expected unit when is undeployed.

Tested in Map action 60 & forcing the AI to undeploy (for example when the affected deployed has a minimum range in the weapon and the enemy is inside that range).

Bugfix of the reported issue:
https://github.com/Phobos-developers/Phobos/issues/1851

Since this is only fixing a very small coding mistake no documentation of any kind should be required.