### PR TITLE
[Vanilla Fix] Fix the issue that units will goto farest location if target is closer than `MinimumRange`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -464,6 +464,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize Ares's radar jam logic
   - Customize if cloning need power
   - Customize type selection for IFV
+  - Fix the issue that units will goto farest location if target is closer than `MinimumRange`
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -274,6 +274,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allow Reveal Crate to take effect when picking up by another player controlled house in campaign.
 - Fixed an issue where the vanilla script ignores jumpjets. Enable it through `[General] -> AIAirTargetingFix=true`.
 - Fixed the bug that naval ship will sink even they destroyed in air.
+- Fixed the issue that units will goto farest location if target is closer than `MinimumRange`
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -505,6 +505,7 @@ Vanilla fixes:
 - Fixed the issue where trigger events 2, 53 and 54 in persistent type triggers would be activated unconditionally after activation (by FlyStar)
 - Fixed the bug that naval ship will sink even they destroyed in air (by NetsuNegi)
 - Fixed MPDebug timer displaying when debug's visibility is off (by 11EJDE11)
+- Fixed the issue that units will goto farest location if target is closer than `MinimumRange` (by NetsuNegi)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Ext/Techno/Hooks.WeaponRange.cpp
+++ b/src/Ext/Techno/Hooks.WeaponRange.cpp
@@ -180,28 +180,33 @@ DEFINE_HOOK(0x4D5FBD, FootClass_ApproachTarget_BeforeSearching, 0xA)
 	GET(TechnoTypeClass*, pType, EAX);
 	R->ESI(pType->MovementZone);
 
-	GET(FootClass*, pThis, EBX);
 	GET_STACK(int, searchRange, STACK_OFFSET(0x158, -0x120));
-	GET_STACK(int, weaponIdx, STACK_OFFSET(0x158, -0xAC));
 	ApproachTargetTemp::FromMaximumRange = true;
 	ApproachTargetTemp::SearchRange = searchRange;
 
 	if (searchRange <= 204)
 		return WantAggressiveCrush;
 
-	const auto pWeapon = pThis->GetWeapon(weaponIdx)->WeaponType;
+	GET_STACK(bool, inRange, STACK_OFFSET(0x158, -0x146));
 
-	if (pWeapon && pWeapon->Range != -512)
+	if (!inRange)
 	{
-		const auto coords = pThis->GetCoords();
-		const int distance = pThis->IsInAir() || pWeapon->Projectile->Arcing || pThis->WhatAmI() == AircraftClass::AbsID
-			? pThis->DistanceFrom(pThis->Target)
-			: pThis->DistanceFrom3D(pThis->Target);
-		const int minimum = pWeapon->MinimumRange;
-		ApproachTargetTemp::FromMaximumRange = distance >= minimum;
+		GET(FootClass*, pThis, EBX);
+		GET_STACK(int, weaponIdx, STACK_OFFSET(0x158, -0xAC));
+		const auto pWeapon = pThis->GetWeapon(weaponIdx)->WeaponType;
 
-		if (!ApproachTargetTemp::FromMaximumRange)
-			searchRange = 204;
+		if (pWeapon && pWeapon->Range != -512)
+		{
+			const auto coords = pThis->GetCoords();
+			const int distance = pThis->IsInAir() || pWeapon->Projectile->Arcing || pThis->WhatAmI() == AircraftClass::AbsID
+				? pThis->DistanceFrom(pThis->Target)
+				: pThis->DistanceFrom3D(pThis->Target);
+			const int minimum = pWeapon->MinimumRange;
+			ApproachTargetTemp::FromMaximumRange = distance >= minimum;
+
+			if (!ApproachTargetTemp::FromMaximumRange)
+				searchRange = 204;
+		}
 	}
 
 	R->ECX(searchRange);

--- a/src/Ext/Techno/Hooks.WeaponRange.cpp
+++ b/src/Ext/Techno/Hooks.WeaponRange.cpp
@@ -187,22 +187,20 @@ DEFINE_HOOK(0x4D5FBD, FootClass_ApproachTarget_BeforeSearching, 0xA)
 	if (searchRange <= 204)
 		return WantAggressiveCrush;
 
-	GET_STACK(bool, inRange, STACK_OFFSET(0x158, -0x146));
+	GET_STACK(const bool, inRange, STACK_OFFSET(0x158, -0x146));
 
 	if (!inRange)
 	{
 		GET(FootClass*, pThis, EBX);
-		GET_STACK(int, weaponIdx, STACK_OFFSET(0x158, -0xAC));
+		GET_STACK(const int, weaponIdx, STACK_OFFSET(0x158, -0xAC));
 		const auto pWeapon = pThis->GetWeapon(weaponIdx)->WeaponType;
 
 		if (pWeapon && pWeapon->Range != -512)
 		{
-			const auto coords = pThis->GetCoords();
-			const int distance = pThis->IsInAir() || pWeapon->Projectile->Arcing || pThis->WhatAmI() == AircraftClass::AbsID
+			const int distance = (pThis->IsInAir() || pWeapon->Projectile->Arcing || pThis->WhatAmI() == AircraftClass::AbsID)
 				? pThis->DistanceFrom(pThis->Target)
 				: pThis->DistanceFrom3D(pThis->Target);
-			const int minimum = pWeapon->MinimumRange;
-			ApproachTargetTemp::FromMaximumRange = distance >= minimum;
+			ApproachTargetTemp::FromMaximumRange = distance >= pWeapon->MinimumRange;
 
 			if (!ApproachTargetTemp::FromMaximumRange)
 				searchRange = 204;


### PR DESCRIPTION
- In the vanilla game, when the distance from unit to target is less than the `MinimumRange`, he still prioritizes searching for the farthest position from the target. In this situation, he will prioritize searching for positions that are closer in distance.
- 在原版游戏中，当单位到目标的距离小于MinimumRange时，他仍然会优先搜索距离目标最远的位置。现在这种情况下他会优先搜索距离更近的位置了.