### PR TITLE
Fix scattered infantry units on game start

### DIFF
--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1579,13 +1579,15 @@ DEFINE_HOOK(0x688F8C, ScenarioClass_ScanPlaceUnit_CheckMovement, 0x5)
 	GET(TechnoClass*, pTechno, EBX);
 	LEA_STACK(CoordStruct*, pCoords, STACK_OFFSET(0x6C, -0x30));
 
-	if (pTechno->WhatAmI() == BuildingClass::AbsID)
+	const auto absType = pTechno->WhatAmI();
+
+	if (absType == BuildingClass::AbsID)
 		return 0;
 
 	const auto pCell = MapClass::Instance.GetCellAt(*pCoords);
 	const auto pTechnoType = pTechno->GetTechnoType();
 
-	return pCell->IsClearToMove(pTechnoType->SpeedType, pTechno->WhatAmI() == InfantryClass::AbsID, false, -1, pTechnoType->MovementZone, -1, 1) ? 0 : NotUsableArea;
+	return pCell->IsClearToMove(pTechnoType->SpeedType, absType == InfantryClass::AbsID, false, -1, pTechnoType->MovementZone, -1, 1) ? 0 : NotUsableArea;
 }
 
 DEFINE_HOOK(0x68927B, ScenarioClass_ScanPlaceUnit_CheckMovement2, 0x5)
@@ -1595,13 +1597,15 @@ DEFINE_HOOK(0x68927B, ScenarioClass_ScanPlaceUnit_CheckMovement2, 0x5)
 	GET(TechnoClass*, pTechno, EDI);
 	LEA_STACK(CoordStruct*, pCoords, STACK_OFFSET(0x6C, -0xC));
 
-	if (pTechno->WhatAmI() == BuildingClass::AbsID)
+	const auto absType = pTechno->WhatAmI();
+
+	if (absType == BuildingClass::AbsID)
 		return 0;
 
 	const auto pCell = MapClass::Instance.GetCellAt(*pCoords);
 	const auto pTechnoType = pTechno->GetTechnoType();
 
-	return pCell->IsClearToMove(pTechnoType->SpeedType, pTechno->WhatAmI() == InfantryClass::AbsID, false, -1, pTechnoType->MovementZone, -1, 1) ? 0 : NotUsableArea;
+	return pCell->IsClearToMove(pTechnoType->SpeedType, absType == InfantryClass::AbsID, false, -1, pTechnoType->MovementZone, -1, 1) ? 0 : NotUsableArea;
 }
 
 DEFINE_HOOK(0x446BF4, BuildingClass_Place_FreeUnit_NearByLocation, 0x6)


### PR DESCRIPTION
Fixes an issue where grouped starting infantry would scatter randomly instead of spawning together at game start.

The hooks `ScenarioClass_ScanPlaceUnit_CheckMovement` and `ScenarioClass_ScanPlaceUnit_CheckMovement2` were introduced to [fix a bug where naval ships could spawn on land](https://github.com/Phobos-developers/Phobos/pull/1552). It used:

```cpp
IsClearToMove(SpeedType, false, false, -1, MovementZone, -1, 1)
```
The first false parameter (ignoreInfantry = false) causes the function to check for infantry occupancy. During starting infantry placement, when multiple infantry are placed in a group, IsClearToMove() would return false for cells that already have infantry from the same group. Since infantry can share cells it causes scattering.

Before:
<img width="694" height="399" alt="before" src="https://github.com/user-attachments/assets/dd16fc07-f2c0-4049-b2c1-67fca228b296" />


After:
<img width="722" height="376" alt="after" src="https://github.com/user-attachments/assets/7111c371-c6da-445d-8576-a8244ca2e242" />
