### PR TITLE
Allow techno type considered as other type when AI recruit techno for teams

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -462,6 +462,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug that building with `CloningFacility=true` and `WeaponsFactory=true` may cloning multiple vehicles and then they get stuck
   - Customize Ares's radar jam logic
   - Customize if cloning need power
+  - Allow techno type considered as other type when AI recruit techno for teams
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1613,6 +1613,16 @@ HeightShadowScaling.MinScale=0.0  ; floating point value
 ShadowSizeCharacteristicHeight=   ; integer, height in leptons
 ```
 
+### Allow techno type considered as other type when AI recruit techno for teams
+
+- It is now possible to make techno type considered as other type when AI recruit techno for teams.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                      ; TechnoType
+TeamMember.ConsideredAs=        ; list of technotypes
+```
+
 ## Terrains
 
 ### Animated TerrainTypes

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -462,6 +462,7 @@ New:
 - [Allow deploy controlled MCV](Fixed-or-Improved-Logics.md#allow-deploy-controlled-mcv) (by NetsuNegi)
 - [Customize if cloning need power](Fixed-or-Improved-Logics.md#customize-if-cloning-need-power) (by NetsuNegi)
 - [Add Target Filtering Options to AttachEffect System](New-or-Enhanced-Logics.md#attached-effects) (by Flactine)
+- Allow techno type considered as other type when AI recruit techno for teams (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Team/Hooks.cpp
+++ b/src/Ext/Team/Hooks.cpp
@@ -1,5 +1,6 @@
 #include "Body.h"
 #include <Utilities/AresHelper.h>
+#include <Ext/TechnoType/Body.h>
 
 // Bugfix: TAction 7,80,107.
 DEFINE_HOOK(0x65DF67, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x6)
@@ -52,4 +53,96 @@ DEFINE_HOOK(0x65DF67, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x6)
 		pTransport->ReceiveGunner(pGunner);
 
 	return 0x65DF8D;
+}
+
+DEFINE_HOOK(0x6EA6BE, TeamClass_CanAddMember_Consideration, 0x6)
+{
+	enum { SkipGameCode = 0x6EA6F2 };
+
+	GET(TeamClass*, pTeam, EBP);
+	GET(FootClass*, pFoot, ESI);
+	GET(int*, idx, EBX);
+	const auto pFootType = pFoot->GetTechnoType();
+	const auto pFootTypeExt = TechnoTypeExt::ExtMap.Find(pFootType);
+	const auto pTaskForce = pTeam->Type->TaskForce;
+
+	do
+	{
+		const auto pType = pTaskForce->Entries[*idx].Type;
+
+		if (pType == pFootType || pFootTypeExt->TeamMember_ConsideredAs.Contains(pType))
+			break;
+
+		*idx = *idx + 1;
+	}
+	while (pTaskForce->CountEntries > *idx);
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x6EA8E7, TeamClass_LiberateMember_Consideration, 0x5)
+{
+	enum { SkipGameCode = 0x6EA91B };
+
+	GET(TeamClass*, pTeam, EDI);
+	GET(FootClass*, pMember, EBP);
+	int idx = 0;
+	const auto pMemberType = pMember->GetTechnoType();
+	const auto pMemberTypeExt = TechnoTypeExt::ExtMap.Find(pMemberType);
+	const auto pTaskForce = pTeam->Type->TaskForce;
+
+	do
+	{
+		const auto pSearchType = pTaskForce->Entries[idx].Type;
+
+		if (pSearchType == pMemberType || pMemberTypeExt->TeamMember_ConsideredAs.Contains(pSearchType))
+			break;
+
+		++idx;
+	}
+	while (pTaskForce->CountEntries > idx);
+
+	R->Stack(STACK_OFFSET(0x14, 0x8), idx);
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x6EAD73, TeamClass_Sub_6EAA90_Consideration, 0x7)
+{
+	enum { ContinueCheck = 0x6EAD8F, SkipThisMember = 0x6EADB3 };
+
+	GET(TeamClass*, pTeam, ECX);
+	GET(UnitClass*, pMember, ESI);
+	GET_STACK(int, idx, STACK_OFFSET(0x3C, 0x4));
+	const auto pMemberType = pMember->Type;
+	const auto pTaskForce = pTeam->Type->TaskForce;
+	const auto pSearchType = pTaskForce->Entries[idx].Type;
+
+	return pSearchType == pMemberType || TechnoTypeExt::ExtMap.Find(pMemberType)->TeamMember_ConsideredAs.Contains(pSearchType) ? ContinueCheck : SkipThisMember;
+}
+
+DEFINE_HOOK(0x6EF57F, TeamClass_GetTaskForceMissingMemberTypes_Consideration, 0x5)
+{
+	enum { ContinueIn = 0x6EF584, SkipThisMember = 0x6EF5A5 };
+
+	GET(int, idx, EAX);
+
+	if (idx != -1)
+		return ContinueIn;
+
+	GET(DynamicVectorClass<TechnoTypeClass*>*, vector, ESI);
+	GET(FootClass*, pMember, EDI);
+	const auto pMemberTypeExt = TechnoTypeExt::ExtMap.Find(pMember->GetTechnoType());
+
+	for (const auto pConsideType : pMemberTypeExt->TeamMember_ConsideredAs)
+	{
+		idx = vector->FindItemIndex(pConsideType);
+
+		if (idx != -1)
+		{
+			R->EAX(idx);
+			return ContinueIn;
+		}
+	}
+
+	return SkipThisMember;
 }

--- a/src/Ext/Team/Hooks.cpp
+++ b/src/Ext/Team/Hooks.cpp
@@ -106,7 +106,7 @@ DEFINE_HOOK(0x6EA8E7, TeamClass_LiberateMember_Consideration, 0x5)
 	return SkipGameCode;
 }
 
-DEFINE_HOOK(0x6EAD73, TeamClass_Sub_6EAA90_Consideration, 0x7)
+DEFINE_HOOK(0x6EAD73, TeamClass_RecruitMember_Consideration, 0x7)
 {
 	enum { ContinueCheck = 0x6EAD8F, SkipThisMember = 0x6EADB3 };
 

--- a/src/Ext/Team/Hooks.cpp
+++ b/src/Ext/Team/Hooks.cpp
@@ -1,6 +1,6 @@
 #include "Body.h"
 #include <Utilities/AresHelper.h>
-#include <Ext/TechnoType/Body.h>
+#include <Ext/Techno/Body.h>
 
 // Bugfix: TAction 7,80,107.
 DEFINE_HOOK(0x65DF67, TeamTypeClass_CreateMembers_LoadOntoTransport, 0x6)
@@ -62,8 +62,8 @@ DEFINE_HOOK(0x6EA6BE, TeamClass_CanAddMember_Consideration, 0x6)
 	GET(TeamClass*, pTeam, EBP);
 	GET(FootClass*, pFoot, ESI);
 	GET(int*, idx, EBX);
-	const auto pFootType = pFoot->GetTechnoType();
-	const auto pFootTypeExt = TechnoTypeExt::ExtMap.Find(pFootType);
+	const auto pFootTypeExt = TechnoExt::ExtMap.Find(pFoot)->TypeExtData;
+	const auto pFootType = pFootTypeExt->OwnerObject();
 	const auto pTaskForce = pTeam->Type->TaskForce;
 
 	do
@@ -87,8 +87,8 @@ DEFINE_HOOK(0x6EA8E7, TeamClass_LiberateMember_Consideration, 0x5)
 	GET(TeamClass*, pTeam, EDI);
 	GET(FootClass*, pMember, EBP);
 	int idx = 0;
-	const auto pMemberType = pMember->GetTechnoType();
-	const auto pMemberTypeExt = TechnoTypeExt::ExtMap.Find(pMemberType);
+	const auto pMemberTypeExt = TechnoExt::ExtMap.Find(pMember)->TypeExtData;
+	const auto pMemberType = pMemberTypeExt->OwnerObject();
 	const auto pTaskForce = pTeam->Type->TaskForce;
 
 	do
@@ -112,7 +112,7 @@ DEFINE_HOOK(0x6EAD73, TeamClass_RecruitMember_Consideration, 0x7)
 
 	GET(TeamClass*, pTeam, ECX);
 	GET(UnitClass*, pMember, ESI);
-	GET_STACK(int, idx, STACK_OFFSET(0x3C, 0x4));
+	GET_STACK(const int, idx, STACK_OFFSET(0x3C, 0x4));
 	const auto pMemberType = pMember->Type;
 	const auto pTaskForce = pTeam->Type->TaskForce;
 	const auto pSearchType = pTaskForce->Entries[idx].Type;
@@ -131,7 +131,7 @@ DEFINE_HOOK(0x6EF57F, TeamClass_GetTaskForceMissingMemberTypes_Consideration, 0x
 
 	GET(DynamicVectorClass<TechnoTypeClass*>*, vector, ESI);
 	GET(FootClass*, pMember, EDI);
-	const auto pMemberTypeExt = TechnoTypeExt::ExtMap.Find(pMember->GetTechnoType());
+	const auto pMemberTypeExt = TechnoExt::ExtMap.Find(pMember)->TypeExtData;
 
 	for (const auto pConsideType : pMemberTypeExt->TeamMember_ConsideredAs)
 	{

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1011,6 +1011,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttackMove_PursuitTarget.Read(exINI, pSection, "AttackMove.PursuitTarget");
 
 	this->InfantryAutoDeploy.Read(exINI, pSection, "InfantryAutoDeploy");
+
+	this->TeamMember_ConsideredAs.Read(exINI, pSection, "TeamMember.ConsideredAs");
 	
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1668,6 +1670,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->VoiceEliteWeaponAttacks)
 
 		.Process(this->InfantryAutoDeploy)
+
+		.Process(this->TeamMember_ConsideredAs)
 
 		.Process(this->TurretResponse)
 		;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -437,6 +437,8 @@ public:
 
 		Nullable<bool> InfantryAutoDeploy;
 
+		ValueableVector<TechnoTypeClass*> TeamMember_ConsideredAs;
+
 		Nullable<bool> TurretResponse;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
@@ -826,6 +828,8 @@ public:
 			, VoiceEliteWeaponAttacks {}
 
 			, InfantryAutoDeploy {}
+
+			, TeamMember_ConsideredAs {}
 
 			, TurretResponse {}
 		{ }


### PR DESCRIPTION
### Allow techno type considered as other type when recruiting techno for teams

- It is now possible to make techno type considered as other type when recruiting techno for teams, both for AI team recruitment and `Create Team` action.
  - Only affect techno that's presented on the map. Cannot make AI produce this type of techno if it doesn't have any.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                      ; TechnoType
TeamMember.ConsideredAs=        ; list of technotypes
```