### PR TITLE
[Ares Fix] 2 Bugfixes about spawn survivors

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -469,7 +469,6 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType`
   - Fix a bug where units can be promoted when created via trigger actions even if they have `Trainable=false`
   - Fix the bug that ai will try to product aircraft even the airport has no free dock for it
-  - Fix the bug that technos cannot spawn survivors if it has been killed by ignore defense damage
   - Fix the issue that technos cannot spawn survivors due to non-probabilistic reasons when the tech type was destroyed
   - Fix the bug that vehicle survivor can spawn on wrong position when transport has been destroyed
 - **Apollo** - Translucent SHP drawing patches

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -469,6 +469,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType`
   - Fix a bug where units can be promoted when created via trigger actions even if they have `Trainable=false`
   - Fix the bug that ai will try to product aircraft even the airport has no free dock for it
+  - Fix the bug that technos cannot spawn survivors if it has been killed by ignore defense damage
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -470,6 +470,8 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where units can be promoted when created via trigger actions even if they have `Trainable=false`
   - Fix the bug that ai will try to product aircraft even the airport has no free dock for it
   - Fix the bug that technos cannot spawn survivors if it has been killed by ignore defense damage
+  - Fix the issue that technos cannot spawn survivors due to non-probabilistic reasons when the tech type was destroyed
+  - Fix the bug that vehicle survivor can spawn on wrong position when transport has been destroyed
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -322,7 +322,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the issue where Ares' `Flash.Duration` cannot override the weapon's repair flash effect.
 - Fixed the bug that building with `CloningFacility=true` and `WeaponsFactory=true` may cloning multiple vehicles and then they get stuck.
 - Fixed a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType`.
-- Fixed the bug that technos cannot spawn survivors if it has been killed by ignore defense damage.
 - Fixed the issue that technos cannot spawn survivors due to non-probabilistic reasons when the tech type was destroyed.
 - Fixed the bug that vehicle survivor can spawn on wrong position when transport has been destroyed.
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -323,6 +323,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that building with `CloningFacility=true` and `WeaponsFactory=true` may cloning multiple vehicles and then they get stuck.
 - Fixed a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType`.
 - Fixed the bug that technos cannot spawn survivors if it has been killed by ignore defense damage.
+- Fixed the issue that technos cannot spawn survivors due to non-probabilistic reasons when the tech type was destroyed.
+- Fixed the bug that vehicle survivor can spawn on wrong position when transport has been destroyed.
 
 ## Newly added global settings
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -322,6 +322,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the issue where Ares' `Flash.Duration` cannot override the weapon's repair flash effect.
 - Fixed the bug that building with `CloningFacility=true` and `WeaponsFactory=true` may cloning multiple vehicles and then they get stuck.
 - Fixed a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType`.
+- Fixed the bug that technos cannot spawn survivors if it has been killed by ignore defense damage.
 
 ## Newly added global settings
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -548,6 +548,7 @@ Fixes / interactions with other extensions:
 - Fixed the bug that building with `CloningFacility=true` and `WeaponsFactory=true` may cloning multiple vehicles and then they get stuck (by NetsuNegi)
 - [Customize Ares's radar jam logic](New-or-Enhanced-Logics.md#customize-ares-s-radar-jam-logic) (by NetsuNegi)
 - Fixed a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType` (by NetsuNegi)
+- Fixed the bug that technos cannot spawn survivors if it has been killed by ignore defense damage (by NetsuNegi)
 ```
 
 ### 0.4.0.1

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -549,6 +549,8 @@ Fixes / interactions with other extensions:
 - [Customize Ares's radar jam logic](New-or-Enhanced-Logics.md#customize-ares-s-radar-jam-logic) (by NetsuNegi)
 - Fixed a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType` (by NetsuNegi)
 - Fixed the bug that technos cannot spawn survivors if it has been killed by ignore defense damage (by NetsuNegi)
+- Fixed the issue that technos cannot spawn survivors due to non-probabilistic reasons when the tech type was destroyed (by NetsuNegi)
+- Fixed the bug that vehicle survivor can spawn on wrong position when transport has been destroyed (by NetsuNegi)
 ```
 
 ### 0.4.0.1

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -548,7 +548,6 @@ Fixes / interactions with other extensions:
 - Fixed the bug that building with `CloningFacility=true` and `WeaponsFactory=true` may cloning multiple vehicles and then they get stuck (by NetsuNegi)
 - [Customize Ares's radar jam logic](New-or-Enhanced-Logics.md#customize-ares-s-radar-jam-logic) (by NetsuNegi)
 - Fixed a bug introduced by Ares where building types that have `UndeploysInto` cannot display `AltCameo` or `AltCameoPCX` even when you infiltrate enemy buildings with `Factory=UnitType` (by NetsuNegi)
-- Fixed the bug that technos cannot spawn survivors if it has been killed by ignore defense damage (by NetsuNegi)
 - Fixed the issue that technos cannot spawn survivors due to non-probabilistic reasons when the tech type was destroyed (by NetsuNegi)
 - Fixed the bug that vehicle survivor can spawn on wrong position when transport has been destroyed (by NetsuNegi)
 ```

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -876,6 +876,103 @@ bool TechnoExt::SimpleDeployerAllowedToDeploy(UnitClass* pThis, bool defaultValu
 	return true;
 }
 
+bool TechnoExt::EjectRandomly(FootClass* pEjectee, const CoordStruct& coords, int distance, bool select)
+{
+	std::vector<CoordStruct> usableCoords;
+
+	for (int direction = 0; direction < 8; ++direction)
+	{
+		const CellStruct tmpCoords = Unsorted::AdjacentCell[direction];
+		CoordStruct ejectCoords { coords.X + tmpCoords.X * distance, coords.Y + tmpCoords.Y * distance, coords.Z };
+		const auto pCell = MapClass::Instance.TryGetCellAt(ejectCoords);
+
+		if (!pCell)
+			continue;
+
+		const auto occupied = pEjectee->IsCellOccupied(pCell, FacingType::None, -1, nullptr, true);
+
+		if (occupied != Move::OK && occupied != Move::MovingBlock)
+			continue;
+
+		if (pEjectee->WhatAmI() == InfantryClass::AbsID)
+		{
+			ejectCoords = pCell->FindInfantrySubposition(ejectCoords, false, false, false);
+			ejectCoords.Z = coords.Z;
+		}
+		else
+		{
+			ejectCoords = CellClass::Cell2Coord(pCell->MapCoords, coords.Z);
+		}
+
+		usableCoords.emplace_back(ejectCoords);
+	}
+
+	const int count = static_cast<int>(usableCoords.size());
+
+	if (!count)
+		return false;
+
+	return TechnoExt::EjectSurvivor(pEjectee, usableCoords[ScenarioClass::Instance->Random(0, count - 1)], select);
+}
+
+bool TechnoExt::EjectSurvivor(FootClass* pSurvivor, CoordStruct coords, bool select)
+{
+	const auto pCell = MapClass::Instance.GetCellAt(coords);
+
+	pSurvivor->OnBridge = pCell->ContainsBridge();
+
+	const int floorZ = pCell->GetCoordsWithBridge().Z;
+	const bool chuted = (coords.Z - floorZ > 2 * Unsorted::LevelHeight);
+
+	if (chuted)
+	{
+		pSurvivor->Limbo();
+
+		++Unsorted::ScenarioInit;
+		const bool result = pSurvivor->SpawnParachuted(coords);
+		--Unsorted::ScenarioInit;
+
+		if (!result)
+			return false;
+	}
+	else
+	{
+		coords.Z = floorZ;
+
+		++Unsorted::ScenarioInit;
+		const bool result = pSurvivor->Unlimbo(coords, static_cast<DirType>(ScenarioClass::Instance->Random(0, 7)));
+		--Unsorted::ScenarioInit;
+
+		if (!result)
+			return false;
+	}
+
+	pSurvivor->Transporter = nullptr;
+	pSurvivor->LastMapCoords = pCell->MapCoords;
+
+	if (chuted)
+	{
+		const bool scat = pSurvivor->OnBridge;
+		const auto occupation = scat ? pCell->AltOccupationFlags : pCell->OccupationFlags;
+
+		if (occupation & 0x1C)
+			pCell->ScatterContent(CoordStruct::Empty, true, true, scat);
+	}
+	else
+	{
+		pSurvivor->Scatter(CoordStruct::Empty, true, false);
+		pSurvivor->QueueMission(pSurvivor->Owner->IsControlledByHuman() ? Mission::Guard : Mission::Hunt, 0);
+	}
+
+	pSurvivor->ShouldEnterOccupiable = false;
+	pSurvivor->ShouldGarrisonStructure = false;
+
+	if (select)
+		pSurvivor->Select();
+
+	return true;
+}
+
 // =============================
 // load / save
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -297,6 +297,9 @@ public:
 	static bool SimpleDeployerAllowedToDeploy(UnitClass* pThis, bool defaultValue, bool alwaysCheckLandTypes);
 	static void ShowPromoteAnim(TechnoClass* pThis);
 
+	static bool EjectRandomly(FootClass* pEjectee, const CoordStruct& coords, int distance, bool select);
+	static bool EjectSurvivor(FootClass* pSurvivor, CoordStruct coords, bool select);
+
 	// WeaponHelpers.cpp
 	static int PickWeaponIndex(TechnoClass* pThis, TechnoClass* pTargetTechno, AbstractClass* pTarget, int weaponIndexOne, int weaponIndexTwo, bool allowFallback = true, bool allowAAFallback = true);
 	static void FireWeaponAtSelf(TechnoClass* pThis, WeaponTypeClass* pWeaponType);

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -76,6 +76,9 @@ void Apply_Ares3_0_Patches()
 	// Amphibious enter fix:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x17536, AresHelper::AresBaseAddress + 0x1754D);
 
+	// SpawnSurvivor fix:
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4C0E8B, { 0x5C });
+
 	// Redirect Ares' getCellSpreadItems to our implementation:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x62267, &Helpers::Alex::getCellSpreadItems);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x528C8, &Helpers::Alex::getCellSpreadItems);
@@ -137,6 +140,9 @@ void Apply_Ares3_0p1_Patches()
 
 	// Amphibious enter fix:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x17C26, AresHelper::AresBaseAddress + 0x17C3D);
+
+	// SpawnSurvivor fix:
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4CD4B, { 0x5C });
 
 	// Redirect Ares' getCellSpreadItems to our implementation:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x62FB7, &Helpers::Alex::getCellSpreadItems);

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -77,7 +77,6 @@ void Apply_Ares3_0_Patches()
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x17536, AresHelper::AresBaseAddress + 0x1754D);
 
 	// SpawnSurvivor fix:
-	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4C0E8B, { 0x5C }); // preventEscape
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x445E0, GET_OFFSET(TechnoExt::EjectRandomly));
 
 	// Redirect Ares' getCellSpreadItems to our implementation:
@@ -143,7 +142,6 @@ void Apply_Ares3_0p1_Patches()
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x17C26, AresHelper::AresBaseAddress + 0x17C3D);
 
 	// SpawnSurvivor fix:
-	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4CD4B, { 0x5C }); // preventEscape
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x450C0, GET_OFFSET(TechnoExt::EjectRandomly));
 
 	// Redirect Ares' getCellSpreadItems to our implementation:

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -77,7 +77,8 @@ void Apply_Ares3_0_Patches()
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x17536, AresHelper::AresBaseAddress + 0x1754D);
 
 	// SpawnSurvivor fix:
-	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4C0E8B, { 0x5C });
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4C0E8B, { 0x5C }); // preventEscape
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x445E0, GET_OFFSET(TechnoExt::EjectRandomly));
 
 	// Redirect Ares' getCellSpreadItems to our implementation:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x62267, &Helpers::Alex::getCellSpreadItems);
@@ -142,7 +143,8 @@ void Apply_Ares3_0p1_Patches()
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x17C26, AresHelper::AresBaseAddress + 0x17C3D);
 
 	// SpawnSurvivor fix:
-	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4CD4B, { 0x5C });
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4CD4B, { 0x5C }); // preventEscape
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x450C0, GET_OFFSET(TechnoExt::EjectRandomly));
 
 	// Redirect Ares' getCellSpreadItems to our implementation:
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x62FB7, &Helpers::Alex::getCellSpreadItems);

--- a/src/Utilities/AresFunctions.h
+++ b/src/Utilities/AresFunctions.h
@@ -31,7 +31,7 @@ public:
 
 	static EBolt* (__stdcall* CreateAresEBolt)(WeaponTypeClass* pWeapon);
 
-	static void(__stdcall* SpawnSurvivors)(FootClass* pThis, TechnoClass* pKiller, bool Select, bool IgnoreDefenses);
+	static void(__stdcall* SpawnSurvivors)(FootClass* pThis, TechnoClass* pKiller, bool Select, bool PreventEscape);
 
 	static bool(__thiscall* ReverseEngineer)(void* pAresHouseExt, TechnoTypeClass* pType);
 


### PR DESCRIPTION
- Fixed the issue that technos cannot spawn survivors due to non-probabilistic reasons when the tech type was destroyed.
- 修复了科技类型会因为非概率原因而无法生成出幸存者的问题.
- Fixed the bug that vehicle survivor can spawn on wrong position when transport has been destroyed.
- 修复了载具幸存者会被生成在错误的位置的bug.