### PR TITLE
Allow the attached animations to be retained and hidden when the unit disappears (f.ex. cloak, enters a vehicle)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -642,6 +642,7 @@ This page lists all the individual contributions to the project by their author.
   - Dehardcode the `ZAdjust` of warhead anim
   - Fix an issue where some effects pointing to a unit were not properly cleared when the unit changed its owner
   - Fix an issue where the vanilla script ignores jumpjets
+  - Allow the attached animations to be retained and hidden when the unit disappears (f.ex. cloak, enters a vehicle)
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -276,6 +276,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allow Reveal Crate to take effect when picking up by another player controlled house in campaign.
 - Fixed an issue where the vanilla script ignores jumpjets. Enable it through `[General] -> AIAirTargetingFix=true`.
 - Fixed the bug that naval ship will sink even they destroyed in air.
+- When a unit disappears (e.g., cloaks, enters a vehicle), the animations attached to it will be hidden instead of removed. Enable this feature through `[General] -> KeepAnimOnLimbo=true`.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -498,6 +498,7 @@ Vanilla fixes:
 - Fixed an issue where the vanilla script ignores jumpjets (by TaranDahl)
 - Fixed the issue where trigger events 2, 53 and 54 in persistent type triggers would be activated unconditionally after activation (by FlyStar)
 - Fixed the bug that naval ship will sink even they destroyed in air (by NetsuNegi)
+- Allow the attached animations to be retained and hidden when the unit disappears (f.ex. cloak, enters a vehicle) (by TaranDahl)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -550,3 +550,25 @@ DEFINE_HOOK(0x4250E1, AnimClass_Middle_CraterDestroyTiberium, 0x6)
 	return AnimTypeExt::ExtMap.Find(pType)->Crater_DestroyTiberium.Get(RulesExt::Global()->AnimCraterDestroyTiberium) ? 0 : SkipDestroyTiberium;
 }
 
+#pragma region KeepAnimOnLimbo
+
+DEFINE_HOOK(0x422C70, AnimClass_DrawIfVisible_DontDrawIfOwnerInLimbo, 0x6)
+{
+	if (!RulesExt::Global()->KeepAnimOnLimbo)
+		return 0;
+
+	GET(AnimClass*, pThis, ECX);
+	R->EAX(pThis->LoopDelay || pThis->OwnerObject && (pThis->OwnerObject->InLimbo || pThis->OwnerObject->VisualCharacter(true, HouseClass::CurrentPlayer) == VisualType::Hidden));
+	return R->Origin() + 0x6;
+}
+
+DEFINE_HOOK(0x425174, AnimClass_PointerExpired_KeepAnimOnLimbo, 0x6)
+{
+	if (!RulesExt::Global()->KeepAnimOnLimbo)
+		return 0;
+
+	GET_STACK(bool, bRemoved, STACK_OFFSET(0xC, 0x8));
+	return bRemoved ? 0 : 0x4251A3;
+}
+
+#pragma endregion

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -336,6 +336,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->SortCameoByName.Read(exINI, GameStrings::General, "SortCameoByName");
 
+	this->KeepAnimOnLimbo.Read(exINI, GameStrings::General, "KeepAnimOnLimbo");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -611,6 +613,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->FallingDownTargetingFix)
 		.Process(this->AIAirTargetingFix)
 		.Process(this->SortCameoByName)
+		.Process(this->KeepAnimOnLimbo)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -284,6 +284,7 @@ public:
 		Valueable<bool> AIAirTargetingFix;
 
 		Valueable<bool> SortCameoByName;
+		Valueable<bool> KeepAnimOnLimbo;
 		
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -508,6 +509,7 @@ public:
 			, AIAirTargetingFix { false }
 
 			, SortCameoByName { false }
+			, KeepAnimOnLimbo { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- When a unit disappears (e.g., cloaks, enters a vehicle), the animations attached to it will be hidden instead of removed. Enable this feature through `[General] -> KeepAnimOnLimbo=true`.