### PR TITLE
Updateable firing anim

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -742,6 +742,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the incorrect mission switching in infantry EnterIdleMode
   - Fix the issue that `BombSight` not being updated correctly in techno conversion
   - Technos with Walk locomotor spawn wake like ship
+  - Updateable firing anim
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2750,3 +2750,6 @@ FiringAnim.Update=false   ; boolean
 Anim.Update=              ; boolean, default to [AudioVisual] -> FiringAnim.Update
 ```
 
+```{note}
+This effect will cause problem when used together with `[AnimType] -> Next`. `Next` modifies the Anim type over time, while this function changes it back, resulting in the Anim being unable to end.
+```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2736,3 +2736,17 @@ In `rulesmd.ini`:
 [SOMEWEAPON]         ; WeaponType
 IsSingleColor=false  ; boolean
 ```
+
+### Updateable firing anim
+
+- In vanilla, firing anims is attached to the firer, but it won't update its type and location to fit the firer's facing. This is now customizable by the following flags.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+FiringAnim.Update=false   ; boolean
+
+[SOMEWEAPON]              ; WeaponType
+Anim.Update=              ; boolean, default to [AudioVisual] -> FiringAnim.Update
+```
+

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -565,6 +565,7 @@ New:
 - [Allow disable an over-optimization in targeting](Fixed-or-Improved-Logics.md#allow-disable-an-over-optimization-in-targeting) (by TaranDahl)
 - [Extra threat](New-or-Enhanced-Logics.md#extra-threat) (by TaranDahl)
 - [Technos with Walk locomotor spawn wake like ship](Fixed-or-Improved-Logics.md#customizable-wake-anim) (by TaranDahl)
+- [Updateable firing anim](Fixed-or-Improved-Logics.md#updateable-firing-anim) (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -112,7 +112,8 @@ void AnimExt::ExtData::UpdateAsFiringAnim()
 			pNewType = pWeapon->Anim.GetItemOrDefault(0);
 		}
 
-		pThis->Type = pNewType;
+		if (pNewType)
+			pThis->Type = pNewType;
 
 		auto burstIdx = pOwner->CurrentBurstIndex;
 		pOwner->CurrentBurstIndex = this->FromBurstIdx;

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -65,29 +65,6 @@ void AnimExt::ExtData::DeleteAttachedSystem()
 	}
 }
 
-inline unsigned int TranslateFixedPoint(size_t bitsFrom, size_t bitsTo, unsigned int value, unsigned int offset = 0)
-{
-	const size_t MaskIn = ((1u << bitsFrom) - 1);
-	const size_t MaskOut = ((1u << bitsTo) - 1);
-
-	if (bitsFrom > bitsTo)
-	{
-		// converting down
-		return (((((value & MaskIn) >> (bitsFrom - bitsTo - 1)) + 1) >> 1) + offset) & MaskOut;
-
-	}
-	else if (bitsFrom < bitsTo)
-	{
-		// converting up
-		return (((value - offset) & MaskIn) << (bitsTo - bitsFrom)) & MaskOut;
-
-	}
-	else
-	{
-		return value & MaskOut;
-	}
-}
-
 void AnimExt::ExtData::UpdateAsFiringAnim()
 {
 	auto pThis = this->OwnerObject();
@@ -95,22 +72,8 @@ void AnimExt::ExtData::UpdateAsFiringAnim()
 
 	if (this->FromWeapon && pOwner)
 	{
-		AnimTypeClass* pNewType = nullptr;
 		auto pWeapon = this->FromWeapon;
-
-		auto highest = Conversions::Int2Highest(pWeapon->Anim.Count);
-
-		// 2^highest is the frame count, 3 means 8 frames
-		if (highest >= 3)
-		{
-			auto offset = 1u << (highest - 3);
-			auto index = TranslateFixedPoint(16, highest, static_cast<WORD>((pOwner)->GetRealFacing().GetValue<16>()), offset);
-			pNewType = pWeapon->Anim.GetItemOrDefault(index);
-		}
-		else
-		{
-			pNewType = pWeapon->Anim.GetItemOrDefault(0);
-		}
+		AnimTypeClass* pNewType = GeneralUtils::GetItemForDirection<AnimTypeClass*>(pWeapon->Anim, pOwner->GetRealFacing());
 
 		if (pNewType)
 			pThis->Type = pNewType;

--- a/src/Ext/Anim/Body.cpp
+++ b/src/Ext/Anim/Body.cpp
@@ -65,6 +65,63 @@ void AnimExt::ExtData::DeleteAttachedSystem()
 	}
 }
 
+inline unsigned int TranslateFixedPoint(size_t bitsFrom, size_t bitsTo, unsigned int value, unsigned int offset = 0)
+{
+	const size_t MaskIn = ((1u << bitsFrom) - 1);
+	const size_t MaskOut = ((1u << bitsTo) - 1);
+
+	if (bitsFrom > bitsTo)
+	{
+		// converting down
+		return (((((value & MaskIn) >> (bitsFrom - bitsTo - 1)) + 1) >> 1) + offset) & MaskOut;
+
+	}
+	else if (bitsFrom < bitsTo)
+	{
+		// converting up
+		return (((value - offset) & MaskIn) << (bitsTo - bitsFrom)) & MaskOut;
+
+	}
+	else
+	{
+		return value & MaskOut;
+	}
+}
+
+void AnimExt::ExtData::UpdateAsFiringAnim()
+{
+	auto pThis = this->OwnerObject();
+	auto pOwner = abstract_cast<TechnoClass*>(pThis->OwnerObject);
+
+	if (this->FromWeapon && pOwner)
+	{
+		AnimTypeClass* pNewType = nullptr;
+		auto pWeapon = this->FromWeapon;
+
+		auto highest = Conversions::Int2Highest(pWeapon->Anim.Count);
+
+		// 2^highest is the frame count, 3 means 8 frames
+		if (highest >= 3)
+		{
+			auto offset = 1u << (highest - 3);
+			auto index = TranslateFixedPoint(16, highest, static_cast<WORD>((pOwner)->GetRealFacing().GetValue<16>()), offset);
+			pNewType = pWeapon->Anim.GetItemOrDefault(index);
+		}
+		else
+		{
+			pNewType = pWeapon->Anim.GetItemOrDefault(0);
+		}
+
+		pThis->Type = pNewType;
+
+		auto burstIdx = pOwner->CurrentBurstIndex;
+		pOwner->CurrentBurstIndex = this->FromBurstIdx;
+		auto flh = pOwner->GetFLH(this->FromWeaponIdx, CoordStruct::Empty);
+		pOwner->CurrentBurstIndex = burstIdx;
+		pThis->SetLocation(flh - pOwner->GetCoords());
+	}
+}
+
 //Modified from Ares
 bool AnimExt::SetAnimOwnerHouseKind(AnimClass* pAnim, HouseClass* pInvoker, HouseClass* pVictim, bool defaultToVictimOwner, bool defaultToInvokerOwner)
 {
@@ -411,6 +468,9 @@ void AnimExt::ExtData::Serialize(T& Stm)
 		.Process(this->DelayedFireRemoveOnNoDelay)
 		.Process(this->IsAttachedEffectAnim)
 		.Process(this->IsShieldIdleAnim)
+		.Process(this->FromWeapon)
+		.Process(this->FromWeaponIdx)
+		.Process(this->FromBurstIdx)
 		;
 }
 

--- a/src/Ext/Anim/Body.h
+++ b/src/Ext/Anim/Body.h
@@ -27,6 +27,9 @@ public:
 		bool DelayedFireRemoveOnNoDelay;
 		bool IsAttachedEffectAnim;
 		bool IsShieldIdleAnim;
+		WeaponTypeClass* FromWeapon;
+		int FromWeaponIdx;
+		int FromBurstIdx;
 
 		ExtData(AnimClass* OwnerObject) : Extension<AnimClass>(OwnerObject)
 			, DeathUnitFacing { 0 }
@@ -41,12 +44,17 @@ public:
 			, DelayedFireRemoveOnNoDelay { false }
 			, IsAttachedEffectAnim { false }
 			, IsShieldIdleAnim { false }
+			, FromWeapon {}
+			, FromWeaponIdx {}
+			, FromBurstIdx {}
 		{ }
 
 		void SetInvoker(TechnoClass* pInvoker);
 		void SetInvoker(TechnoClass* pInvoker, HouseClass* pInvokerHouse);
 		void CreateAttachedSystem();
 		void DeleteAttachedSystem();
+
+		void UpdateAsFiringAnim();
 
 		virtual ~ExtData() override;
 

--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -25,6 +25,8 @@ DEFINE_HOOK(0x423B95, AnimClass_AI_HideIfNoOre_Threshold, 0x8)
 		pThis->Invisible = pThis->GetCell()->GetContainedTiberiumValue() <= nThreshold;
 	}
 
+	AnimExt::ExtMap.Find(pThis)->UpdateAsFiringAnim();
+
 	return 0x423BBF;
 }
 
@@ -551,3 +553,27 @@ DEFINE_HOOK(0x4250E1, AnimClass_Middle_CraterDestroyTiberium, 0x6)
 	return AnimTypeExt::ExtMap.Find(pType)->Crater_DestroyTiberium.Get(RulesExt::Global()->AnimCraterDestroyTiberium) ? 0 : SkipDestroyTiberium;
 }
 
+#pragma region FiringAnimUpdate
+
+DEFINE_HOOK(0x6FF42B, TechnoClass_Fire_Anim, 0x7)
+{
+	enum { SkipBuildingCheck = 0x6FF437 };
+
+	GET(TechnoClass*, pThis, ESI);
+	GET(AnimClass*, pAnim, EDI);
+	GET(WeaponTypeClass*, pWeapon, EBX);
+	GET_BASE(int, wpIdx, 0xC);
+
+	auto pAnimExt = AnimExt::ExtMap.Find(pAnim);
+
+	if (WeaponTypeExt::ExtMap.Find(pWeapon)->Anim_Update.Get(RulesExt::Global()->FiringAnim_Update))
+	{
+		pAnimExt->FromWeapon = pWeapon;
+		pAnimExt->FromWeaponIdx = wpIdx;
+		pAnimExt->FromBurstIdx = pThis->CurrentBurstIndex;
+	}
+
+	return SkipBuildingCheck;
+}
+
+#pragma endregion

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -392,6 +392,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->HoverLocomotorMakesWake.Read(exINI, GameStrings::AudioVisual, "HoverLocomotionClassMakesWake");
 	this->ShipLocomotorMakesWake.Read(exINI, GameStrings::AudioVisual, "ShipLocomotionClassMakesWake");
 	
+	this->FiringAnim_Update.Read(exINI, GameStrings::AudioVisual, "FiringAnim.Update");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -711,6 +713,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->DriveLocomotorMakesWake)
 		.Process(this->HoverLocomotorMakesWake)
 		.Process(this->ShipLocomotorMakesWake)
+		.Process(this->FiringAnim_Update)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -311,6 +311,8 @@ public:
 
 		Valueable<bool> ApplyPerTargetEffectsOnDetonate;
 
+		Valueable<bool> FiringAnim_Update;
+		
 		Valueable<bool> AutoTarget_NoThreatBuildings;
 		Valueable<bool> AutoTargetAI_NoThreatBuildings;
 
@@ -622,6 +624,7 @@ public:
 			, DriveLocomotorMakesWake { true }
 			, HoverLocomotorMakesWake { true }
 			, ShipLocomotorMakesWake { true }
+			, FiringAnim_Update { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -168,6 +168,7 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->AttackCursorOnFriendlies.Read(exINI, pSection, "AttackCursorOnFriendlies");
 	this->AttackNoThreatBuildings.Read(exINI, pSection, "AttackNoThreatBuildings");
 	this->CylinderRangefinding.Read(exINI, pSection, "CylinderRangefinding");
+	this->Anim_Update.Read(exINI, pSection, "Anim.Update");
 
 	// handle SkipWeaponPicking
 	if (this->CanTarget != AffectedTarget::All || this->CanTargetHouses != AffectedHouse::All
@@ -264,6 +265,7 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttackCursorOnFriendlies)
 		.Process(this->AttackNoThreatBuildings)
 		.Process(this->CylinderRangefinding)
+		.Process(this->Anim_Update)
 		;
 };
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -96,6 +96,8 @@ public:
 		Nullable<bool> AttackCursorOnFriendlies;
 		Nullable<bool> AttackNoThreatBuildings;
 
+		Nullable<bool> Anim_Update;
+
 		bool SkipWeaponPicking;
 
 		Nullable<bool> CylinderRangefinding;
@@ -181,6 +183,7 @@ public:
 			, AttackCursorOnFriendlies {}
 			, AttackNoThreatBuildings {}
 			, CylinderRangefinding {}
+			, Anim_Update {}
 		{ }
 
 		int GetBurstDelay(int burstIndex) const;

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -62,43 +62,10 @@ public:
 	// Vector is expected to have 2^n items where n >= 3 and n <= 16 for the logic to work correctly, other cases return first item.
 	// Do not pass an empty vector, size/indices are not sanity checked here.
 	template<typename T>
-	static T GetItemForDirection(std::vector<T> const& items, DirStruct const& direction)
+	static T GetItemForDirection(Iterator<T> const& items, DirStruct const& direction)
 	{
 		// Log base 2
 		unsigned int bitsTo = Conversions::Int2Highest(static_cast<int>(items.size()));
-
-		if (bitsTo >= 3 && bitsTo <= 16)
-		{
-			// Same shit as DirStruct::TranslateFixedPoint().
-			// Because it uses template args and it is necessary to use
-			// non-compile time values here, it is duplicated & inlined.
-			unsigned int index = direction.Raw;
-			const unsigned int offset = 1 << (bitsTo - 3);
-			const unsigned int bitsFrom = 16;
-			const unsigned int maskIn = ((1 << bitsFrom) - 1);
-			const unsigned int maskOut = (1 << bitsTo) - 1;
-
-			if (bitsFrom > bitsTo)
-				index = (((((index & maskIn) >> (bitsFrom - bitsTo - 1)) + 1) >> 1) + offset) & maskOut;
-			else if (bitsFrom < bitsTo)
-				index = (((index - offset) & maskIn) << (bitsTo - bitsFrom)) & maskOut;
-			else
-				index = index & maskOut;
-
-			return items[index];
-		}
-
-		return items[0];
-	}
-
-	// Returns item from vector based on given direction and number of items in the vector, f.ex directional animations.
-	// Vector is expected to have 2^n items where n >= 3 and n <= 16 for the logic to work correctly, other cases return first item.
-	// Do not pass an empty vector, size/indices are not sanity checked here.
-	template<typename T>
-	static T GetItemForDirection(DynamicVectorClass<T> const& items, DirStruct const& direction)
-	{
-		// Log base 2
-		unsigned int bitsTo = Conversions::Int2Highest(static_cast<int>(items.Count));
 
 		if (bitsTo >= 3 && bitsTo <= 16)
 		{

--- a/src/Utilities/GeneralUtils.h
+++ b/src/Utilities/GeneralUtils.h
@@ -90,4 +90,37 @@ public:
 
 		return items[0];
 	}
+
+	// Returns item from vector based on given direction and number of items in the vector, f.ex directional animations.
+	// Vector is expected to have 2^n items where n >= 3 and n <= 16 for the logic to work correctly, other cases return first item.
+	// Do not pass an empty vector, size/indices are not sanity checked here.
+	template<typename T>
+	static T GetItemForDirection(DynamicVectorClass<T> const& items, DirStruct const& direction)
+	{
+		// Log base 2
+		unsigned int bitsTo = Conversions::Int2Highest(static_cast<int>(items.Count));
+
+		if (bitsTo >= 3 && bitsTo <= 16)
+		{
+			// Same shit as DirStruct::TranslateFixedPoint().
+			// Because it uses template args and it is necessary to use
+			// non-compile time values here, it is duplicated & inlined.
+			unsigned int index = direction.Raw;
+			const unsigned int offset = 1 << (bitsTo - 3);
+			const unsigned int bitsFrom = 16;
+			const unsigned int maskIn = ((1 << bitsFrom) - 1);
+			const unsigned int maskOut = (1 << bitsTo) - 1;
+
+			if (bitsFrom > bitsTo)
+				index = (((((index & maskIn) >> (bitsFrom - bitsTo - 1)) + 1) >> 1) + offset) & maskOut;
+			else if (bitsFrom < bitsTo)
+				index = (((index - offset) & maskIn) << (bitsTo - bitsFrom)) & maskOut;
+			else
+				index = index & maskOut;
+
+			return items[index];
+		}
+
+		return items[0];
+	}
 };


### PR DESCRIPTION
### Updateable firing anim

- In vanilla, firing anims is attached to the firer, but it won't update its type and location to fit the firer's facing. This is now customizable by the following flags.

In `rulesmd.ini`:
```ini
[AudioVisual]
FiringAnim.Update=false   ; boolean

[SOMEWEAPON]              ; WeaponType
Anim.Update=              ; boolean, default to [AudioVisual] -> FiringAnim.Update
```

```{note}
This effect will cause problem when used together with `[AnimType] -> Next`. `Next` modifies the Anim type over time, while this function changes it back, resulting in the Anim being unable to end.
```