### PR TITLE
Map Event 1000 - Force the check of events in sequential order

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -152,6 +152,7 @@ This page lists all the individual contributions to the project by their author.
   - Warhead activation target health thresholds enhancements
   - Event 606: AttachEffect is attaching to a Techno
   - Linked superweapons
+  - Force the check of events in sequential order
 - **Starkku**:
   - Misc. minor bugfixes & improvements
   - AI script actions:

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="src\Ext\Infantry\Hooks.Firing.cpp" />
     <ClCompile Include="src\Ext\TechnoType\Hooks.MultiWeapon.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Targeting.cpp" />
+    <ClCompile Include="src\Ext\Trigger\Body.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.DrawIt.cpp" />
     <ClCompile Include="src\Ext\Unit\Hooks.Firing.cpp" />
     <ClCompile Include="src\Ext\EBolt\Body.cpp" />
@@ -218,6 +219,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Ext\EBolt\Body.h" />
+    <ClInclude Include="src\Ext\Trigger\Body.h" />
     <ClInclude Include="src\New\Entity\Ares\RadarJammerClass.h" />
     <ClInclude Include="src\New\Type\Affiliated\CreateUnitTypeClass.h" />
     <ClInclude Include="src\Blowfish\blowfish.h" />

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -881,3 +881,18 @@ In `mycampaign.map`:
 ID=EventCount,...,606,2,0,[AttachEffectType],...
 ...
 ```
+
+### `1000` Force the check of events in sequential order
+
+- By default, the game evaluates all map triggers in parallel. Adding this map event forces short-circuit evaluation as soon as any subsequent event returns `false`.
+- This only affects evaluation from this control event (inclusive) to the last event in the list.
+- All events placed before this control event still work in a non-short-circuiting manner.
+- Sequential events will not begin evaluation until all preceding events have successfully completed.
+
+In `mycampaign.map`:
+```ini
+[Events]
+...
+ID=EventCount,...,1000,0,0,0,...
+...
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -463,6 +463,7 @@ New:
 - [Customize if cloning need power](Fixed-or-Improved-Logics.md#customize-if-cloning-need-power) (by NetsuNegi)
 - [Added Target Filtering Options to AttachEffect System](New-or-Enhanced-Logics.md#attached-effects) (by Flactine)
 - [Customize type selection for IFV](Fixed-or-Improved-Logics.md#customize-type-selection-for-ifv) (by NetsuNegi)
+- Force the check of events in sequential order (by FS-21)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/TEvent/Body.h
+++ b/src/Ext/TEvent/Body.h
@@ -56,6 +56,8 @@ enum PhobosTriggerEvent
 	CellHasAnyTechnoTypeFromList = 605,
 	AttachedIsUnderAttachedEffect = 606,
 
+	ForceSequentialEvents = 1000,
+
 	_DummyMaximum,
 };
 

--- a/src/Ext/Trigger/Body.cpp
+++ b/src/Ext/Trigger/Body.cpp
@@ -1,0 +1,101 @@
+#include "Body.h"
+
+#include <BuildingClass.h>
+#include <InfantryClass.h>
+#include <HouseClass.h>
+
+#include <Ext/Scenario/Body.h>
+#include <Ext/Techno/Body.h>
+
+//Static init
+TriggerExt::ExtContainer TriggerExt::ExtMap;
+
+// =============================
+// load / save
+
+template <typename T>
+void TriggerExt::ExtData::Serialize(T& Stm)
+{
+	Stm
+		.Process(this->SortedEventsList)
+		.Process(this->SequentialTimers)
+		.Process(this->SequentialTimersOriginalValue)
+		.Process(this->ParallelTimers)
+		.Process(this->ParallelTimersOriginalValue)
+		.Process(this->SequentialSwitchModeIndex)
+		;
+}
+
+void TriggerExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)
+{
+	Extension<TriggerClass>::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void TriggerExt::ExtData::SaveToStream(PhobosStreamWriter& Stm)
+{
+	Extension<TriggerClass>::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+DEFINE_HOOK(0x7260C8, TriggerClass_CTOR, 0x8)
+{
+	GET(TriggerClass*, pItem, ESI);
+
+	TriggerExt::ExtMap.Allocate(pItem);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x72617D, TriggerClass_DTOR, 0xF)
+{
+	GET(TriggerClass*, pItem, ESI);
+
+	TriggerExt::ExtMap.Remove(pItem);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x726860, TriggerClass_Load_Prefix, 0x5)
+{
+	GET_STACK(TriggerClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	TriggerExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7268CB, TriggerClass_Load_Suffix, 0x4)
+{
+	TriggerExt::ExtMap.LoadStatic();
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7268D0, TriggerClass_Save_Prefix, 0x8)
+{
+	GET_STACK(TriggerClass*, pItem, 0x4);
+	GET_STACK(IStream*, pStm, 0x8);
+
+	TriggerExt::ExtMap.PrepareStream(pItem, pStm);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x7268EA, TriggerClass_Save_Suffix, 0x5)
+{
+	TriggerExt::ExtMap.SaveStatic();
+
+	return 0;
+}
+
+// =============================
+// container
+
+TriggerExt::ExtContainer::ExtContainer() : Container("TriggerClass") { }
+
+TriggerExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// container hooks

--- a/src/Ext/Trigger/Body.h
+++ b/src/Ext/Trigger/Body.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <TriggerClass.h>
+#include <timer.h>
+
+#include <map>
+
+#include <Helpers/Macro.h>
+#include <Utilities/Container.h>
+#include <Utilities/Constructs.h>
+#include <Utilities/Template.h>
+
+class TriggerExt
+{
+public:
+	using base_type = TriggerClass;
+
+	static constexpr DWORD Canary = 0x73171331;
+
+	class ExtData final : public Extension<TriggerClass>
+	{
+	public:
+		std::vector<TEventClass*> SortedEventsList;
+		PhobosMap<int, CDTimerClass> SequentialTimers;
+		std::map<int, int> SequentialTimersOriginalValue;
+		PhobosMap<int, CDTimerClass> ParallelTimers;
+		std::map<int, int> ParallelTimersOriginalValue;
+		int SequentialSwitchModeIndex = -1;
+
+		ExtData(TriggerClass* OwnerObject) : Extension<TriggerClass>(OwnerObject)
+			, SortedEventsList {}
+			, SequentialTimers {}
+			, SequentialTimersOriginalValue {}
+			, ParallelTimers {}
+			, ParallelTimersOriginalValue {}
+			, SequentialSwitchModeIndex { -1 }
+		{ }
+
+		virtual ~ExtData() = default;
+
+		virtual void InvalidatePointer(void* ptr, bool bRemoved) override { }
+
+		virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+	private:
+		template <typename T>
+		void Serialize(T& Stm);
+	};
+
+	class ExtContainer final : public Container<TriggerExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+	};
+
+	static ExtContainer ExtMap;
+};

--- a/src/Ext/Trigger/Hooks.cpp
+++ b/src/Ext/Trigger/Hooks.cpp
@@ -102,6 +102,7 @@ DEFINE_HOOK(0x7264C0, TriggerClass_RegisterEvent_ForceSequentialEvents, 0x0)
 		R->AL(false);
 		return SkipGameCode;
 	}
+
 	auto pExt = TriggerExt::ExtMap.Find(pThis);
 	bool isSequentialMode = false; // Flag: Controls if short-circuit is active for subsequent events
 	bool allEventsSuccessful = true;
@@ -123,18 +124,16 @@ DEFINE_HOOK(0x7264C0, TriggerClass_RegisterEvent_ForceSequentialEvents, 0x0)
 			}
 			else if (pExt->SequentialTimers.contains(i))
 			{
-				eventTimer = pExt->SequentialTimers[i];
-
-				if (eventTimer.HasTimeLeft()
-				&& !eventTimer.InProgress()
-				&& !eventTimer.Completed())
+				if (pExt->SequentialTimers[i].HasTimeLeft()
+				&& !pExt->SequentialTimers[i].InProgress()
+				&& !pExt->SequentialTimers[i].Completed())
 				{
 					pExt->SequentialTimers[i].Resume();
-					eventTimer.Resume();
 				}
+
+				eventTimer = pExt->SequentialTimers[i];
 			}
 
-			// *** 1. Lógica del Interruptor de Modo (Evento 1000) ***
 			if (static_cast<int>(pCurrentEvent->EventKind) == PhobosTriggerEvent::ForceSequentialEvents)
 			{
 				bool predecessorsCompleted = false;
@@ -155,15 +154,6 @@ DEFINE_HOOK(0x7264C0, TriggerClass_RegisterEvent_ForceSequentialEvents, 0x0)
 					R->AL(false);
 					return SkipGameCode; // Short-circuit
 				}
-			}
-
-			if (pExt->SequentialTimers.contains(i)
-				&& eventTimer.HasTimeLeft()
-				&& !eventTimer.InProgress()
-				&& !eventTimer.Completed())
-			{
-				pExt->SequentialTimers[i].Resume();
-				eventTimer = pExt->SequentialTimers[i];
 			}
 
 			if (!alreadyOccured)

--- a/src/Ext/Trigger/Hooks.cpp
+++ b/src/Ext/Trigger/Hooks.cpp
@@ -234,6 +234,9 @@ DEFINE_HOOK(0x7264C0, TriggerClass_RegisterEvent_ForceSequentialEvents, 0x0)
 		}
 	}
 
+	if (allEventsSuccessful)
+		Debug::Log("Starting actions of the trigger: [%s] - %s\n", pThis->Type->ID, pThis->Type->Name);
+
 	R->AL(allEventsSuccessful);
 
 	return SkipGameCode;

--- a/src/Ext/Trigger/Hooks.cpp
+++ b/src/Ext/Trigger/Hooks.cpp
@@ -1,8 +1,11 @@
 #include <TriggerClass.h>
+#include <TriggerTypeClass.h>
+#include <HouseClass.h>
 
 #include <Helpers/Macro.h>
 
 #include <Ext/TEvent/Body.h>
+#include <Ext/Trigger/Body.h>
 
 DEFINE_HOOK(0x727064, TriggerTypeClass_HasLocalSetOrClearedEvent, 0x5)
 {
@@ -26,4 +29,222 @@ DEFINE_HOOK(0x727024, TriggerTypeClass_HasGlobalSetOrClearedEvent, 0x5)
 		|| nIndex == static_cast<int>(TriggerEvent::GlobalSet)
 		? 0x72702E
 		: 0x727029;
+}
+
+DEFINE_HOOK(0x72612C, TriggerClass_CTOR_ForceSequentialEvents, 0x7)
+{
+	GET(TriggerClass*, pThis, ESI);
+
+	if (!pThis->Type)
+		return 0;
+
+	auto pExt = TriggerExt::ExtMap.Find(pThis);
+	auto pCurrentEvent = pThis->Type->FirstEvent;
+
+	while (pCurrentEvent)
+	{
+		pExt->SortedEventsList.emplace_back(pCurrentEvent);
+		pCurrentEvent = pCurrentEvent->NextEvent;
+	}
+
+	std::reverse(pExt->SortedEventsList.begin(), pExt->SortedEventsList.end());
+
+	for (std::size_t i = 0; i < pExt->SortedEventsList.size(); i++)
+	{
+		pCurrentEvent = pExt->SortedEventsList[i];
+
+		if (static_cast<int>(pCurrentEvent->EventKind) == PhobosTriggerEvent::ForceSequentialEvents)
+		{
+			pExt->SequentialSwitchModeIndex = i;
+			continue;
+		}
+
+		if (pCurrentEvent->EventKind != TriggerEvent::ElapsedTime && pCurrentEvent->EventKind != TriggerEvent::RandomDelay)
+			continue;
+
+		int countdown = 0;
+
+		if (pCurrentEvent->EventKind == TriggerEvent::ElapsedTime) // Event 13 "Elapsed Time..."
+			countdown = pCurrentEvent->Value;
+		else // Event 51 "Random delay..."
+			countdown = ScenarioClass::Instance->Random.RandomRanged(static_cast<int>(pCurrentEvent->Value * 0.5), static_cast<int>(pCurrentEvent->Value * 1.5));
+
+		if (pExt->SequentialSwitchModeIndex >= 0)
+		{
+			pExt->SequentialTimersOriginalValue[i] = pCurrentEvent->EventKind == TriggerEvent::ElapsedTime ? pCurrentEvent->Value : pCurrentEvent->Value * -1;
+			pExt->SequentialTimers[i].Start(15 * countdown);
+			pExt->SequentialTimers[i].Pause();
+		}
+		else
+		{
+			pExt->ParallelTimersOriginalValue[i] = pCurrentEvent->EventKind == TriggerEvent::ElapsedTime ? pCurrentEvent->Value : pCurrentEvent->Value * -1;
+			pExt->ParallelTimers[i].Start(15 * countdown);
+		}
+	}
+
+	return 0;
+}
+
+// TriggerClass::RegisterEvent(...) rewrite
+DEFINE_HOOK(0x7264C0, TriggerClass_RegisterEvent_ForceSequentialEvents, 0x0)
+{
+	enum { SkipGameCode = 0x7265B1 };
+
+	GET(TriggerClass*, pThis, ECX);
+	GET_STACK(TriggerEvent, nEvent, 0x4);
+	GET_STACK(TechnoClass*, pTechno, 0x8);
+	GET_STACK(bool, skipStuff, 0xC);
+	GET_STACK(bool, isPersistant, 0x10);
+	GET_STACK(ObjectClass*, pPayback, 0x14); // <-- Warning! YRpp call HasOccured(...) doesn't have the last argument...
+
+	if (!pThis->Enabled || pThis->Destroyed)
+	{
+		R->AL(false);
+		return SkipGameCode;
+	}
+	auto pExt = TriggerExt::ExtMap.Find(pThis);
+	bool isSequentialMode = false; // Flag: Controls if short-circuit is active for subsequent events
+	bool allEventsSuccessful = true;
+	int nPredecessorEventsCompleted = 0;
+
+	if (!skipStuff)
+	{
+		// Check status of the trigger events in sequential logic (INI order)
+		for (std::size_t i = 0; i < pExt->SortedEventsList.size(); i++)
+		{
+			const auto pCurrentEvent = pExt->SortedEventsList[i];
+			bool alreadyOccured = pThis->HasEventOccured(i);
+			bool triggeredNow = false;
+			auto eventTimer = pThis->Timer; // Fallback
+
+			if (pExt->ParallelTimers.contains(i))
+			{
+				eventTimer = pExt->ParallelTimers[i];
+			}
+			else if (pExt->SequentialTimers.contains(i))
+			{
+				eventTimer = pExt->SequentialTimers[i];
+
+				if (eventTimer.HasTimeLeft()
+				&& !eventTimer.InProgress()
+				&& !eventTimer.Completed())
+				{
+					pExt->SequentialTimers[i].Resume();
+					eventTimer.Resume();
+				}
+			}
+
+			// *** 1. Lógica del Interruptor de Modo (Evento 1000) ***
+			if (static_cast<int>(pCurrentEvent->EventKind) == PhobosTriggerEvent::ForceSequentialEvents)
+			{
+				bool predecessorsCompleted = false;
+
+				if (nPredecessorEventsCompleted >= pExt->SequentialSwitchModeIndex)
+					predecessorsCompleted = true;
+
+				if (predecessorsCompleted)
+				{
+					pThis->MarkEventAsOccured(i);
+					alreadyOccured = true;
+					triggeredNow = true;
+					isSequentialMode = true; // Activate sequential mode for the rest of the INI events
+				}
+				else
+				{
+					allEventsSuccessful = false;
+					R->AL(false);
+					return SkipGameCode; // Short-circuit
+				}
+			}
+
+			if (pExt->SequentialTimers.contains(i)
+				&& eventTimer.HasTimeLeft()
+				&& !eventTimer.InProgress()
+				&& !eventTimer.Completed())
+			{
+				pExt->SequentialTimers[i].Resume();
+				eventTimer = pExt->SequentialTimers[i];
+			}
+
+			if (!alreadyOccured)
+			{
+				HouseClass* pEventOwner = HouseClass::FindByCountryName(pThis->Type->House->ID);
+				TechnoClass* pPaybackTechno = static_cast<TechnoClass*>(pPayback);
+
+				triggeredNow = pCurrentEvent->HasOccured(
+									static_cast<int>(nEvent),
+									pEventOwner,
+									pTechno,
+									&eventTimer,
+									&isPersistant);
+				// Note: I think HasOccured in YRpp is wrong, where is the last parameter for "pPaybackTechno"? I mean this "payback1":
+				// TEventClass::operator()(v8, tevent, v9, &techno->r.m.o, &this->Event.Timer, &is_persistant, payback1)) )
+				// In pseudocode:
+				// bool __thiscall TEventClass::operator()(TEventClass *this, int event, HouseClass *house, ObjectClass *obj, CDTimerClass *td, bool *bool1, TechnoClass *source)
+			}
+
+			if (alreadyOccured || triggeredNow)
+			{
+				HouseClass* pNewHouse = pCurrentEvent->House;
+
+				if (pNewHouse)
+					pThis->House = pNewHouse;
+
+				if (isPersistant && pCurrentEvent->GetStateA() && pCurrentEvent->GetStateB())
+					pThis->MarkEventAsOccured(i); //pThis->OccuredEvents |= eventBit;
+
+				nPredecessorEventsCompleted++;
+			}
+			else
+			{
+				// Conditional short-circuit on Failure
+				allEventsSuccessful = false;
+
+				if (isSequentialMode)
+				{
+					R->AL(false);
+					return SkipGameCode;
+				}
+			}
+		}
+	}
+
+	if (allEventsSuccessful || skipStuff)
+	{
+		if (isPersistant)
+		{
+			pThis->ResetTimers(); // Is really needed now? Maybe, because YRpp is incomplete and looks that each event have its own timer inside a struct... or something similar. I'll preserve this for now that doesn't hurt having this here...
+
+			for (std::size_t i = 0; i < pExt->ParallelTimersOriginalValue.size(); i++)
+			{
+				int timerValue = pExt->ParallelTimersOriginalValue[i];
+
+				if (timerValue < 0)
+				{
+					// Generate random value for event 51 "Delayed timer"
+					timerValue = ScenarioClass::Instance->Random.RandomRanged(static_cast<int>(std::abs(timerValue) * 0.5), static_cast<int>(std::abs(timerValue) * 1.5));
+				}
+
+				pExt->ParallelTimers[i].Start(15 * timerValue);
+			}
+
+			for (std::size_t i = 0; i < pExt->SequentialTimersOriginalValue.size(); i++)
+			{
+				int timerValue = pExt->SequentialTimersOriginalValue[i];
+
+				if (timerValue < 0)
+				{
+					// Generate random value for event 51 "Delayed timer"
+					timerValue = ScenarioClass::Instance->Random.RandomRanged(static_cast<int>(std::abs(timerValue) * 0.5), static_cast<int>(std::abs(timerValue) * 1.5));
+				}
+
+				pExt->SequentialTimers[i].Start(15 * timerValue);
+				pExt->SequentialTimers[i].Pause();
+			}
+		}
+	}
+
+	R->AL(allEventsSuccessful);
+
+	return SkipGameCode;
 }


### PR DESCRIPTION
- By default, the game evaluates all map triggers in parallel. Adding this map event forces short-circuit evaluation as soon as any subsequent event returns `false`.
- This only affects evaluation from this control event (inclusive) to the last event in the list.
- All events placed before this control event still work in a non-short-circuiting manner.
- Sequential events will not begin evaluation until all preceding events have successfully completed.

In `mycampaign.map`:
```ini
[Events]
...
ID=EventCount,...,1000,0,0,0,...
...
```