### PR TITLE
[Vanilla Enhancement] Customize size for mind controlled unit

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -469,6 +469,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType`
   - Fix a bug where units can be promoted when created via trigger actions even if they have `Trainable=false`
   - Fix the bug that ai will try to product aircraft even the airport has no free dock for it
+  - Customize size for mind controlled unit
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1797,6 +1797,7 @@ Please notice that if the object is a unit which carries passengers, they will n
 *Multiple Mind Control unit auto-releases the first victim in [Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-adventure)*
 
 - Mind controllers now can have the upper limit of the control distance. Tag values greater than 0 will activate this feature.
+- Mind controlled targets can have size of control, like passengers in transport.
 - Mind controllers now can decide which house can see the link drawn between itself and the controlled units.
 - Mind controllers with multiple controlling slots can now release the first controlled unit when they have reached the control limit and are ordered to control a new target.
 
@@ -1804,6 +1805,8 @@ In `rulesmd.ini`:
 ```ini
 [SOMETECHNO]                          ; TechnoType
 MindControlRangeLimit=-1.0            ; floating point value
+MindControl.IgnoreSize=true             ; boolean
+MindControlSize=1                       ; integer
 MindControlLink.VisibleToHouse=all    ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 MultiMindControl.ReleaseVictim=false  ; boolean
 ```

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1815,8 +1815,8 @@ In `rulesmd.ini`:
 ```ini
 [SOMETECHNO]                          ; TechnoType
 MindControlRangeLimit=-1.0            ; floating point value
-MindControl.IgnoreSize=true             ; boolean
-MindControlSize=1                       ; integer
+MindControl.IgnoreSize=true           ; boolean
+MindControlSize=1                     ; integer
 MindControlLink.VisibleToHouse=all    ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 MultiMindControl.ReleaseVictim=false  ; boolean
 ```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -471,6 +471,7 @@ New:
 - AutoDeath upon ownership change (by Ollerus)
 - [Script Action 14004 for forcing all new actions to target only the main owner's enemy](AI-Scripting-and-Mapping.md#force-global-onlytargethouseenemy-value-in-teams-for-new-attack-move-actions-introduced-by-phobos) (by FS-21)
 - [Allow merging AOE damage to buildings into one](New-or-Enhanced-Logics.md#allow-merging-aoe-damage-to-buildings-into-one) (by CrimRecya)
+- Customize size for mind controlled unit (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/CaptureManager/Body.cpp
+++ b/src/Ext/CaptureManager/Body.cpp
@@ -70,7 +70,7 @@ bool CaptureManagerExt::CanCapture(CaptureManagerClass* pManager, TechnoClass* p
 	}
 
 	// disallow capturing bunkered units
-	if (pTarget->BunkerLinkedItem)
+	if (pTarget->BunkerLinkedItem && pTarget->WhatAmI() == AbstractType::Unit)
 		return false;
 
 	if (pTarget->IsMindControlled() || pTarget->MindControlledByHouse)

--- a/src/Ext/CaptureManager/Body.cpp
+++ b/src/Ext/CaptureManager/Body.cpp
@@ -10,7 +10,7 @@ int CaptureManagerExt::GetControlledTotalSize(CaptureManagerClass* pManager)
 	for (const auto pNode : pManager->ControlNodes)
 	{
 		if (const auto pTechno = pNode->Unit)
-			totalSize += TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType())->MindControlSize;
+			totalSize += TechnoExt::ExtMap.Find(pTechno)->TypeExtData->MindControlSize;
 	}
 
 	return totalSize;
@@ -79,7 +79,7 @@ bool CaptureManagerExt::CanCapture(CaptureManagerClass* pManager, TechnoClass* p
 	// free slot? (move on if infinite or single slot which will be freed if used)
 	if (!pManager->InfiniteMindControl && pManager->MaxControlNodes != 1)
 	{
-		const auto pOwnerTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->GetTechnoType());
+		const auto pOwnerTypeExt = TechnoExt::ExtMap.Find(pOwner)->TypeExtData;
 
 		if (!pOwnerTypeExt->MindControl_IgnoreSize)
 		{

--- a/src/Ext/CaptureManager/Body.h
+++ b/src/Ext/CaptureManager/Body.h
@@ -12,9 +12,11 @@
 class CaptureManagerExt
 {
 public:
+	static int GetControlledTotalSize(CaptureManagerClass* pManager);
+
 	static bool CanCapture(CaptureManagerClass* pManager, TechnoClass* pTarget);
 	static bool FreeUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool silent = false);
-	static bool CaptureUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool bRemoveFirst,
+	static bool CaptureUnit(CaptureManagerClass* pManager, TechnoClass* pTarget, bool removeFirst,
 		AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType, bool silent = false, int threatDelay = 0);
 	static bool CaptureUnit(CaptureManagerClass* pManager, AbstractClass* pTechno,
 		AnimTypeClass* pControlledAnimType = RulesClass::Instance->ControlledAnimationType, int threatDelay = 0);

--- a/src/Ext/CaptureManager/Hooks.cpp
+++ b/src/Ext/CaptureManager/Hooks.cpp
@@ -34,7 +34,7 @@ DEFINE_HOOK(0x471C90, CaptureManagerClass_CanCapture, 0x6)
 
 static int __fastcall _GetControlledCount(CaptureManagerClass* pThis)
 {
-	const auto pOwnerTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Owner->GetTechnoType());
+	const auto pOwnerTypeExt = TechnoExt::ExtMap.Find(pThis->Owner)->TypeExtData;
 
 	if (!pOwnerTypeExt->MindControl_IgnoreSize)
 		return CaptureManagerExt::GetControlledTotalSize(pThis);

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -992,7 +992,7 @@ void TechnoExt::ExtData::UpdateTypeData(TechnoTypeClass* pCurrentType)
 		}
 		else if (pOldTypeExt->Convert_ResetMindControl)
 		{
-			if (!infiniteCapture && pCaptureManager->ControlNodes.Count > maxCapture)
+			if (!infiniteCapture && pCaptureManager->GetControlledCount() > maxCapture)
 			{
 				// Remove excess nodes.
 				for (int i = pCaptureManager->ControlNodes.Count - 1; i >= maxCapture; --i)

--- a/src/Ext/Techno/Body.Visuals.cpp
+++ b/src/Ext/Techno/Body.Visuals.cpp
@@ -540,7 +540,7 @@ void TechnoExt::GetValuesForDisplay(TechnoClass* pThis, TechnoTypeClass* pType, 
 		if (!pCaptureManager)
 			return;
 
-		value = pCaptureManager->ControlNodes.Count;
+		value = pCaptureManager->GetControlledCount();
 		maxValue = pCaptureManager->MaxControlNodes;
 		break;
 	}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -727,6 +727,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->RadarJamAffect.Read(exINI, pSection, "RadarJamAffect");
 	this->RadarJamIgnore.Read(exINI, pSection, "RadarJamIgnore");
 	this->MindControlRangeLimit.Read(exINI, pSection, "MindControlRangeLimit");
+	this->MindControl_IgnoreSize.Read(exINI, pSection, "MindControl.IgnoreSize");
+	this->MindControlSize.Read(exINI, pSection, "MindControlSize");
 	this->MindControlLink_VisibleToHouse.Read(exINI, pSection, "MindControlLink.VisibleToHouse");
 	this->FactoryPlant_Multiplier.Read(exINI, pSection, "FactoryPlant.Multiplier");
 
@@ -1385,6 +1387,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->UIDescription)
 		.Process(this->LowSelectionPriority)
 		.Process(this->MindControlRangeLimit)
+		.Process(this->MindControl_IgnoreSize)
+		.Process(this->MindControlSize)
 		.Process(this->MindControlLink_VisibleToHouse)
 		.Process(this->FactoryPlant_Multiplier)
 

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -46,6 +46,8 @@ public:
 		Nullable<int> DesignatorRange;
 		Valueable<float> FactoryPlant_Multiplier;
 		Valueable<Leptons> MindControlRangeLimit;
+		Valueable<bool> MindControl_IgnoreSize;
+		Valueable<int> MindControlSize;
 		Valueable<AffectedHouse> MindControlLink_VisibleToHouse;
 
 		std::unique_ptr<InterceptorTypeClass> InterceptorType;
@@ -471,6 +473,8 @@ public:
 			, DesignatorRange { }
 			, FactoryPlant_Multiplier { 1.0 }
 			, MindControlRangeLimit {}
+			, MindControl_IgnoreSize { true }
+			, MindControlSize { 1 }
 			, MindControlLink_VisibleToHouse{ AffectedHouse::All }
 
 			, InterceptorType { nullptr }


### PR DESCRIPTION
- Mind controlled targets can have size of control, like passengers in transport.
- 被心灵控制的单位现在可以设置大小，就像乘客在载具中那样.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                          ; TechnoType
MindControl.IgnoreSize=true             ; boolean
MindControlSize=1                       ; integer
```