### PR TITLE
[Minor] Auto Target Fix - Prioritize checking if the target is dead

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -394,6 +394,7 @@ This page lists all the individual contributions to the project by their author.
   - Health bar permanently displayed
   - Unlimbo Detonate warhead
   - Fast access structure
+  - The target of death is excluded from automatic target selection
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -265,6 +265,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that the currently hovered planning node not update up-to-date, such as using hotkeys to select technos.
 - Fixed an issue that infantry walking through a cell containing a tree would cause it to be impassable to other houses.
 - Fixed the bug that techno unit will draw with ironcurtain and airstrike color and intensity who disguised as terrain or overlay.
+- The target of death is excluded from automatic target selection.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -478,6 +478,7 @@ Vanilla fixes:
 - Fixed an issue that the jumpjet vehicles cannot stop correctly after going berserk (by TaranDahl)
 - Fixed an issue that infantry walking through a cell containing a tree would cause it to be impassable to other houses (by TaranDahl)
 - Fixed the bug that techno unit will draw with ironcurtain and airstrike color and intensity who disguised as terrain or overlay (by NetsuNegi)
+- The target of death is excluded from automatic target selection (by FlyStar)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1,4 +1,4 @@
-﻿#include <AircraftClass.h>
+#include <AircraftClass.h>
 #include <AircraftTrackerClass.h>
 #include <AnimClass.h>
 #include <BuildingClass.h>
@@ -2696,6 +2696,21 @@ DEFINE_HOOK(0x5218C2, InfantryClass_UnmarkAllOccupationBits_ResetOwnerIdx, 0x6)
 	// Vanilla check only the flag to decide if the InfantryOwnerIndex should be reset. 
 	// But the tree take one of the flag bit. So if a infantry walk through a cell with a tree, the InfantryOwnerIndex won't be reset.
 	return (newFlag & 0x1C) == 0 || pExt->InfantryCount == 0 ? Reset : NoReset;
+}
+
+#pragma endregion
+
+#pragma region CanAutoTargetFix
+
+DEFINE_JUMP(LJMP, 0x6F7D88, 0x6F7DA9)	// They should be placed at the front.
+
+DEFINE_HOOK(0x6F7CB7, TechnoClass_CanAutoTargetObject_IsAlive, 0x7)
+{
+	enum { ReturnFalse = 0x6F894F };
+
+	GET(TechnoClass*, pTarget, ESI);
+
+	return (!pTarget || !pTarget->IsAlive || pTarget->Health <= 0 || pTarget->InLimbo) ? ReturnFalse : 0;
 }
 
 #pragma endregion

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2749,13 +2749,31 @@ DEFINE_HOOK(0x44242A, BuildingClass_ReceiveDamage_SetLATime, 0x8)
 
 DEFINE_JUMP(LJMP, 0x6F7D88, 0x6F7DA9)	// They should be placed at the front.
 
-DEFINE_HOOK(0x6F7CB7, TechnoClass_CanAutoTargetObject_IsAlive, 0x7)
+DEFINE_HOOK_AGAIN(0x6F8B56, TechnoClass_CheckAutoTargetObject_OnMap, 0x5)	// TechnoClass::TryAutoTargetObject
+DEFINE_HOOK_AGAIN(0x6F9C89, TechnoClass_CheckAutoTargetObject_OnMap, 0x8)	// TechnoClass::SelectAutoTargetObject_TechnoClass.Array
+DEFINE_HOOK_AGAIN(0x6F9B9C, TechnoClass_CheckAutoTargetObject_OnMap, 0x8)	// TechnoClass::SelectAutoTargetObject_AircraftClass.Array
+DEFINE_HOOK(0x6F91F2, TechnoClass_CheckAutoTargetObject_OnMap, 0x9)			// TechnoClass::SelectAutoTargetObject_AircraftTrackerClass
 {
-	enum { ReturnFalse = 0x6F894F };
+	const DWORD address = R->Origin();
+	TechnoClass* const pTarget = (address == 0x6F91F2 || address == 0x6F8B56) ?
+		R->EBP<TechnoClass*>() : R->EDI<TechnoClass*>();
 
-	GET(TechnoClass*, pTarget, ESI);
+	if (!pTarget->IsAlive || pTarget->Health <= 0 || pTarget->InLimbo)
+	{
+		switch (address)
+		{
+		case 0x6F91F2:
+			return 0x6F9377;
+		case 0x6F9B9C:
+			return 0x6F9C48;
+		case 0x6F8B56:
+			return 0x6F8C07;
+		default:
+			return 0x6F9D93;
+		}
+	}
 
-	return (!pTarget || !pTarget->IsAlive || pTarget->Health <= 0 || pTarget->InLimbo) ? ReturnFalse : 0;
+	return 0;
 }
 
 #pragma endregion


### PR DESCRIPTION
Units that have already died enter auto-target checking, which can cause some issues, so try to fix them.
已经死亡的单位会进入自动索敌检查，它们可能会造成一些问题，因此尝试修复。