### PR TITLE
Fix owner change messing up building buildups if occuring simultaneously

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -279,6 +279,7 @@ This page lists all the individual contributions to the project by their author.
   - Delayed fire weapons
   - Changes / fixes to `Vertical` projectile logic and customizing projectile initial facing behavior
   - Bugfixes to map trigger action `125 Build At...`
+  - Owner change during buildup bugfix
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -303,6 +303,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue that technos head to building's dock even they are not going to dock.
 - Fixed an issue that the jumpjet vehicles cannot stop correctly after going berserk.
 - Fixed the issue where Ares' `Flash.Duration` cannot override the weapon's repair flash effect.
+- Fixed buildings that have their owner changed during buildup skipping buildup and sometimes not correctly clearing the state.
 
 ```{note}
 The described behavior is a replica of and is compliant with XNA CnCNet Client's multiplayer save game support.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -488,6 +488,7 @@ Vanilla fixes:
 - Iron Curtain/Custom Tint Support for SHP Turreted Vehicles (by NetsuNegi & FlyStar)
 - Reactivate unused trigger events 2, 53, and 54 (by FlyStar)
 - Fixed the bug that vehicle fall on infantry will make all cell content has been removed (by NetsuNegi)
+- Fixed buildings that have their owner changed during buildup skipping buildup and sometimes not correctly clearing the state (by Starkku)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)


### PR DESCRIPTION
Fixes a vanilla bug that causes owner change on buildings during buildup to instantly clear the buildup state. It was only working partially for buildings created by trigger action 125 (BState flag was not set to idle which caused buildup anims to loop indefinitely even though mission was reset), this fix should fix any remaining problems with that for mappers who use it on conjunction with house changing as well.