### PR TITLE
Map event 601 behaviour change

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -523,6 +523,7 @@ Phobos fixes:
 - Fixed an issue where the game would only use `Weapon1` and `Weapon2` for auto-targeting even when `MultiWeapon=yes` was set (by FlyStar)
 - Fixed a game load crash caused by `MultiWeapon.IsSecondary=-1` or non-projectile weapons (by FlyStar)
 - Fixed an issue that caused Ares's `Battery.KeepOnline` cannot keep defense buildings works fine (by NetsuNegi)
+- Map Event 601 should return true only when exists in the map like other similar map events (by FS-21)
 
 Fixes / interactions with other extensions:
 <!--  - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)  -->

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -214,7 +214,27 @@ bool TEventExt::HouseOwnsTechnoTypeTEvent(TEventClass* pThis)
 	if (!pHouse)
 		return false;
 
-	return pHouse->CountOwnedNow(pType) > 0;
+	if (pType->WhatAmI() == AbstractType::BuildingType)
+	{
+		auto const pHouseExt = HouseExt::ExtMap.Find(pHouse);
+		auto& vec = pHouseExt->OwnedLimboDeliveredBuildings;
+
+		for (auto pBuilding : pHouse->Buildings)
+		{
+			if (pBuilding->Type != pType)
+				continue;
+
+			if (pBuilding->IsAlive && pBuilding->Health > 0 && !pBuilding->InLimbo)
+				return true;
+		}
+
+		return false;
+	}
+	else
+	{
+		int count = pHouse->CountOwnedNow(pType);
+		return pHouse->CountOwnedNow(pType) > 0;
+	}
 }
 
 bool TEventExt::HouseDoesntOwnTechnoTypeTEvent(TEventClass* pThis)

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -206,17 +206,19 @@ bool TEventExt::VariableCheckBinary(TEventClass* pThis)
 
 bool TEventExt::HouseOwnsTechnoTypeTEvent(TEventClass* pThis)
 {
-	auto pType = TechnoTypeClass::Find(pThis->String);
+	auto const pType = TechnoTypeClass::Find(pThis->String);
+
 	if (!pType)
 		return false;
 
-	auto pHouse = HouseClass::Index_IsMP(pThis->Value) ? HouseClass::FindByIndex(pThis->Value) : HouseClass::FindByCountryIndex(pThis->Value);
+	auto const pHouse = HouseClass::Index_IsMP(pThis->Value) ? HouseClass::FindByIndex(pThis->Value) : HouseClass::FindByCountryIndex(pThis->Value);
+
 	if (!pHouse)
 		return false;
 
 	if (pType->WhatAmI() == AbstractType::BuildingType)
 	{
-		for (auto pBuilding : pHouse->Buildings)
+		for (auto const pBuilding : pHouse->Buildings)
 		{
 			if (pBuilding->Type != pType)
 				continue;
@@ -227,11 +229,8 @@ bool TEventExt::HouseOwnsTechnoTypeTEvent(TEventClass* pThis)
 
 		return false;
 	}
-	else
-	{
-		int count = pHouse->CountOwnedNow(pType);
-		return pHouse->CountOwnedNow(pType) > 0;
-	}
+
+	return pHouse->CountOwnedNow(pType) > 0;
 }
 
 bool TEventExt::HouseDoesntOwnTechnoTypeTEvent(TEventClass* pThis)

--- a/src/Ext/TEvent/Body.cpp
+++ b/src/Ext/TEvent/Body.cpp
@@ -216,9 +216,6 @@ bool TEventExt::HouseOwnsTechnoTypeTEvent(TEventClass* pThis)
 
 	if (pType->WhatAmI() == AbstractType::BuildingType)
 	{
-		auto const pHouseExt = HouseExt::ExtMap.Find(pHouse);
-		auto& vec = pHouseExt->OwnedLimboDeliveredBuildings;
-
 		for (auto pBuilding : pHouse->Buildings)
 		{
 			if (pBuilding->Type != pType)


### PR DESCRIPTION
By default the Map Event 601 returns TRUE as soon as you click in the sidebar for producing the techno instead of return TRUE when is placed.

The expected behaviour was like other map events that checks if exists in the map.

Since is a change/fix shouldn't be necessary more documentation about this.
