### PR TITLE
Implement open-topped building support and fix building self-attack issue

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -51,6 +51,8 @@ This page lists all the individual contributions to the project by their author.
   - Warhead activation target health thresholds
   - MP saves support for quicksave command and savegame trigger action
   - Ported XNA CnCNet Client MP save handling
+  - Open-topped buildings
+  - Building unload self-attack fix
 - **Uranusian (Thrifinesma)**:
   - Mind Control enhancement
   - Custom warhead splash list

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -262,6 +262,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `DeployingAnim` using unit drawer now also tint accordingly with the unit.
 - Fixed an issue that jumpjets in air can not correctly spawn missiles.
 - Fixed an issue that the currently hovered planning node not update up-to-date, such as using hotkeys to select technos.
+- Fixed `OpenTopped` to work with buildings.
+- Fixed buildings giving an order to attack self when unloading (manifested with opentopped buildings and garrisons leaving buildings sometimes).
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -473,6 +473,8 @@ Vanilla fixes:
 - `DeployingAnim` using unit drawer now also tint accordingly with the unit (by Starkku)
 - Jumpjets in air now can correctly spawn missiles (by TaranDahl)
 - Fixed an issue that the currently hovered planning node not update up-to-date, such as using hotkeys to select technos (by CrimRecya)
+- Fixed `OpenTopped` to work with buildings (by Kerbiter)
+- Fixed buildings giving an order to attack self when unloading (manifested with opentopped buildings and garrisons leaving buildings sometimes) (by Kerbiter)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -1130,6 +1130,7 @@ void TechnoExt::ExtData::UpdateTypeData_Foot()
 
 	// Update open topped state of potential passengers if transport's OpenTopped value changes.
 	// OpenTopped does not work properly with buildings to begin with which is why this is here rather than in the Techno update one.
+	// TODO move to non-foot since we now have proper building open-topped support
 	if (pThis->Passengers.NumPassengers > 0)
 	{
 		const bool toOpenTopped = pCurrentType->OpenTopped;


### PR DESCRIPTION
- Fixed `OpenTopped` to work with buildings.
- Fixed buildings giving an order to attack self when unloading (manifested with opentopped buildings and garrisons leaving buildings sometimes).

TODO: need to move UpdateTypeData_Foot thing related to OpenTopped to generic UpdateTypeData