### PR TITLE
[Vanilla Enhancement] Ignore center to minor radar event position

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -550,6 +550,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue that units' `LaserTrails` will always lags behind by one frame
   - Fix an issue that the currently hovered planning node not update up-to-date, such as using hotkeys to select technos
   - Allow the aircraft to enter area guard mission and not crash immediately without any airport
+  - Ignore center to minor radar event position
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -194,6 +194,7 @@
     <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
     <ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
     <ClCompile Include="src\Misc\Hooks.Overlay.cpp" />
+    <ClCompile Include="src\Misc\Hooks.RadarEvent.cpp" />
     <ClCompile Include="src\New\Type\Affiliated\TypeConvertGroup.cpp" />
     <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
     <ClCompile Include="src\Phobos.COM.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2376,3 +2376,14 @@ DropPod.Weapon.HitLandOnly=   ; boolean, default to no
 ```{note}
 `[General] -> DropPodTrailer` is [Ares feature](https://ares-developers.github.io/Ares-docs/new/droppod.html).
 ```
+
+## Radar event
+
+In vanilla game, any type of radar event will establish a new event position which can be centered when the hotkey is pressed.
+Now, by setting `IgnoreCenterMinorRadarEvent` to true, it is possible to skip setting some active and minor event positions (unit produced, unit repaired, building infiltrated, building captured, bridge repaired and garrison abandoned), while passive events are not affected (base attacked, ally base attacked, harvester attacked, superweapon detected, superweapon activated, unit lost, enemy sensed .etc).
+
+In `rulesmd.ini`:
+```ini
+[General]
+IgnoreCenterMinorRadarEvent=false  ; boolean
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -452,6 +452,7 @@ New:
 - [Unlimbo Detonate warhead](New-or-Enhanced-Logics.md#unlimbo-detonate-warhead) (by FlyStar)
 - Attack and damage technos underground (by TaranDahl)
 - Fast access structure (by FlyStar)
+- Ignore center to minor radar event position (by CrimRecya)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -315,10 +315,12 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->PlayerAttackMoveTargetingDelay.Read(exINI, GameStrings::General, "PlayerAttackMoveTargetingDelay");
 	this->DistributeTargetingFrame.Read(exINI, GameStrings::General, "DistributeTargetingFrame");
 	this->DistributeTargetingFrame_AIOnly.Read(exINI, GameStrings::General, "DistributeTargetingFrame.AIOnly");
-	
+
 	this->InfantryAutoDeploy.Read(exINI, GameStrings::General, "InfantryAutoDeploy");
 
 	this->AdjacentWallDamage.Read(exINI, GameStrings::CombatDamage, "AdjacentWallDamage");
+
+	this->IgnoreCenterMinorRadarEvent.Read(exINI, GameStrings::General, "IgnoreCenterMinorRadarEvent");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -589,6 +591,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Parasite_GrappleAnim)
 		.Process(this->InfantryAutoDeploy)
 		.Process(this->AdjacentWallDamage)
+		.Process(this->IgnoreCenterMinorRadarEvent)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -270,7 +270,9 @@ public:
 		Valueable<bool> InfantryAutoDeploy;
 
 		Valueable<int> AdjacentWallDamage;
-		
+
+		Valueable<bool> IgnoreCenterMinorRadarEvent;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -480,6 +482,8 @@ public:
 			, Parasite_GrappleAnim {}
 			, InfantryAutoDeploy { false }
 			, AdjacentWallDamage { 200 }
+
+			, IgnoreCenterMinorRadarEvent { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.RadarEvent.cpp
+++ b/src/Misc/Hooks.RadarEvent.cpp
@@ -1,0 +1,27 @@
+﻿#include <RadarEventClass.h>
+#include <Ext/Rules/Body.h>
+#include <Utilities/Macro.h>
+
+DEFINE_HOOK(0x65FC6E, RadarEventClass_CTOR_SkipSetRadarEventCell, 0x6)
+{
+	if (!RulesExt::Global()->IgnoreCenterMinorRadarEvent)
+		return 0;
+
+	GET(RadarEventClass*, pThis, ESI);
+
+	switch (pThis->Type)
+	{
+	case RadarEventType::UnitProduced:
+	case RadarEventType::UnitRepaired:
+	case RadarEventType::BuildingInfiltrated:
+	case RadarEventType::BuildingCaptured:
+	case RadarEventType::BridgeRepaired:
+	case RadarEventType::GarrisonAbandoned:
+		break;
+	default:
+		return 0;
+	}
+
+	R->ECX(Make_Global<int>(0xB04DB8)); // RadarEventClass::Array.Count
+	return 0x65FC9E;
+}


### PR DESCRIPTION
In vanilla game, any type of radar event will establish a new event position which can be centered when the hotkey is pressed.
Now, by setting `IgnoreCenterMinorRadarEvent` to true, it is possible to skip setting some active and minor event positions (unit produced, unit repaired, building infiltrated, building captured, bridge repaired and garrison abandoned), while passive events are not affected (base attacked, ally base attacked, harvester attacked, superweapon detected, superweapon activated, unit lost, enemy sensed .etc).

In `rulesmd.ini`:
```ini
[General]
IgnoreCenterMinorRadarEvent=false  ; boolean
```