### PR TITLE
Replace game's CRT function call in floating point number INI parser

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -554,6 +554,7 @@ Phobos fixes:
 - Fixed an issue with `Powered`/`PoweredSpecial` building animation ownership change fix (by Trsdy)
 - Fixed `DisplayIncome`, `Transact.Money` etc. display strings showing through shroud and for objects that are supposed to be hidden such as cloaked, undetected enemies (by Starkku)
 - Fixed an issue that could cause crashes when `FeedbackWeapon` was used to convert the firer to another TechnoType with less or no weapons (by Starkku)
+- Fixed an issue with parsing floating point numbers from INI that may have in some cases contributed to desyncs (by Starkku)
 ```
 
 ### 0.4

--- a/src/Utilities/Parser.h
+++ b/src/Utilities/Parser.h
@@ -263,8 +263,10 @@ inline bool Parser<double>::TryParse(const char* pValue, OutType* outValue)
 	errno = 0;
 	char* end;
 
-	// Nov 23, 2025 - Starkku: strtod() + cast result to float produces results
-	// more similar to game's CRT functions than using sscanf_s.
+	// Nov 23, 2025 - Starkku, Kerbiter: strtod() + cast result to float produces
+	// results more similar to game's CRT functions than using sscanf_s. For some
+	// reason CnC-DDraw in DirectX mode causes game's CRT function usage here to change
+	// for some players, causing stably reproducible desyncs when CMIN appears, f.ex.
 	double value = strtod(pValue, &end);
 
 	if (pValue == end || errno == ERANGE)

--- a/src/Utilities/Parser.h
+++ b/src/Utilities/Parser.h
@@ -35,7 +35,6 @@
 #include <type_traits>
 #include <Windows.h>
 #include <stdio.h>
-#include <CRT.h>
 
 //! Parses strings into one or more elements of another type.
 /*!
@@ -261,35 +260,45 @@ inline bool Parser<int>::TryParse(const char* pValue, OutType* outValue)
 template<>
 inline bool Parser<double>::TryParse(const char* pValue, OutType* outValue)
 {
+	errno = 0;
+	char* end;
 
-	// Game doesn't use double precision when parsing, using double here would create inconsistency.
-	float buffer = 0.0;
+	// Nov 23, 2025 - Starkku: strtod() + cast result to float produces results
+	// more similar to game's CRT functions than using sscanf_s.
+	double value = strtod(pValue, &end);
 
-	// Use game's sscanf function, the C library one has different precision/rounding.
-	if (CRT::sscanf(pValue, "%f", &buffer) == 1)
+	if (pValue == end || errno == ERANGE)
+		return false;
+
+	float floatValue = static_cast<float>(value);
+
+	if (strchr(pValue, '%'))
 	{
-		if (strchr(pValue, '%'))
-		{
-			buffer *= 0.01f;
-		}
-		if (outValue)
-		{
-			*outValue = buffer;
-		}
-		return true;
+		floatValue *= 0.01f;
 	}
-	return false;
+	if (outValue)
+	{
+		*outValue = floatValue;
+	}
+	return true;
 };
 
 template<>
 inline bool Parser<float>::TryParse(const char* pValue, OutType* outValue)
 {
 	double buffer = 0.0;
+
 	if (Parser<double>::TryParse(pValue, &buffer))
 	{
+		float floatValue = static_cast<float>(buffer);
+
+		if (strchr(pValue, '%'))
+		{
+			floatValue *= 0.01f;
+		}
 		if (outValue)
 		{
-			*outValue = static_cast<float>(buffer);
+			*outValue = floatValue;
 		}
 		return true;
 	}


### PR DESCRIPTION
Attempts to address one of the issues presented in #1970 by working around the changes introduced in 9c8bd9ecf9a81b4da294875cf5e1f842471fae49 by replacing calling game's CRT functions. `sscanf(_s)` produces results with different precision from game's `sscanf`. Using `strtod` and casting the result double into float appears to be more accurate but whether or not these results are consistent across different systems I do not know.

This merely addresses the floating point number parsing in Phobos (which also replaces game's floating point number INI parser, see hook `INIClass_ReadDouble_Overwrite` in `Misc\Hooks.INIInheritance.cpp`) and does not in any way involve any potential root causes for why calling game's CRT functions is problematic in the first place.