### PR TITLE
Add veterancy-based target filtering for weapons and warheads

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -656,7 +656,9 @@ This page lists all the individual contributions to the project by their author.
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)
-- **Flactine** - add target filtering options to attacheffect system
+- **Flactine** 
+  - add target filtering options to attacheffect system
+  - add veterancy-based target filtering for weapons and warheads
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -657,8 +657,8 @@ This page lists all the individual contributions to the project by their author.
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)
 - **Flactine** 
-  - add target filtering options to attacheffect system
-  - add veterancy-based target filtering for weapons and warheads
+  - Add target filtering options to attacheffect system
+  - Add veterancy-based target filtering for weapons and warheads
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2326,8 +2326,8 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]               ; WarheadType
 AffectsBelowPercent=1.0     ; floating point value, percents or absolute
 AffectsAbovePercent=0.0     ; floating point value, percents or absolute
-AffectsBelowVeterancy=2.0     ; floating point value, percents or absolute, default to [General] -> VeteranCap
-AffectsAboveVeterancy=0.0     ; floating point value, percents or absolute
+AffectsBelowVeterancy=2.0     ; double, default to [General] -> VeteranCap
+AffectsAboveVeterancy=0.0     ; double
 AffectsNeutral=true         ; boolean
 EffectsRequireVerses=false  ; boolean
 ```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2326,8 +2326,8 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]               ; WarheadType
 AffectsBelowPercent=1.0     ; floating point value, percents or absolute
 AffectsAbovePercent=0.0     ; floating point value, percents or absolute
-AffectsBelowVeterancy=2.0     ; double, default to [General] -> VeteranCap
-AffectsAboveVeterancy=0.0     ; double
+AffectsBelowVeterancy=     ; floating point value, percents or absolute, default to [General] -> VeteranCap
+AffectsAboveVeterancy=0.0     ; floating point value, percents or absolute
 AffectsNeutral=true         ; boolean
 EffectsRequireVerses=false  ; boolean
 ```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2326,6 +2326,8 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]               ; WarheadType
 AffectsBelowPercent=1.0     ; floating point value, percents or absolute
 AffectsAbovePercent=0.0     ; floating point value, percents or absolute
+AffectsBelowVeterancy=2.0     ; floating point value, percents or absolute, default to [General] -> VeteranCap
+AffectsAboveVeterancy=0.0     ; floating point value, percents or absolute
 AffectsNeutral=true         ; boolean
 EffectsRequireVerses=false  ; boolean
 ```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2326,8 +2326,8 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]               ; WarheadType
 AffectsBelowPercent=1.0     ; floating point value, percents or absolute
 AffectsAbovePercent=0.0     ; floating point value, percents or absolute
-AffectsBelowVeterancy=     ; floating point value, percents or absolute, default to [General] -> VeteranCap
-AffectsAboveVeterancy=0.0     ; floating point value, percents or absolute
+AffectsBelowVeterancy=      ; floating point value, percents or absolute, default to [General] -> VeteranCap
+AffectsAboveVeterancy=0.0   ; floating point value, percents or absolute
 AffectsNeutral=true         ; boolean
 EffectsRequireVerses=false  ; boolean
 ```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2312,7 +2312,7 @@ Conventional.IgnoreUnits=false  ; boolean
 ### Customizable Warhead trigger conditions
 
 - `AffectsBelowPercent` and `AffectsAbovePercent` can be used to set the health percentage thresholds that target needs to be below/equal and/or above of for the Warhead to detonate. If target has zero health left this check is bypassed.
-- `AffectsAboveVeterancy` and `AffectsBelowVeterancy` can be used to set the veterancy thresholds that target needs to be below/equal and/or above of for the Warhead to detonate.
+- `AffectsAboveVeterancy` and `AffectsBelowVeterancy` can be used to set veterancy thresholds for Warhead activation. The target's veterancy must be greater than or equal to `AffectsAboveVeterancy`, and strictly less than `AffectsBelowVeterancy`.
   - Veterancy values are interpreted as follows:
     - `0.0` = Rookie
     - `1.0` = Veteran
@@ -2326,7 +2326,7 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]               ; WarheadType
 AffectsBelowPercent=1.0     ; floating point value, percents or absolute
 AffectsAbovePercent=0.0     ; floating point value, percents or absolute
-AffectsBelowVeterancy=      ; floating point value, percents or absolute, default to [General] -> VeteranCap
+AffectsBelowVeterancy=      ; floating point value, percents or absolute, default to [General] -> VeteranCap + 1.0
 AffectsAboveVeterancy=0.0   ; floating point value, percents or absolute
 AffectsNeutral=true         ; boolean
 EffectsRequireVerses=false  ; boolean

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2308,6 +2308,12 @@ Conventional.IgnoreUnits=false  ; boolean
 ### Customizable Warhead trigger conditions
 
 - `AffectsBelowPercent` and `AffectsAbovePercent` can be used to set the health percentage thresholds that target needs to be below/equal and/or above of for the Warhead to detonate. If target has zero health left this check is bypassed.
+- `AffectsAboveVeterancy` and `AffectsBelowVeterancy` can be used to set the veterancy thresholds that target needs to be below/equal and/or above of for the Warhead to detonate.
+  - Veterancy values are interpreted as follows:
+    - `0.0` = Rookie
+    - `1.0` = Veteran
+    - `2.0` = Elite
+  - TechnoTypes with `Trainable=no` are always treated as having a veterancy level of `0.0` (Rookie) for the purpose of this check.
 - If set to `false`, `AffectsNeutral` makes the warhead can't damage or affect target that belongs to neutral house.
 - If set to `false`, `EffectsRequireVerses` makes the Phobos-introduced warhead effects trigger even if it can't damage the target because of it's current ArmorType (e.g. 0% in `Verses`).
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2348,12 +2348,7 @@ Conventional.IgnoreUnits=false  ; boolean
 ### Customizable Warhead trigger conditions
 
 - `AffectsBelowPercent` and `AffectsAbovePercent` can be used to set the health percentage thresholds that target needs to be below/equal and/or above of for the Warhead to detonate. If target has zero health left this check is bypassed.
-- `AffectsAboveVeterancy` and `AffectsBelowVeterancy` can be used to set veterancy thresholds for Warhead activation. The target's veterancy must be greater than or equal to `AffectsAboveVeterancy`, and strictly less than `AffectsBelowVeterancy`.
-  - Veterancy values are interpreted as follows:
-    - `0.0` = Rookie
-    - `1.0` = Veteran
-    - `2.0` = Elite
-  - TechnoTypes with `Trainable=no` are always treated as having a veterancy level of `0.0` (Rookie) for the purpose of this check.
+- `AffectsVeterancy` sets the veterancy levels that allow the Warhead to detonate on the target.
 - If set to `false`, `AffectsNeutral` makes the warhead can't damage or affect target that belongs to neutral house.
 - If set to `false`, `EffectsRequireVerses` makes the Phobos-introduced warhead effects trigger even if it can't damage the target because of it's current ArmorType (e.g. 0% in `Verses`).
 
@@ -2362,8 +2357,7 @@ In `rulesmd.ini`:
 [SOMEWARHEAD]               ; WarheadType
 AffectsBelowPercent=1.0     ; floating point value, percents or absolute
 AffectsAbovePercent=0.0     ; floating point value, percents or absolute
-AffectsBelowVeterancy=      ; floating point value, percents or absolute, default to [General] -> VeteranCap + 1.0
-AffectsAboveVeterancy=0.0   ; floating point value, percents or absolute
+AffectsVeterancy=all        ; List of Affected Veterancy Enumeration (none|rookie|veteran|elite|all)
 AffectsNeutral=true         ; boolean
 EffectsRequireVerses=false  ; boolean
 ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2862,8 +2862,8 @@ CanTarget=all            ; List of Affected Target Enumeration (none|land|water|
 CanTargetHouses=all      ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 CanTarget.MaxHealth=1.0  ; floating point value, percents or absolute
 CanTarget.MinHealth=0.0  ; floating point value, percents or absolute
-CanTarget.MaxVeterancy=2.0  ; floating point value, percents or absolute, default to [General] -> VeteranCap
-CanTarget.MinVeterancy=0.0  ; floating point value, percents or absolute
+CanTarget.MaxVeterancy=2.0  ; double, default to [General] -> VeteranCap
+CanTarget.MinVeterancy=0.0  ; double
 ```
 
 ```{note}

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2857,12 +2857,12 @@ This function is only used as an additional scattering visual display, which is 
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWEAPON]             ; WeaponType
-CanTarget=all            ; List of Affected Target Enumeration (none|land|water|empty|infantry|units|buildings|all)
-CanTargetHouses=all      ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
-CanTarget.MaxHealth=1.0  ; floating point value, percents or absolute
-CanTarget.MinHealth=0.0  ; floating point value, percents or absolute
-CanTarget.MaxVeterancy=  ; floating point value, percents or absolute, default to [General] -> VeteranCap
+[SOMEWEAPON]                ; WeaponType
+CanTarget=all               ; List of Affected Target Enumeration (none|land|water|empty|infantry|units|buildings|all)
+CanTargetHouses=all         ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+CanTarget.MaxHealth=1.0     ; floating point value, percents or absolute
+CanTarget.MinHealth=0.0     ; floating point value, percents or absolute
+CanTarget.MaxVeterancy=     ; floating point value, percents or absolute, default to [General] -> VeteranCap
 CanTarget.MinVeterancy=0.0  ; floating point value, percents or absolute
 ```
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2862,8 +2862,8 @@ CanTarget=all            ; List of Affected Target Enumeration (none|land|water|
 CanTargetHouses=all      ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 CanTarget.MaxHealth=1.0  ; floating point value, percents or absolute
 CanTarget.MinHealth=0.0  ; floating point value, percents or absolute
-CanTarget.MaxVeterancy=2.0  ; double, default to [General] -> VeteranCap
-CanTarget.MinVeterancy=0.0  ; double
+CanTarget.MaxVeterancy=  ; floating point value, percents or absolute, default to [General] -> VeteranCap
+CanTarget.MinVeterancy=0.0  ; floating point value, percents or absolute
 ```
 
 ```{note}

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2826,6 +2826,12 @@ This function is only used as an additional scattering visual display, which is 
 
 - You can now specify which targets or houses a weapon can fire at. This also affects weapon selection, other than certain special cases where the selection is fixed.
   - `CanTarget.MaxHealth` and `CanTarget.MinHealth` set health percentage thresholds for allowed targets (TechnoTypes only) that the target's health must be above and/or below/equal to, respectively. If target has zero health left this check is bypassed.
+  - `CanTarget.MinVeterancy` and `CanTarget.MaxVeterancy` define the allowed veterancy range for targets. The target's veterancy must be greater than or equal to `MinVeterancy` and less than or equal to `MaxVeterancy` in order to be considered a valid target.
+    - Veterancy values are interpreted as follows:
+      - `0.0` = Rookie
+      - `1.0` = Veteran
+      - `2.0` = Elite
+	- TechnoTypes with `Trainable=no` are always treated as having a veterancy level of `0.0` (Rookie) for the purpose of this check.
 
 In `rulesmd.ini`:
 ```ini
@@ -2834,6 +2840,8 @@ CanTarget=all            ; List of Affected Target Enumeration (none|land|water|
 CanTargetHouses=all      ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 CanTarget.MaxHealth=1.0  ; floating point value, percents or absolute
 CanTarget.MinHealth=0.0  ; floating point value, percents or absolute
+CanTarget.MaxVeterancy=2.0  ; floating point value, percents or absolute
+CanTarget.MinVeterancy=0.0  ; floating point value, percents or absolute
 ```
 
 ```{note}

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2848,7 +2848,7 @@ This function is only used as an additional scattering visual display, which is 
 
 - You can now specify which targets or houses a weapon can fire at. This also affects weapon selection, other than certain special cases where the selection is fixed.
   - `CanTarget.MaxHealth` and `CanTarget.MinHealth` set health percentage thresholds for allowed targets (TechnoTypes only) that the target's health must be above and/or below/equal to, respectively. If target has zero health left this check is bypassed.
-  - `CanTarget.MinVeterancy` and `CanTarget.MaxVeterancy` define the allowed veterancy range for targets. The target's veterancy must be greater than or equal to `MinVeterancy` and less than or equal to `MaxVeterancy` in order to be considered a valid target.
+  - `CanTarget.MinVeterancy` and `CanTarget.MaxVeterancy` define the allowed veterancy range for targets. The target's veterancy must be greater than or equal to `MinVeterancy` and less than to `MaxVeterancy` in order to be considered a valid target.
     - Veterancy values are interpreted as follows:
       - `0.0` = Rookie
       - `1.0` = Veteran
@@ -2862,7 +2862,7 @@ CanTarget=all               ; List of Affected Target Enumeration (none|land|wat
 CanTargetHouses=all         ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 CanTarget.MaxHealth=1.0     ; floating point value, percents or absolute
 CanTarget.MinHealth=0.0     ; floating point value, percents or absolute
-CanTarget.MaxVeterancy=     ; floating point value, percents or absolute, default to [General] -> VeteranCap
+CanTarget.MaxVeterancy=     ; floating point value, percents or absolute, default to [General] -> VeteranCap + 1.0
 CanTarget.MinVeterancy=0.0  ; floating point value, percents or absolute
 ```
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2862,7 +2862,7 @@ CanTarget=all            ; List of Affected Target Enumeration (none|land|water|
 CanTargetHouses=all      ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 CanTarget.MaxHealth=1.0  ; floating point value, percents or absolute
 CanTarget.MinHealth=0.0  ; floating point value, percents or absolute
-CanTarget.MaxVeterancy=2.0  ; floating point value, percents or absolute
+CanTarget.MaxVeterancy=2.0  ; floating point value, percents or absolute, default to [General] -> VeteranCap
 CanTarget.MinVeterancy=0.0  ; floating point value, percents or absolute
 ```
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2989,12 +2989,6 @@ This function is only used as an additional scattering visual display, which is 
 
 - You can now specify which targets or houses a weapon can fire at. This also affects weapon selection, other than certain special cases where the selection is fixed.
   - `CanTarget.MaxHealth` and `CanTarget.MinHealth` set health percentage thresholds for allowed targets (TechnoTypes only) that the target's health must be above and/or below/equal to, respectively. If target has zero health left this check is bypassed.
-  - `CanTarget.MinVeterancy` and `CanTarget.MaxVeterancy` define the allowed veterancy range for targets. The target's veterancy must be greater than or equal to `MinVeterancy` and less than to `MaxVeterancy` in order to be considered a valid target.
-    - Veterancy values are interpreted as follows:
-      - `0.0` = Rookie
-      - `1.0` = Veteran
-      - `2.0` = Elite
-	- TechnoTypes with `Trainable=no` are always treated as having a veterancy level of `0.0` (Rookie) for the purpose of this check.
 
 In `rulesmd.ini`:
 ```ini
@@ -3003,8 +2997,7 @@ CanTarget=all               ; List of Affected Target Enumeration (none|land|wat
 CanTargetHouses=all         ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 CanTarget.MaxHealth=1.0     ; floating point value, percents or absolute
 CanTarget.MinHealth=0.0     ; floating point value, percents or absolute
-CanTarget.MaxVeterancy=     ; floating point value, percents or absolute, default to [General] -> VeteranCap + 1.0
-CanTarget.MinVeterancy=0.0  ; floating point value, percents or absolute
+CanTargetVeterancy=all      ; List of Affected Veterancy Enumeration (none|rookie|veteran|elite|all)
 ```
 
 ```{note}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -465,12 +465,12 @@ New:
 - [Customize if cloning need power](Fixed-or-Improved-Logics.md#customize-if-cloning-need-power) (by NetsuNegi)
 - [Added Target Filtering Options to AttachEffect System](New-or-Enhanced-Logics.md#attached-effects) (by Flactine)
 - [Customize type selection for IFV](Fixed-or-Improved-Logics.md#customize-type-selection-for-ifv) (by NetsuNegi)
-- [Weapon target filtering by target veterancy](New-or-Enhanced-Logics.md#weapon-targeting-filter) (by Flactine)
-- [Warhead effect filtering by target veterancy](Fixed-or-Improved-Logics.md#customizable-warhead-trigger-conditions) (by Flactine)
 - [CellSpread in cylinder shape](New-or-Enhanced-Logics.md#cellspread-enhancement) (by TaranDahl)
 - [CellSpread damage check if victim is in air or on floor](New-or-Enhanced-Logics.md#cellspread-enhancement) (by TaranDahl)
 - OpenTopped range bonus and damage multiplier customization for passengers (by Ollerus)
 - AutoDeath upon ownership change (by Ollerus)
+- [Weapon target filtering by target veterancy](New-or-Enhanced-Logics.md#weapon-targeting-filter) (by Flactine)
+- [Warhead effect filtering by target veterancy](Fixed-or-Improved-Logics.md#customizable-warhead-trigger-conditions) (by Flactine)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -465,8 +465,6 @@ New:
 - [Customize if cloning need power](Fixed-or-Improved-Logics.md#customize-if-cloning-need-power) (by NetsuNegi)
 - [Added Target Filtering Options to AttachEffect System](New-or-Enhanced-Logics.md#attached-effects) (by Flactine)
 - [Customize type selection for IFV](Fixed-or-Improved-Logics.md#customize-type-selection-for-ifv) (by NetsuNegi)
-- CellSpread in cylinder shape (by TaranDahl)
-- CellSpread damage check if victim is in air or on floor (by TaranDahl)
 - [Weapon target filtering by target veterancy](New-or-Enhanced-Logics.md#weapon-targeting-filter) (by Flactine)
 - [Warhead effect filtering by target veterancy](Fixed-or-Improved-Logics.md#customizable-warhead-trigger-conditions) (by Flactine)
 - [CellSpread in cylinder shape](New-or-Enhanced-Logics.md#cellspread-enhancement) (by TaranDahl)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -466,6 +466,8 @@ New:
 - [Customize type selection for IFV](Fixed-or-Improved-Logics.md#customize-type-selection-for-ifv) (by NetsuNegi)
 - CellSpread in cylinder shape (by TaranDahl)
 - CellSpread damage check if victim is in air or on floor (by TaranDahl)
+- [Weapon target filtering by target veterancy](New-or-Enhanced-Logics.md#weapon-targeting-filter) (by Flactine)
+- [Warhead effect filtering by target veterancy](Fixed-or-Improved-Logics.md#customizable-warhead-trigger-conditions) (by Flactine)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Bullet/Hooks.DetonateLogics.cpp
+++ b/src/Ext/Bullet/Hooks.DetonateLogics.cpp
@@ -26,7 +26,7 @@ DEFINE_HOOK(0x4690D4, BulletClass_Logics_NewChecks, 0x6)
 	if (auto const pTarget = abstract_cast<TechnoClass*>(pBullet->Target))
 	{
 		// Check if the WH should affect the techno target or skip it
-		if (!pExt->IsHealthInThreshold(pTarget) || (!pExt->AffectsNeutral && pTarget->Owner->IsNeutral()))
+		if (!pExt->IsHealthInThreshold(pTarget) || !pExt->IsVeterancyInThreshold(pTarget) || (!pExt->AffectsNeutral && pTarget->Owner->IsNeutral()))
 			return GoToExtras;
 	}
 
@@ -380,7 +380,7 @@ DEFINE_HOOK(0x469AA4, BulletClass_Logics_Extras, 0x5)
 			auto const pWHExt = WarheadTypeExt::ExtMap.Find(pWH);
 			auto const pTarget = abstract_cast<TechnoClass*>(pThis->Target);
 
-			if (pTarget && !pWHExt->IsHealthInThreshold(pTarget))
+			if (pTarget && !pWHExt->IsHealthInThreshold(pTarget) && !pWHExt->IsVeterancyInThreshold(pTarget))
 				continue;
 
 			int damage = defaultDamage;
@@ -554,7 +554,8 @@ static bool IsAllowedSplitsTarget(TechnoClass* pSource, HouseClass* pOwner, Weap
 		if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pOwner, pTarget->Owner)
 			|| !EnumFunctions::IsCellEligible(pTarget->GetCell(), pWeaponExt->CanTarget, true, true)
 			|| !EnumFunctions::IsTechnoEligible(pTarget, pWeaponExt->CanTarget)
-			|| !pWeaponExt->IsHealthInThreshold(pTarget))
+			|| !pWeaponExt->IsHealthInThreshold(pTarget)
+			|| !pWeaponExt->IsVeterancyInThreshold(pTarget))
 		{
 			return false;
 		}

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -280,7 +280,7 @@ DEFINE_HOOK(0x46A4FB, BulletClass_Shrapnel_Targeting, 0x6)
 			if (!pWeaponExt->SkipWeaponPicking)
 			{
 				if (!EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pOwner, pTechno->Owner) || !EnumFunctions::IsTechnoEligible(pTechno, pWeaponExt->CanTarget)
-					|| !pWeaponExt->IsHealthInThreshold(pTechno) || !pWeaponExt->HasRequiredAttachedEffects(pTechno, pSource))
+					|| !pWeaponExt->IsHealthInThreshold(pTechno) || !pWeaponExt->IsVeterancyInThreshold(pTechno) || !pWeaponExt->HasRequiredAttachedEffects(pTechno, pSource))
 				{
 					return SkipObject;
 				}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -743,6 +743,25 @@ bool TechnoExt::IsHealthInThreshold(TechnoClass* pObject, double min, double max
 	return (hp > 0 ? hp > min : hp >= min) && hp <= max;
 }
 
+bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pObject, int min, int max)
+{
+	VeterancyStruct* pVeterancy = &pObject->Veterancy;
+	if (pVeterancy == nullptr)
+		return true;
+
+	min = std::clamp(min, 0, 2);
+	max = std::clamp(max, 0, 2);
+
+	int level = 0;
+
+	if (pVeterancy->IsElite())
+		level = 2;
+	else if (pVeterancy->IsVeteran())
+		level = 1;
+
+	return level >= min && level <= max;
+}
+
 bool TechnoExt::CannotMove(UnitClass* pThis)
 {
 	const auto loco = pThis->Locomotor;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -745,13 +745,10 @@ bool TechnoExt::IsHealthInThreshold(TechnoClass* pObject, double min, double max
 
 bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pTechno, float min, float max)
 {
-	Debug::Log("[Developer] min:[%.2f], max:[%.2f]\n", min, max);
 	float veterancy = 0.0f;
 
 	if (pTechno->GetTechnoType()->Trainable)
 		veterancy = pTechno->Veterancy.Veterancy;
-
-	Debug::Log("[Developer] veterancy:[%.2f]\n", veterancy);
 
 	return veterancy >= min && veterancy <= max;
 }

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -750,7 +750,7 @@ bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pTechno, double min, double 
 	if (pTechno->GetTechnoType()->Trainable)
 		veterancy = pTechno->Veterancy.Veterancy;
 
-	return veterancy >= min && veterancy <= max;
+	return veterancy >= min && veterancy < max;
 }
 
 bool TechnoExt::CannotMove(UnitClass* pThis)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -745,10 +745,13 @@ bool TechnoExt::IsHealthInThreshold(TechnoClass* pObject, double min, double max
 
 bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pTechno, float min, float max)
 {
-	float veterancy = 0.0;
+	Debug::Log("[Developer] min:[%.2f], max:[%.2f]\n", min, max);
+	float veterancy = 0.0f;
 
 	if (pTechno->GetTechnoType()->Trainable)
 		veterancy = pTechno->Veterancy.Veterancy;
+
+	Debug::Log("[Developer] veterancy:[%.2f]\n", veterancy);
 
 	return veterancy >= min && veterancy <= max;
 }

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -743,23 +743,14 @@ bool TechnoExt::IsHealthInThreshold(TechnoClass* pObject, double min, double max
 	return (hp > 0 ? hp > min : hp >= min) && hp <= max;
 }
 
-bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pObject, int min, int max)
+bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pTechno, float min, float max)
 {
-	VeterancyStruct* pVeterancy = &pObject->Veterancy;
-	if (pVeterancy == nullptr)
-		return true;
+	float veterancy = 0.0;
 
-	min = std::clamp(min, 0, 2);
-	max = std::clamp(max, 0, 2);
+	if (pTechno->GetTechnoType()->Trainable)
+		veterancy = pTechno->Veterancy.Veterancy;
 
-	int level = 0;
-
-	if (pVeterancy->IsElite())
-		level = 2;
-	else if (pVeterancy->IsVeteran())
-		level = 1;
-
-	return level >= min && level <= max;
+	return veterancy >= min && veterancy <= max;
 }
 
 bool TechnoExt::CannotMove(UnitClass* pThis)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -743,9 +743,9 @@ bool TechnoExt::IsHealthInThreshold(TechnoClass* pObject, double min, double max
 	return (hp > 0 ? hp > min : hp >= min) && hp <= max;
 }
 
-bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pTechno, float min, float max)
+bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pTechno, double min, double max)
 {
-	float veterancy = 0.0f;
+	double veterancy = 0.0;
 
 	if (pTechno->GetTechnoType()->Trainable)
 		veterancy = pTechno->Veterancy.Veterancy;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -746,16 +746,6 @@ bool TechnoExt::IsHealthInThreshold(TechnoClass* pObject, double min, double max
 	return (hp > 0 ? hp > min : hp >= min) && hp <= max;
 }
 
-bool TechnoExt::IsVeterancyInThreshold(TechnoClass* pTechno, double min, double max)
-{
-	double veterancy = 0.0;
-
-	if (pTechno->GetTechnoType()->Trainable)
-		veterancy = pTechno->Veterancy.Veterancy;
-
-	return veterancy >= min && veterancy < max;
-}
-
 bool TechnoExt::CannotMove(UnitClass* pThis)
 {
 	const auto loco = pThis->Locomotor;

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -289,7 +289,7 @@ public:
 	static void CreateDelayedFireAnim(TechnoClass* pThis, AnimTypeClass* pAnimType, int weaponIndex, bool attach, bool center, bool removeOnNoDelay, bool onTurret, CoordStruct firingCoords);
 	static bool HandleDelayedFireWithPauseSequence(TechnoClass* pThis, WeaponTypeClass* pWeapon, int weaponIndex, int frame, int firingFrame);
 	static bool IsHealthInThreshold(TechnoClass* pObject, double min, double max);
-	static bool IsVeterancyInThreshold(TechnoClass* pObject, int min, int max);
+	static bool IsVeterancyInThreshold(TechnoClass* pObject, float min, float max);
 	static UnitTypeClass* GetUnitTypeExtra(UnitClass* pUnit, TechnoTypeExt::ExtData* pData);
 	static AircraftTypeClass* GetAircraftTypeExtra(AircraftClass* pAircraft);
 	static bool CannotMove(UnitClass* pThis);

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -289,6 +289,7 @@ public:
 	static void CreateDelayedFireAnim(TechnoClass* pThis, AnimTypeClass* pAnimType, int weaponIndex, bool attach, bool center, bool removeOnNoDelay, bool onTurret, CoordStruct firingCoords);
 	static bool HandleDelayedFireWithPauseSequence(TechnoClass* pThis, WeaponTypeClass* pWeapon, int weaponIndex, int frame, int firingFrame);
 	static bool IsHealthInThreshold(TechnoClass* pObject, double min, double max);
+	static bool IsVeterancyInThreshold(TechnoClass* pObject, int min, int max);
 	static UnitTypeClass* GetUnitTypeExtra(UnitClass* pUnit, TechnoTypeExt::ExtData* pData);
 	static AircraftTypeClass* GetAircraftTypeExtra(AircraftClass* pAircraft);
 	static bool CannotMove(UnitClass* pThis);

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -289,7 +289,7 @@ public:
 	static void CreateDelayedFireAnim(TechnoClass* pThis, AnimTypeClass* pAnimType, int weaponIndex, bool attach, bool center, bool removeOnNoDelay, bool onTurret, CoordStruct firingCoords);
 	static bool HandleDelayedFireWithPauseSequence(TechnoClass* pThis, WeaponTypeClass* pWeapon, int weaponIndex, int frame, int firingFrame);
 	static bool IsHealthInThreshold(TechnoClass* pObject, double min, double max);
-	static bool IsVeterancyInThreshold(TechnoClass* pObject, float min, float max);
+	static bool IsVeterancyInThreshold(TechnoClass* pObject, double min, double max);
 	static UnitTypeClass* GetUnitTypeExtra(UnitClass* pUnit, TechnoTypeExt::ExtData* pData);
 	static AircraftTypeClass* GetAircraftTypeExtra(AircraftClass* pAircraft);
 	static bool CannotMove(UnitClass* pThis);

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -345,6 +345,7 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 			if (!EnumFunctions::IsTechnoEligible(pTargetTechno, pWeaponExt->CanTarget)
 				|| !EnumFunctions::CanTargetHouse(pWeaponExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner)
 				|| !pWeaponExt->IsHealthInThreshold(pTargetTechno)
+				|| !pWeaponExt->IsVeterancyInThreshold(pTargetTechno)
 				|| !pWeaponExt->HasRequiredAttachedEffects(pTargetTechno, pThis))
 			{
 				return CannotFire;

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -24,7 +24,7 @@ DEFINE_HOOK(0x701900, TechnoClass_ReceiveDamage_Shield, 0x6)
 
 	// AffectsAbove/BelowPercent & AffectsNeutral can ignore IgnoreDefenses like AffectsAllies/Enmies/Owner
 	// They should be checked here to cover all cases that directly use ReceiveDamage to deal damage
-	if (!pWHExt->IsHealthInThreshold(pThis) || (!pWHExt->AffectsNeutral && pThis->Owner->IsNeutral()))
+	if (!pWHExt->IsHealthInThreshold(pThis) || !pWHExt->IsVeterancyInThreshold(pThis) || (!pWHExt->AffectsNeutral && pThis->Owner->IsNeutral()))
 	{
 		damage = 0;
 		return 0;

--- a/src/Ext/Techno/WeaponHelpers.cpp
+++ b/src/Ext/Techno/WeaponHelpers.cpp
@@ -43,6 +43,7 @@ int TechnoExt::PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, A
 			if (!EnumFunctions::IsTechnoEligible(pTargetTechno, pSecondExt->CanTarget)
 				|| !EnumFunctions::CanTargetHouse(pSecondExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner)
 				|| !pSecondExt->IsHealthInThreshold(pTargetTechno)
+				|| !pSecondExt->IsVeterancyInThreshold(pTargetTechno)
 				|| !pSecondExt->HasRequiredAttachedEffects(pTargetTechno, pThis))
 			{
 				return weaponIndexOne;
@@ -73,6 +74,7 @@ int TechnoExt::PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, A
 			if (!EnumFunctions::IsTechnoEligible(pTargetTechno, pFirstExt->CanTarget)
 				|| !EnumFunctions::CanTargetHouse(pFirstExt->CanTargetHouses, pThis->Owner, pTargetTechno->Owner)
 				|| !pFirstExt->IsHealthInThreshold(pTargetTechno)
+				|| !pFirstExt->IsVeterancyInThreshold(pTargetTechno)
 				|| !firstAllowedAE)
 			{
 				return weaponIndexTwo;

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -303,8 +303,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AffectsGround.Read(exINI, pSection, "AffectsGround");
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
-	this->HealthCheck = this->AffectsBelowPercent > 0.0 || this->AffectsAbovePercent < 1.0;
-	this->VeterancyCheck = this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap) > 0.0 || this->AffectsAboveVeterancy < RulesClass::Instance->VeteranCap;
+	this->HealthCheck = this->AffectsAbovePercent > 0.0 || this->AffectsBelowPercent < 1.0;
+	this->VeterancyCheck = this->AffectsAboveVeterancy > 0.0 || this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap) < RulesClass::Instance->VeteranCap;
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -64,7 +64,7 @@ bool WarheadTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 	if (!this->VeterancyCheck)
 		return true;
 
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap));
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0));
 }
 
 // Checks if Warhead can affect target that might or might be currently invulnerable.
@@ -304,12 +304,12 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
 	this->HealthCheck = this->AffectsAbovePercent > 0.0 || this->AffectsBelowPercent < 1.0;
-	this->VeterancyCheck = this->AffectsAboveVeterancy > 0.0 || this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap) < RulesClass::Instance->VeteranCap;
+	this->VeterancyCheck = this->AffectsAboveVeterancy > 0.0 || this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0) < RulesClass::Instance->VeteranCap + 1.0;
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);
 
-	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap))
+	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0))
 		Debug::Log("[Developer warning][%s] AffectsAboveVeterancy is bigger than AffectsBelowVeterancy, the warhead will never activate!\n", pSection);
 
 	this->ReverseEngineer.Read(exINI, pSection, "ReverseEngineer");

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -304,7 +304,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
 	this->HealthCheck = this->AffectsBelowPercent > 0.0 || this->AffectsAbovePercent < 1.0;
-	this->VeterancyCheck = this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) > 0.0f || this->AffectsAboveVeterancy < 2.0f;
+	this->VeterancyCheck = this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) > 0.0f || this->AffectsAboveVeterancy < static_cast<float>(RulesClass::Instance->VeteranCap);
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -64,7 +64,7 @@ bool WarheadTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 	if (!this->VeterancyCheck)
 		return true;
 
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)));
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap));
 }
 
 // Checks if Warhead can affect target that might or might be currently invulnerable.
@@ -304,12 +304,12 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
 	this->HealthCheck = this->AffectsBelowPercent > 0.0 || this->AffectsAbovePercent < 1.0;
-	this->VeterancyCheck = this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) > 0.0f || this->AffectsAboveVeterancy < static_cast<float>(RulesClass::Instance->VeteranCap);
+	this->VeterancyCheck = this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap) > 0.0 || this->AffectsAboveVeterancy < RulesClass::Instance->VeteranCap;
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);
 
-	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)))
+	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap))
 		Debug::Log("[Developer warning][%s] AffectsAboveVeterancy is bigger than AffectsBelowVeterancy, the warhead will never activate!\n", pSection);
 
 	this->ReverseEngineer.Read(exINI, pSection, "ReverseEngineer");

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -304,7 +304,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
 	this->HealthCheck = this->AffectsBelowPercent > 0.0 || this->AffectsAbovePercent < 1.0;
-	this->VeterancyCheck = this->AffectsBelowVeterancy > 0.0 || this->AffectsAboveVeterancy < 2.0;
+	this->VeterancyCheck = this->AffectsBelowVeterancy > 0.0f || this->AffectsAboveVeterancy < 2.0f;
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -42,6 +42,9 @@ bool WarheadTypeExt::ExtData::CanAffectTarget(TechnoClass* pTarget) const
 	if (!IsHealthInThreshold(pTarget))
 		return false;
 
+	if (!IsVeterancyInThreshold(pTarget))
+		return false;
+
 	if (!this->EffectsRequireVerses)
 		return true;
 
@@ -54,6 +57,14 @@ bool WarheadTypeExt::ExtData::IsHealthInThreshold(TechnoClass* pTarget) const
 		return true;
 
 	return TechnoExt::IsHealthInThreshold(pTarget, this->AffectsAbovePercent, this->AffectsBelowPercent);
+}
+
+bool WarheadTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
+{
+	if (!this->VeterancyCheck)
+		return true;
+
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy);
 }
 
 // Checks if Warhead can affect target that might or might be currently invulnerable.
@@ -286,14 +297,20 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->AffectsBelowPercent.Read(exINI, pSection, "AffectsBelowPercent");
 	this->AffectsAbovePercent.Read(exINI, pSection, "AffectsAbovePercent");
+	this->AffectsBelowPercent.Read(exINI, pSection, "AffectsBelowVeterancy");
+	this->AffectsAbovePercent.Read(exINI, pSection, "AffectsAboveVeterancy");
 	this->AffectsNeutral.Read(exINI, pSection, "AffectsNeutral");
 	this->AffectsGround.Read(exINI, pSection, "AffectsGround");
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
 	this->HealthCheck = this->AffectsBelowPercent > 0.0 || this->AffectsAbovePercent < 1.0;
+	this->VeterancyCheck = this->AffectsBelowVeterancy > 0.0 || this->AffectsAboveVeterancy < 2.0;
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);
+
+	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy)
+		Debug::Log("[Developer warning][%s] AffectsAboveVeterancy is bigger than AffectsBelowVeterancy, the warhead will never activate!\n", pSection);
 
 	this->ReverseEngineer.Read(exINI, pSection, "ReverseEngineer");
 
@@ -538,11 +555,14 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->AffectsBelowPercent)
 		.Process(this->AffectsAbovePercent)
+		.Process(this->AffectsBelowVeterancy)
+		.Process(this->AffectsAboveVeterancy)
 		.Process(this->AffectsNeutral)
 		.Process(this->AffectsGround)
 		.Process(this->AffectsAir)
 		.Process(this->CellSpread_Cylinder)
 		.Process(this->HealthCheck)
+		.Process(this->VeterancyCheck)
 
 		.Process(this->InflictLocomotor)
 		.Process(this->RemoveInflictedLocomotor)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -64,7 +64,7 @@ bool WarheadTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 	if (!this->VeterancyCheck)
 		return true;
 
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy);
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)));
 }
 
 // Checks if Warhead can affect target that might or might be currently invulnerable.
@@ -304,12 +304,12 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
 	this->HealthCheck = this->AffectsBelowPercent > 0.0 || this->AffectsAbovePercent < 1.0;
-	this->VeterancyCheck = this->AffectsBelowVeterancy > 0.0f || this->AffectsAboveVeterancy < 2.0f;
+	this->VeterancyCheck = this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) > 0.0f || this->AffectsAboveVeterancy < 2.0f;
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);
 
-	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy)
+	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)))
 		Debug::Log("[Developer warning][%s] AffectsAboveVeterancy is bigger than AffectsBelowVeterancy, the warhead will never activate!\n", pSection);
 
 	this->ReverseEngineer.Read(exINI, pSection, "ReverseEngineer");

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -297,8 +297,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->AffectsBelowPercent.Read(exINI, pSection, "AffectsBelowPercent");
 	this->AffectsAbovePercent.Read(exINI, pSection, "AffectsAbovePercent");
-	this->AffectsBelowPercent.Read(exINI, pSection, "AffectsBelowVeterancy");
-	this->AffectsAbovePercent.Read(exINI, pSection, "AffectsAboveVeterancy");
+	this->AffectsBelowVeterancy.Read(exINI, pSection, "AffectsBelowVeterancy");
+	this->AffectsAboveVeterancy.Read(exINI, pSection, "AffectsAboveVeterancy");
 	this->AffectsNeutral.Read(exINI, pSection, "AffectsNeutral");
 	this->AffectsGround.Read(exINI, pSection, "AffectsGround");
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -59,7 +59,7 @@ bool WarheadTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 	if (!this->VeterancyCheck)
 		return true;
 
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->AffectsAboveVeterancy, this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0));
+	return EnumFunctions::CanTargetVeterancy(this->AffectsVeterancy, pTarget);
 }
 
 // Checks if Warhead can affect target that might or might be currently invulnerable.
@@ -294,20 +294,16 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->AffectsBelowPercent.Read(exINI, pSection, "AffectsBelowPercent");
 	this->AffectsAbovePercent.Read(exINI, pSection, "AffectsAbovePercent");
-	this->AffectsBelowVeterancy.Read(exINI, pSection, "AffectsBelowVeterancy");
-	this->AffectsAboveVeterancy.Read(exINI, pSection, "AffectsAboveVeterancy");
+	this->AffectsVeterancy.Read(exINI, pSection, "AffectsVeterancy");
 	this->AffectsNeutral.Read(exINI, pSection, "AffectsNeutral");
 	this->AffectsGround.Read(exINI, pSection, "AffectsGround");
 	this->AffectsAir.Read(exINI, pSection, "AffectsAir");
 	this->CellSpread_Cylinder.Read(exINI, pSection, "CellSpread.Cylinder");
 	this->HealthCheck = this->AffectsAbovePercent > 0.0 || this->AffectsBelowPercent < 1.0;
-	this->VeterancyCheck = this->AffectsAboveVeterancy > 0.0 || this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0) < RulesClass::Instance->VeteranCap + 1.0;
+	this->VeterancyCheck = this->AffectsVeterancy != AffectedVeterancy::All;
 
 	if (this->AffectsAbovePercent > this->AffectsBelowPercent)
 		Debug::Log("[Developer warning][%s] AffectsAbovePercent is bigger than AffectsBelowPercent, the warhead will never activate!\n", pSection);
-
-	if (this->AffectsAboveVeterancy > this->AffectsBelowVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0))
-		Debug::Log("[Developer warning][%s] AffectsAboveVeterancy is bigger than AffectsBelowVeterancy, the warhead will never activate!\n", pSection);
 
 	this->ReverseEngineer.Read(exINI, pSection, "ReverseEngineer");
 
@@ -554,8 +550,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->AffectsBelowPercent)
 		.Process(this->AffectsAbovePercent)
-		.Process(this->AffectsBelowVeterancy)
-		.Process(this->AffectsAboveVeterancy)
+		.Process(this->AffectsVeterancy)
 		.Process(this->AffectsNeutral)
 		.Process(this->AffectsGround)
 		.Process(this->AffectsAir)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -192,8 +192,8 @@ public:
 
 		Valueable<double> AffectsBelowPercent;
 		Valueable<double> AffectsAbovePercent;
-		Nullable<float> AffectsBelowVeterancy;
-		Valueable<float> AffectsAboveVeterancy;
+		Nullable<double> AffectsBelowVeterancy;
+		Valueable<double> AffectsAboveVeterancy;
 		Valueable<bool> AffectsNeutral;
 		Valueable<bool> AffectsGround;
 		Valueable<bool> AffectsAir;
@@ -406,7 +406,7 @@ public:
 			, AffectsBelowPercent { 1.0 }
 			, AffectsAbovePercent { 0.0 }
 			, AffectsBelowVeterancy {}
-			, AffectsAboveVeterancy { 0.0f }
+			, AffectsAboveVeterancy { 0.0 }
 			, AffectsNeutral { true }
 			, AffectsGround { true }
 			, AffectsAir { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -457,6 +457,7 @@ public:
 		bool CanAffectInvulnerable(TechnoClass* pTarget) const;
 		bool EligibleForFullMapDetonation(TechnoClass* pTechno, TechnoTypeClass* pType, HouseClass* pOwner) const;
 		bool IsHealthInThreshold(TechnoClass* pTarget) const;
+		bool IsVeterancyInThreshold(TechnoClass* pTarget) const;
 
 		virtual ~ExtData() = default;
 		virtual void LoadFromINIFile(CCINIClass* pINI) override;

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -192,8 +192,8 @@ public:
 
 		Valueable<double> AffectsBelowPercent;
 		Valueable<double> AffectsAbovePercent;
-		Valueable<float> AffectsBelowVeterancy;
-		Valueable<float> AffectsAboveVeterancy;
+		Nullable<float> AffectsBelowVeterancy;
+		Nullable<float> AffectsAboveVeterancy;
 		Valueable<bool> AffectsNeutral;
 		Valueable<bool> AffectsGround;
 		Valueable<bool> AffectsAir;
@@ -405,7 +405,7 @@ public:
 
 			, AffectsBelowPercent { 1.0 }
 			, AffectsAbovePercent { 0.0 }
-			, AffectsBelowVeterancy { static_cast<float>(RulesClass::Instance->VeteranCap) }
+			, AffectsBelowVeterancy {}
 			, AffectsAboveVeterancy { 0.0f }
 			, AffectsNeutral { true }
 			, AffectsGround { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -192,6 +192,8 @@ public:
 
 		Valueable<double> AffectsBelowPercent;
 		Valueable<double> AffectsAbovePercent;
+		Valueable<float> AffectsBelowVeterancy;
+		Valueable<float> AffectsAboveVeterancy;
 		Valueable<bool> AffectsNeutral;
 		Valueable<bool> AffectsGround;
 		Valueable<bool> AffectsAir;
@@ -230,6 +232,7 @@ public:
 		int RemainingAnimCreationInterval;
 		bool PossibleCellSpreadDetonate;
 		bool HealthCheck;
+		bool VeterancyCheck;
 		TechnoClass* DamageAreaTarget;
 
 	private:
@@ -402,6 +405,8 @@ public:
 
 			, AffectsBelowPercent { 1.0 }
 			, AffectsAbovePercent { 0.0 }
+			, AffectsBelowVeterancy { 2.0 }
+			, AffectsAboveVeterancy { 0.0 }
 			, AffectsNeutral { true }
 			, AffectsGround { true }
 			, AffectsAir { true }
@@ -423,6 +428,7 @@ public:
 			, RemainingAnimCreationInterval { 0 }
 			, PossibleCellSpreadDetonate { false }
 			, HealthCheck { false }
+			, VeterancyCheck { false }
 			, DamageAreaTarget {}
 
 			, CanKill { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -405,8 +405,8 @@ public:
 
 			, AffectsBelowPercent { 1.0 }
 			, AffectsAbovePercent { 0.0 }
-			, AffectsBelowVeterancy { 2.0 }
-			, AffectsAboveVeterancy { 0.0 }
+			, AffectsBelowVeterancy { 2.0f }
+			, AffectsAboveVeterancy { 0.0f }
 			, AffectsNeutral { true }
 			, AffectsGround { true }
 			, AffectsAir { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -405,7 +405,7 @@ public:
 
 			, AffectsBelowPercent { 1.0 }
 			, AffectsAbovePercent { 0.0 }
-			, AffectsBelowVeterancy { 2.0f }
+			, AffectsBelowVeterancy { RulesClass::Instance->VeteranCap }
 			, AffectsAboveVeterancy { 0.0f }
 			, AffectsNeutral { true }
 			, AffectsGround { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -405,7 +405,7 @@ public:
 
 			, AffectsBelowPercent { 1.0 }
 			, AffectsAbovePercent { 0.0 }
-			, AffectsBelowVeterancy { RulesClass::Instance->VeteranCap }
+			, AffectsBelowVeterancy { static_cast<float>(RulesClass::Instance->VeteranCap) }
 			, AffectsAboveVeterancy { 0.0f }
 			, AffectsNeutral { true }
 			, AffectsGround { true }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -193,7 +193,7 @@ public:
 		Valueable<double> AffectsBelowPercent;
 		Valueable<double> AffectsAbovePercent;
 		Nullable<float> AffectsBelowVeterancy;
-		Nullable<float> AffectsAboveVeterancy;
+		Valueable<float> AffectsAboveVeterancy;
 		Valueable<bool> AffectsNeutral;
 		Valueable<bool> AffectsGround;
 		Valueable<bool> AffectsAir;

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -191,8 +191,8 @@ public:
 
 		Valueable<double> AffectsBelowPercent;
 		Valueable<double> AffectsAbovePercent;
-		Nullable<double> AffectsBelowVeterancy;
-		Valueable<double> AffectsAboveVeterancy;
+		Valueable<AffectedVeterancy> AffectsVeterancy;
+
 		Valueable<bool> AffectsNeutral;
 		Valueable<bool> AffectsGround;
 		Valueable<bool> AffectsAir;
@@ -408,8 +408,7 @@ public:
 
 			, AffectsBelowPercent { 1.0 }
 			, AffectsAbovePercent { 0.0 }
-			, AffectsBelowVeterancy {}
-			, AffectsAboveVeterancy { 0.0 }
+			, AffectsVeterancy { AffectedVeterancy::All }
 			, AffectsNeutral { true }
 			, AffectsGround { true }
 			, AffectsAir { true }

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -164,7 +164,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
 		|| this->CanTarget_MaxHealth < 1.0 || this->CanTarget_MinHealth > 0.0
-		|| this->CanTarget_MaxVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) < 2.0f || this->CanTarget_MinVeterancy > 0.0f
+		|| this->CanTarget_MaxVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) < static_cast<float>(RulesClass::Instance->VeteranCap) || this->CanTarget_MinVeterancy > 0.0f
 		|| this->AttachEffect_RequiredTypes.size() || this->AttachEffect_RequiredGroups.size()
 		|| this->AttachEffect_DisallowedTypes.size() || this->AttachEffect_DisallowedGroups.size())
 	{

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -164,7 +164,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
 		|| this->CanTarget_MaxHealth < 1.0 || this->CanTarget_MinHealth > 0.0
-		|| this->CanTarget_MaxVeterancy < 2.0 || this->CanTarget_MinVeterancy > 0.0
+		|| this->CanTarget_MaxVeterancy < 2.0f || this->CanTarget_MinVeterancy > 0.0f
 		|| this->AttachEffect_RequiredTypes.size() || this->AttachEffect_RequiredGroups.size()
 		|| this->AttachEffect_DisallowedTypes.size() || this->AttachEffect_DisallowedGroups.size())
 	{

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -48,7 +48,7 @@ bool WeaponTypeExt::ExtData::IsHealthInThreshold(TechnoClass* pTarget) const
 
 bool WeaponTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 {
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy);
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)));
 }
 
 void WeaponTypeExt::ExtData::Initialize()
@@ -164,7 +164,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
 		|| this->CanTarget_MaxHealth < 1.0 || this->CanTarget_MinHealth > 0.0
-		|| this->CanTarget_MaxVeterancy < 2.0f || this->CanTarget_MinVeterancy > 0.0f
+		|| this->CanTarget_MaxVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) < 2.0f || this->CanTarget_MinVeterancy > 0.0f
 		|| this->AttachEffect_RequiredTypes.size() || this->AttachEffect_RequiredGroups.size()
 		|| this->AttachEffect_DisallowedTypes.size() || this->AttachEffect_DisallowedGroups.size())
 	{

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -48,7 +48,7 @@ bool WeaponTypeExt::ExtData::IsHealthInThreshold(TechnoClass* pTarget) const
 
 bool WeaponTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 {
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)));
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap));
 }
 
 void WeaponTypeExt::ExtData::Initialize()
@@ -164,7 +164,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
 		|| this->CanTarget_MaxHealth < 1.0 || this->CanTarget_MinHealth > 0.0
-		|| this->CanTarget_MaxVeterancy.Get(static_cast<float>(RulesClass::Instance->VeteranCap)) < static_cast<float>(RulesClass::Instance->VeteranCap) || this->CanTarget_MinVeterancy > 0.0f
+		|| this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap) < RulesClass::Instance->VeteranCap || this->CanTarget_MinVeterancy > 0.0
 		|| this->AttachEffect_RequiredTypes.size() || this->AttachEffect_RequiredGroups.size()
 		|| this->AttachEffect_DisallowedTypes.size() || this->AttachEffect_DisallowedGroups.size())
 	{

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -48,7 +48,7 @@ bool WeaponTypeExt::ExtData::IsHealthInThreshold(TechnoClass* pTarget) const
 
 bool WeaponTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 {
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap));
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0));
 }
 
 void WeaponTypeExt::ExtData::Initialize()
@@ -164,7 +164,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
 		|| this->CanTarget_MaxHealth < 1.0 || this->CanTarget_MinHealth > 0.0
-		|| this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap) < RulesClass::Instance->VeteranCap || this->CanTarget_MinVeterancy > 0.0
+		|| this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0) < RulesClass::Instance->VeteranCap + 1.0 || this->CanTarget_MinVeterancy > 0.0
 		|| this->AttachEffect_RequiredTypes.size() || this->AttachEffect_RequiredGroups.size()
 		|| this->AttachEffect_DisallowedTypes.size() || this->AttachEffect_DisallowedGroups.size())
 	{

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -46,6 +46,11 @@ bool WeaponTypeExt::ExtData::IsHealthInThreshold(TechnoClass* pTarget) const
 	return TechnoExt::IsHealthInThreshold(pTarget, this->CanTarget_MinHealth, this->CanTarget_MaxHealth);
 }
 
+bool WeaponTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
+{
+	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy);
+}
+
 void WeaponTypeExt::ExtData::Initialize()
 {
 	this->RadType = RadTypeClass::FindOrAllocate(GameStrings::Radiation);
@@ -104,6 +109,8 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->CanTargetHouses.Read(exINI, pSection, "CanTargetHouses");
 	this->CanTarget_MaxHealth.Read(exINI, pSection, "CanTarget.MaxHealth");
 	this->CanTarget_MinHealth.Read(exINI, pSection, "CanTarget.MinHealth");
+	this->CanTarget_MaxVeterancy.Read(exINI, pSection, "CanTarget.MaxVeterancy");
+	this->CanTarget_MinVeterancy.Read(exINI, pSection, "CanTarget.MinVeterancy");
 	this->Burst_Delays.Read(exINI, pSection, "Burst.Delays");
 	this->Burst_FireWithinSequence.Read(exINI, pSection, "Burst.FireWithinSequence");
 	this->Burst_NoDelay.Read(exINI, pSection, "Burst.NoDelay");
@@ -157,6 +164,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
 		|| this->CanTarget_MaxHealth < 1.0 || this->CanTarget_MinHealth > 0.0
+		|| this->CanTarget_MaxVeterancy < 2.0 || this->CanTarget_MinVeterancy > 0.0
 		|| this->AttachEffect_RequiredTypes.size() || this->AttachEffect_RequiredGroups.size()
 		|| this->AttachEffect_DisallowedTypes.size() || this->AttachEffect_DisallowedGroups.size())
 	{
@@ -186,6 +194,8 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->CanTargetHouses)
 		.Process(this->CanTarget_MaxHealth)
 		.Process(this->CanTarget_MinHealth)
+		.Process(this->CanTarget_MaxVeterancy)
+		.Process(this->CanTarget_MinVeterancy)
 		.Process(this->RadType)
 		.Process(this->Burst_Delays)
 		.Process(this->Burst_FireWithinSequence)

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -47,7 +47,7 @@ bool WeaponTypeExt::ExtData::IsHealthInThreshold(TechnoClass* pTarget) const
 
 bool WeaponTypeExt::ExtData::IsVeterancyInThreshold(TechnoClass* pTarget) const
 {
-	return TechnoExt::IsVeterancyInThreshold(pTarget, this->CanTarget_MinVeterancy, this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0));
+	return EnumFunctions::CanTargetVeterancy(this->CanTargetVeterancy, pTarget);
 }
 
 void WeaponTypeExt::ExtData::Initialize()
@@ -108,8 +108,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->CanTargetHouses.Read(exINI, pSection, "CanTargetHouses");
 	this->CanTarget_MaxHealth.Read(exINI, pSection, "CanTarget.MaxHealth");
 	this->CanTarget_MinHealth.Read(exINI, pSection, "CanTarget.MinHealth");
-	this->CanTarget_MaxVeterancy.Read(exINI, pSection, "CanTarget.MaxVeterancy");
-	this->CanTarget_MinVeterancy.Read(exINI, pSection, "CanTarget.MinVeterancy");
+	this->CanTargetVeterancy.Read(exINI, pSection, "CanTargetVeterancy");
 	this->Burst_Delays.Read(exINI, pSection, "Burst.Delays");
 	this->Burst_FireWithinSequence.Read(exINI, pSection, "Burst.FireWithinSequence");
 	this->Burst_NoDelay.Read(exINI, pSection, "Burst.NoDelay");
@@ -170,7 +169,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
 		|| this->CanTarget_MaxHealth < 1.0 || this->CanTarget_MinHealth > 0.0
-		|| this->CanTarget_MaxVeterancy.Get(RulesClass::Instance->VeteranCap + 1.0) < RulesClass::Instance->VeteranCap + 1.0 || this->CanTarget_MinVeterancy > 0.0
+		|| this->CanTargetVeterancy != AffectedVeterancy::All
 		|| this->AttachEffect_RequiredTypes.size() || this->AttachEffect_RequiredGroups.size()
 		|| this->AttachEffect_DisallowedTypes.size() || this->AttachEffect_DisallowedGroups.size())
 	{
@@ -200,8 +199,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->CanTargetHouses)
 		.Process(this->CanTarget_MaxHealth)
 		.Process(this->CanTarget_MinHealth)
-		.Process(this->CanTarget_MaxVeterancy)
-		.Process(this->CanTarget_MinVeterancy)
+		.Process(this->CanTargetVeterancy)
 		.Process(this->RadType)
 		.Process(this->Burst_Delays)
 		.Process(this->Burst_FireWithinSequence)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -42,8 +42,8 @@ public:
 		Valueable<AffectedHouse> CanTargetHouses;
 		Valueable<double> CanTarget_MaxHealth;
 		Valueable<double> CanTarget_MinHealth;
-		Nullable<float> CanTarget_MaxVeterancy;
-		Valueable<float> CanTarget_MinVeterancy;
+		Nullable<double> CanTarget_MaxVeterancy;
+		Valueable<double> CanTarget_MinVeterancy;
 		ValueableVector<int> Burst_Delays;
 		Valueable<bool> Burst_FireWithinSequence;
 		Valueable<bool> Burst_NoDelay;
@@ -117,7 +117,7 @@ public:
 			, CanTarget_MaxHealth { 1.0 }
 			, CanTarget_MinHealth { 0.0 }
 			, CanTarget_MaxVeterancy {}
-			, CanTarget_MinVeterancy { 0.0f }
+			, CanTarget_MinVeterancy { 0.0 }
 			, Burst_Delays {}
 			, Burst_FireWithinSequence { false }
 			, Burst_NoDelay { false }

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -116,7 +116,7 @@ public:
 			, CanTargetHouses { AffectedHouse::All }
 			, CanTarget_MaxHealth { 1.0 }
 			, CanTarget_MinHealth { 0.0 }
-			, CanTarget_MaxVeterancy { 2.0f }
+			, CanTarget_MaxVeterancy { RulesClass::Instance->VeteranCap }
 			, CanTarget_MinVeterancy { 0.0f }
 			, Burst_Delays {}
 			, Burst_FireWithinSequence { false }

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -42,6 +42,8 @@ public:
 		Valueable<AffectedHouse> CanTargetHouses;
 		Valueable<double> CanTarget_MaxHealth;
 		Valueable<double> CanTarget_MinHealth;
+		Valueable<float> CanTarget_MaxVeterancy;
+		Valueable<float> CanTarget_MinVeterancy;
 		ValueableVector<int> Burst_Delays;
 		Valueable<bool> Burst_FireWithinSequence;
 		Valueable<bool> Burst_NoDelay;
@@ -114,6 +116,8 @@ public:
 			, CanTargetHouses { AffectedHouse::All }
 			, CanTarget_MaxHealth { 1.0 }
 			, CanTarget_MinHealth { 0.0 }
+			, CanTarget_MaxVeterancy { 2.0 }
+			, CanTarget_MinVeterancy { 0.0 }
 			, Burst_Delays {}
 			, Burst_FireWithinSequence { false }
 			, Burst_NoDelay { false }
@@ -169,6 +173,7 @@ public:
 		int GetBurstDelay(int burstIndex) const;
 		bool HasRequiredAttachedEffects(TechnoClass* pTechno, TechnoClass* pFirer) const;
 		bool IsHealthInThreshold(TechnoClass* pTarget) const;
+		bool IsVeterancyInThreshold(TechnoClass* pTarget) const;
 
 		virtual ~ExtData() = default;
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -116,7 +116,7 @@ public:
 			, CanTargetHouses { AffectedHouse::All }
 			, CanTarget_MaxHealth { 1.0 }
 			, CanTarget_MinHealth { 0.0 }
-			, CanTarget_MaxVeterancy { RulesClass::Instance->VeteranCap }
+			, CanTarget_MaxVeterancy { static_cast<float>(RulesClass::Instance->VeteranCap) }
 			, CanTarget_MinVeterancy { 0.0f }
 			, Burst_Delays {}
 			, Burst_FireWithinSequence { false }

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -43,7 +43,7 @@ public:
 		Valueable<double> CanTarget_MaxHealth;
 		Valueable<double> CanTarget_MinHealth;
 		Nullable<float> CanTarget_MaxVeterancy;
-		Nullable<float> CanTarget_MinVeterancy;
+		Valueable<float> CanTarget_MinVeterancy;
 		ValueableVector<int> Burst_Delays;
 		Valueable<bool> Burst_FireWithinSequence;
 		Valueable<bool> Burst_NoDelay;

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -42,8 +42,8 @@ public:
 		Valueable<AffectedHouse> CanTargetHouses;
 		Valueable<double> CanTarget_MaxHealth;
 		Valueable<double> CanTarget_MinHealth;
-		Valueable<float> CanTarget_MaxVeterancy;
-		Valueable<float> CanTarget_MinVeterancy;
+		Nullable<float> CanTarget_MaxVeterancy;
+		Nullable<float> CanTarget_MinVeterancy;
 		ValueableVector<int> Burst_Delays;
 		Valueable<bool> Burst_FireWithinSequence;
 		Valueable<bool> Burst_NoDelay;
@@ -116,7 +116,7 @@ public:
 			, CanTargetHouses { AffectedHouse::All }
 			, CanTarget_MaxHealth { 1.0 }
 			, CanTarget_MinHealth { 0.0 }
-			, CanTarget_MaxVeterancy { static_cast<float>(RulesClass::Instance->VeteranCap) }
+			, CanTarget_MaxVeterancy {}
 			, CanTarget_MinVeterancy { 0.0f }
 			, Burst_Delays {}
 			, Burst_FireWithinSequence { false }

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -116,8 +116,8 @@ public:
 			, CanTargetHouses { AffectedHouse::All }
 			, CanTarget_MaxHealth { 1.0 }
 			, CanTarget_MinHealth { 0.0 }
-			, CanTarget_MaxVeterancy { 2.0 }
-			, CanTarget_MinVeterancy { 0.0 }
+			, CanTarget_MaxVeterancy { 2.0f }
+			, CanTarget_MinVeterancy { 0.0f }
 			, Burst_Delays {}
 			, Burst_FireWithinSequence { false }
 			, Burst_NoDelay { false }

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -36,8 +36,7 @@ public:
 		Valueable<AffectedHouse> CanTargetHouses;
 		Valueable<double> CanTarget_MaxHealth;
 		Valueable<double> CanTarget_MinHealth;
-		Nullable<double> CanTarget_MaxVeterancy;
-		Valueable<double> CanTarget_MinVeterancy;
+		Valueable<AffectedVeterancy> CanTargetVeterancy;
 		ValueableVector<int> Burst_Delays;
 		Valueable<bool> Burst_FireWithinSequence;
 		Valueable<bool> Burst_NoDelay;
@@ -117,8 +116,7 @@ public:
 			, CanTargetHouses { AffectedHouse::All }
 			, CanTarget_MaxHealth { 1.0 }
 			, CanTarget_MinHealth { 0.0 }
-			, CanTarget_MaxVeterancy {}
-			, CanTarget_MinVeterancy { 0.0 }
+			, CanTargetVeterancy { AffectedVeterancy::All }
 			, Burst_Delays {}
 			, Burst_FireWithinSequence { false }
 			, Burst_NoDelay { false }

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -111,6 +111,18 @@ enum class AffectedTarget : unsigned char
 
 MAKE_ENUM_FLAGS(AffectedTarget);
 
+enum class AffectedVeterancy : unsigned char
+{
+	None = 0x0,
+	Rookie = 0x1,
+	Veteran = 0x2,
+	Elite = 0x4,
+
+	All = Rookie | Veteran | Elite
+};
+
+MAKE_ENUM_FLAGS(AffectedVeterancy);
+
 enum class AffectedHouse : unsigned char
 {
 	None = 0x0,

--- a/src/Utilities/EnumFunctions.cpp
+++ b/src/Utilities/EnumFunctions.cpp
@@ -11,6 +11,23 @@ bool EnumFunctions::CanTargetHouse(AffectedHouse flags, HouseClass* ownerHouse, 
 	return (flags & AffectedHouse::Enemies) != AffectedHouse::None;
 }
 
+bool EnumFunctions::CanTargetVeterancy(AffectedVeterancy flags, TechnoClass* pTechno)
+{
+	if (flags == AffectedVeterancy::All)
+		return true;
+
+	switch (pTechno->Veterancy.GetRemainingLevel())
+	{
+	case Rank::Elite:
+		return (flags & AffectedVeterancy::Elite) != AffectedVeterancy::None;
+	case Rank::Veteran:
+		return (flags & AffectedVeterancy::Veteran) != AffectedVeterancy::None;
+	default:
+		return (flags & AffectedVeterancy::Rookie) != AffectedVeterancy::None;
+	}
+}
+
+
 bool EnumFunctions::IsCellEligible(CellClass* const pCell, AffectedTarget allowed, bool explicitEmptyCells, bool considerBridgesLand)
 {
 	if (allowed == AffectedTarget::All)

--- a/src/Utilities/EnumFunctions.h
+++ b/src/Utilities/EnumFunctions.h
@@ -9,6 +9,7 @@ class EnumFunctions
 {
 public:
 	static bool CanTargetHouse(AffectedHouse flags, HouseClass* ownerHouse, HouseClass* targetHouse);
+	static bool CanTargetVeterancy(AffectedVeterancy flags, TechnoClass* pTechno);
 	static bool IsCellEligible(CellClass* const pCell, AffectedTarget allowed, bool explicitEmptyCells = false, bool considerBridgesLand = false);
 	static bool IsTechnoEligible(TechnoClass* const pTechno, AffectedTarget allowed, bool considerAircraftSeparately = false);
 	static bool AreCellAndObjectsEligible(CellClass* const pCell, AffectedTarget allowed, AffectedHouse allowedHouses, HouseClass* owner, bool explicitEmptyCells = false, bool considerAircraftSeparately = false, bool allowBridges = false);

--- a/src/Utilities/TemplateDef.h
+++ b/src/Utilities/TemplateDef.h
@@ -788,6 +788,52 @@ namespace detail
 	}
 
 	template <>
+	inline bool read<AffectedVeterancy>(AffectedVeterancy& value, INI_EX& parser, const char* pSection, const char* pKey)
+	{
+		if (parser.ReadString(pSection, pKey))
+		{
+			static const std::pair<const char*, AffectedVeterancy> Names[] =
+			{
+				{"rookie",  AffectedVeterancy::Rookie},
+				{"veteran", AffectedVeterancy::Veteran},
+				{"elite",   AffectedVeterancy::Elite},
+				{"all",     AffectedVeterancy::All},
+				{"none",    AffectedVeterancy::None},
+			};
+
+
+			auto parsed = AffectedVeterancy::None;
+			for (auto&& part : std::string_view { parser.value() } | std::views::split(','))
+			{
+				std::string_view&& cur { part.begin(),part.end() };
+				*const_cast<char*>(cur.data() + cur.find_last_not_of(" \t\r") + 1) = 0;
+				auto pCur = cur.data() + cur.find_first_not_of(" \t\r");
+				bool matched = false;
+				for (auto const& [name, val] : Names)
+				{
+					if (_strcmpi(pCur, name) == 0)
+					{
+						parsed |= val;
+						matched = true;
+						break;
+					}
+				}
+				if (!matched)
+				{
+					Debug::INIParseFailed(pSection, pKey, pCur, "Expected an affected veterancy");
+					return false;
+				}
+			}
+
+			value = parsed;
+			return true;
+		}
+
+		return false;
+	}
+
+
+	template <>
 	inline bool read<AttachedAnimFlag>(AttachedAnimFlag& value, INI_EX& parser, const char* pSection, const char* pKey)
 	{
 		if (parser.ReadString(pSection, pKey))


### PR DESCRIPTION
This PR introduces **veterancy-based filtering** for both weapon targeting and warhead effect application.

---

## 1. Weapon target filtering by target veterancy

Weapons can now restrict which targets they are allowed to attack based on the target’s veterancy level.
This affects both weapon firing eligibility and weapon selection logic (except for special cases where weapon selection is fixed by the engine).

### New INI options:

```ini
[SOMEWEAPON]             ; WeaponType
CanTargetVeterancy=all     ; List of Affected Veterancy Enumeration (none|rookie|veteran|elite|all)
```

Targets whose veterancy is not included in the specified enumeration will not be considered valid targets for the weapon.

---

## 2. Warhead effect filtering by target veterancy

Warheads can now conditionally apply their effects based on the target’s veterancy level.
Unlike weapon filtering, this logic does **not** affect whether a weapon can fire, but instead determines whether the warhead’s effects will be applied after detonation.

### New INI options:

```ini
[SOMEWARHEAD]               ; WarheadType
AffectsVeterancy=all        ; List of Affected Veterancy Enumeration (none|rookie|veteran|elite|all)
```

* The warhead will only affect targets whose veterancy is explicitly listed in AffectsVeterancy.

---

---

---

本次更新新增了**基于目标等级（Veterancy）的筛选逻辑**，分别作用于**武器攻击判定**和**弹头效果生效判定**。

---

## 1. 基于目标等级的武器筛选

武器现在可以根据目标单位的经验等级，决定是否允许对其进行攻击。
该逻辑不仅影响武器能否开火，也会影响武器选择流程（部分引擎强制固定选择的特殊情况除外）。

### 新增 INI 选项（WeaponType）：

```ini
[SOMEWEAPON]             ; 武器类型
CanTargetVeterancy=all     ; List of Affected Veterancy Enumeration (none|rookie|veteran|elite|all)
```

当目标的等级未被列入指定枚举时，武器将不会将其视为可攻击目标。

---

## 2. 基于目标等级的弹头效果筛选

弹头现在可以根据目标单位的经验等级，决定爆炸后是否对其产生效果。
与武器筛选不同，此逻辑**不影响武器是否开火**，而是作用于爆炸结算阶段。

### 新增 INI 选项：

```ini
[SOMEWARHEAD]               ; 弹头类型
AffectsVeterancy=all        ; List of Affected Veterancy Enumeration (none|rookie|veteran|elite|all)
```

* 只有等级被列入指定枚举的目标才会受到弹头效果影响