### PR TITLE
Refactor Fog of War round 2

### DIFF
--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -31,7 +31,6 @@
     <ClCompile Include="src\Blowfish\blowfish.cpp" />
     <ClCompile Include="src\Blowfish\Hooks.Blowfish.cpp" />
     <ClCompile Include="src\Ext\Cell\Body.cpp" />
-    <ClCompile Include="src\Ext\HouseType\Body.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.ForceEnemy.cpp" />
     <ClCompile Include="src\Commands\ToggleSWSidebar.cpp" />
     <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWColumnClass.cpp" />
@@ -44,9 +43,6 @@
     <ClCompile Include="src\Ext\Unit\Hooks.Sinking.cpp" />
     <ClCompile Include="src\Misc\Hooks.AlphaImage.cpp" />
     <ClCompile Include="src\New\Entity\AttachEffectClass.cpp" />
-    <ClCompile Include="src\New\AnonymousType\GiftBox.cpp" />
-    <ClCompile Include="src\New\AnonymousType\GiftBoxData.cpp" />
-    <ClCompile Include="src\New\AnonymousType\GiftBoxFunctional.cpp" />
     <ClCompile Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.cpp" />
     <ClCompile Include="src\New\Type\AttachEffectTypeClass.cpp" />
     <ClCompile Include="src\Misc\MessageColumn.cpp" />
@@ -61,7 +57,6 @@
     <ClCompile Include="src\Commands\ToggleDesignatorRange.cpp" />
     <ClCompile Include="src\Commands\ToggleDigitalDisplay.cpp" />
     <ClCompile Include="src\Commands\SaveVariablesToFile.cpp" />
-    <ClCompile Include="src\Commands\ShowTechnoNames.cpp" />
     <ClCompile Include="src\Ext\Anim\Body.cpp" />
     <ClCompile Include="src\Ext\Anim\Hooks.cpp" />
     <ClCompile Include="src\Ext\Anim\Hooks.AnimCreateUnit.cpp" />
@@ -98,7 +93,6 @@
     <ClCompile Include="src\Locomotion\TestLocomotionClass.cpp" />
     <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
     <ClCompile Include="src\Misc\Hooks.Ares.cpp" />
-    <ClCompile Include="src\Misc\Debug.CrashDiagnostics.cpp" />
     <ClCompile Include="src\Misc\Hooks.Crates.cpp" />
     <ClCompile Include="src\Misc\Hooks.LightEffects.cpp" />
     <ClCompile Include="src\Misc\Hooks.VeinholeMonster.cpp" />
@@ -192,10 +186,8 @@
     <ClCompile Include="src\Ext\BuildingType\Hooks.Placing.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Body.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Hooks.cpp" />
-    <ClCompile Include="src\Ext\WarheadType\Transact.cpp" />
     <ClCompile Include="src\Misc\FlyingStrings.cpp" />
     <ClCompile Include="src\Misc\Hooks.BugFixes.cpp" />
-    <ClCompile Include="src\Misc\Hooks.Otamaa.cpp" />
     <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
     <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
@@ -237,11 +229,7 @@
     <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWSidebarClass.h" />
     <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWButtonClass.h" />
     <ClInclude Include="src\Ext\Sidebar\SWSidebar\ToggleSWButtonClass.h" />
-    <ClInclude Include="src\Ext\HouseType\Body.h" />
     <ClInclude Include="src\New\Entity\AttachEffectClass.h" />
-    <ClInclude Include="src\New\AnonymousType\GiftBox.h" />
-    <ClInclude Include="src\New\AnonymousType\GiftBoxData.h" />
-    <ClInclude Include="src\New\AnonymousType\GiftBoxFunctional.h" />
     <ClInclude Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.h" />
     <ClInclude Include="src\New\Type\AttachEffectTypeClass.h" />
     <ClInclude Include="src\Misc\MessageColumn.h" />
@@ -257,7 +245,6 @@
     <ClInclude Include="src\Commands\ToggleDesignatorRange.h" />
     <ClInclude Include="src\Commands\ToggleDigitalDisplay.h" />
     <ClInclude Include="src\Commands\SaveVariablesToFile.h" />
-    <ClInclude Include="src\Commands\ShowTechnoNames.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="src\Blowfish\blowfish.cpp" />
     <ClCompile Include="src\Blowfish\Hooks.Blowfish.cpp" />
     <ClCompile Include="src\Ext\Cell\Body.cpp" />
+    <ClCompile Include="src\Ext\HouseType\Body.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.ForceEnemy.cpp" />
     <ClCompile Include="src\Commands\ToggleSWSidebar.cpp" />
     <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWColumnClass.cpp" />
@@ -43,6 +44,9 @@
     <ClCompile Include="src\Ext\Unit\Hooks.Sinking.cpp" />
     <ClCompile Include="src\Misc\Hooks.AlphaImage.cpp" />
     <ClCompile Include="src\New\Entity\AttachEffectClass.cpp" />
+    <ClCompile Include="src\New\AnonymousType\GiftBox.cpp" />
+    <ClCompile Include="src\New\AnonymousType\GiftBoxData.cpp" />
+    <ClCompile Include="src\New\AnonymousType\GiftBoxFunctional.cpp" />
     <ClCompile Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.cpp" />
     <ClCompile Include="src\New\Type\AttachEffectTypeClass.cpp" />
     <ClCompile Include="src\Misc\MessageColumn.cpp" />
@@ -57,6 +61,7 @@
     <ClCompile Include="src\Commands\ToggleDesignatorRange.cpp" />
     <ClCompile Include="src\Commands\ToggleDigitalDisplay.cpp" />
     <ClCompile Include="src\Commands\SaveVariablesToFile.cpp" />
+    <ClCompile Include="src\Commands\ShowTechnoNames.cpp" />
     <ClCompile Include="src\Ext\Anim\Body.cpp" />
     <ClCompile Include="src\Ext\Anim\Hooks.cpp" />
     <ClCompile Include="src\Ext\Anim\Hooks.AnimCreateUnit.cpp" />
@@ -93,6 +98,7 @@
     <ClCompile Include="src\Locomotion\TestLocomotionClass.cpp" />
     <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
     <ClCompile Include="src\Misc\Hooks.Ares.cpp" />
+    <ClCompile Include="src\Misc\Debug.CrashDiagnostics.cpp" />
     <ClCompile Include="src\Misc\Hooks.Crates.cpp" />
     <ClCompile Include="src\Misc\Hooks.LightEffects.cpp" />
     <ClCompile Include="src\Misc\Hooks.VeinholeMonster.cpp" />
@@ -186,11 +192,14 @@
     <ClCompile Include="src\Ext\BuildingType\Hooks.Placing.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Body.cpp" />
     <ClCompile Include="src\Ext\WarheadType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\WarheadType\Transact.cpp" />
     <ClCompile Include="src\Misc\FlyingStrings.cpp" />
     <ClCompile Include="src\Misc\Hooks.BugFixes.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Otamaa.cpp" />
     <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
     <ClCompile Include="src\Misc\Hooks.UI.cpp" />
     <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
+    <ClCompile Include="src\Misc\Hooks.RadBeam.cpp" />
     <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
     <ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
     <ClCompile Include="src\Misc\Hooks.Overlay.cpp" />
@@ -228,7 +237,11 @@
     <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWSidebarClass.h" />
     <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWButtonClass.h" />
     <ClInclude Include="src\Ext\Sidebar\SWSidebar\ToggleSWButtonClass.h" />
+    <ClInclude Include="src\Ext\HouseType\Body.h" />
     <ClInclude Include="src\New\Entity\AttachEffectClass.h" />
+    <ClInclude Include="src\New\AnonymousType\GiftBox.h" />
+    <ClInclude Include="src\New\AnonymousType\GiftBoxData.h" />
+    <ClInclude Include="src\New\AnonymousType\GiftBoxFunctional.h" />
     <ClInclude Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.h" />
     <ClInclude Include="src\New\Type\AttachEffectTypeClass.h" />
     <ClInclude Include="src\Misc\MessageColumn.h" />
@@ -244,6 +257,7 @@
     <ClInclude Include="src\Commands\ToggleDesignatorRange.h" />
     <ClInclude Include="src\Commands\ToggleDigitalDisplay.h" />
     <ClInclude Include="src\Commands\SaveVariablesToFile.h" />
+    <ClInclude Include="src\Commands\ShowTechnoNames.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />
@@ -264,6 +278,7 @@
     <ClInclude Include="src\Misc\PhobosToolTip.h" />
     <ClInclude Include="src\Misc\SyncLogging.h" />
     <ClInclude Include="src\Misc\MapRevealer.h" />
+    <ClInclude Include="src\Misc\Hooks.RadBeam.h" />
     <ClInclude Include="src\New\Entity\FoggedObject.h" />
     <ClInclude Include="src\New\Entity\BannerClass.h" />
     <ClInclude Include="src\New\Type\BannerTypeClass.h" />

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -194,6 +194,9 @@
     <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
     <ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
     <ClCompile Include="src\Misc\Hooks.Overlay.cpp" />
+    <ClCompile Include="src\Misc\FogOfWar.cpp" />
+    <ClCompile Include="src\Misc\MapRevealer.cpp" />
+    <ClCompile Include="src\New\Entity\FoggedObject.cpp" />
     <ClCompile Include="src\New\Type\Affiliated\TypeConvertGroup.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
     <ClCompile Include="src\Phobos.COM.cpp" />
@@ -260,6 +263,8 @@
     <ClInclude Include="src\Misc\FlyingStrings.h" />
     <ClInclude Include="src\Misc\PhobosToolTip.h" />
     <ClInclude Include="src\Misc\SyncLogging.h" />
+    <ClInclude Include="src\Misc\MapRevealer.h" />
+    <ClInclude Include="src\New\Entity\FoggedObject.h" />
     <ClInclude Include="src\New\Entity\BannerClass.h" />
     <ClInclude Include="src\New\Type\BannerTypeClass.h" />
     <ClInclude Include="src\New\Type\Affiliated\TypeConvertGroup.h" />

--- a/src/Ext/Building/Hooks.Refinery.cpp
+++ b/src/Ext/Building/Hooks.Refinery.cpp
@@ -52,7 +52,19 @@ DEFINE_HOOK(0x522E4F, InfantryClass_SlaveGiveMoney_CheckBalanceAfter, 0x6)
 	else if (auto const pBldTypeExt = BuildingTypeExt::ExtMap.TryFind(slaveMiner->GetTechnoType()->DeploysInto))
 	{
 		if (pBldTypeExt->DisplayIncome.Get(RulesExt::Global()->DisplayIncome.Get()))
-			FlyingStrings::AddMoneyString(money, slaveMiner->Owner, RulesExt::Global()->DisplayIncome_Houses.Get(), slaveMiner->Location);
+		{
+			// Only show flying strings if slave miner location is visible (not fogged)
+			if (auto const pCell = MapClass::Instance.TryGetCellAt(slaveMiner->Location))
+			{
+				if (!pCell->IsFogged() && !pCell->IsShrouded())
+				{
+					FlyingStrings::AddMoneyString(
+						money, slaveMiner->Owner,
+						RulesExt::Global()->DisplayIncome_Houses.Get(),
+						slaveMiner->Location);
+				}
+			}
+		}
 	}
 
 	return 0;

--- a/src/Ext/Building/Hooks.Selling.cpp
+++ b/src/Ext/Building/Hooks.Selling.cpp
@@ -19,7 +19,16 @@ DEFINE_HOOK(0x4D9F7B, FootClass_Sell, 0x6)
 	}
 
 	if (RulesExt::Global()->DisplayIncome.Get())
-		FlyingStrings::AddMoneyString(money, pOwner, RulesExt::Global()->DisplayIncome_Houses.Get(), pThis->Location);
+	{
+		// Only show flying strings if building location is visible (not fogged)
+		if (auto const pCell = MapClass::Instance.TryGetCellAt(pThis->Location))
+		{
+			if (!pCell->IsFogged() && !pCell->IsShrouded())
+			{
+				FlyingStrings::AddMoneyString(money, pOwner, RulesExt::Global()->DisplayIncome_Houses.Get(), pThis->Location);
+			}
+		}
+	}
 
 	return ReadyToVanish;
 }

--- a/src/Ext/Cell/Body.cpp
+++ b/src/Ext/Cell/Body.cpp
@@ -15,6 +15,7 @@ void CellExt::ExtData::Serialize(T& Stm)
 	Stm
 		.Process(this->RadSites)
 		.Process(this->RadLevels)
+		.Process(this->FoggedObjects)
 		;
 }
 
@@ -70,7 +71,7 @@ DEFINE_HOOK(0x47BDA1, CellClass_CTOR, 0x5)
 {
 	GET(CellClass*, pItem, ESI);
 
-	CellExt::ExtMap.Allocate(pItem);
+	CellExt::ExtMap.FindOrAllocate(pItem);
 
 	return 0;
 }

--- a/src/Ext/Cell/Body.h
+++ b/src/Ext/Cell/Body.h
@@ -6,6 +6,10 @@
 #include <Utilities/Constructs.h>
 #include <Utilities/Template.h>
 
+#include <New/Entity/FoggedObject.h>
+
+class FoggedObject;
+
 class CellExt
 {
 public:
@@ -36,8 +40,10 @@ public:
 	public:
 		std::vector<RadSiteClass*> RadSites {};
 		std::vector<RadLevel> RadLevels { };
+		DynamicVectorClass<FoggedObject*> FoggedObjects;
 
-		ExtData(CellClass* OwnerObject) : Extension<CellClass>(OwnerObject)
+		ExtData(CellClass* OwnerObject) : Extension<CellClass>(OwnerObject),
+			FoggedObjects {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Cell/Body.h
+++ b/src/Ext/Cell/Body.h
@@ -41,6 +41,7 @@ public:
 		std::vector<RadSiteClass*> RadSites {};
 		std::vector<RadLevel> RadLevels { };
 		DynamicVectorClass<FoggedObject*> FoggedObjects;
+		int InCleanFog { 0 };
 
 		ExtData(CellClass* OwnerObject) : Extension<CellClass>(OwnerObject),
 			FoggedObjects {}

--- a/src/Ext/EBolt/Hooks.cpp
+++ b/src/Ext/EBolt/Hooks.cpp
@@ -11,6 +11,16 @@
 #define FOW_DEBUG 0
 
 
+// stable, single-pass erase of the first matching pointer; preserves order
+template<typename T>
+static __forceinline void stable_erase_first(std::vector<T*>& v, T* value)
+{
+	for (size_t i = 0, n = v.size(); i < n; ++i)
+	{
+		if (v[i] == value) { v.erase(v.begin() + i); return; }
+	}
+}
+
 namespace BoltTemp
 {
 	EBoltExt::ExtData* ExtData = nullptr;
@@ -58,11 +68,33 @@ DWORD _cdecl EBoltExt::_EBolt_Draw_Colors(REGISTERS* R)
 	BoltTemp::ExtData = pExt;
 	BoltTemp::FogHidden = false;
 
+	#if FOW_DEBUG
+	static int totalBolts = 0;
+	if (totalBolts++ < 10) {
+		Debug::Log("[FOW] EBolt fog check: ScenarioClass=%p FogOfWar=%d Owner=%p\n",
+			ScenarioClass::Instance,
+			(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar) ? 1 : 0,
+			pThis->Owner);
+	}
+	#endif
+
 	// DESYNC SAFETY: Only apply fog gating for local player's view
 	// This is purely visual and must not affect game simulation or synchronized state
 	if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar) {
+		#if FOW_DEBUG
+		if (totalBolts <= 10) {
+			Debug::Log("[FOW] EBolt in fog mode: CurrentPlayer=%p SpySat=%d\n",
+				HouseClass::CurrentPlayer,
+				HouseClass::CurrentPlayer ? (HouseClass::CurrentPlayer->SpySatActive ? 1 : 0) : -1);
+		}
+		#endif
 		if (auto* me = HouseClass::CurrentPlayer; me && !me->SpySatActive) {
 			// Owner-only fog gate: if you can see the shooter, you can see their bolt
+			#if FOW_DEBUG
+			if (totalBolts <= 10) {
+				Debug::Log("[FOW] EBolt owner check: Owner=%p\n", pThis->Owner);
+			}
+			#endif
 			if (pThis->Owner) {
 				// Convert to cell → back to the cell center; clamp Z to 0 so height can't bite us
 				CoordStruct ownerWorld = pThis->Owner->GetCoords();
@@ -95,13 +127,54 @@ DWORD _cdecl EBoltExt::_EBolt_Draw_Colors(REGISTERS* R)
 
 				#if FOW_DEBUG
 				if (debugCount <= 20) {
-					Debug::Log("[FOW] Fog methods: coord=%d cell=%d\n", foggedByCoord ? 1 : 0, foggedByCell ? 1 : 0);
+					Debug::Log("[FOW] Fog methods: cell=%d\n", foggedByCell ? 1 : 0);
 				}
 				#endif
 
 				// Use cell-based method since coord-based is giving wrong results
 				if (foggedByCell) {
 					BoltTemp::FogHidden = true;
+				}
+			} else {
+				#if FOW_DEBUG
+				if (totalBolts <= 10) {
+					Debug::Log("[FOW] EBolt has no owner - using source/target coords for fog check\n");
+				}
+				#endif
+
+				// Fallback for EBolts without owners (like shrapnel) - check source and target
+				bool sourceVisible = false, targetVisible = false;
+
+				// Check source coordinates (Point1)
+				CoordStruct sourceCoords = pThis->Point1;
+				CellStruct sourceCell = CellClass::Coord2Cell(sourceCoords);
+				if (auto* sourceCellObj = MapClass::Instance.GetCellAt(sourceCell)) {
+					sourceVisible = !sourceCellObj->IsFogged();
+				}
+
+				// Check target coordinates (Point2)
+				CoordStruct targetCoords = pThis->Point2;
+				CellStruct targetCell = CellClass::Coord2Cell(targetCoords);
+				if (auto* targetCellObj = MapClass::Instance.GetCellAt(targetCell)) {
+					targetVisible = !targetCellObj->IsFogged();
+				}
+
+				#if FOW_DEBUG
+				if (totalBolts <= 10) {
+					Debug::Log("[FOW] EBolt endpoint fog check: source(%d,%d)=%s target(%d,%d)=%s\n",
+						sourceCell.X, sourceCell.Y, sourceVisible ? "visible" : "fogged",
+						targetCell.X, targetCell.Y, targetVisible ? "visible" : "fogged");
+				}
+				#endif
+
+				// Hide EBolt if both endpoints are fogged (either-endpoint visible policy)
+				if (!sourceVisible && !targetVisible) {
+					BoltTemp::FogHidden = true;
+					#if FOW_DEBUG
+					if (totalBolts <= 10) {
+						Debug::Log("[FOW] EBolt both endpoints fogged - hiding\n");
+					}
+					#endif
 				}
 			}
 		}
@@ -134,6 +207,13 @@ DEFINE_HOOK(0x4C20BC, EBolt_DrawArcs, 0xB)
 DEFINE_JUMP(LJMP, 0x4C24BE, 0x4C24C3)// Disable Ares's hook EBolt_Draw_Color1
 DEFINE_HOOK(0x4C24C3, EBolt_DrawFirst_Color, 0x9)
 {
+	// TRIPWIRE: If this executes you will SEE magenta bolts briefly
+	static int trip = 0;
+	if (trip++ < 3) {
+		Debug::Log("[FOW] TRIPWIRE: EBolt hook running - you should see magenta bolt!\n");
+		R->EAX(Drawing::RGB_To_Int(ColorStruct{255, 0, 255})); // Bright magenta
+		return 0x4C24E4; // continue with forced color
+	}
 
 	#if FOW_DEBUG
 	static int c=0;
@@ -201,7 +281,7 @@ void EBoltFake::_RemoveFromOwner()
 {
 	auto const pExt = TechnoExt::ExtMap.Find(this->Owner);
 	auto& vec = pExt->ElectricBolts;
-	vec.erase(std::remove(vec.begin(), vec.end(), this), vec.end());
+	stable_erase_first(vec, static_cast<EBolt*>(this)); // Performance optimization: was erase(remove(...))
 	this->Owner = nullptr;
 }
 

--- a/src/Ext/EBolt/Hooks.cpp
+++ b/src/Ext/EBolt/Hooks.cpp
@@ -6,11 +6,22 @@
 #include <Utilities/Macro.h>
 #include <Utilities/AresHelper.h>
 #include <Helpers/Macro.h>
+#include <Misc/FogOfWar.h>
+
+#define FOW_DEBUG 1
+
+// Static initializer to confirm this DLL is loaded
+namespace {
+	struct _EBoltInitPing {
+		_EBoltInitPing() { Debug::Log("[FOW] EBolt hooks compiled into this build.\n"); }
+	} _eboltInitPing;
+}
 
 namespace BoltTemp
 {
 	EBoltExt::ExtData* ExtData = nullptr;
 	int Color[3];
+	bool FogHidden = false; // Flag to track if current bolt should be hidden due to fog
 }
 
 // Skip create particlesystem in EBolt::Fire
@@ -43,24 +54,103 @@ DWORD _cdecl EBoltExt::_EBolt_Draw_Colors(REGISTERS* R)
 {
 	enum { SkipGameCode = 0x4C1F66 };
 
-	GET(EBolt*, pThis, ECX);
-	const auto pExt = BoltTemp::ExtData = EBoltExt::ExtMap.Find(pThis);
-	const auto& color = pExt->Color;
+	// Always log first few calls to confirm hook is running
+	static int hookCount = 0;
+	if (hookCount < 3) {
+		Debug::Log("[FOW] _EBolt_Draw_Colors hook running (call #%d)\n", ++hookCount);
+	}
 
-	for (int idx = 0; idx < 3; ++idx)
-		BoltTemp::Color[idx] = Drawing::RGB_To_Int(color[idx]);
+	GET(EBolt*, pThis, ECX);
+	if (!pThis || !*(void**)pThis) return SkipGameCode;
+
+	auto* pExt = EBoltExt::ExtMap.Find(pThis);
+	if (!pExt) return SkipGameCode;
+
+	BoltTemp::ExtData = pExt;
+	BoltTemp::FogHidden = false;
+
+	// DESYNC SAFETY: Only apply fog gating for local player's view
+	// This is purely visual and must not affect game simulation or synchronized state
+	if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar) {
+		static int fogCheckCount = 0;
+		if (fogCheckCount++ < 3) {
+			Debug::Log("[FOW] FogOfWar is enabled, checking conditions (call #%d)\n", fogCheckCount);
+		}
+		if (auto* me = HouseClass::CurrentPlayer; me && !me->SpySatActive) {
+			// Owner-only fog gate: if you can see the shooter, you can see their bolt
+			if (pThis->Owner) {
+				// Convert to cell → back to the cell center; clamp Z to 0 so height can't bite us
+				CoordStruct ownerWorld = pThis->Owner->GetCoords();
+				const CellStruct ownerCell = CellClass::Coord2Cell(ownerWorld);
+				ownerWorld = CellClass::Cell2Coord(ownerCell);
+				ownerWorld.Z = 0;
+
+				#if FOW_DEBUG
+				static int debugCount = 0;
+				if (debugCount++ < 20) {
+					CoordStruct originalOwner = pThis->Owner->GetCoords();
+					Debug::Log("[FOW] EBolt coord compare: original(%d,%d,%d) cell(%d,%d) cellCenter(%d,%d,0) fogged=%d\n",
+						originalOwner.X, originalOwner.Y, originalOwner.Z,
+						ownerCell.X, ownerCell.Y, ownerWorld.X, ownerWorld.Y,
+						Fog::IsFogged(ownerWorld) ? 1 : 0);
+
+					// Also test the original coordinates for comparison
+					Debug::Log("[FOW] Original coord fogged=%d, cell center fogged=%d\n",
+						Fog::IsFogged(originalOwner) ? 1 : 0, Fog::IsFogged(ownerWorld) ? 1 : 0);
+				}
+				#endif
+
+				// Try different fog checking methods to find what matches visual fog
+				bool foggedByCoord = Fog::IsFogged(ownerWorld);
+				bool foggedByCell = false;
+
+				// Try direct cell fog check
+				auto* cellObj = MapClass::Instance.GetCellAt(ownerCell);
+				if (cellObj) {
+					foggedByCell = cellObj->IsFogged();
+				}
+
+				#if FOW_DEBUG
+				if (debugCount <= 20) {
+					Debug::Log("[FOW] Fog methods: coord=%d cell=%d\n", foggedByCoord ? 1 : 0, foggedByCell ? 1 : 0);
+				}
+				#endif
+
+				// Use cell-based method since coord-based is giving wrong results
+				if (foggedByCell) {
+					BoltTemp::FogHidden = true;
+				}
+			}
+		}
+	}
+
+	// Always populate colors; some code expects them even if we end up hidden
+	const auto& color = pExt->Color;
+	for (int i = 0; i < 3; ++i)
+		BoltTemp::Color[i] = Drawing::RGB_To_Int(color[i]);
 
 	return SkipGameCode;
 }
 
 DEFINE_HOOK(0x4C1F33, EBolt_Draw_Colors, 0x7)
 {
+	static int hookTest = 0;
+	if (hookTest++ < 3) {
+		Debug::Log("[FOW] EBolt_Draw_Colors hook entry (call #%d)\n", hookTest);
+	}
 	return EBoltExt::_EBolt_Draw_Colors(R);
 }
 
 DEFINE_HOOK(0x4C20BC, EBolt_DrawArcs, 0xB)
 {
 	enum { DoLoop = 0x4C20C7, Break = 0x4C2400 };
+
+	// Reduced logging to prevent performance issues
+	static int arcTest = 0;
+	if (arcTest < 2) {
+		arcTest++;
+		Debug::Log("[FOW] EBolt_DrawArcs: FogHidden=%d\n", BoltTemp::FogHidden ? 1 : 0);
+	}
 
 	GET_STACK(int, plotIndex, STACK_OFFSET(0x408, -0x3E0));
 	const int arcCount = BoltTemp::ExtData->Arcs;
@@ -71,7 +161,22 @@ DEFINE_HOOK(0x4C20BC, EBolt_DrawArcs, 0xB)
 DEFINE_JUMP(LJMP, 0x4C24BE, 0x4C24C3)// Disable Ares's hook EBolt_Draw_Color1
 DEFINE_HOOK(0x4C24C3, EBolt_DrawFirst_Color, 0x9)
 {
-	if (BoltTemp::ExtData->Disable[0])
+	// TRIPWIRE: If this executes you will SEE magenta bolts briefly
+	static int trip = 0;
+	if (trip++ < 3) {
+		R->EAX(Drawing::RGB_To_Int(ColorStruct{255, 0, 255})); // Bright magenta
+		return 0x4C24E4; // continue with forced color
+	}
+
+	#if FOW_DEBUG
+	static int c=0;
+	if (c++ < 5) {
+		Debug::Log("[FOW] EBolt_DrawFirst_Color: FogHidden=%d Disable[0]=%d\n",
+			BoltTemp::FogHidden ? 1 : 0, BoltTemp::ExtData->Disable[0] ? 1 : 0);
+	}
+	#endif
+
+	if (BoltTemp::FogHidden || BoltTemp::ExtData->Disable[0])
 		return 0x4C2515;
 
 	R->EAX(BoltTemp::Color[0]);
@@ -81,7 +186,7 @@ DEFINE_HOOK(0x4C24C3, EBolt_DrawFirst_Color, 0x9)
 DEFINE_JUMP(LJMP, 0x4C25CB, 0x4C25D0)// Disable Ares's hook EBolt_Draw_Color2
 DEFINE_HOOK(0x4C25D0, EBolt_DrawSecond_Color, 0x6)
 {
-	if (BoltTemp::ExtData->Disable[1])
+	if (BoltTemp::FogHidden || BoltTemp::ExtData->Disable[1])
 		return 0x4C262A;
 
 	R->Stack(STACK_OFFSET(0x424, -0x40C), BoltTemp::Color[1]);
@@ -91,7 +196,7 @@ DEFINE_HOOK(0x4C25D0, EBolt_DrawSecond_Color, 0x6)
 DEFINE_JUMP(LJMP, 0x4C26CF, 0x4C26D5)// Disable Ares's hook EBolt_Draw_Color3
 DEFINE_HOOK(0x4C26D5, EBolt_DrawThird_Color, 0x6)
 {
-	if (BoltTemp::ExtData->Disable[2])
+	if (BoltTemp::FogHidden || BoltTemp::ExtData->Disable[2])
 		return 0x4C2710;
 
 	R->EAX(BoltTemp::Color[2]);

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -98,6 +98,8 @@ public:
 		Valueable<double> HeightShadowScaling_MinScale;
 		double AirShadowBaseScale_log;
 
+		Valueable<bool> RemoveShroudGlobally;
+
 		Valueable<bool> ExtendedAircraftMissions;
 		Valueable<int> ExtendedAircraftMissions_UnlandDamage;
 		Valueable<bool> AmphibiousEnter;
@@ -523,4 +525,6 @@ public:
 	{
 		Global()->InvalidatePointer(ptr, removed);
 	}
+
+	static void ApplyRemoveShroudGlobally();
 };

--- a/src/Ext/Sidebar/Placement.cpp
+++ b/src/Ext/Sidebar/Placement.cpp
@@ -1,0 +1,103 @@
+#include <Phobos.h>
+#include <Misc/FogOfWar.h>
+
+#include <WWMouseClass.h>
+#include <TacticalClass.h>
+#include <BuildingTypeClass.h>
+#include <HouseClass.h>
+
+// Producer-side fog gating for building placement
+// No binary patches, just client-side preview validation
+
+namespace BuildingPlacementFog {
+
+	// Check if building placement is allowed at current mouse position
+	bool PlacementAllowedHere(const BuildingTypeClass* pType, HouseClass* pHouse) {
+		if (!pType || !pHouse)
+			return true; // Let other validation handle null cases
+
+		// Only apply fog restrictions to human players
+		if (!pHouse->IsControlledByCurrentPlayer())
+			return true; // AI can place anywhere
+
+		// Only apply if fog of war is enabled
+		if (!ScenarioClass::Instance->SpecialFlags.FogOfWar)
+			return true; // No restrictions if fog disabled
+
+		// Get mouse world coordinates
+		if (!WWMouseClass::Instance || !TacticalClass::Instance)
+			return true; // Safety check - allow if instances not ready
+
+		const Point2D mouse = WWMouseClass::Instance->XY1;
+		const CoordStruct world = TacticalClass::Instance->ClientToCoords(mouse);
+
+		// Use the safe helper function
+		return CanPlaceBuildingInFog(world, const_cast<BuildingTypeClass*>(pType));
+	}
+
+	// Check if specific coordinates allow building placement
+	bool PlacementAllowedAt(const CoordStruct& coords, const BuildingTypeClass* pType, HouseClass* pHouse) {
+		if (!pType || !pHouse)
+			return true;
+
+		// Only apply fog restrictions to human players
+		if (!pHouse->IsControlledByCurrentPlayer())
+			return true;
+
+		// Only apply if fog of war is enabled
+		if (!ScenarioClass::Instance->SpecialFlags.FogOfWar)
+			return true;
+
+		// Use the safe helper function
+		return CanPlaceBuildingInFog(coords, const_cast<BuildingTypeClass*>(pType));
+	}
+
+	// Wrapper for AI placement that respects fog (if desired)
+	bool AIPlacementAllowedAt(const CoordStruct& coords, const BuildingTypeClass* pType) {
+		if (!pType)
+			return true;
+
+		// For AI, you might want different rules
+		// Currently allows AI to place anywhere, but you can customize this
+		return true;
+	}
+
+	// Check if deployment (MCV -> Construction Yard) is allowed
+	bool DeploymentAllowedHere(HouseClass* pHouse) {
+		if (!pHouse || !pHouse->IsControlledByCurrentPlayer())
+			return true; // AI can deploy anywhere
+
+		if (!ScenarioClass::Instance->SpecialFlags.FogOfWar)
+			return true; // No restrictions if fog disabled
+
+		// Get mouse world coordinates
+		if (!WWMouseClass::Instance || !TacticalClass::Instance)
+			return true;
+
+		const Point2D mouse = WWMouseClass::Instance->XY1;
+		const CoordStruct world = TacticalClass::Instance->ClientToCoords(mouse);
+
+		// For deployment, just check the single cell
+		return Fog::ShouldShowActiveAt(world);
+	}
+}
+
+// Usage examples in your UI/sidebar code:
+//
+// In building placement preview logic:
+//   if (!BuildingPlacementFog::PlacementAllowedHere(buildingType, currentPlayer)) {
+//       // Show red preview, block placement
+//       return false;
+//   }
+//
+// In MCV deployment logic:
+//   if (!BuildingPlacementFog::DeploymentAllowedHere(currentPlayer)) {
+//       // Block deployment, show message
+//       return false;
+//   }
+//
+// For AI placement validation:
+//   if (!BuildingPlacementFog::AIPlacementAllowedAt(coords, buildingType)) {
+//       // AI finds different location
+//       return false;
+//   }

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -38,6 +38,11 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 		// Use the helper added for the NaturalParticleSystem gate
 		if (FoW::EnemyTechnoUnderFog(pThis)) {
 			// Clean up all particle systems that could leak info
+			if (auto* ps = pThis->NaturalParticleSystem) {
+				Debug::Log("DEBUG: Destroying NaturalParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->NaturalParticleSystem = nullptr;
+			}
 			if (auto* ps = pThis->DamageParticleSystem) {
 				Debug::Log("DEBUG: Destroying DamageParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
 				ps->UnInit();

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -18,13 +18,63 @@
 #include <Ext/Scenario/Body.h>
 #include <Utilities/EnumFunctions.h>
 #include <Utilities/AresFunctions.h>
+#include <Misc/FogOfWar.h>
 
 
 // TechnoClass_AI_0x6F9E50
 // It's not recommended to do anything more here it could have a better place for performance consideration
 void TechnoExt::ExtData::OnEarlyUpdate()
 {
-	auto const pType = this->OwnerObject()->GetTechnoType();
+	auto* const pThis = this->OwnerObject();
+	auto const pType = pThis->GetTechnoType();
+
+	// Hide enemy particles under fog (client-side only)
+	if (ScenarioClass::Instance
+		&& ScenarioClass::Instance->SpecialFlags.FogOfWar
+		&& HouseClass::CurrentPlayer
+		&& pThis && pThis->Owner
+		&& !HouseClass::CurrentPlayer->IsAlliedWith(pThis->Owner))
+	{
+		// Use the helper added for the NaturalParticleSystem gate
+		if (FoW::EnemyTechnoUnderFog(pThis)) {
+			// Clean up all particle systems that could leak info
+			if (auto* ps = pThis->DamageParticleSystem) {
+				Debug::Log("DEBUG: Destroying DamageParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->DamageParticleSystem = nullptr;
+			}
+			if (auto* ps = pThis->FireParticleSystem) {
+				Debug::Log("DEBUG: Destroying FireParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->FireParticleSystem = nullptr;
+			}
+			if (auto* ps = pThis->SparkParticleSystem) {
+				Debug::Log("DEBUG: Destroying SparkParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->SparkParticleSystem = nullptr;
+			}
+			if (auto* ps = pThis->RailgunParticleSystem) {
+				Debug::Log("DEBUG: Destroying RailgunParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->RailgunParticleSystem = nullptr;
+			}
+			if (auto* ps = pThis->FiringParticleSystem) {
+				Debug::Log("DEBUG: Destroying FiringParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->FiringParticleSystem = nullptr;
+			}
+			if (auto* ps = pThis->unk1ParticleSystem) {
+				Debug::Log("DEBUG: Destroying unk1ParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->unk1ParticleSystem = nullptr;
+			}
+			if (auto* ps = pThis->unk2ParticleSystem) {
+				Debug::Log("DEBUG: Destroying unk2ParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				ps->UnInit();
+				pThis->unk2ParticleSystem = nullptr;
+			}
+		}
+	}
 
 	// Set only if unset or type is changed
 	// Notice that Ares may handle type conversion in the same hook here, which is executed right before this one thankfully

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -28,18 +28,16 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 	auto* const pThis = this->OwnerObject();
 	auto const pType = pThis->GetTechnoType();
 
-	// Hide enemy particles under fog (client-side only)
+	// Hide particles under fog (client-side only) - now includes all technos, not just enemies
 	if (ScenarioClass::Instance
 		&& ScenarioClass::Instance->SpecialFlags.FogOfWar
-		&& HouseClass::CurrentPlayer
-		&& pThis && pThis->Owner
-		&& !HouseClass::CurrentPlayer->IsAlliedWith(pThis->Owner))
+		&& HouseClass::CurrentPlayer && pThis)
 	{
-		// Use the helper added for the NaturalParticleSystem gate
-		if (FoW::EnemyTechnoUnderFog(pThis)) {
+		// Use current visibility check (same as working refinery smoke hooks)
+		if (Fog::IsFogged(pThis->GetCoords())) {
 			// Clean up all particle systems that could leak info
 			if (auto* ps = pThis->NaturalParticleSystem) {
-				Debug::Log("DEBUG: Destroying NaturalParticleSystem for enemy %s under fog\n", pThis->GetTechnoType()->ID);
+				Debug::Log("DEBUG: Destroying NaturalParticleSystem for %s under fog\n", pThis->GetTechnoType()->ID);
 				ps->UnInit();
 				pThis->NaturalParticleSystem = nullptr;
 			}

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -121,6 +121,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// Miscs
 	this->Reveal.Read(exINI, pSection, "Reveal");
 	this->CreateGap.Read(exINI, pSection, "CreateGap");
+	this->RemoveShroudOnly.Read(exINI, pSection, "RemoveShroudOnly");
 	this->TransactMoney.Read(exINI, pSection, "TransactMoney");
 	this->TransactMoney_Display.Read(exINI, pSection, "TransactMoney.Display");
 	this->TransactMoney_Display_Houses.Read(exINI, pSection, "TransactMoney.Display.Houses");
@@ -400,6 +401,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 	Stm
 		.Process(this->Reveal)
 		.Process(this->CreateGap)
+		.Process(this->RemoveShroudOnly)
 		.Process(this->TransactMoney)
 		.Process(this->TransactMoney_Display)
 		.Process(this->TransactMoney_Display_Houses)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -23,6 +23,7 @@ public:
 
 		Valueable<int> Reveal;
 		Valueable<int> CreateGap;
+		Valueable<int> RemoveShroudOnly;
 		Valueable<int> TransactMoney;
 		Valueable<bool> TransactMoney_Display;
 		Valueable<AffectedHouse> TransactMoney_Display_Houses;

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -170,7 +170,15 @@ void WarheadTypeExt::ExtData::Detonate(TechnoClass* pOwner, HouseClass* pHouse, 
 			if (this->TransactMoney_Display)
 			{
 				auto displayCoords = this->TransactMoney_Display_AtFirer ? (pOwner ? pOwner->Location : coords) : coords;
-				FlyingStrings::AddMoneyString(this->TransactMoney, pHouse, this->TransactMoney_Display_Houses, displayCoords, this->TransactMoney_Display_Offset);
+
+				// Only show flying strings if location is visible (not fogged)
+				if (auto const pCell = MapClass::Instance.TryGetCellAt(displayCoords))
+				{
+					if (!pCell->IsFogged() && !pCell->IsShrouded())
+					{
+						FlyingStrings::AddMoneyString(this->TransactMoney, pHouse, this->TransactMoney_Display_Houses, displayCoords, this->TransactMoney_Display_Offset);
+					}
+				}
 			}
 		}
 

--- a/src/Ext/Weapon/FogEffects.cpp
+++ b/src/Ext/Weapon/FogEffects.cpp
@@ -1,0 +1,76 @@
+#include <Phobos.h>
+#include <Misc/FogOfWar.h>
+
+#include <LaserDrawClass.h>
+#include <ParticleSystemClass.h>
+#include <AnimClass.h>
+
+// Producer-side fog gating for weapon effects
+// No binary patches, no crashes - just don't create effects in fog
+
+namespace WeaponFog {
+
+	// Lasers - hide if either endpoint is fogged
+	bool SpawnLaserIfVisible(const CoordStruct& source, const CoordStruct& target,
+		const ColorStruct& innerColor, const ColorStruct& outerColor,
+		const ColorStruct& outerSpread, int duration) {
+
+		if (!Fog::ShouldShowActiveAt(source) || !Fog::ShouldShowActiveAt(target))
+			return false; // Don't spawn laser in fog
+
+		// Create the laser using existing game mechanics
+		auto pLaser = GameCreate<LaserDrawClass>(source, target, innerColor, outerColor, outerSpread, duration);
+		return pLaser != nullptr;
+	}
+
+	// Particles/sparks - hide if spawn location is fogged
+	bool SpawnParticleSystemIfVisible(const CoordStruct& at, ParticleSystemTypeClass* pType) {
+		if (!pType || !Fog::ShouldShowActiveAt(at))
+			return false;
+
+		// Create particle system at location
+		auto pSystem = GameCreate<ParticleSystemClass>(pType, at, nullptr, nullptr, CoordStruct::Empty, nullptr);
+		return pSystem != nullptr;
+	}
+
+	// Explosion animations - hide if explosion location is fogged
+	bool SpawnExplosionAnimIfVisible(const CoordStruct& at, AnimTypeClass* pType) {
+		if (!pType || !Fog::ShouldShowActiveAt(at))
+			return false;
+
+		// Create explosion animation
+		auto pAnim = GameCreate<AnimClass>(pType, at);
+		return pAnim != nullptr;
+	}
+
+	// Electric bolts/arcs - hide if either endpoint is fogged
+	bool SpawnElectricBoltIfVisible(const CoordStruct& source, const CoordStruct& target) {
+		if (!Fog::ShouldShowActiveAt(source) || !Fog::ShouldShowActiveAt(target))
+			return false;
+
+		// Your electric bolt creation logic here
+		// This is a placeholder - replace with actual implementation
+		return true;
+	}
+
+	// Weapon trail effects - hide if weapon location is fogged
+	bool SpawnWeaponTrailIfVisible(const CoordStruct& at, const CoordStruct& target) {
+		if (!Fog::ShouldShowActiveAt(at) || !Fog::ShouldShowActiveAt(target))
+			return false;
+
+		// Your weapon trail creation logic here
+		// This is a placeholder - replace with actual implementation
+		return true;
+	}
+}
+
+// Usage examples:
+// Replace direct laser creation:
+//   auto laser = GameCreate<LaserDrawClass>(source, target, colors...);
+// With:
+//   WeaponFog::SpawnLaserIfVisible(source, target, colors...);
+//
+// Replace direct particle creation:
+//   auto particles = GameCreate<ParticleSystemClass>(type, at, ...);
+// With:
+//   WeaponFog::SpawnParticleSystemIfVisible(at, type);

--- a/src/Misc/FogEffects.h
+++ b/src/Misc/FogEffects.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <CoordStruct.h>
+#include <ColorScheme.h>
+
+// Forward declarations
+class LaserDrawClass;
+class ParticleSystemTypeClass;
+class AnimTypeClass;
+class BuildingTypeClass;
+class HouseClass;
+
+// Producer-side fog effect wrappers
+// Safe, crash-free alternatives to low-level draw hooks
+
+// Weapon effects - hide active visuals in fog
+namespace WeaponFog {
+	bool SpawnLaserIfVisible(const CoordStruct& source, const CoordStruct& target,
+		const ColorStruct& innerColor, const ColorStruct& outerColor,
+		const ColorStruct& outerSpread, int duration);
+
+	bool SpawnParticleSystemIfVisible(const CoordStruct& at, ParticleSystemTypeClass* pType);
+	bool SpawnExplosionAnimIfVisible(const CoordStruct& at, AnimTypeClass* pType);
+	bool SpawnElectricBoltIfVisible(const CoordStruct& source, const CoordStruct& target);
+	bool SpawnWeaponTrailIfVisible(const CoordStruct& at, const CoordStruct& target);
+}
+
+// World text - hide floating text in fog
+namespace WorldTextFog {
+	void SpawnDamageTextIfVisible(int damage, const CoordStruct& at, ColorSchemeIndex color);
+	void SpawnBountyTextIfVisible(int credits, const CoordStruct& at, HouseClass* pHouse);
+	void SpawnCashDisplayTextIfVisible(int credits, const CoordStruct& at, HouseClass* pHouse);
+	void SpawnWorldTextIfVisible(const wchar_t* text, const CoordStruct& at, ColorSchemeIndex color, HouseClass* pHouse = nullptr);
+	void SpawnPromotionTextIfVisible(const wchar_t* rankText, const CoordStruct& at, HouseClass* pHouse);
+}
+
+// Building placement - block placement in fog
+namespace BuildingPlacementFog {
+	bool PlacementAllowedHere(const BuildingTypeClass* pType, HouseClass* pHouse);
+	bool PlacementAllowedAt(const CoordStruct& coords, const BuildingTypeClass* pType, HouseClass* pHouse);
+	bool AIPlacementAllowedAt(const CoordStruct& coords, const BuildingTypeClass* pType);
+	bool DeploymentAllowedHere(HouseClass* pHouse);
+}
+
+// Usage Guide:
+//
+// 1. Include this header: #include <Misc/FogEffects.h>
+//
+// 2. Replace direct effect creation with fog-aware wrappers:
+//    OLD: auto laser = GameCreate<LaserDrawClass>(source, target, colors...);
+//    NEW: WeaponFog::SpawnLaserIfVisible(source, target, colors...);
+//
+// 3. Replace direct text creation with fog-aware wrappers:
+//    OLD: FlyingStrings::AddMoneyString(text, at, color, house, true);
+//    NEW: WorldTextFog::SpawnDamageTextIfVisible(damage, at, color);
+//
+// 4. Add placement validation in your UI code:
+//    if (!BuildingPlacementFog::PlacementAllowedHere(type, house)) {
+//        // Show red preview, block placement
+//    }
+//
+// Benefits:
+// - Zero crashes (no binary patches)
+// - Engine-friendly (works with existing fog mechanics)
+// - Easy to use (drop-in replacements)
+// - Maintainable (clear separation of concerns)

--- a/src/Misc/FogOfWar.cpp
+++ b/src/Misc/FogOfWar.cpp
@@ -735,7 +735,8 @@ DEFINE_HOOK(0x51F95F, InfantryClass_GetCursorOverCell_OverFog, 0x6)
 			{
 				pType = pObject->BuildingData.Type;
 
-				if (pThis->Type->Engineer && pThis->Owner->IsControlledByCurrentPlayer())
+				// Safety check: Ensure pType is valid before accessing its members
+				if (pType && pThis->Type->Engineer && pThis->Owner->IsControlledByCurrentPlayer())
 				{
 					if (pType->BridgeRepairHut)
 					{

--- a/src/Misc/FogOfWar.cpp
+++ b/src/Misc/FogOfWar.cpp
@@ -1,0 +1,610 @@
+#include <Phobos.h>
+
+#include <Helpers/Macro.h>
+
+#include <Ext/Cell/Body.h>
+#include <New/Entity/FoggedObject.h>
+
+#include <Misc/MapRevealer.h>
+
+#include <AnimClass.h>
+#include <TerrainClass.h>
+#include <ScenarioClass.h>
+#include <Drawing.h>
+#include <OverlayTypeClass.h>
+#include <InfantryClass.h>
+#include <InfantryTypeClass.h>
+
+DEFINE_HOOK(0x6B8E7A, ScenarioClass_LoadSpecialFlags, 0x5)
+{
+	ScenarioClass::Instance->SpecialFlags.FogOfWar =
+		RulesClass::Instance->FogOfWar || R->EAX<bool>() || GameModeOptionsClass::Instance.FogOfWar;
+
+	R->ECX(R->EDI());
+	return 0x6B8E8B;
+}
+
+DEFINE_HOOK(0x686C03, SetScenarioFlags_FogOfWar, 0x5)
+{
+	GET(ScenarioFlags, SFlags, EAX);
+
+	SFlags.FogOfWar = RulesClass::Instance->FogOfWar || GameModeOptionsClass::Instance.FogOfWar;
+
+	R->EDX<int>(*reinterpret_cast<int*>(&SFlags));
+	return 0x686C0E;
+}
+
+DEFINE_HOOK(0x5F4B3E, ObjectClass_DrawIfVisible, 0x6)
+{
+	GET(ObjectClass*, pThis, ESI);
+
+	if (pThis->InLimbo)
+		return 0x5F4B7F;
+
+	if (!ScenarioClass::Instance->SpecialFlags.FogOfWar)
+		return 0x5F4B48;
+
+	// SpySat reveals everything, so bypass fog checks when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+		return 0x5F4B48;
+
+	switch (pThis->WhatAmI())
+	{
+	case AbstractType::Anim:
+		if (!static_cast<AnimClass*>(pThis)->Type->ShouldFogRemove)
+			return 0x5F4B48;
+		break;
+
+	case AbstractType::Unit:
+	case AbstractType::Cell:
+	case AbstractType::Building:  // Allow buildings to be processed for fog
+		break;
+
+	default:
+		return 0x5F4B48;
+	}
+
+	if (!MapClass::Instance.IsLocationFogged(pThis->GetCoords()))
+		return 0x5F4B48;
+
+	pThis->NeedsRedraw = false;
+	return 0x5F4D06;
+}
+
+DEFINE_HOOK(0x6F5190, TechnoClass_DrawExtras_CheckFog, 0x6)
+{
+	GET(TechnoClass*, pThis, ECX);
+
+	return MapClass::Instance.IsLocationFogged(pThis->GetCoords()) ? 0x6F5EEC : 0;
+}
+
+DEFINE_HOOK(0x6D6EDA, TacticalClass_Overlay_CheckFog1, 0xA)
+{
+	GET(CellClass*, pCell, EAX);
+
+	// SpySat reveals entire map, so no cell is fogged when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+		return pCell->OverlayTypeIndex == -1 ? 0x6D7006 : 0x6D6EE4;
+
+	return pCell->OverlayTypeIndex == -1 || pCell->IsFogged() ? 0x6D7006 : 0x6D6EE4;
+}
+
+DEFINE_HOOK(0x6D70BC, TacticalClass_Overlay_CheckFog2, 0xA)
+{
+	GET(CellClass*, pCell, EAX);
+
+	// SpySat reveals entire map, so no cell is fogged when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+		return pCell->OverlayTypeIndex == -1 ? 0x6D71A4 : 0x6D70C6;
+
+	return pCell->OverlayTypeIndex == -1 || pCell->IsFogged() ? 0x6D71A4 : 0x6D70C6;
+}
+
+DEFINE_HOOK(0x71CC8C, TerrainClass_DrawIfVisible, 0x6)
+{
+	GET(TerrainClass*, pThis, EDI);
+	pThis->NeedsRedraw = false;
+
+	return pThis->InLimbo || MapClass::Instance.IsLocationFogged(pThis->GetCoords()) ? 0x71CD8D : 0x71CC9A;
+}
+
+DEFINE_HOOK(0x4804A4, CellClass_DrawTile_DrawSmudgeIfVisible, 0x6)
+{
+	GET(CellClass*, pThis, ESI);
+
+	// SpySat reveals entire map, so no cell is fogged when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+		return 0;
+
+	return pThis->IsFogged() ? 0x4804FB : 0;
+}
+
+DEFINE_HOOK(0x5865E2, MapClass_IsLocationFogged, 0x3)
+{
+	GET_STACK(CoordStruct*, pCoord, 0x4);
+
+	// SpySat reveals entire map (both fog and shroud), so no location is fogged when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+	{
+		R->EAX<bool>(false);
+		return 0;
+	}
+
+	MapRevealer revealer(*pCoord);
+	CellClass* pCell = MapClass::Instance.GetCellAt(revealer.Base());
+
+	R->EAX<bool>(pCell->Flags & CellFlags::EdgeRevealed ?
+		false :
+		!(pCell->GetNeighbourCell(static_cast<FacingType>(3))->Flags & CellFlags::EdgeRevealed));
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6D7A4F, TacticalClass_DrawPixelEffects_FullFogged, 0x6)
+{
+	GET(CellClass*, pCell, ESI);
+
+	// SpySat reveals entire map, so no cell is fogged when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+		return 0;
+
+	return pCell->IsFogged() ? 0x6D7BB8 : 0;
+}
+
+
+DEFINE_HOOK(0x4ACE3C, MapClass_TryReshroudCell_SetCopyFlag, 0x6)
+{
+	GET(CellClass*, pCell, EAX);
+
+	bool bNoFog = static_cast<bool>(pCell->AltFlags & AltCellFlags::NoFog);
+	pCell->AltFlags &= ~AltCellFlags::NoFog;
+	int Index = TacticalClass::Instance->GetOcclusion(pCell->MapCoords, false);
+
+	if ((bNoFog || pCell->Visibility != Index) && Index >= 0 && pCell->Visibility >= -1)
+	{
+		pCell->AltFlags |= AltCellFlags::Mapped;
+		pCell->Visibility = static_cast<char>(Index);
+	}
+
+	TacticalClass::Instance->RegisterCellAsVisible(pCell);
+
+	return 0x4ACE57;
+}
+
+DEFINE_HOOK(0x4A9CA0, MapClass_RevealFogShroud, 0x8)
+{
+	GET(MapClass*, pThis, ECX);
+	GET_STACK(CellStruct*, pMapCoords, 0x4);
+	GET_STACK(HouseClass*, pHouse, 0x8);
+	GET_STACK(bool, bIncreaseShroudCounter, 0xC);
+
+	auto const pCell = pThis->GetCellAt(*pMapCoords);
+	bool bRevealed = false;
+	bool const bShouldCleanFog = !(pCell->Flags & CellFlags::EdgeRevealed);
+
+	if (bShouldCleanFog || !(pCell->AltFlags & AltCellFlags::Mapped))
+		bRevealed = true;
+
+	bool const bWasRevealed = bRevealed;
+
+	pCell->Flags = pCell->Flags & ~CellFlags::IsPlot | CellFlags::EdgeRevealed;
+	pCell->AltFlags = pCell->AltFlags & ~AltCellFlags::NoFog | AltCellFlags::Mapped;
+
+	if (bIncreaseShroudCounter)
+		pCell->IncreaseShroudCounter();
+	else
+		pCell->ReduceShroudCounter();
+
+	char Visibility = TacticalClass::Instance->GetOcclusion(*pMapCoords, false);
+	if (pCell->Visibility != Visibility)
+	{
+		bRevealed = true;
+		pCell->Visibility = Visibility;
+	}
+	if (pCell->Visibility == -1)
+		pCell->AltFlags |= AltCellFlags::NoFog;
+
+	char Foggness = TacticalClass::Instance->GetOcclusion(*pMapCoords, true);
+	if (pCell->Foggedness != Foggness)
+	{
+		bRevealed = true;
+		pCell->Foggedness = Foggness;
+	}
+	if (pCell->Foggedness == -1)
+		pCell->Flags |= CellFlags::CenterRevealed;
+
+	if (bRevealed)
+	{
+		TacticalClass::Instance->RegisterCellAsVisible(pCell);
+		pThis->RevealCheck(pCell, pHouse, bWasRevealed);
+	}
+
+	if (bShouldCleanFog)
+		pCell->CleanFog();
+
+	R->EAX(bRevealed);
+
+	return 0x4A9DC6;
+}
+
+// CellClass_CleanFog
+DEFINE_HOOK(0x486C50, CellClass_ClearFoggedObjects, 0x6)
+{
+	GET(CellClass*, pThis, ECX);
+
+	auto pExt = CellExt::ExtMap.Find(pThis);
+	for (auto const pObject : pExt->FoggedObjects)
+	{
+		if (pObject->CoveredType == FoggedObject::CoveredType::Building)
+		{
+			CellClass* pRealCell = MapClass::Instance.GetCellAt(pObject->Location);
+
+			for (auto pFoundation = pObject->BuildingData.Type->GetFoundationData(false);
+				pFoundation->X != 0x7FFF || pFoundation->Y != 0x7FFF;
+				++pFoundation)
+			{
+				CellStruct mapCoord =
+				{
+					pRealCell->MapCoords.X + pFoundation->X,
+					pRealCell->MapCoords.Y + pFoundation->Y
+				};
+
+				CellClass* pCell = MapClass::Instance.GetCellAt(mapCoord);
+				if (pCell != pThis)
+					CellExt::ExtMap.Find(pCell)->FoggedObjects.Remove(pObject);
+			}
+
+		}
+		GameDelete(pObject);
+	}
+	pExt->FoggedObjects.Clear();
+
+	return 0x486D8A;
+}
+
+DEFINE_HOOK(0x486A70, CellClass_FogCell, 0x5)
+{
+	GET(CellClass*, pThis, ECX);
+
+	// SpySat reveals everything for the owning player, so actively remove fog instead of adding it
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+	{
+		// Clear fog from this cell and surrounding area
+		auto location = pThis->MapCoords;
+		for (int i = 1; i < 15; i += 2)
+		{
+			CellClass* pCell = MapClass::Instance.GetCellAt(location);
+			if (pCell->Flags & CellFlags::Fogged)
+			{
+				pCell->Flags &= ~CellFlags::Fogged;
+				// Also clear fogged objects from this cell
+				CellExt::ExtMap.Find(pCell)->FoggedObjects.Clear();
+			}
+		}
+		return 0x486BE6; // Skip normal fog processing
+	}
+
+	if (ScenarioClass::Instance->SpecialFlags.FogOfWar)
+	{
+		auto location = pThis->MapCoords;
+		for (int i = 1; i < 15; i += 2)
+		{
+			CellClass* pCell = MapClass::Instance.GetCellAt(location);
+			int nLevel = pCell->Level;
+
+			if (nLevel >= i - 2 && nLevel <= i)
+			{
+				if (!(pCell->Flags & CellFlags::Fogged))
+				{
+					pCell->Flags |= CellFlags::Fogged;
+
+					for (ObjectClass* pObject = pCell->FirstObject; pObject; pObject = pObject->NextObject)
+					{
+						switch (pObject->WhatAmI())
+						{
+						case AbstractType::Unit:
+						case AbstractType::Infantry:
+						case AbstractType::Aircraft:
+							pObject->Deselect();
+							break;
+
+						case AbstractType::Building:
+							if (BuildingClass* pBld = abstract_cast<BuildingClass*>(pObject))
+							{
+								if (pBld->IsAllFogged())
+									pBld->FreezeInFog(nullptr, pCell, !pBld->IsStrange() && pBld->Translucency != 15);
+							}
+							break;
+
+						case AbstractType::Terrain:
+							if (TerrainClass* pTerrain = abstract_cast<TerrainClass*>(pObject))
+							{
+								// pTerrain
+								FoggedObject* pFoggedTer = GameCreate<FoggedObject>(pTerrain);
+								CellExt::ExtMap.Find(pCell)->FoggedObjects.AddItem(pFoggedTer);
+							}
+							break;
+
+						default:
+							continue;
+						}
+					}
+					if (pCell->OverlayTypeIndex != -1)
+					{
+						FoggedObject* pFoggedOvl = GameCreate<FoggedObject>(pCell, true);
+						CellExt::ExtMap.Find(pCell)->FoggedObjects.AddItem(pFoggedOvl);
+					}
+					if (pCell->SmudgeTypeIndex != -1)
+					{
+						FoggedObject* pFoggedSmu = GameCreate<FoggedObject>(pCell, false);
+						CellExt::ExtMap.Find(pCell)->FoggedObjects.AddItem(pFoggedSmu);
+					}
+				}
+			}
+
+			++location.X;
+			++location.Y;
+		}
+	}
+
+	return 0x486BE6;
+}
+
+DEFINE_HOOK(0x457AA0, BuildingClass_FreezeInFog, 0x5)
+{
+	GET(BuildingClass*, pThis, ECX);
+	GET_STACK(CellClass*, pCell, 0x8);
+	GET_STACK(bool, IsVisible, 0xC);
+
+	// SpySat reveals everything, so don't freeze buildings in fog when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+	{
+		// When SpySat is active, clear all existing fogged buildings (one-time cleanup)
+		static bool hasUnfrozen = false;
+		if (!hasUnfrozen) {
+			hasUnfrozen = true;
+			
+			// Iterate through all cells and properly unfreeze buildings using CleanFog
+			LTRBStruct bounds = MapClass::Instance.MapCoordBounds;
+			for (int y = bounds.Top; y < bounds.Bottom; y++) {
+				for (int x = bounds.Left; x < bounds.Right; x++) {
+					CellStruct cellCoord { static_cast<short>(x), static_cast<short>(y) };
+					if (auto pCurrentCell = MapClass::Instance.TryGetCellAt(cellCoord)) {
+						// Clear fog flag
+						pCurrentCell->Flags &= ~CellFlags::Fogged;
+						
+						// Properly clean fog from this cell (this should restore building animations)
+						pCurrentCell->CleanFog();
+					}
+				}
+			}
+		}
+		
+		// Reset flag when SpySat goes offline
+		static bool wasActive = true;
+		if (!HouseClass::CurrentPlayer->SpySatActive && wasActive) {
+			hasUnfrozen = false;
+		}
+		wasActive = HouseClass::CurrentPlayer->SpySatActive;
+		
+		return 0x457C80; // Skip fog freezing
+	}
+
+	if (!pCell)
+		pCell = pThis->GetCell();
+
+	pThis->Deselect();
+	FoggedObject* pFoggedBld = GameCreate<FoggedObject>(pThis, IsVisible);
+	CellExt::ExtMap.Find(pCell)->FoggedObjects.AddItem(pFoggedBld);
+
+	auto MapCoords = pThis->GetMapCoords();
+
+	for (auto pFoundation = pThis->Type->GetFoundationData(false);
+		pFoundation->X != 0x7FFF || pFoundation->Y != 0x7FFF;
+		++pFoundation)
+	{
+		CellStruct currentMapCoord { MapCoords.X + pFoundation->X,MapCoords.Y + pFoundation->Y };
+		CellClass* pCurrentCell = MapClass::Instance.GetCellAt(currentMapCoord);
+		if (pCurrentCell != pCell)
+			CellExt::ExtMap.Find(pCurrentCell)->FoggedObjects.AddItem(pFoggedBld);
+	}
+
+	return 0x457C80;
+}
+
+// 486C50 = CellClass_ClearFoggedObjects, 6 Dumplcate
+
+DEFINE_HOOK(0x70076E, TechnoClass_GetCursorOverCell_OverFog, 0x5)
+{
+	GET(CellClass*, pCell, EBP);
+	auto const pExt = CellExt::ExtMap.Find(pCell);
+
+	int nOvlIdx = -1;
+	for (auto const pObject : pExt->FoggedObjects)
+	{
+		if (pObject->Visible)
+		{
+			if (pObject->CoveredType == FoggedObject::CoveredType::Overlay)
+				nOvlIdx = pObject->OverlayData.Overlay;
+			else if (pObject->CoveredType == FoggedObject::CoveredType::Building)
+			{
+				if (HouseClass::CurrentPlayer->IsAlliedWith(pObject->BuildingData.Owner) && pObject->BuildingData.Type->LegalTarget)
+					R->Stack<bool>(STACK_OFFSET(0x2C, 0x19), true);
+			}
+		}
+	}
+
+	if (nOvlIdx != -1)
+		R->Stack<OverlayTypeClass*>(STACK_OFFSET(0x2C, 0x18), OverlayTypeClass::Array.GetItem(nOvlIdx));
+
+	return 0x700815;
+}
+
+DEFINE_HOOK(0x51F95F, InfantryClass_GetCursorOverCell_OverFog, 0x6)
+{
+	GET(InfantryClass*, pThis, EDI);
+	GET(CellClass*, pCell, EAX);
+	GET_STACK(const bool, bFog, STACK_OFFSET(0x1C, -0x8));
+
+	BuildingTypeClass* pType = nullptr;
+	int ret = 0x51FA93;
+
+	do
+	{
+		if (!ScenarioClass::Instance->SpecialFlags.FogOfWar || !bFog)
+			break;
+
+		for (const auto pObject : CellExt::ExtMap.Find(pCell)->FoggedObjects)
+		{
+			if (pObject->Visible && pObject->CoveredType == FoggedObject::CoveredType::Building)
+			{
+				pType = pObject->BuildingData.Type;
+
+				if (pThis->Type->Engineer && pThis->Owner->IsControlledByCurrentPlayer())
+				{
+					if (pType->BridgeRepairHut)
+					{
+						R->EAX(&pObject->Location);
+						ret = 0x51FA35;
+					}
+					else // Ares hook 51FA82 = InfantryClass_GetActionOnCell_EngineerRepairable, 6
+						ret = 0x51FA82;
+				}
+				break;
+			}
+		}
+	}
+	while (false);
+
+	R->EBP(pType);
+	return ret;
+}
+
+DEFINE_HOOK(0x6D3470, TacticalClass_DrawFoggedObject, 0x8)
+{
+	GET(TacticalClass*, pThis, ECX);
+	GET_STACK(RectangleStruct*, pRect1, 0x4);
+	GET_STACK(RectangleStruct*, pRect2, 0x8);
+	GET_STACK(bool, bForceViewBounds, 0xC);
+
+	// SpySat reveals everything, so don't draw fogged objects when SpySat is active
+	if (HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)
+		return 0x6D3650; // Skip fogged object rendering
+
+	RectangleStruct finalRect { 0,0,0,0 };
+	if (bForceViewBounds && DSurface::ViewBounds.Width > 0 && DSurface::ViewBounds.Height > 0)
+		finalRect = std::move(FoggedObject::Union(finalRect, DSurface::ViewBounds));
+	else
+	{
+		if (pRect1->Width > 0 && pRect1->Height > 0)
+			finalRect = std::move(FoggedObject::Union(finalRect, *pRect1));
+		if (pRect2->Width > 0 && pRect2->Height > 0)
+			finalRect = std::move(FoggedObject::Union(finalRect, *pRect2));
+
+		if (const auto nVisibleCellCount = pThis->VisibleCellCount)
+		{
+			RectangleStruct buffer;
+			buffer.Width = buffer.Height = 60;
+
+			for (int i = 0; i < nVisibleCellCount; ++i)
+			{
+				auto const pCell = pThis->VisibleCells[i];
+				auto location = pCell->GetCoords();
+				auto [point, visible] = TacticalClass::Instance->CoordsToClient(location);
+				buffer.X = DSurface::ViewBounds.X + point.X - 30;
+				buffer.Y = DSurface::ViewBounds.Y + point.Y;
+				finalRect = std::move(FoggedObject::Union(finalRect, buffer));
+			}
+		}
+
+		// TODO: Fix Drawing::DirtyAreas() access - may not exist in current Phobos
+		//for (int i = 0; i < Drawing::DirtyAreas().Count; i++)
+		//{
+		//	RectangleStruct buffer = Drawing::DirtyAreas()[i].Rect;
+		//	buffer.Y += DSurface::ViewBounds.Y;
+		//	if (buffer.Width > 0 && buffer.Height > 0)
+		//		finalRect = std::move(FoggedObject::Union(finalRect, buffer));
+		//}
+	}
+
+	if (finalRect.Width > 0 && finalRect.Height > 0)
+	{
+		finalRect.X = std::max(finalRect.X, 0);
+		finalRect.Y = std::max(finalRect.Y, 0);
+		finalRect.Width = std::min(finalRect.Width, DSurface::ViewBounds.Width - finalRect.X);
+		finalRect.Height = std::min(finalRect.Height, DSurface::ViewBounds.Height - finalRect.Y);
+
+		for (const auto pObject : FoggedObject::FoggedObjects)
+			pObject->Render(finalRect);
+	}
+
+	return 0x6D3650;
+}
+
+DEFINE_HOOK(0x4ADFF0, MapClass_RevealMapShroud, 0x5)
+{
+	GET_STACK(bool, bHideBuilding, 0x4);
+	GET_STACK(bool, bFog, 0x8);
+
+	for (int i = 0; i < TechnoClass::Array.Count; i++)
+	{
+		auto const pTechno = TechnoClass::Array.GetItem(i);
+
+		if (pTechno->WhatAmI() != AbstractType::Building || !bHideBuilding)
+		{
+			if (pTechno->GetTechnoType()->RevealToAll ||
+				pTechno->DiscoveredByCurrentPlayer && pTechno->Owner->IsControlledByCurrentPlayer() ||
+				RulesClass::Instance->AllyReveal && pTechno->Owner->IsAlliedWith(HouseClass::CurrentPlayer))
+			{
+				pTechno->See(0, bFog);
+				if (pTechno->IsInAir())
+					MapClass::Instance.RevealArea3(&pTechno->Location,
+						pTechno->LastSightRange - 3, pTechno->LastSightRange + 3, false);
+			}
+		}
+	}
+
+	return 0x4AE0A5;
+}
+
+DEFINE_HOOK(0x577EBF, MapClass_Reveal, 0x6)
+{
+	GET(CellClass*, pCell, EAX);
+
+	// Vanilla YR code
+	pCell->ShroudCounter = 0;
+	pCell->GapsCoveringThisCell = 0;
+	pCell->AltFlags |= AltCellFlags::Clear;
+	pCell->Flags |= CellFlags::Revealed;
+
+	// Extra process
+	pCell->CleanFog();
+
+	return 0x577EE9;
+}
+
+DEFINE_HOOK(0x586683, CellClass_DiscoverTechno, 0x5)
+{
+	GET(TechnoClass*, pTechno, EAX);
+	GET(CellClass*, pThis, ESI);
+	GET_STACK(HouseClass*, pHouse, STACK_OFFSET(0x18, -0x8));
+
+	if (pTechno)
+		pTechno->DiscoveredBy(pHouse);
+	if (pThis->Jumpjet)
+		pThis->Jumpjet->DiscoveredBy(pHouse);
+
+	// EAX seems not to be used actually, so we needn't to set EAX here
+
+	return 0x586696;
+}
+
+DEFINE_HOOK(0x4FC1FF, HouseClass_PlayerDefeated_MapReveal, 0x6)
+{
+	GET(HouseClass*, pHouse, ESI);
+
+	*(int*)0xA8B538 = 1;
+	MapClass::Instance.Reveal(pHouse);
+
+	return 0x4FC214;
+}

--- a/src/Misc/FogOfWar.cpp
+++ b/src/Misc/FogOfWar.cpp
@@ -181,6 +181,7 @@ DEFINE_HOOK(0x6F5190, TechnoClass_DrawExtras_CheckFog, 0x6)
 	return MapClass::Instance.IsLocationFogged(pThis->GetCoords()) ? 0x6F5EEC : 0;
 }
 
+
 DEFINE_HOOK(0x6D6EDA, TacticalClass_Overlay_CheckFog1, 0xA)
 {
 	GET(CellClass*, pCell, EAX);
@@ -493,7 +494,7 @@ DEFINE_HOOK(0x70076E, TechnoClass_GetCursorOverCell_OverFog, 0x5)
 				nOvlIdx = pObject->OverlayData.Overlay;
 			else if (pObject->CoveredType == FoggedObject::CoveredType::Building)
 			{
-				if (HouseClass::CurrentPlayer->IsAlliedWith(pObject->BuildingData.Owner) && pObject->BuildingData.Type->LegalTarget)
+				if (pObject->BuildingData.Owner && HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->IsAlliedWith(pObject->BuildingData.Owner) && pObject->BuildingData.Type->LegalTarget)
 					R->Stack<bool>(STACK_OFFSET(0x2C, 0x19), true);
 			}
 		}

--- a/src/Misc/FogOfWar.h
+++ b/src/Misc/FogOfWar.h
@@ -30,5 +30,22 @@ namespace Fog {
 	inline bool ShouldShowPassiveAt(const CoordStruct& c) { return !IsShrouded(c); }
 }
 
+// Helper for creation-time particle gates
+namespace FoW {
+	inline bool EnemyTechnoUnderFog(AbstractClass* owner) {
+		if (!(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar)) return false;
+		if (!HouseClass::CurrentPlayer || !owner) return false;
+
+		TechnoClass* t = abstract_cast<TechnoClass*>(owner);
+		if (!t) { if (auto* b = abstract_cast<BuildingClass*>(owner)) t = b; }
+		if (!t || !t->Owner) return false;
+		if (HouseClass::CurrentPlayer->IsAlliedWith(t->Owner)) return false;
+
+		const auto cs = CellClass::Coord2Cell(t->GetCoords());
+		const auto* cell = MapClass::Instance.TryGetCellAt(cs);
+		return !cell || !(cell->Flags & CellFlags::EdgeRevealed);
+	}
+}
+
 // Check if building placement should be allowed at location (respects fog like shroud)
 bool CanPlaceBuildingInFog(const CoordStruct& coords, BuildingTypeClass* pBuildingType);

--- a/src/Misc/FogOfWar.h
+++ b/src/Misc/FogOfWar.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <GeneralDefinitions.h>
+#include <BuildingTypeClass.h>
+#include <CellClass.h>
+#include <MapClass.h>
+#include <TacticalClass.h>
+
+// Central fog of war utility functions - safe, producer-side approach
+
+// Active = must be visible now; Passive = visible once revealed, hidden only by shroud.
+namespace Fog {
+	inline bool IsFogged(const CoordStruct& c) {
+		auto cs = CellClass::Coord2Cell(c);
+		auto* p = (&MapClass::Instance) ? MapClass::Instance.TryGetCellAt(cs) : nullptr;
+		CellStruct se{ short(cs.X + 1), short(cs.Y + 1) };
+		auto* pse = (&MapClass::Instance) ? MapClass::Instance.TryGetCellAt(se) : nullptr;
+		const bool e1 = p && (p->Flags & CellFlags::EdgeRevealed);
+		const bool e2 = pse && (pse->Flags & CellFlags::EdgeRevealed);
+		return !(e1 || e2);
+	}
+
+	inline bool IsShrouded(const CoordStruct& c) {
+		// Same test as above — engine treats 'edge revealed' as "ever seen".
+		return IsFogged(c);
+	}
+
+	// Policy helpers
+	inline bool ShouldShowActiveAt(const CoordStruct& c) { return !IsFogged(c); }
+	inline bool ShouldShowPassiveAt(const CoordStruct& c) { return !IsShrouded(c); }
+}
+
+// Check if building placement should be allowed at location (respects fog like shroud)
+bool CanPlaceBuildingInFog(const CoordStruct& coords, BuildingTypeClass* pBuildingType);

--- a/src/Misc/FogOfWar.h
+++ b/src/Misc/FogOfWar.h
@@ -32,6 +32,14 @@ namespace Fog {
 
 // Helper for creation-time particle gates
 namespace FoW {
+	inline bool IsUnrevealedForLocal(const CoordStruct& c) {
+		if (!(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar && HouseClass::CurrentPlayer))
+			return false;
+		const auto cs = CellClass::Coord2Cell(c);
+		const auto* cc = MapClass::Instance.TryGetCellAt(cs);
+		return !cc || !(cc->Flags & CellFlags::EdgeRevealed);
+	}
+
 	inline bool EnemyTechnoUnderFog(AbstractClass* owner) {
 		if (!(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar)) return false;
 		if (!HouseClass::CurrentPlayer || !owner) return false;
@@ -41,9 +49,7 @@ namespace FoW {
 		if (!t || !t->Owner) return false;
 		if (HouseClass::CurrentPlayer->IsAlliedWith(t->Owner)) return false;
 
-		const auto cs = CellClass::Coord2Cell(t->GetCoords());
-		const auto* cell = MapClass::Instance.TryGetCellAt(cs);
-		return !cell || !(cell->Flags & CellFlags::EdgeRevealed);
+		return IsUnrevealedForLocal(t->GetCoords());
 	}
 }
 

--- a/src/Misc/Hooks.LaserDraw.cpp
+++ b/src/Misc/Hooks.LaserDraw.cpp
@@ -5,6 +5,9 @@
 #include <Utilities/Debug.h>
 #include <Utilities/Macro.h>
 #include <Utilities/GeneralUtils.h>
+#include <Misc/FogOfWar.h>
+
+#define LASER_FOW_DEBUG 0
 
 namespace LaserDrawTemp
 {

--- a/src/Misc/Hooks.LaserDraw.cpp
+++ b/src/Misc/Hooks.LaserDraw.cpp
@@ -6,12 +6,44 @@
 #include <Utilities/Macro.h>
 #include <Utilities/GeneralUtils.h>
 #include <Misc/FogOfWar.h>
+#include <ScenarioClass.h>
+#include <HouseClass.h>
+#include <MapClass.h>
+#include <CellClass.h>
 
 #define LASER_FOW_DEBUG 0
 
 namespace LaserDrawTemp
 {
 	ColorStruct maxColor;
+	bool FogHidden = false; // Flag to track if current laser should be hidden due to fog
+}
+
+// Simple fog gate for vanilla lasers - basic working version
+DEFINE_HOOK(0x550260, LaserDrawClass_Draw_FogGate, 0x6)
+{
+    enum { SkipDrawing = 0x5509D2 };
+
+    GET(LaserDrawClass*, pThis, ECX);
+    if(!pThis) return 0;
+
+    // Treat (0,0) source as fogged to avoid a single startup frame
+    if((pThis->Source.X | pThis->Source.Y) == 0) return SkipDrawing;
+
+    // Simple fog check using source coordinates
+    if(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar) {
+        if(HouseClass::CurrentPlayer && !HouseClass::CurrentPlayer->SpySatActive) {
+            const CoordStruct from = pThis->Source;
+            const CellStruct cell = CellClass::Coord2Cell(from);
+            if(auto* c = MapClass::Instance.GetCellAt(cell)) {
+                if(c->IsFogged()) {
+                    return SkipDrawing;
+                }
+            }
+        }
+    }
+
+    return 0;
 }
 
 DEFINE_HOOK(0x550D1F, LaserDrawClass_DrawInHouseColor_Context_Set, 0x6)
@@ -49,3 +81,4 @@ DEFINE_HOOK(0x550F47, LaserDrawClass_DrawInHouseColor_BetterDrawing, 0x0)
 
 	return 0x550F9D;
 }
+

--- a/src/Misc/Hooks.RadBeam.cpp
+++ b/src/Misc/Hooks.RadBeam.cpp
@@ -1,0 +1,138 @@
+// src/Misc/Hooks.RadBeam.cpp
+#include <YRPP.h>
+#include <Helpers/Macro.h>
+
+#include <MapClass.h>
+#include <ScenarioClass.h>
+#include <HouseClass.h>
+#include <CellClass.h>
+#include <RadBeam.h>
+#include <Utilities/Debug.h>
+
+#define RADBEAM_FOW_DEBUG 1
+
+// "either-endpoint visible" to match Laser feel; fail closed.
+static __forceinline bool EitherEndVisible(const CoordStruct& a, const CoordStruct& b) {
+    // No fog → always visible
+    if(!(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar)) {
+        return true;
+    }
+    // Global reveal
+    if(HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive) {
+        return true;
+    }
+    // A endpoint
+    if(auto* ca = MapClass::Instance.GetCellAt(CellClass::Coord2Cell(a))) {
+        if(!ca->IsFogged()) { return true; }
+    }
+    // B endpoint
+    if(auto* cb = MapClass::Instance.GetCellAt(CellClass::Coord2Cell(b))) {
+        if(!cb->IsFogged()) { return true; }
+    }
+    return false;
+}
+
+/*
+  RadBeam fog gating - DISABLED due to Ares conflicts
+
+  Multiple approaches tried but all crash due to Ares interaction:
+  1. Post-prologue hooks (0x6596ED/0x659666) - stack corruption
+  2. Call-site hook (0x6592BB) - ECX doesn't contain RadBeam pointer
+
+  RadBeam fog gating remains unimplemented until Ares compatibility resolved.
+
+  Working fog gates: EBolt, LaserDraw, LaserTrail
+*/
+
+namespace RadBeamTemp
+{
+    bool FogHidden = false; // Flag to track if current beam should be hidden due to fog
+}
+
+#include <Windows.h>
+
+static __forceinline bool CellVisible(const CellStruct& cs) {
+    if(!(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar)) return true;
+    if(HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive) return true;
+    if(auto* c = MapClass::Instance.GetCellAt(cs)) return !c->IsFogged();
+    return false;
+}
+
+// Original draw (whatever Ares/others already point the CALL to)
+static void (__thiscall* RadBeam_Draw_Orig)(RadBeam*) = nullptr;
+
+// Called from the *patched CALL* (so we have real CALL/RET semantics).
+static void __fastcall RadBeam_Draw_Gate(RadBeam* pThis, void* /*edx*/) {
+#if RADBEAM_FOW_DEBUG
+    static int dbg = 0;
+    if(dbg++ < 8 && pThis) {
+        Debug::Log("[RADBEAM_FOW] Gate pThis=%p from=(%d,%d,%d) to=(%d,%d,%d)\n",
+            pThis,
+            pThis->SourceLocation.X, pThis->SourceLocation.Y, pThis->SourceLocation.Z,
+            pThis->TargetLocation.X, pThis->TargetLocation.Y, pThis->TargetLocation.Z);
+    }
+#endif
+    if(!pThis) return;
+    if(!(ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar)) { RadBeam_Draw_Orig(pThis); return; }
+    if(HouseClass::CurrentPlayer && HouseClass::CurrentPlayer->SpySatActive)        { RadBeam_Draw_Orig(pThis); return; }
+    if(EitherEndVisible(pThis->SourceLocation, pThis->TargetLocation))               { RadBeam_Draw_Orig(pThis); return; }
+
+#if RADBEAM_FOW_DEBUG
+    if(dbg <= 8) Debug::Log("[RADBEAM_FOW] both fogged → skip draw\n");
+#endif
+    // both fogged → do nothing, return to caller (after CALL)
+}
+
+static void* ResolveCallTarget(uintptr_t callSite) {
+    if(*reinterpret_cast<uint8_t*>(callSite) != 0xE8) return nullptr; // must be CALL rel32
+    int32_t rel = *reinterpret_cast<int32_t*>(callSite + 1);
+    return reinterpret_cast<void*>(callSite + 5 + rel);
+}
+
+static bool PatchCALL(uintptr_t callSite, void* newTarget) {
+    DWORD oldProt;
+    if(!VirtualProtect(reinterpret_cast<void*>(callSite), 5, PAGE_EXECUTE_READWRITE, &oldProt)) return false;
+    *reinterpret_cast<uint8_t*>(callSite) = 0xE8;
+    int32_t rel = static_cast<int32_t>(reinterpret_cast<uintptr_t>(newTarget) - (callSite + 5));
+    *reinterpret_cast<int32_t*>(callSite + 1) = rel;
+    VirtualProtect(reinterpret_cast<void*>(callSite), 5, oldProt, &oldProt);
+    FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<void*>(callSite), 5);
+    return true;
+}
+
+// Call this once during DLL init, after Ares has done its own patches.
+void Install_RadBeamFogGate() {
+    // Verified CALL site to RadBeam::Draw inside DrawAll:
+    const uintptr_t site = 0x6592C6;   // next instruction is 0x6592CB
+
+    // Must be CALL (0xE8). If a previous JMP hook sits here, bail.
+    if(*reinterpret_cast<uint8_t*>(site) != 0xE8) {
+#if RADBEAM_FOW_DEBUG
+        Debug::Log("[RADBEAM_FOW] ERROR: 0x%08X is not CALL (byte=%02X)\n",
+                   site, *reinterpret_cast<uint8_t*>(site));
+#endif
+        return;
+    }
+
+    // Capture original target (this may be Ares' wrapper — that's fine)
+    void* target = ResolveCallTarget(site);
+    RadBeam_Draw_Orig = reinterpret_cast<decltype(RadBeam_Draw_Orig)>(target);
+#if RADBEAM_FOW_DEBUG
+    Debug::Log("[RADBEAM_FOW] Captured original draw target = %p from site 0x%08X\n",
+               RadBeam_Draw_Orig, site);
+#endif
+    if(!RadBeam_Draw_Orig) return;
+
+    // Redirect that CALL to our gate
+    PatchCALL(site, reinterpret_cast<void*>(&RadBeam_Draw_Gate));
+#if RADBEAM_FOW_DEBUG
+    Debug::Log("[RADBEAM_FOW] Patched CALL at 0x%08X to gate\n", site);
+#endif
+}
+
+// Install the patch during initialization - use a different hook point
+DEFINE_HOOK(0x685659, Scenario_ClearClasses_RadBeamInit, 0xA)
+{
+    Install_RadBeamFogGate();
+    return 0;
+}

--- a/src/Misc/Hooks.RadBeam.h
+++ b/src/Misc/Hooks.RadBeam.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// RadBeam fog gating installation function
+void Install_RadBeamFogGate();

--- a/src/Misc/MapRevealer.cpp
+++ b/src/Misc/MapRevealer.cpp
@@ -1,0 +1,221 @@
+#include "MapRevealer.h"
+
+#include <MouseClass.h>
+#include <ScenarioClass.h>
+#include <MapClass.h>
+#include <CellClass.h>
+#include <Helpers/Enumerators.h>
+#include <RulesClass.h>
+
+#include <Utilities/Macro.h>
+
+MapRevealer::MapRevealer(const CoordStruct& coords) :
+	BaseCell(this->TranslateBaseCell(coords)),
+	CellOffset(this->GetOffset(coords, this->Base())),
+	RequiredChecks(RequiresExtraChecks())
+{
+	auto const& Rect = MapClass::Instance.MapRect;
+	this->MapWidth = Rect.Width;
+	this->MapHeight = Rect.Height;
+
+	this->CheckedCells[0] = { 7, static_cast<short>(this->MapWidth + 5) };
+	this->CheckedCells[1] = { 13, static_cast<short>(this->MapWidth + 11) };
+	this->CheckedCells[2] = { static_cast<short>(this->MapHeight + 13),
+		static_cast<short>(this->MapHeight + this->MapWidth - 15) };
+}
+
+MapRevealer::MapRevealer(const CellStruct& cell) :
+	MapRevealer(MapClass::Instance.GetCellAt(cell)->GetCoordsWithBridge())
+{
+}
+
+template <typename T>
+void MapRevealer::RevealImpl(const CoordStruct& coords, int const radius, HouseClass* const pHouse, bool const onlyOutline, bool const allowRevealByHeight, T func) const
+{
+	auto const level = coords.Z / *reinterpret_cast<int*>(0xABDE88);
+	auto const& base = this->Base();
+
+	if (this->AffectsHouse(pHouse) && this->IsCellAvailable(base) && radius > 0)
+	{
+		auto const spread = std::min(static_cast<size_t>(radius), CellSpreadEnumerator::Max);
+		auto const spread_limit_sqr = (spread + 1) * (spread + 1);
+
+		auto const start = (!RulesClass::Instance->RevealByHeight && onlyOutline && spread > 2)
+			? spread - 3 : 0u;
+
+		auto const checkLevel = allowRevealByHeight && RulesClass::Instance->RevealByHeight;
+
+		for (CellSpreadEnumerator it(spread, start); it; ++it)
+		{
+			auto const& offset = *it;
+			auto const cell = base + offset;
+
+			if (this->IsCellAvailable(cell))
+			{
+				if (std::abs(offset.X) <= static_cast<int>(spread) && offset.MagnitudeSquared() < spread_limit_sqr)
+				{
+					if (!checkLevel || this->CheckLevel(offset, level))
+					{
+						auto pCell = MapClass::Instance.GetCellAt(cell);
+						func(pCell);
+					}
+				}
+			}
+		}
+	}
+};
+
+void MapRevealer::Reveal0(const CoordStruct& coords, int const radius, HouseClass* const pHouse, bool onlyOutline, bool unknown, bool fog, bool allowRevealByHeight, bool add) const
+{
+	this->RevealImpl(coords, radius, pHouse, onlyOutline, allowRevealByHeight, [=](CellClass* const pCell)
+ {
+ this->Process0(pCell, unknown, fog, add);
+	});
+}
+
+void MapRevealer::Reveal1(const CoordStruct& coords, int const radius, HouseClass* const pHouse, bool onlyOutline, bool fog, bool allowRevealByHeight, bool add) const
+{
+	this->RevealImpl(coords, radius, pHouse, onlyOutline, allowRevealByHeight, [=](CellClass* const pCell)
+ {
+ this->Process1(pCell, fog, add);
+	});
+}
+
+void MapRevealer::UpdateShroud(size_t start, size_t radius, bool fog) const
+{
+	if (!fog)
+	{
+		auto const& base = this->Base();
+		radius = std::min(radius, CellSpreadEnumerator::Max);
+		start = std::min(start, CellSpreadEnumerator::Max - 3);
+
+		for (CellSpreadEnumerator it(radius, start); it; ++it)
+		{
+			auto const& offset = *it;
+			auto const cell = base + offset;
+			auto const pCell = MapClass::Instance.GetCellAt(cell);
+
+			bool bFlag = false;
+			if (pCell->Visibility != 0xFF)
+			{
+				auto shroudOcculusion = TacticalClass::Instance->GetOcclusion(cell, false);
+				if (pCell->Visibility != shroudOcculusion)
+				{
+					pCell->Visibility = shroudOcculusion;
+					pCell->VisibilityChanged = true;
+					bFlag = true;
+				}
+			}
+
+			if (!ScenarioClass::Instance->SpecialFlags.FogOfWar && !bFlag)
+			{
+				continue;
+			}
+
+			if (pCell->Foggedness != 0xFF)
+			{
+				auto foggedOcclusion = TacticalClass::Instance->GetOcclusion(cell, true);
+				if (pCell->Foggedness != foggedOcclusion)
+				{
+					pCell->Foggedness = foggedOcclusion;
+					bFlag = true;
+				}
+			}
+
+			if (bFlag)
+			{
+				TacticalClass::Instance->RegisterCellAsVisible(pCell);
+			}
+
+			/*auto shroudOcclusion = TacticalClass::Instance->GetOcclusion(cell, false);
+			if (pCell->Visibility != shroudOcclusion) {
+				pCell->Visibility = shroudOcclusion;
+				pCell->VisibilityChanged = true;
+				TacticalClass::Instance->RegisterCellAsVisible(pCell);
+			}*/
+		}
+	}
+}
+
+void MapRevealer::Process0(CellClass* const pCell, bool unknown, bool fog, bool add) const
+{
+	pCell->Flags &= ~CellFlags::IsPlot;
+
+	if (this->IsCellAllowed(pCell->MapCoords))
+	{
+		if (fog)
+		{
+			if ((pCell->Flags & CellFlags::Revealed) != CellFlags::Revealed && pCell->AltFlags & AltCellFlags::Mapped)
+			{
+				MouseClass::Instance.MapCellFoggedness(&pCell->MapCoords, HouseClass::CurrentPlayer);
+			}
+		}
+		else
+		{
+			if ((pCell->AltFlags & AltCellFlags::Clear) != AltCellFlags::Clear || (pCell->Flags & CellFlags::Revealed) != CellFlags::Revealed)
+			{
+				if (!unknown)
+				{
+					if (add)
+					{
+						MouseClass::Instance.RevealFogShroud(&pCell->MapCoords, HouseClass::CurrentPlayer, false);
+					}
+					else
+					{
+						pCell->Unshroud();
+					}
+				}
+			}
+		}
+	}
+}
+
+void MapRevealer::Process1(CellClass* const pCell, bool fog, bool add) const
+{
+	pCell->Flags &= ~CellFlags::IsPlot;
+
+	if (fog)
+	{
+		if ((pCell->Flags & CellFlags::Revealed) != CellFlags::Revealed && pCell->AltFlags & AltCellFlags::Mapped)
+		{
+			MouseClass::Instance.MapCellFoggedness(&pCell->MapCoords, HouseClass::CurrentPlayer);
+		}
+	}
+	else
+	{
+		if (this->IsCellAllowed(pCell->MapCoords))
+		{
+			MouseClass::Instance.RevealFogShroud(&pCell->MapCoords, HouseClass::CurrentPlayer, add);
+		}
+	}
+}
+
+void __fastcall MapRevealer::MapClass_RevealArea0(MapClass* pThis, void*, CoordStruct* pCoord,
+	int nRadius, HouseClass* pHouse, int bOutlineOnly, bool bNoShroudUpdate, bool bFog,
+	bool bAllowRevealByHeight, bool bHideOnRadar)
+{
+	MapRevealer const revealer(*pCoord);
+	revealer.Reveal0(*pCoord, nRadius, pHouse, bOutlineOnly, bNoShroudUpdate, bFog, bAllowRevealByHeight, bHideOnRadar);
+	revealer.UpdateShroud(0, static_cast<size_t>(std::max(nRadius, 0)), false);
+}
+
+void __fastcall MapRevealer::MapClass_RevealArea1(MapClass* pThis, void*, CoordStruct* pCoord,
+	int nRadius, HouseClass* pHouse, int bOutlineOnly, bool bNoShroudUpdate, bool bFog,
+	bool bAllowRevealByHeight, bool bIncreaseShroudCounter)
+{
+	MapRevealer const revealer(*pCoord);
+	revealer.Reveal1(*pCoord, nRadius, pHouse, bOutlineOnly, bFog, bAllowRevealByHeight, bIncreaseShroudCounter);
+}
+
+void __fastcall MapRevealer::MapClass_RevealArea2(MapClass* pThis, void*,
+	CoordStruct* Coords, int Height, int Radius, bool bSkipReveal)
+{
+	MapRevealer const revealer(*Coords);
+	revealer.UpdateShroud(static_cast<size_t>(std::max(Height, 0)), static_cast<size_t>(std::max(Radius, 0)), bSkipReveal);
+}
+
+DEFINE_FUNCTION_JUMP(LJMP, 0x5673A0, MapRevealer::MapClass_RevealArea0);
+
+DEFINE_FUNCTION_JUMP(LJMP, 0x5678E0, MapRevealer::MapClass_RevealArea1);
+
+DEFINE_FUNCTION_JUMP(LJMP, 0x567DA0, MapRevealer::MapClass_RevealArea2);

--- a/src/Misc/MapRevealer.h
+++ b/src/Misc/MapRevealer.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <MapClass.h>
+#include <CellClass.h>
+#include <TacticalClass.h>
+#include <HouseClass.h>
+#include <SessionClass.h>
+#include <RulesClass.h>
+#include <GameModeOptionsClass.h>
+#include <Helpers/Enumerators.h>
+#include <YRMath.h>
+
+class MapRevealer
+{
+public:
+	MapRevealer(const CoordStruct& coords);
+
+	MapRevealer(const CellStruct& cell);
+
+	const CellStruct& Base() const
+	{
+		return this->BaseCell;
+	}
+
+	void Reveal0(const CoordStruct& coords, int const radius, HouseClass* const pHouse, bool onlyOutline, bool unknown, bool fog, bool allowRevealByHeight, bool add) const;
+
+	void Reveal1(const CoordStruct& coords, int const radius, HouseClass* const pHouse, bool onlyOutline, bool fog, bool allowRevealByHeight, bool add) const;
+
+	void UpdateShroud(size_t start, size_t radius, bool fog = false) const;
+
+	void Process0(CellClass* const pCell, bool unknown, bool fog, bool add) const;
+
+	void Process1(CellClass* const pCell, bool fog, bool add) const;
+
+	bool IsCellAllowed(const CellStruct& cell) const
+	{
+		if (this->RequiredChecks)
+		{
+			for (const auto& checkedCell : CheckedCells)
+			{
+				if (checkedCell == cell)
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	bool IsCellAvailable(const CellStruct& cell) const
+	{
+		auto const sum = cell.X + cell.Y;
+
+		return sum > this->MapWidth
+			&& cell.X - cell.Y < this->MapWidth
+			&& cell.Y - cell.X < this->MapWidth
+			&& sum <= this->MapWidth + 2 * this->MapHeight;
+	}
+
+	bool CheckLevel(const CellStruct& offset, int level) const
+	{
+		auto const cellLevel = this->Base() + offset + GetRelation(offset) - this->CellOffset;
+		return MapClass::Instance.GetCellAt(cellLevel)->Level < level + CellClass::BridgeLevels;
+	}
+
+	static bool AffectsHouse(HouseClass* const pHouse)
+	{
+		auto const Player = HouseClass::CurrentPlayer;
+
+		if (pHouse == Player)
+		{
+			return true;
+		}
+
+		if (!pHouse || !Player)
+		{
+			return false;
+		}
+
+		return pHouse->RadarVisibleTo.Contains(Player) ||
+			(RulesClass::Instance->AllyReveal && pHouse->IsAlliedWith(Player));
+	}
+
+	static bool RequiresExtraChecks()
+	{
+		auto const Session = SessionClass::Instance;
+		return Session.GameMode == GameMode::LAN || Session.GameMode == GameMode::Internet &&
+			Session.MPGameMode && !Session.MPGameMode->vt_entry_04();
+	}
+
+	static CellStruct GetRelation(const CellStruct& offset)
+	{
+		return{ static_cast<short>(Math::sgn(-offset.X)),
+			static_cast<short>(Math::sgn(-offset.Y)) };
+	}
+
+private:
+	CellStruct TranslateBaseCell(const CoordStruct& coords) const
+	{
+		auto const adjust = (TacticalClass::AdjustForZ(coords.Z) / -30) << 8;
+		auto const baseCoords = coords + CoordStruct { adjust, adjust, 0 };
+		return CellClass::Coord2Cell(baseCoords);
+	}
+
+	CellStruct GetOffset(const CoordStruct& coords, const CellStruct& base) const
+	{
+		return base - CellClass::Coord2Cell(coords) - CellStruct { 2, 2 };
+	}
+
+	template <typename T>
+	void RevealImpl(const CoordStruct& coords, int radius, HouseClass* pHouse, bool onlyOutline, bool allowRevealByHeight, T func) const;
+
+	CellStruct BaseCell;
+	CellStruct CellOffset;
+	CellStruct CheckedCells[3];
+	bool RequiredChecks;
+	int MapWidth;
+	int MapHeight;
+
+public:
+	// Reveal_Area
+	static void __fastcall MapClass_RevealArea0(MapClass* pThis, void*, CoordStruct* pCoord,
+		int nRadius, HouseClass* pHouse, int bOutlineOnly, bool bNoShroudUpdate, bool bFog,
+		bool bAllowRevealByHeight, bool bHideOnRadar);
+
+	// Sight_From
+	static void __fastcall MapClass_RevealArea1(MapClass* pThis, void*, CoordStruct* pCoord,
+		int nRadius, HouseClass* pHouse, int bOutlineOnly, bool bNoShroudUpdate, bool bFog,
+		bool bAllowRevealByHeight, bool bIncreaseShroudCounter);
+
+	static void __fastcall MapClass_RevealArea2(MapClass* pThis, void*,
+		CoordStruct* Coords, int Height, int Radius, bool bSkipReveal);
+};

--- a/src/New/Entity/FoggedObject.cpp
+++ b/src/New/Entity/FoggedObject.cpp
@@ -1,0 +1,545 @@
+#include "FoggedObject.h"
+
+#include <Ext/Cell/Body.h>
+#include <Ext/TechnoType/Body.h>
+#include <Ext/BuildingType/Body.h>
+
+#include <TacticalClass.h>
+#include <SmudgeTypeClass.h>
+#include <AnimClass.h>
+#include <TerrainClass.h>
+#include <HouseClass.h>
+#include <Drawing.h>
+
+DynamicVectorClass<FoggedObject*> FoggedObject::FoggedObjects;
+char FoggedObject::BuildingVXLDrawer[sizeof(BuildingClass)];
+
+void FoggedObject::SaveGlobal(IStream* pStm)
+{
+	pStm->Write(&FoggedObjects.Count, sizeof(FoggedObjects.Count), nullptr);
+	for (auto const pObject : FoggedObjects)
+	{
+		pStm->Write(&pObject, sizeof(pObject), nullptr);
+		pObject->Save(pStm);
+	}
+
+	pStm->Write(BuildingVXLDrawer, sizeof(BuildingVXLDrawer), nullptr);
+}
+
+void FoggedObject::LoadGlobal(IStream* pStm)
+{
+	int nCount;
+	pStm->Read(&nCount, sizeof(nCount), nullptr);
+	while (nCount--)
+	{
+		auto pObject = GameCreate<FoggedObject>();
+		long pOldObject;
+		pStm->Read(&pOldObject, sizeof(pOldObject), nullptr);
+		SwizzleManagerClass::Instance.Here_I_Am(pOldObject, pObject);
+		pObject->Load(pStm);
+	}
+
+	pStm->Read(BuildingVXLDrawer, sizeof(BuildingVXLDrawer), nullptr);
+}
+
+FoggedObject::FoggedObject() noexcept
+{
+	FoggedObjects.AddItem(this);
+}
+
+FoggedObject::FoggedObject(BuildingClass* pBld, bool IsVisible) noexcept
+{
+	CoveredType = CoveredType::Building;
+
+	Location = pBld->Location;
+	Visible = IsVisible;
+	BuildingData.Owner = pBld->Owner;
+	BuildingData.Type = pBld->Type;
+	BuildingData.ShapeFrame = pBld->GetShapeNumber();
+	BuildingData.PrimaryFacing = pBld->PrimaryFacing;
+	BuildingData.BarrelFacing = pBld->BarrelFacing;
+	BuildingData.TurretRecoil = pBld->TurretRecoil;
+	BuildingData.BarrelRecoil = pBld->BarrelRecoil;
+	BuildingData.IsFirestormWall = pBld->Type->FirestormWall;
+	BuildingData.TurretAnimFrame = pBld->TurretAnimFrame;
+	pBld->GetRenderDimensions(&Bound);
+
+	memset(BuildingData.Anims, 0, sizeof(BuildingData.Anims));
+	auto pAnimData = BuildingData.Anims;
+	for (auto pAnim : pBld->Anims)
+	{
+		if (pAnim)
+		{
+			pAnimData->AnimType = pAnim->Type;
+			pAnimData->AnimFrame = pAnim->Animation.Value + pAnimData->AnimType->Start;
+			pAnimData->ZAdjust = pAnim->ZAdjust + pAnimData->AnimType->YDrawOffset - TacticalClass::AdjustForZ(pAnim->Location.Z);
+			pAnimData->ZAdjust -= pAnimData->AnimType->Flat ? 3 : 2;
+			++pAnimData;
+
+			pAnim->IsFogged = true;
+			RectangleStruct buffer;
+			pAnim->GetDimensions(&buffer);
+			Bound = std::move(Drawing::Union(Bound, buffer));
+		}
+	}
+
+	TacticalClass::Instance->RegisterDirtyArea(Bound, false);
+	Bound.X += TacticalClass::Instance->TacticalPos.X;
+	Bound.Y += TacticalClass::Instance->TacticalPos.Y;
+	pBld->IsFogged = true;
+
+	if (!BuildingVXLDrawer[0] && pBld->Type->TurretAnimIsVoxel || pBld->Type->BarrelAnimIsVoxel)
+	{
+		memcpy(BuildingVXLDrawer, pBld, sizeof(BuildingClass));
+		reinterpret_cast<BuildingClass*>(BuildingVXLDrawer)->BeingWarpedOut = false;
+		reinterpret_cast<BuildingClass*>(BuildingVXLDrawer)->WarpFactor = 0.0f;
+	}
+
+	FoggedObjects.AddItem(this);
+}
+
+FoggedObject::FoggedObject(TerrainClass* pTerrain) noexcept
+{
+	Location = pTerrain->Location;
+	CoveredType = CoveredType::Terrain;
+
+	pTerrain->GetRenderDimensions(&Bound);
+	Bound.X += TacticalClass::Instance->TacticalPos.X - DSurface::ViewBounds.X;
+	Bound.Y += TacticalClass::Instance->TacticalPos.Y - DSurface::ViewBounds.Y;
+
+	TerrainData.Type = pTerrain->Type;
+	TerrainData.Frame = 0;
+	if (TerrainData.Type->IsAnimated)
+		TerrainData.Frame = pTerrain->Animation.Value;
+	else if (pTerrain->IsCrumbling)
+		TerrainData.Frame = pTerrain->Animation.Value + 1;
+	else if (pTerrain->IsBurning)
+		TerrainData.Frame = 2;
+
+	TerrainData.Flat = TerrainData.Type->IsAnimated || pTerrain->IsCrumbling;
+
+	FoggedObjects.AddItem(this);
+}
+
+FoggedObject::FoggedObject(CellClass* pCell, bool IsOverlay) noexcept
+{
+	pCell->GetCoords(&Location);
+	if (IsOverlay)
+	{
+		CoveredType = CoveredType::Overlay;
+
+		RectangleStruct containingRect;
+		RectangleStruct shapeRect;
+		pCell->ShapeRect(&shapeRect);
+		pCell->GetContainingRect(&containingRect);
+		Bound = std::move(Drawing::Union(shapeRect, containingRect));
+		Bound.X += TacticalClass::Instance->TacticalPos.X;
+		Bound.Y += TacticalClass::Instance->TacticalPos.Y;
+
+		OverlayData.Overlay = pCell->OverlayTypeIndex;
+		OverlayData.OverlayData = pCell->OverlayData;
+	}
+	else
+	{
+		CoveredType = CoveredType::Smudge;
+
+		Location.Z = pCell->Level * Unsorted::LevelHeight;
+		auto [position, visible] = TacticalClass::Instance->CoordsToClient(Location);
+
+		Bound = RectangleStruct
+		{
+			position.X - 30 + TacticalClass::Instance->TacticalPos.X,
+			position.Y - 15 + TacticalClass::Instance->TacticalPos.Y,
+			60,
+			30
+		};
+
+		SmudgeData.Smudge = pCell->SmudgeTypeIndex;
+		SmudgeData.SmudgeData = pCell->SmudgeData;
+		SmudgeData.Height = Location.Z;
+	}
+
+	FoggedObjects.AddItem(this);
+}
+
+void FoggedObject::Load(IStream* pStm)
+{
+	pStm->Read(this, sizeof(FoggedObject), nullptr);
+
+	if (CoveredType == CoveredType::Building)
+	{
+		SWIZZLE(BuildingData.Owner);
+		SWIZZLE(BuildingData.Type);
+		for (auto& Anim : BuildingData.Anims)
+		{
+			if (!Anim.AnimType)
+				break;
+			SWIZZLE(Anim.AnimType);
+		}
+	}
+	else if (CoveredType == CoveredType::Terrain)
+	{
+		SWIZZLE(TerrainData.Type);
+	}
+}
+
+void FoggedObject::Save(IStream* pStm)
+{
+	pStm->Write(this, sizeof(FoggedObject), nullptr);
+}
+
+FoggedObject::~FoggedObject()
+{
+	FoggedObjects.Remove(this);
+
+	if (this->CoveredType == CoveredType::Building)
+	{
+		auto pCell = MapClass::Instance.GetCellAt(Location);
+		if (auto pBld = pCell->GetBuilding())
+		{
+			pBld->IsFogged = false;
+			for (auto pAnim : pBld->Anims)
+				if (pAnim)
+					pAnim->IsFogged = false;
+		}
+	}
+}
+
+void FoggedObject::Render(const RectangleStruct& viewRect) const
+{
+	if (!Visible)
+		return;
+
+	RectangleStruct buffer = Bound;
+	buffer.X += DSurface::ViewBounds.X - TacticalClass::Instance->TacticalPos.X;
+	buffer.Y += DSurface::ViewBounds.Y - TacticalClass::Instance->TacticalPos.Y;
+	RectangleStruct finalRect = Drawing::Intersect(buffer, viewRect);
+	if (finalRect.Width <= 0 || finalRect.Height <= 0)
+		return;
+
+	switch (CoveredType)
+	{
+	case CoveredType::Building:
+		RenderAsBuilding(viewRect);
+		break;
+
+	case CoveredType::Overlay:
+		RenderAsOverlay(viewRect);
+		break;
+
+	case CoveredType::Terrain:
+		RenderAsTerrain(viewRect);
+		break;
+
+	case CoveredType::Smudge:
+		RenderAsSmudge(viewRect);
+		break;
+	}
+}
+
+RectangleStruct FoggedObject::Union(const RectangleStruct& rect1, const RectangleStruct& rect2)
+{
+	if (rect1.Width <= 0 || rect1.Height <= 0)
+		return rect2;
+	if (rect2.Width <= 0 || rect2.Height <= 0)
+		return rect1;
+
+	return
+	{
+		std::min(rect1.X,rect2.X),
+		std::min(rect1.Y,rect2.Y),
+		std::max(rect1.X + rect1.Width,rect2.X + rect2.Width),
+		std::max(rect1.Y + rect1.Height,rect2.Y + rect2.Height)
+	};
+}
+
+int FoggedObject::GetIndexID() const
+{
+	int x = Location.X / 256;
+	int y = Location.Y / 256;
+	return (y - ((x + y) << 9) - x) - static_cast<int>(CoveredType) * 0x80000 + INT_MAX;
+}
+
+void FoggedObject::RenderAsBuilding(const RectangleStruct& viewRect) const
+{
+	auto const pType = BuildingData.Type;
+	if (pType->InvisibleInGame)
+		return;
+
+	auto pScheme = ColorScheme::Array.GetItem(BuildingData.Owner->ColorSchemeIndex);
+	auto pSHP = pType->GetImage();
+	CoordStruct coord = { Location.X - 128,Location.Y - 128,Location.Z };
+	auto [point, visible] = TacticalClass::Instance->CoordsToClient(coord);
+	point.X += DSurface::ViewBounds.X - viewRect.X;
+	point.Y += DSurface::ViewBounds.Y - viewRect.Y;
+
+	auto pCell = MapClass::Instance.GetCellAt(Location);
+	ConvertClass* pConvert;
+	if (!pType->TerrainPalette)
+		pConvert = pScheme->LightConvert;
+	else
+	{
+		if (!pCell->LightConvert)
+			pCell->InitLightConvert();
+		pConvert = pCell->LightConvert;
+	}
+	if (pType->Palette)
+		pConvert = pType->Palette->GetItem(BuildingData.Owner->ColorSchemeIndex)->LightConvert;
+
+	if (pSHP)
+	{
+		RectangleStruct rect = viewRect;
+		int height = point.Y + pSHP->Height / 2;
+		if (rect.Height > height)
+			rect.Height = height;
+		int ZAdjust = -2 - TacticalClass::AdjustForZ(Location.Z);
+		int Intensity = pCell->Intensity_Normal + pType->ExtraLight;
+		if (rect.Height > 0)
+		{
+			if (BuildingData.IsFirestormWall)
+			{
+				CC_Draw_Shape(DSurface::Temp, pConvert, pSHP, BuildingData.ShapeFrame, &point, &rect,
+					BlitterFlags::ZReadWrite | BlitterFlags::Alpha | BlitterFlags::bf_400 | BlitterFlags::Centered,
+					0, ZAdjust, ZGradient::Ground, Intensity, 0, nullptr, 0, 0, 0);
+			}
+			else
+			{
+				CC_Draw_Shape(DSurface::Temp, pConvert, pSHP, BuildingData.ShapeFrame, &point, &rect,
+					BlitterFlags::ZReadWrite | BlitterFlags::Alpha | BlitterFlags::bf_400 | BlitterFlags::Centered,
+					0, ZAdjust, ZGradient::Deg90, Intensity, 0, nullptr, 0, 0, 0);
+				CC_Draw_Shape(DSurface::Temp, pConvert, pSHP, BuildingData.ShapeFrame + pSHP->Frames / 2, &point, &rect,
+					BlitterFlags::ZReadWrite | BlitterFlags::Alpha | BlitterFlags::bf_400 | BlitterFlags::Centered | BlitterFlags::Darken,
+					0, ZAdjust, ZGradient::Ground, 1000, 0, nullptr, 0, 0, 0);
+				if (pType->BibShape)
+				{
+					CC_Draw_Shape(DSurface::Temp, pConvert, pType->BibShape, BuildingData.ShapeFrame, &point, &viewRect,
+						BlitterFlags::ZReadWrite | BlitterFlags::Alpha | BlitterFlags::bf_400 | BlitterFlags::Centered,
+						0, ZAdjust - 1, ZGradient::Deg90, Intensity, 0, nullptr, 0, 0, 0);
+				}
+			}
+		}
+		Point2D turretPoint
+		{
+			point.X + pType->GetBuildingAnim(BuildingAnimSlot::Turret).Position.X,
+			point.Y + pType->GetBuildingAnim(BuildingAnimSlot::Turret).Position.Y
+		};
+		if (pType->TurretAnimIsVoxel || pType->BarrelAnimIsVoxel)
+		{
+			auto pVXLDrawer = reinterpret_cast<BuildingClass*>(BuildingVXLDrawer);
+			pVXLDrawer->Type = pType;
+			pVXLDrawer->SecondaryFacing = BuildingData.PrimaryFacing;
+			pVXLDrawer->BarrelFacing = BuildingData.BarrelFacing;
+			pVXLDrawer->TurretRecoil = BuildingData.TurretRecoil;
+			pVXLDrawer->BarrelRecoil = BuildingData.BarrelRecoil;
+			pVXLDrawer->Owner = BuildingData.Owner;
+			pVXLDrawer->Location = Location;
+			pVXLDrawer->TurretAnimFrame = BuildingData.TurretAnimFrame;
+
+			auto const primaryDir = BuildingData.PrimaryFacing.Current();
+			int turretFacing = 0;
+			int barrelFacing = 0;
+			if (pType->TurretVoxel.HVA)
+				turretFacing = BuildingData.TurretAnimFrame % pType->TurretVoxel.HVA->FrameCount;
+			if (pType->BarrelVoxel.HVA)
+				barrelFacing = BuildingData.TurretAnimFrame % pType->BarrelVoxel.HVA->FrameCount;
+			int val32 = primaryDir.Raw;
+			int turretExtra = ((unsigned char)turretFacing << 16) | val32;
+			int barrelExtra = ((unsigned char)barrelFacing << 16) | val32;
+
+			if (pType->TurretVoxel.VXL)
+			{
+				Matrix3D matrixturret;
+				matrixturret.MakeIdentity();
+				matrixturret.RotateZ(static_cast<float>(primaryDir.GetRadian<256>()));
+				TechnoTypeExt::ApplyTurretOffset(pType, &matrixturret, 0.125);
+
+				Vector3D<float> negativevector = { -matrixturret.Row[0].W ,-matrixturret.Row[1].W,-matrixturret.Row[2].W };
+				Vector3D<float> vector = { matrixturret.Row[0].W ,matrixturret.Row[1].W,matrixturret.Row[2].W };
+				Matrix3D matrixbarrel = matrixturret;
+				if (BuildingData.TurretRecoil.State != RecoilData::RecoilState::Inactive)
+				{
+					matrixturret.TranslateX(-BuildingData.TurretRecoil.TravelSoFar);
+					turretExtra = -1;
+				}
+				Matrix3D::MatrixMultiply(&matrixturret, &Matrix3D::VoxelDefaultMatrix, &matrixturret);
+
+				bool bDrawBarrel = pType->BarrelVoxel.VXL && pType->BarrelVoxel.HVA;
+				if (bDrawBarrel)
+				{
+					matrixbarrel.Translate(negativevector);
+					if (BuildingData.BarrelRecoil.State != RecoilData::RecoilState::Inactive)
+					{
+						matrixbarrel.TranslateX(-BuildingData.BarrelRecoil.TravelSoFar);
+						barrelExtra = -1;
+					}
+					matrixbarrel.RotateY(-static_cast<float>(BuildingData.BarrelFacing.Current().GetRadian<256>()));
+					matrixbarrel.Translate(vector);
+					Matrix3D::MatrixMultiply(&matrixbarrel, &Matrix3D::VoxelDefaultMatrix, &matrixbarrel);
+				}
+
+				int facetype = (((((*(unsigned int*)&primaryDir) >> 13) + 1) >> 1) & 3);
+				if (facetype == 0 || facetype == 3) // Draw barrel first
+				{
+					// TODO: Fix voxel drawing
+					// if (bDrawBarrel)
+					//	pVXLDrawer->DrawVoxel(...);
+					// pVXLDrawer->DrawVoxel(...);
+					
+				}
+				else
+				{
+					// TODO: Fix voxel drawing
+					// pVXLDrawer->DrawVoxel(...);
+					// if (bDrawBarrel)
+					//	pVXLDrawer->DrawVoxel(...);
+				}
+			}
+			else if (pType->BarrelVoxel.VXL && pType->BarrelVoxel.HVA)
+			{
+				Matrix3D matrixbarrel;
+				matrixbarrel.MakeIdentity();
+				Vector3D<float> negativevector = { -matrixbarrel.Row[0].W ,-matrixbarrel.Row[1].W,-matrixbarrel.Row[2].W };
+				Vector3D<float> vector = { matrixbarrel.Row[0].W ,matrixbarrel.Row[1].W,matrixbarrel.Row[2].W };
+				matrixbarrel.Translate(negativevector);
+				matrixbarrel.RotateZ(static_cast<float>(BuildingData.PrimaryFacing.Current().GetRadian<256>()));
+				matrixbarrel.RotateY(-static_cast<float>(BuildingData.BarrelFacing.Current().GetRadian<256>()));
+				matrixbarrel.Translate(vector);
+				Matrix3D::MatrixMultiply(&matrixbarrel, &Matrix3D::VoxelDefaultMatrix, &matrixbarrel);
+				// TODO: Fix voxel drawing
+				// pVXLDrawer->DrawVoxel(...);
+			}
+		}
+	}
+
+	for (const auto& AnimData : BuildingData.Anims)
+	{
+		if (!AnimData.AnimType)
+			break;
+
+		auto pAnimType = AnimData.AnimType;
+		if (auto pAnimSHP = pAnimType->GetImage())
+		{
+			ConvertClass* pAnimConvert = pAnimType->ShouldUseCellDrawer ? pScheme->LightConvert : FileSystem::ANIM_PAL;
+
+			CC_Draw_Shape(DSurface::Temp, pAnimConvert, pAnimSHP, AnimData.AnimFrame, &point, &viewRect,
+				BlitterFlags::ZReadWrite | BlitterFlags::Alpha | BlitterFlags::bf_400 | BlitterFlags::Centered,
+				0, AnimData.ZAdjust, pAnimType->Flat ? ZGradient::Ground : ZGradient::Deg90,
+				pAnimType->UseNormalLight ? 1000 : pCell->Intensity_Normal, 0, nullptr, 0, 0, 0);
+			if (pAnimType->Shadow)
+			{
+				CC_Draw_Shape(DSurface::Temp, pAnimConvert, pAnimSHP, AnimData.AnimFrame + pAnimSHP->Frames / 2, &point, &viewRect,
+					BlitterFlags::ZReadWrite | BlitterFlags::Alpha | BlitterFlags::bf_400 | BlitterFlags::Centered | BlitterFlags::Darken,
+					0, AnimData.ZAdjust, ZGradient::Deg90, 1000, 0, nullptr, 0, 0, 0);
+			}
+		}
+	}
+}
+
+void FoggedObject::RenderAsSmudge(const RectangleStruct& viewRect) const
+{
+	auto const pSmudge = SmudgeTypeClass::Array.GetItem(SmudgeData.Smudge);
+	Point2D position
+	{
+		this->Bound.X - TacticalClass::Instance->TacticalPos.X - viewRect.X + DSurface::ViewBounds.X + 30,
+		this->Bound.Y - TacticalClass::Instance->TacticalPos.Y - viewRect.Y + DSurface::ViewBounds.Y
+	};
+	CellStruct MapCoord = CellClass::Coord2Cell(Location);
+	pSmudge->DrawIt(position, viewRect, SmudgeData.SmudgeData, SmudgeData.Height, MapCoord);
+}
+
+void FoggedObject::RenderAsOverlay(const RectangleStruct& viewRect) const
+{
+	if (auto pCell = MapClass::Instance.TryGetCellAt(Location))
+	{
+		CoordStruct coords =
+		{
+			(((pCell->MapCoords.X << 8) + 128) / 256) << 8,
+			(((pCell->MapCoords.Y << 8) + 128) / 256) << 8,
+			0
+		};
+		auto [position, visible] = TacticalClass::Instance->CoordsToClient(coords);
+		position.X -= 30;
+
+		// Temporarily swap overlay data for rendering
+		auto originalOverlayType = pCell->OverlayTypeIndex;
+		auto originalOverlayData = pCell->OverlayData;
+		
+		pCell->OverlayTypeIndex = this->OverlayData.Overlay;
+		pCell->OverlayData = this->OverlayData.OverlayData;
+		
+		pCell->DrawOverlay(position, viewRect);
+		pCell->DrawOverlayShadow(position, viewRect);
+
+		// Restore original data
+		pCell->OverlayTypeIndex = originalOverlayType;
+		pCell->OverlayData = originalOverlayData;
+	}
+}
+
+void FoggedObject::RenderAsTerrain(const RectangleStruct& viewRect) const
+{
+	auto pCell = MapClass::Instance.GetCellAt(Location);
+	if (auto pSHP = TerrainData.Type->GetImage())
+	{
+		int nZAdjust = -TacticalClass::AdjustForZ(Location.Z);
+		auto [point, visible] = TacticalClass::Instance->CoordsToClient(Location);
+		point.X += DSurface::ViewBounds.X - viewRect.X;
+		point.Y += DSurface::ViewBounds.Y - viewRect.Y;
+		if (!pCell->LightConvert)
+			pCell->InitLightConvert();
+
+		BlitterFlags blitterFlag = BlitterFlags::Centered | BlitterFlags::bf_400 | BlitterFlags::Alpha;
+		if (TerrainData.Flat)
+			blitterFlag |= BlitterFlags::Flat;
+		else
+			blitterFlag |= BlitterFlags::ZReadWrite;
+
+		ConvertClass* pConvert;
+		int nIntensity;
+
+		if (TerrainData.Type->SpawnsTiberium)
+		{
+			pConvert = FileSystem::GRFTXT_TIBERIUM_PAL;
+			nIntensity = pCell->Intensity_Normal;
+			point.Y -= 16;
+		}
+		else
+		{
+			pConvert = pCell->LightConvert;
+			nIntensity = pCell->Intensity_Terrain;
+		}
+
+		CC_Draw_Shape(DSurface::Temp, pConvert, pSHP, TerrainData.Frame, &point,
+			&viewRect, blitterFlag, 0, nZAdjust - 12, ZGradient::Deg90, nIntensity,
+			0, 0, 0, 0, 0);
+		if (Game::bDrawShadow)
+			CC_Draw_Shape(DSurface::Temp, pConvert, pSHP, TerrainData.Frame + pSHP->Frames / 2, &point,
+				&viewRect, blitterFlag | BlitterFlags::Darken, 0, nZAdjust - 3,
+				ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
+	}
+}
+
+DEFINE_HOOK(0x67D32C, Put_All_FoggedObjects, 0x5)
+{
+	GET(IStream*, pStm, ESI);
+
+	FoggedObject::SaveGlobal(pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x67E826, Decode_All_FoggedObjects, 0x6)
+{
+	GET(IStream*, pStm, ESI);
+
+	FoggedObject::LoadGlobal(pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x685659, Clear_Scenario_FoggedObjects, 0xA)
+{
+	FoggedObject::FoggedObjects.Clear();
+
+	return 0;
+}

--- a/src/New/Entity/FoggedObject.h
+++ b/src/New/Entity/FoggedObject.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <AbstractClass.h>
+#include <BuildingClass.h>
+#include <TechnoClass.h>
+#include <TerrainClass.h>
+#include <AnimTypeClass.h>
+#include <HouseClass.h>
+
+// Forward declaration to avoid circular include
+class CellExt;
+
+class FoggedObject
+{
+public:
+	static DynamicVectorClass<FoggedObject*> FoggedObjects;
+
+	static void SaveGlobal(IStream* pStm);
+	static void LoadGlobal(IStream* pStm);
+
+	explicit FoggedObject() noexcept;
+	explicit FoggedObject(BuildingClass* pBld, bool IsVisible) noexcept;
+	explicit FoggedObject(TerrainClass* pTerrain) noexcept;
+
+	// Handles Smudge and Overlay Construct
+	explicit FoggedObject(CellClass* pCell, bool IsOverlay) noexcept;
+
+	void Load(IStream* pStm);
+	void Save(IStream* pStm);
+
+	//Destructor
+	virtual ~FoggedObject();
+
+	void Render(const RectangleStruct& viewRect) const;
+
+	static RectangleStruct Union(const RectangleStruct& rect1, const RectangleStruct& rect2);
+protected:
+	inline int GetIndexID() const;
+
+	void RenderAsBuilding(const RectangleStruct& viewRect) const;
+	void RenderAsSmudge(const RectangleStruct& viewRect) const;
+	void RenderAsOverlay(const RectangleStruct& viewRect) const;
+	void RenderAsTerrain(const RectangleStruct& viewRect) const;
+
+	static char BuildingVXLDrawer[sizeof(BuildingClass)];
+public:
+	enum class CoveredType : char
+	{
+		Building = 1,
+		Terrain,
+		Smudge,
+		Overlay
+	};
+
+	CoordStruct Location;
+	CoveredType CoveredType;
+	RectangleStruct Bound;
+	bool Visible { true };
+
+	union
+	{
+		struct
+		{
+			int Overlay;
+			unsigned char OverlayData;
+		} OverlayData;
+		struct
+		{
+			TerrainTypeClass* Type;
+			int Frame;
+			bool Flat;
+		} TerrainData;
+		struct
+		{
+			HouseClass* Owner;
+			BuildingTypeClass* Type;
+			int ShapeFrame;
+			FacingClass PrimaryFacing;
+			FacingClass BarrelFacing;
+			RecoilData TurretRecoil;
+			RecoilData BarrelRecoil;
+			bool IsFirestormWall;
+			int TurretAnimFrame;
+			struct
+			{
+				AnimTypeClass* AnimType;
+				int AnimFrame;
+				int ZAdjust;
+			} Anims[21];
+		} BuildingData;
+		struct
+		{
+			int Smudge;
+			int SmudgeData;
+			int Height;
+		} SmudgeData;
+	};
+};

--- a/src/New/Entity/LaserTrailClass.cpp
+++ b/src/New/Entity/LaserTrailClass.cpp
@@ -23,23 +23,23 @@ bool LaserTrailClass::Update(CoordStruct location)
 		{
 			if (pType->DrawType == LaserTrailDrawType::Laser)
 			{
-				// FOG CHECK: Only create laser if both endpoints are visible
+				// FOG CHECK: Only create laser if both endpoints are visible (updated method)
 				bool sourceVisible = true;
 				bool targetVisible = true;
 
 				// Check if fog of war is enabled and we have valid instances
 				if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar &&
-					&MapClass::Instance && TacticalClass::Instance) {
+					HouseClass::CurrentPlayer && !HouseClass::CurrentPlayer->SpySatActive) {
 
-					// Check source location
+					// Check source location using cell-based fog (matches EBolt method)
 					auto sourceCs = CellClass::Coord2Cell(this->LastLocation.Get());
-					auto* sourceCell = MapClass::Instance.TryGetCellAt(sourceCs);
-					sourceVisible = sourceCell && (sourceCell->Flags & CellFlags::EdgeRevealed);
+					auto* sourceCell = MapClass::Instance.GetCellAt(sourceCs);
+					sourceVisible = sourceCell && !sourceCell->IsFogged();
 
-					// Check target location
+					// Check target location using cell-based fog
 					auto targetCs = CellClass::Coord2Cell(location);
-					auto* targetCell = MapClass::Instance.TryGetCellAt(targetCs);
-					targetVisible = targetCell && (targetCell->Flags & CellFlags::EdgeRevealed);
+					auto* targetCell = MapClass::Instance.GetCellAt(targetCs);
+					targetVisible = targetCell && !targetCell->IsFogged();
 				}
 
 				// Only create laser if both endpoints are visible
@@ -62,17 +62,17 @@ bool LaserTrailClass::Update(CoordStruct location)
 
 				// Check if fog of war is enabled and we have valid instances
 				if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar &&
-					&MapClass::Instance && TacticalClass::Instance) {
+					HouseClass::CurrentPlayer && !HouseClass::CurrentPlayer->SpySatActive) {
 
-					// Check source location
+					// Check source location using cell-based fog (matches EBolt method)
 					auto sourceCs = CellClass::Coord2Cell(this->LastLocation.Get());
-					auto* sourceCell = MapClass::Instance.TryGetCellAt(sourceCs);
-					sourceVisible = sourceCell && (sourceCell->Flags & CellFlags::EdgeRevealed);
+					auto* sourceCell = MapClass::Instance.GetCellAt(sourceCs);
+					sourceVisible = sourceCell && !sourceCell->IsFogged();
 
-					// Check target location
+					// Check target location using cell-based fog
 					auto targetCs = CellClass::Coord2Cell(location);
-					auto* targetCell = MapClass::Instance.TryGetCellAt(targetCs);
-					targetVisible = targetCell && (targetCell->Flags & CellFlags::EdgeRevealed);
+					auto* targetCell = MapClass::Instance.GetCellAt(targetCs);
+					targetVisible = targetCell && !targetCell->IsFogged();
 				}
 
 				// Only create EBolt if both endpoints are visible
@@ -111,17 +111,17 @@ bool LaserTrailClass::Update(CoordStruct location)
 
 				// Check if fog of war is enabled and we have valid instances
 				if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar &&
-					&MapClass::Instance && TacticalClass::Instance) {
+					HouseClass::CurrentPlayer && !HouseClass::CurrentPlayer->SpySatActive) {
 
-					// Check source location
+					// Check source location using cell-based fog (matches EBolt method)
 					auto sourceCs = CellClass::Coord2Cell(this->LastLocation.Get());
-					auto* sourceCell = MapClass::Instance.TryGetCellAt(sourceCs);
-					sourceVisible = sourceCell && (sourceCell->Flags & CellFlags::EdgeRevealed);
+					auto* sourceCell = MapClass::Instance.GetCellAt(sourceCs);
+					sourceVisible = sourceCell && !sourceCell->IsFogged();
 
-					// Check target location
+					// Check target location using cell-based fog
 					auto targetCs = CellClass::Coord2Cell(location);
-					auto* targetCell = MapClass::Instance.TryGetCellAt(targetCs);
-					targetVisible = targetCell && (targetCell->Flags & CellFlags::EdgeRevealed);
+					auto* targetCell = MapClass::Instance.GetCellAt(targetCs);
+					targetVisible = targetCell && !targetCell->IsFogged();
 				}
 
 				// Only create RadBeam if both endpoints are visible

--- a/src/New/Entity/LaserTrailClass.cpp
+++ b/src/New/Entity/LaserTrailClass.cpp
@@ -23,18 +23,61 @@ bool LaserTrailClass::Update(CoordStruct location)
 		{
 			if (pType->DrawType == LaserTrailDrawType::Laser)
 			{
-				const auto pLaser = GameCreate<LaserDrawClass>(
-					this->LastLocation.Get(), location,
-					this->CurrentColor, ColorStruct { 0, 0, 0 }, ColorStruct { 0, 0, 0 },
-					pType->FadeDuration.Get(64));
+				// FOG CHECK: Only create laser if both endpoints are visible
+				bool sourceVisible = true;
+				bool targetVisible = true;
 
-				pLaser->Thickness = pType->Thickness;
-				pLaser->IsHouseColor = true;
-				pLaser->IsSupported = pType->IsIntense;
+				// Check if fog of war is enabled and we have valid instances
+				if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar &&
+					&MapClass::Instance && TacticalClass::Instance) {
+
+					// Check source location
+					auto sourceCs = CellClass::Coord2Cell(this->LastLocation.Get());
+					auto* sourceCell = MapClass::Instance.TryGetCellAt(sourceCs);
+					sourceVisible = sourceCell && (sourceCell->Flags & CellFlags::EdgeRevealed);
+
+					// Check target location
+					auto targetCs = CellClass::Coord2Cell(location);
+					auto* targetCell = MapClass::Instance.TryGetCellAt(targetCs);
+					targetVisible = targetCell && (targetCell->Flags & CellFlags::EdgeRevealed);
+				}
+
+				// Only create laser if both endpoints are visible
+				if (sourceVisible && targetVisible) {
+					const auto pLaser = GameCreate<LaserDrawClass>(
+						this->LastLocation.Get(), location,
+						this->CurrentColor, ColorStruct { 0, 0, 0 }, ColorStruct { 0, 0, 0 },
+						pType->FadeDuration.Get(64));
+
+					pLaser->Thickness = pType->Thickness;
+					pLaser->IsHouseColor = true;
+					pLaser->IsSupported = pType->IsIntense;
+				}
 			}
 			else if (pType->DrawType == LaserTrailDrawType::EBolt)
 			{
-				const auto pBolt = GameCreate<EBolt>();
+				// FOG CHECK: Only create EBolt if both endpoints are visible
+				bool sourceVisible = true;
+				bool targetVisible = true;
+
+				// Check if fog of war is enabled and we have valid instances
+				if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar &&
+					&MapClass::Instance && TacticalClass::Instance) {
+
+					// Check source location
+					auto sourceCs = CellClass::Coord2Cell(this->LastLocation.Get());
+					auto* sourceCell = MapClass::Instance.TryGetCellAt(sourceCs);
+					sourceVisible = sourceCell && (sourceCell->Flags & CellFlags::EdgeRevealed);
+
+					// Check target location
+					auto targetCs = CellClass::Coord2Cell(location);
+					auto* targetCell = MapClass::Instance.TryGetCellAt(targetCs);
+					targetVisible = targetCell && (targetCell->Flags & CellFlags::EdgeRevealed);
+				}
+
+				// Only create EBolt if both endpoints are visible
+				if (sourceVisible && targetVisible) {
+					const auto pBolt = GameCreate<EBolt>();
 				const auto pBoltExt = EBoltExt::ExtMap.Find(pBolt);
 				const auto& boltDisable = pType->Bolt_Disable;
 				const auto& boltColor = pType->Bolt_Color;
@@ -53,22 +96,45 @@ bool LaserTrailClass::Update(CoordStruct location)
 						pBoltExt->Color[idx] = Drawing::Int_To_RGB(idx < 2 ? defaultAlternate : defaultWhite);
 				}
 
-				pBoltExt->Arcs = pType->Bolt_Arcs;
-				pBolt->Lifetime = 1 << (std::clamp(pType->FadeDuration.Get(17), 1, 31) - 1);
-				pBolt->AlternateColor = pType->IsAlternateColor;
+					pBoltExt->Arcs = pType->Bolt_Arcs;
+					pBolt->Lifetime = 1 << (std::clamp(pType->FadeDuration.Get(17), 1, 31) - 1);
+					pBolt->AlternateColor = pType->IsAlternateColor;
 
-				pBolt->Fire(this->LastLocation, location, 0);
+					pBolt->Fire(this->LastLocation, location, 0);
+				}
 			}
 			else if (pType->DrawType == LaserTrailDrawType::RadBeam)
 			{
-				const auto pRadBeam = RadBeam::Allocate(RadBeamType::RadBeam);
-				pRadBeam->SetCoordsSource(this->LastLocation);
-				pRadBeam->SetCoordsTarget(location);
-				pRadBeam->Period = pType->FadeDuration.Get(15);
-				pRadBeam->Amplitude = pType->Beam_Amplitude;
+				// FOG CHECK: Only create RadBeam if both endpoints are visible
+				bool sourceVisible = true;
+				bool targetVisible = true;
 
-				const ColorStruct beamColor = pType->Beam_Color.Get(RulesClass::Instance->RadColor);
-				pRadBeam->SetColor(beamColor);
+				// Check if fog of war is enabled and we have valid instances
+				if (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.FogOfWar &&
+					&MapClass::Instance && TacticalClass::Instance) {
+
+					// Check source location
+					auto sourceCs = CellClass::Coord2Cell(this->LastLocation.Get());
+					auto* sourceCell = MapClass::Instance.TryGetCellAt(sourceCs);
+					sourceVisible = sourceCell && (sourceCell->Flags & CellFlags::EdgeRevealed);
+
+					// Check target location
+					auto targetCs = CellClass::Coord2Cell(location);
+					auto* targetCell = MapClass::Instance.TryGetCellAt(targetCs);
+					targetVisible = targetCell && (targetCell->Flags & CellFlags::EdgeRevealed);
+				}
+
+				// Only create RadBeam if both endpoints are visible
+				if (sourceVisible && targetVisible) {
+					const auto pRadBeam = RadBeam::Allocate(RadBeamType::RadBeam);
+					pRadBeam->SetCoordsSource(this->LastLocation);
+					pRadBeam->SetCoordsTarget(location);
+					pRadBeam->Period = pType->FadeDuration.Get(15);
+					pRadBeam->Amplitude = pType->Beam_Amplitude;
+
+					const ColorStruct beamColor = pType->Beam_Color.Get(RulesClass::Instance->RadColor);
+					pRadBeam->SetColor(beamColor);
+				}
 			}
 
 			result = true;

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -12,6 +12,10 @@
 #include <Ext/TechnoType/Body.h>
 #include <Ext/Rules/Body.h>
 
+#include <Windows.h>
+#include <RadBeam.h>
+#include "Misc/Hooks.RadBeam.h"
+
 #ifndef IS_RELEASE_VER
 bool HideWarning = false;
 #endif
@@ -24,6 +28,7 @@ wchar_t Phobos::wideBuffer[Phobos::readLength];
 const char* Phobos::AppIconPath = nullptr;
 
 bool Phobos::DisplayDamageNumbers = false;
+bool Phobos::DisplayTechnoNames = false;
 bool Phobos::IsLoadingSaveGame = false;
 
 bool Phobos::Optimizations::Applied = false;
@@ -225,6 +230,7 @@ DEFINE_HOOK(0x67E68A, LoadGame_UnsetFlag, 0x5)
 {
 	Phobos::IsLoadingSaveGame = false;
 	Phobos::ApplyOptimizations();
+	
 	return 0;
 }
 
@@ -232,6 +238,10 @@ DEFINE_HOOK(0x683E7F, ScenarioClass_Start_Optimizations, 0x7)
 {
 	Phobos::ApplyOptimizations();
 	RulesExt::ApplyRemoveShroudGlobally();
+
+	// Initialize RadBeam fog gating after other systems are ready
+	Install_RadBeamFogGate();
+
 	return 0;
 }
 

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -28,7 +28,6 @@ wchar_t Phobos::wideBuffer[Phobos::readLength];
 const char* Phobos::AppIconPath = nullptr;
 
 bool Phobos::DisplayDamageNumbers = false;
-bool Phobos::DisplayTechnoNames = false;
 bool Phobos::IsLoadingSaveGame = false;
 
 bool Phobos::Optimizations::Applied = false;

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -9,6 +9,8 @@
 #include <Utilities/Macro.h>
 #include "Utilities/AresHelper.h"
 #include "Utilities/Parser.h"
+#include <Ext/TechnoType/Body.h>
+#include <Ext/Rules/Body.h>
 
 #ifndef IS_RELEASE_VER
 bool HideWarning = false;
@@ -229,8 +231,11 @@ DEFINE_HOOK(0x67E68A, LoadGame_UnsetFlag, 0x5)
 DEFINE_HOOK(0x683E7F, ScenarioClass_Start_Optimizations, 0x7)
 {
 	Phobos::ApplyOptimizations();
+	RulesExt::ApplyRemoveShroudGlobally();
 	return 0;
 }
+
+
 
 #ifndef IS_RELEASE_VER
 DEFINE_HOOK(0x4F4583, GScreenClass_DrawText, 0x6)

--- a/src/UI/WorldText.cpp
+++ b/src/UI/WorldText.cpp
@@ -1,0 +1,75 @@
+#include <Phobos.h>
+#include <Misc/FogOfWar.h>
+
+#include <FlyingStrings.h>
+#include <ColorScheme.h>
+
+// Producer-side fog gating for world-anchored text
+// No low-level text hooks, just don't spawn text in fog
+
+namespace WorldTextFog {
+
+	// Floating damage numbers - hide if unit location is fogged
+	void SpawnDamageTextIfVisible(int damage, const CoordStruct& at, ColorSchemeIndex color) {
+		if (!Fog::ShouldShowActiveAt(at))
+			return; // Don't spawn damage text in fog
+
+		// Create floating damage text
+		wchar_t damageStr[32];
+		swprintf_s(damageStr, L"-%d", damage);
+		FlyingStrings::AddMoneyString(damageStr, at, color, nullptr, true);
+	}
+
+	// Bounty credit display - hide if target location is fogged
+	void SpawnBountyTextIfVisible(int credits, const CoordStruct& at, HouseClass* pHouse) {
+		if (!Fog::ShouldShowActiveAt(at))
+			return; // Don't spawn bounty text in fog
+
+		// Create floating credit text
+		wchar_t creditStr[32];
+		swprintf_s(creditStr, L"+$%d", credits);
+		ColorSchemeIndex color = pHouse ? pHouse->ColorSchemeIndex : ColorSchemeIndex::Yellow;
+		FlyingStrings::AddMoneyString(creditStr, at, color, pHouse, true);
+	}
+
+	// ProduceCashDisplay credits - hide if building location is fogged
+	void SpawnCashDisplayTextIfVisible(int credits, const CoordStruct& at, HouseClass* pHouse) {
+		if (!Fog::ShouldShowActiveAt(at))
+			return; // Don't spawn cash display text in fog
+
+		// Create floating cash text
+		wchar_t cashStr[32];
+		swprintf_s(cashStr, L"+$%d", credits);
+		ColorSchemeIndex color = pHouse ? pHouse->ColorSchemeIndex : ColorSchemeIndex::Green;
+		FlyingStrings::AddMoneyString(cashStr, at, color, pHouse, true);
+	}
+
+	// Generic floating text - hide if location is fogged
+	void SpawnWorldTextIfVisible(const wchar_t* text, const CoordStruct& at, ColorSchemeIndex color, HouseClass* pHouse = nullptr) {
+		if (!text || !Fog::ShouldShowActiveAt(at))
+			return; // Don't spawn text in fog
+
+		// Create floating text
+		FlyingStrings::AddMoneyString(text, at, color, pHouse, true);
+	}
+
+	// Experience/promotion text - hide if unit location is fogged
+	void SpawnPromotionTextIfVisible(const wchar_t* rankText, const CoordStruct& at, HouseClass* pHouse) {
+		if (!rankText || !Fog::ShouldShowActiveAt(at))
+			return; // Don't spawn promotion text in fog
+
+		ColorSchemeIndex color = pHouse ? pHouse->ColorSchemeIndex : ColorSchemeIndex::White;
+		FlyingStrings::AddMoneyString(rankText, at, color, pHouse, true);
+	}
+}
+
+// Usage examples:
+// Replace direct damage text creation:
+//   FlyingStrings::AddMoneyString(damageStr, at, color, house, true);
+// With:
+//   WorldTextFog::SpawnDamageTextIfVisible(damage, at, color);
+//
+// Replace direct bounty text creation:
+//   FlyingStrings::AddMoneyString(creditStr, at, color, house, true);
+// With:
+//   WorldTextFog::SpawnBountyTextIfVisible(credits, at, house);


### PR DESCRIPTION
### Picking up the closed PR [#530 ](#530 ).

**Forward ported the old PR and fixed the following from showing under fog:**

- [x] Ebolt
- [x] Shrapnel related Ebolts (ownerless?)
- [x] NaturalParticleSystem
- [x] RefinerySmokeParticleSystem (from UnitTypes)
- [x] DamageParticleSystems
- [x] SparkParticleSystem
- [x] LaserTrailClass (all 3 types)
- [x] LaserDrawClass (includes DiskLaserClass)
- [x] RadBeam
- [x] CaptureManager (MindControl unit link)
- [x] Phobos FlyingStrings
- [x] SpySat=yes support

**Other improvements:**
- Can be enabled via CnCNet Client, e.g. 
- Implemented `RemoveShroudGlobally` to combat the Shroud=no issue below
- Reworked fog proxy drawing to stop `BuildingType`, `OverlayType` and `TerrainType` flickering/vanishing under fog

**RemoveShroudGlobally**
I added this as a way to bypass the Shroud=no issue, it works by removing Shroud at the beginning of the game, while keeping Fog intact. How to use:
```
[General]
RemoveShroudGlobally=yes
```
_Note: this can also be enabled via CnCNet Client configuration_

**CnCNet Client**
In your game/skirmish/multiplayerlobby config, add a GameLobbyCheckBox with:
```
SpawnIniOption=FogOfWar
Checked=True
```




### **Still to do:**

> General
- [ ] Buildings fog proxy silhouette will disappear if they are destroyed, correct behaviour is to remain until revealed
- [ ] Sometimes XParticleSystem becomes visible
- [ ] Voxel turrets on BuildingTypes do not show currently
- [ ] Add coauth @secsome 
- [ ] Remove debug messages and comments in debug.log and code.

> Ares

- [ ] IonBlastClass::Draw / applyRipples / `Ripple.Radius`
- [ ] `ProduceCashDisplay`
- [ ] Flying strings such as Bounty

> Vanilla

- [ ] Sparky=yes on WH
- [ ] RevealToAll=yes - does reveal the building but it gets fogged soon after
- [ ] RadSite
- [ ] `RefinerySmokeParticleSystem` created by Slaved `InfantryTypes` still shows under fog

**Severe issues:**

- [ ] **Save/Load is not working, crash on load, not sure how far back I need to troubleshoot**
- [ ] Shroud=no completely breaks everything (offset by `RemoveShroudGlobally`)
- [ ] Performance, lots of objects under fog after some time = big impact on FPS, not sure why or how to tackle it.

**Future QOL:**
- [ ] LaserTrail drawing should respect height vs fog, e.g. 3D vs Cell drawn at ground level/Z.
- [ ] If we want` Shroud=no` instead of `RemoveShroudGlobally=yes`, a pro will need to look into it.


https://github.com/user-attachments/assets/fe707706-def8-4710-9441-4206b2dca752



<img width="1258" height="864" alt="image" src="https://github.com/user-attachments/assets/2bbad92e-ab13-4ecd-bb79-64585e2a1073" />

<img width="1265" height="861" alt="image" src="https://github.com/user-attachments/assets/d912a62e-01bf-497b-9bab-ccc1c15bd67c" />

