### PR TITLE
Fix for Ares considering slave miners as buildings in short game

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -691,4 +691,6 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
-- **11EJDE11** - Prevent mpdebug number from being drawn when visibility toggled off
+- **11EJDE11**:
+  - Prevent mpdebug number from being drawn when visibility toggled off
+  - Short Game defeat check fix for Ares so deployable buildings that undeploy into non-BaseUnit vehicles (e.g. deployed Slave Miner) no longer keep a player alive

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="src\Ext\House\Hooks.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.AINavalProduction.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.UnitFromFactory.cpp" />
+    <ClCompile Include="src\Ext\House\Hooks.ShortGame.cpp" />
     <ClCompile Include="src\Ext\ParticleSystemType\Body.cpp" />
     <ClCompile Include="src\Ext\RadSite\Body.cpp" />
     <ClCompile Include="src\Ext\RadSite\Hooks.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -26,6 +26,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug where jumpjet units that are `Crashable` do not crashing to ground properly if destroyed while being pulled by a `Locomotor` warhead.
 - Fixed the bug that prevents jumpjet units from turn to the target when firing from a different direction.
 - Fixed the bug allowing jumpjet units to continue firing at enemy target when crashing.
+- Short Game defeat checks now ignore deployable buildings that only undeploy into non-BaseUnit vehicles (e.g., deployed Slave Miner), so they don’t keep the player alive when using Ares.
 
 ![image](_static/images/jumpjet-turning.gif)
 *Jumpjet turning to target applied in Robot Storm X*

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -540,6 +540,7 @@ Fixes / interactions with other extensions:
 - Fixed the bug that building with `CloningFacility=true` and `WeaponsFactory=true` may cloning multiple vehicles and then they get stuck (by NetsuNegi)
 - [Customize Ares's radar jam logic](New-or-Enhanced-Logics.md#customize-ares-s-radar-jam-logic) (by NetsuNegi)
 - Fixed a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType` (by NetsuNegi)
+- Fixed Short Game defeat detection with Ares so deployable buildings that undeploy into non-BaseUnit vehicles (e.g., deployed Slave Miner) no longer keep a player alive (by 11EJDE11)
 ```
 
 ### 0.4.0.1

--- a/src/Ext/House/Hooks.ShortGame.cpp
+++ b/src/Ext/House/Hooks.ShortGame.cpp
@@ -1,0 +1,85 @@
+#include <Ext/House/Body.h>
+
+// Fix for Ares bug where deployed Slave Miner prevents defeat in Short Game mode
+// Ares hooks at 0x4F8EBD and checks OwnedBuildings, but doesn't account for
+// buildings that can undeploy (like deployed Slave Miner) in Short Game mode.
+DWORD __cdecl HouseClass_Update_HasBeenDefeated(int param_1)
+{
+	enum { ReturnNotDefeated = 0x4F8F87 };
+
+	auto* const pThis = *reinterpret_cast<HouseClass**>(param_1 + 0xC);
+
+	auto Eligible = [pThis](FootClass* pFoot) -> bool
+	{
+		if (pFoot->Owner != pThis)
+			return false;
+
+		if (!pFoot->InLimbo)
+			return true;
+
+		return pFoot->ParasiteImUsing != nullptr;
+	};
+
+	if (GameModeOptionsClass::Instance.ShortGame)
+	{
+		if (pThis->OwnedBuildings > 0)
+		{
+			for (auto const& pBld : pThis->Buildings)
+			{
+				const auto pUndeploysInto = pBld->Type->UndeploysInto;
+
+				if (!pUndeploysInto)
+					return ReturnNotDefeated;
+
+				for (auto const pBaseUnit : RulesClass::Instance->BaseUnit)
+				{
+					if (pUndeploysInto == pBaseUnit)
+						return ReturnNotDefeated;
+				}
+			}
+		}
+
+		for (auto const pBaseUnit : RulesClass::Instance->BaseUnit)
+		{
+			if (pThis->OwnedUnitTypes.GetItemCount(pBaseUnit->ArrayIndex) > 0)
+				return ReturnNotDefeated;
+		}
+	}
+	else
+	{
+		if (pThis->OwnedBuildings)
+			return ReturnNotDefeated;
+
+		if (pThis->OwnedUnitTypes.Total)
+		{
+			for (auto const pTechno : UnitClass::Array)
+			{
+				if (Eligible(pTechno))
+					return ReturnNotDefeated;
+			}
+		}
+
+		if (pThis->OwnedInfantryTypes.Total)
+		{
+			for (auto const pTechno : InfantryClass::Array)
+			{
+				if (Eligible(pTechno))
+					return ReturnNotDefeated;
+			}
+		}
+
+		if (pThis->OwnedAircraftTypes.Total)
+		{
+			for (auto const pTechno : AircraftClass::Array)
+			{
+				if (Eligible(pTechno))
+					return ReturnNotDefeated;
+			}
+		}
+	}
+
+	pThis->DestroyAll();
+	pThis->AcceptDefeat();
+
+	return ReturnNotDefeated;
+}

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -66,10 +66,15 @@ static bool __fastcall CameoIsVeteran(TechnoTypeClass** pTypeExt_Ares, void*, Ho
 	return TechnoTypeExt::ExtMap.Find(*pTypeExt_Ares)->CameoIsVeteran(pHouse);
 }
 
+DWORD __cdecl HouseClass_Update_HasBeenDefeated(int param_1);
+
 _GET_FUNCTION_ADDRESS(RadarJammerClass::Update, AresRadarJammerClass_Update_GetAddr)
 
 void Apply_Ares3_0_Patches()
 {
+	// Short Game deployed unit fix: override Ares' handler to ignore deployable miners
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x254B0, GET_OFFSET(HouseClass_Update_HasBeenDefeated));
+
 	// Abductor fix:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x54CDF, AresHelper::AresBaseAddress + 0x54D3C);
 
@@ -120,7 +125,7 @@ void Apply_Ares3_0_Patches()
 
 	// Redirect Ares's RadarJammerClass::Update to our implementation
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x68500, AresRadarJammerClass_Update_GetAddr());
-  
+
 	// Redirect Ares's function to our implementation:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x112D0, &BuildingExt::KickOutClone);
 
@@ -130,6 +135,8 @@ void Apply_Ares3_0_Patches()
 
 void Apply_Ares3_0p1_Patches()
 {
+	// Short Game deployed unit fix: override Ares' handler to ignore deployable miners
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x254B0, GET_OFFSET(HouseClass_Update_HasBeenDefeated));
 	// Abductor fix:
 	// Issue: moving vehicles leave permanent occupation stats on terrain
 	// What's done here: Skip Mark_Occupation_Bits cuz pFoot->Remove/Limbo() will do it.
@@ -182,7 +189,7 @@ void Apply_Ares3_0p1_Patches()
 
 	// Redirect Ares's RadarJammerClass::Update to our implementation
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x69470, AresRadarJammerClass_Update_GetAddr());
-  
+
 	// Redirect Ares's function to our implementation:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x11860, &BuildingExt::KickOutClone);
 


### PR DESCRIPTION
When short game is enabled, Ares considers deployed slave miners as buildings. This is a departure from vanilla. This PR addresses that by having Phobos take over the check and ignore deployable buildings that undeploy into non-BaseUnit vehicles (e.g., a deployed Slave Miner, not MCV), so they don’t keep players alive in Short Game

Based off: https://github.com/Phobos-developers/Antares/blob/7241a5ff20f4dbf7153cc77e16edca5c9db473d4/src/Ext/House/Hooks.cpp#L66

Not entirely sure I am doing everything correctly here (particularly `src/Misc/Hooks.Ares.cpp`) so please correct me if I am wrong.