### PR TITLE
Distribution Mode Extension

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -509,11 +509,14 @@ For this command to work in multiplayer - you need to use a version of [YRpp spa
 - `AllowDistributionCommand.SpreadMode` & `AllowDistributionCommand.FilterMode` allow you to set spread range and target filter by hotkeys, which default to `DefaultDistributionSpreadMode` and `DefaultDistributionFilterMode`.
   - When the range is 0, it is the original default behavior of the game. The range can be adjusted to 4, 8 or 16 cells by another shortcut key. You can also adjust this by using the mouse wheel while holding down the specific hotkey if `AllowDistributionCommand.SpreadModeScroll` set to true;
     - The targets within the range will be allocated equally to the selected technos. Only when the behavior to be performed by the current techno is the same as that displayed by the mouse will it be allocated. Otherwise, it will return to the original default behavior of the game (it will not be effective for technos in the air). This will display a range ring.
+    - You can also set a list of integers in `DistributionMode.SpreadRanges`. In this case, the range of each step will follow these settings instead of being 0, 4, 8 and 16.
   - When the filter is `None`, it is the default behavior of the game. If the range is not zero at this time, a green ring will be displayed. You can adjust the filter mode to:
     - `Like` - only targets with the same armor type (Completely identical `Armor`) will be selected among the targets allocated in the range. At this time, a blue ring will be displayed.
     - `Type` - only targets of the same type (like infantries, vehicles or buildings) will be selected among the targets allocated in the range. At this time, a yellow ring will be displayed.
     - `Name` - only targets of the same name (or with the same `GroupAs`) will be selected among the targets allocated in the range. At this time, a red ring will be displayed.
 - `AllowDistributionCommand.AffectsAllies` & `AllowDistributionCommand.AffectsEnemies` allow the distribution command to work on allies (including owner) or enemies target. If picking a target that's not eligible, it'll fallback to vanilla command.
+- `DistributionMode.AllowActions` & `DistributionMode.DisallowActions` determine the missions that can or can't be used for distribution command. If picking a target that's not eligible, it'll fallback to vanilla command.
+  - By default `DistributionMode.AllowActions` is an empty list, which means all missions are eligible for distribution command unless listed in `DistributionMode.DisallowActions`.
 - It's possible to add a button for distribution mode in the bottom bar by adding `DistributionMode` in the `ButtonList` of `AdvancedCommandBar` and `MultiplayerAdvancedCommandBar`.
   - The positions of each button are hardcoded, so it'll only decide whether enable this button or not. Distribute Mode button is now always listed after all the vanilla ones.
   - The asset of these buttons should be added in `sidec0x.mix` files which correspond to different sides, with the name `button12.shp`.
@@ -530,6 +533,11 @@ AllowDistributionCommand.FilterMode=true            ; boolean
 AllowDistributionCommand.AffectsAllies=true         ; boolean
 AllowDistributionCommand.AffectsEnemies=true        ; boolean
 
+[General]
+DistributionMode.AllowActions=                      ; list of Action
+DistributionMode.DisallowActions=                   ; list of Action
+DistributionMode.SpreadRanges=0,4,8,16              ; list of integer
+
 [AudioVisual]
 StartDistributionModeSound=                         ; sound entry
 EndDistributionModeSound=                           ; sound entry
@@ -540,7 +548,7 @@ In `ra2md.ini`:
 ```ini
 [Phobos]
 DefaultApplyNoMoveCommand=true                      ; boolean
-DefaultDistributionSpreadMode=2                     ; integer, 0 - r=0 , 1 - r=4 , 2 - r=8 , 3 - r=16
+DefaultDistributionSpreadMode=2                     ; integer, index of values in DistributionMode.SpreadRanges
 DefaultDistributionFilterMode=2                     ; integer, 0 - None , 1 - Like , 2 - Type , 3 - Name
 ```
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -1,4 +1,4 @@
-﻿#include "Body.h"
+#include "Body.h"
 #include <Ext/Side/Body.h>
 #include <Utilities/TemplateDef.h>
 #include <FPSCounter.h>
@@ -263,6 +263,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->StartDistributionModeSound.Read(exINI, GameStrings::AudioVisual, "StartDistributionModeSound");
 	this->EndDistributionModeSound.Read(exINI, GameStrings::AudioVisual, "EndDistributionModeSound");
 	this->AddDistributionModeCommandSound.Read(exINI, GameStrings::AudioVisual, "AddDistributionModeCommandSound");
+	this->DistributionMode_AllowActions.Read(exINI, GameStrings::General, "DistributionMode.AllowActions");
+	this->DistributionMode_DisallowActions.Read(exINI, GameStrings::General, "DistributionMode.DisallowActions");
+	this->DistributionMode_SpreadRanges.Read(exINI, GameStrings::General, "DistributionMode.SpreadRanges");
 
 	this->ReplaceVoxelLightSources();
 
@@ -558,6 +561,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->StartDistributionModeSound)
 		.Process(this->EndDistributionModeSound)
 		.Process(this->AddDistributionModeCommandSound)
+		.Process(this->DistributionMode_AllowActions)
+		.Process(this->DistributionMode_DisallowActions)
+		.Process(this->DistributionMode_SpreadRanges)
 		.Process(this->UseFixedVoxelLighting)
 		.Process(this->AIAutoDeployMCV)
 		.Process(this->AISetBaseCenter)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -205,6 +205,9 @@ public:
 		ValueableIdx<VocClass> StartDistributionModeSound;
 		ValueableIdx<VocClass> EndDistributionModeSound;
 		ValueableIdx<VocClass> AddDistributionModeCommandSound;
+		ValueableVector<Action> DistributionMode_AllowActions;
+		ValueableVector<Action> DistributionMode_DisallowActions;
+		ValueableVector<int> DistributionMode_SpreadRanges;
 
 		Nullable<Vector3D<float>> VoxelLightSource;
 		// Nullable<Vector3D<float>> VoxelShadowLightSource;
@@ -439,6 +442,9 @@ public:
 			, StartDistributionModeSound { -1 }
 			, EndDistributionModeSound { -1 }
 			, AddDistributionModeCommandSound { -1 }
+			, DistributionMode_AllowActions { }
+			, DistributionMode_DisallowActions { }
+			, DistributionMode_SpreadRanges { }
 			, UseFixedVoxelLighting { false }
 			, AIAutoDeployMCV { true }
 			, AISetBaseCenter { true }

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -121,7 +121,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 
 	Phobos::Config::ApplyNoMoveCommand = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "DefaultApplyNoMoveCommand", true);
 	Phobos::Config::DistributionSpreadMode = CCINIClass::INI_RA2MD.ReadInteger(phobosSection, "DefaultDistributionSpreadMode", 2);
-	Phobos::Config::DistributionSpreadMode = std::clamp(Phobos::Config::DistributionSpreadMode, 0, 3);
+	//Phobos::Config::DistributionSpreadMode = std::clamp(Phobos::Config::DistributionSpreadMode, 0, 3);
 	Phobos::Config::DistributionFilterMode = CCINIClass::INI_RA2MD.ReadInteger(phobosSection, "DefaultDistributionFilterMode", 2);
 	Phobos::Config::DistributionFilterMode = std::clamp(Phobos::Config::DistributionFilterMode, 0, 3);
 


### PR DESCRIPTION
- `DistributionMode.AllowActions` & `DistributionMode.DisallowActions` determine the missions that can or can't be used for distribution command. If picking a target that's not eligible, it'll fallback to vanilla command.
  - By default `DistributionMode.AllowActions` is an empty list, which means all missions are eligible for distribution command unless listed in `DistributionMode.DisallowActions`.
- You can also set a list of integers in `DistributionMode.SpreadRanges`. In this case, the range of each step will follow these settings instead of being 0, 4, 8 and 16.

In `rulesmd.ini`:
```ini
[General]
DistributionMode.AllowActions=                      ; list of Action
DistributionMode.DisallowActions=                   ; list of Action
DistributionMode.SpreadRanges=0,4,8,16              ; list of integer
```

In `ra2md.ini`:
```ini
[Phobos]
DefaultDistributionSpreadMode=2                     ; integer, index of values in DistributionMode.SpreadRanges
```

TODO:
- implement Read function for Action
- more debugs