### PR TITLE
[MINOR] Fix MPDebug timer displaying when debug's visibility is off

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -685,3 +685,4 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
+- **11EJDE11** - Prevent mpdebug number from being drawn when visibility toggled off

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -501,6 +501,7 @@ Vanilla fixes:
 - Fixed an issue where the vanilla script ignores jumpjets (by TaranDahl)
 - Fixed the issue where trigger events 2, 53 and 54 in persistent type triggers would be activated unconditionally after activation (by FlyStar)
 - Fixed the bug that naval ship will sink even they destroyed in air (by NetsuNegi)
+- Fixed MPDebug timer displaying when debug's visibility is off (by 11EJDE11)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -502,3 +502,14 @@ DEFINE_HOOK(0x552F79, LoadProgressManager_Draw_MissingLoadingScreenDefaults, 0x6
 
 	return 0;
 }
+
+// Hides the number at top-left of screen when debug stats are not being drawn
+DEFINE_HOOK(0x55F1F8, MPDebugPrint_CheckDrawFlag, 0x8)
+{
+	if (!Game::DrawMPDebugStats)
+	{
+		return 0x55F280;
+	}
+
+	return 0;
+}

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -506,10 +506,5 @@ DEFINE_HOOK(0x552F79, LoadProgressManager_Draw_MissingLoadingScreenDefaults, 0x6
 // Hides the number at top-left of screen when debug stats are not being drawn
 DEFINE_HOOK(0x55F1F8, MPDebugPrint_CheckDrawFlag, 0x8)
 {
-	if (!Game::DrawMPDebugStats)
-	{
-		return 0x55F280;
-	}
-
-	return 0;
+    return Game::DrawMPDebugStats ? 0 : 0x55F280;
 }


### PR DESCRIPTION
In vanilla, the MP debug number at top-left shows even when debug stats display is toggled off. This change hides the number when `DrawMPDebugStats` is false which makes it consistent with the rest of the debug stats panel.

I'm not sure what the number represents - event timing perhaps.

<img width="448" height="512" alt="image" src="https://github.com/user-attachments/assets/b9e5fbab-8f8f-440d-8e89-e348c0ae6c52" />
