### PR TITLE
Allow replacing vanilla repairing with togglable auto repairing

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -744,7 +744,7 @@ This page lists all the individual contributions to the project by their author.
   - Technos with Walk locomotor spawn wake like ship
   - Updateable firing anim
   - Fix the issue where the sidebar would not refresh when an unit dies in limbo
-  - Replace vanilla repairing with togglable auto repairing
+  - Allow replacing vanilla repairing with togglable auto repairing
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -744,6 +744,7 @@ This page lists all the individual contributions to the project by their author.
   - Technos with Walk locomotor spawn wake like ship
   - Updateable firing anim
   - Fix the issue where the sidebar would not refresh when an unit dies in limbo
+  - Replace vanilla repairing with togglable auto repairing
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -736,6 +736,18 @@ In `rulesmd.ini`:
 Sidebar.ProducingProgress.Offset=0,0  ; X,Y, pixels relative to default
 ```
 
+### Replace vanilla repairing with togglable auto repairing
+
+- Now you can replace the vanilla repair method with a togglable auto-repair.
+  - Pressing repair button or hotkey will no longer change your mouse, but will toggle your auto-repair state on/off.
+  - When auto-repair state is toggled off, buildings will stop repairing.
+
+  In `rulesmd.ini`:
+```ini
+[General]
+ExtendedPlayerRepair=false    ; boolean
+```
+
 ### Specify Sidebar style
 
 - It's now possible to switch hardcoded sidebar button coords to use GDI sidebar coords by setting `Sidebar.GDIPosition`. Defaults to true for first side, false for all others.

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -574,6 +574,18 @@ SaveGameOnScenarioStart=true ; boolean
 ## Sidebar / Battle UI
 
 
+### Allow replacing vanilla repairing with togglable auto repairing
+
+- Now you can replace the vanilla repair method with a togglable auto-repair.
+  - Pressing repair button or hotkey will no longer change your mouse, but will toggle your auto-repair state on/off.
+  - When auto-repair state is toggled off, buildings will stop repairing.
+
+  In `rulesmd.ini`:
+```ini
+[General]
+ExtendedPlayerRepair=false    ; boolean
+```
+
 ### Building Production Queue
 
 ![Building Production Queue](_static/images/buildingQueue.png)
@@ -734,18 +746,6 @@ In `rulesmd.ini`:
 ```ini
 [SOMESIDE]                            ; Side
 Sidebar.ProducingProgress.Offset=0,0  ; X,Y, pixels relative to default
-```
-
-### Replace vanilla repairing with togglable auto repairing
-
-- Now you can replace the vanilla repair method with a togglable auto-repair.
-  - Pressing repair button or hotkey will no longer change your mouse, but will toggle your auto-repair state on/off.
-  - When auto-repair state is toggled off, buildings will stop repairing.
-
-  In `rulesmd.ini`:
-```ini
-[General]
-ExtendedPlayerRepair=false    ; boolean
 ```
 
 ### Specify Sidebar style

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -568,6 +568,7 @@ New:
 - [Technos with Walk locomotor spawn wake like ship](Fixed-or-Improved-Logics.md#customizable-wake-anim) (by TaranDahl)
 - [Hotkey for deselect object from current selection](User-Interface.md#deselect-object) (by FrozenFog)
 - [Updateable firing anim](Fixed-or-Improved-Logics.md#updateable-firing-anim) (by TaranDahl)
+- [Replace vanilla repairing with togglable auto repairing](User-Interface.md#replace-vanilla-repairing-with-togglable-auto-repairing) (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -568,7 +568,7 @@ New:
 - [Technos with Walk locomotor spawn wake like ship](Fixed-or-Improved-Logics.md#customizable-wake-anim) (by TaranDahl)
 - [Hotkey for deselect object from current selection](User-Interface.md#deselect-object) (by FrozenFog)
 - [Updateable firing anim](Fixed-or-Improved-Logics.md#updateable-firing-anim) (by TaranDahl)
-- [Replace vanilla repairing with togglable auto repairing](User-Interface.md#replace-vanilla-repairing-with-togglable-auto-repairing) (by TaranDahl)
+- [Allow replacing vanilla repairing with togglable auto repairing](User-Interface.md#allow-replacing-vanilla-repairing-with-togglable-auto-repairing) (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Event/Body.cpp
+++ b/src/Ext/Event/Body.cpp
@@ -1,10 +1,14 @@
+
 #include "Body.h"
 
-#include <EventClass.h>
-#include <FootClass.h>
-#include <HouseClass.h>
+#include <Ext/House/Body.h>
+#include <Ext/Rules/Body.h>
 
 #include <Helpers/Macro.h>
+#include <EventClass.h>
+#include <HouseClass.h>
+#include <FootClass.h>
+#include <ShapeButtonClass.h>
 
 bool EventExt::AddEvent()
 {
@@ -18,10 +22,22 @@ void EventExt::RespondEvent()
 	case EventTypeExt::ApproachObject:
 		this->RespondApproachObject();
 		break;
-
+	case EventTypeExt::TogglePlayerAutoRepair:
+		this->RespondToTogglePlayerAutoRepair();
+		break;
 	default:
 		break;
 	}
+}
+
+void EventExt::RaiseTogglePlayerAutoRepair()
+{
+	EventExt eventExt {};
+	eventExt.Type = EventTypeExt::TogglePlayerAutoRepair;
+	eventExt.HouseIndex = (char)HouseClass::CurrentPlayer->ArrayIndex; // not used
+	eventExt.Frame = Unsorted::CurrentFrame;
+	eventExt.AddEvent();
+	Debug::LogGame("Adding event TOGGLE_PLAYER_AUTOREPAIR\n");
 }
 
 size_t EventExt::GetDataSize(EventTypeExt type)
@@ -30,7 +46,8 @@ size_t EventExt::GetDataSize(EventTypeExt type)
 	{
 	case EventTypeExt::ApproachObject:
 		return sizeof(EventExt::ApproachObject);
-
+	case EventTypeExt::TogglePlayerAutoRepair:
+		return sizeof(EventExt::TogglePlayerAutoRepair);
 	default:
 		break;
 	}
@@ -94,6 +111,30 @@ void EventExt::RespondApproachObject()
 	pSource->Target = nullptr;
 }
 
+void EventExt::RespondToTogglePlayerAutoRepair()
+{
+	if (this->HouseIndex >= HouseClass::Array.Count)
+		return;
+
+	if (!RulesExt::Global()->ExtendedPlayerRepair)
+		return;
+
+	auto pHouse = HouseClass::Array.GetItem(this->HouseIndex);
+	auto pHouseExt = HouseExt::ExtMap.Find(pHouse);
+	pHouseExt->PlayerAutoRepair = !pHouseExt->PlayerAutoRepair;
+
+	if (HouseClass::CurrentPlayer == pHouse)
+	{
+		SidebarClass::Instance.SidebarNeedsRedraw = true;
+		auto pButton = &Make_Global<ShapeButtonClass>(0xB0B3A0);
+
+		if (pHouseExt->PlayerAutoRepair)
+			pButton->TurnOn();
+		else
+			pButton->TurnOff();
+	}
+}
+
 // hooks
 
 DEFINE_HOOK(0x4C6CC8, Networking_RespondToEvent, 0x5)
@@ -155,3 +196,4 @@ DEFINE_HOOK(0x64C30E, sub_64BDD0_GetEventSize2, 0x6)
 
 	return 0;
 }
+

--- a/src/Ext/Event/Body.cpp
+++ b/src/Ext/Event/Body.cpp
@@ -34,7 +34,7 @@ void EventExt::RaiseTogglePlayerAutoRepair()
 {
 	EventExt eventExt {};
 	eventExt.Type = EventTypeExt::TogglePlayerAutoRepair;
-	eventExt.HouseIndex = (char)HouseClass::CurrentPlayer->ArrayIndex; // not used
+	eventExt.HouseIndex = (char)HouseClass::CurrentPlayer->ArrayIndex;
 	eventExt.Frame = Unsorted::CurrentFrame;
 	eventExt.AddEvent();
 	Debug::LogGame("Adding event TOGGLE_PLAYER_AUTOREPAIR\n");

--- a/src/Ext/Event/Body.cpp
+++ b/src/Ext/Event/Body.cpp
@@ -126,12 +126,11 @@ void EventExt::RespondToTogglePlayerAutoRepair()
 	if (HouseClass::CurrentPlayer == pHouse)
 	{
 		SidebarClass::Instance.SidebarNeedsRedraw = true;
-		auto pButton = &Make_Global<ShapeButtonClass>(0xB0B3A0);
 
 		if (pHouseExt->PlayerAutoRepair)
-			pButton->TurnOn();
+			SidebarClass::ToggelRepairButton.TurnOn();
 		else
-			pButton->TurnOff();
+			SidebarClass::ToggelRepairButton.TurnOff();
 	}
 }
 

--- a/src/Ext/Event/Body.h
+++ b/src/Ext/Event/Body.h
@@ -4,6 +4,8 @@
 #include <cstddef>
 #include <stdint.h>
 
+#include <HouseClass.h>
+
 enum class EventTypeExt : uint8_t
 {
 	// Vanilla game used Events from 0x00 to 0x2F
@@ -11,9 +13,10 @@ enum class EventTypeExt : uint8_t
 	// Ares used Events 0x60 and 0x61
 
 	ApproachObject = 0x40,
+	TogglePlayerAutoRepair = 0x41,
 
 	FIRST = ApproachObject,
-	LAST = ApproachObject
+	LAST = TogglePlayerAutoRepair
 };
 
 #pragma pack(push, 1)
@@ -33,12 +36,16 @@ public:
 			TargetClass Whom;
 			TargetClass Target;
 		} ApproachObject;
+		struct TogglePlayerAutoRepair
+		{ } TogglePlayerAutoRepair;
 	};
 
 	bool AddEvent();
 	void RespondEvent();
 
 	void RespondApproachObject();
+	static void RaiseTogglePlayerAutoRepair();
+	void RespondToTogglePlayerAutoRepair();
 
 	static size_t GetDataSize(EventTypeExt type);
 	static bool IsValidType(EventTypeExt type);
@@ -47,3 +54,4 @@ public:
 static_assert(sizeof(EventExt) == 111);
 static_assert(offsetof(EventExt, DataBuffer) == 7);
 #pragma pack(pop)
+

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -711,6 +711,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 		.Process(this->TeamDelay)
 		.Process(this->FreeRadar)
 		.Process(this->ForceRadar)
+		.Process(this->PlayerAutoRepair)
 		;
 }
 

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -67,6 +67,8 @@ public:
 		bool FreeRadar;
 		bool ForceRadar;
 
+		bool PlayerAutoRepair;
+
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, PowerPlantEnhancers {}
 			, OwnedLimboDeliveredBuildings {}
@@ -100,6 +102,7 @@ public:
 			, TeamDelay(-1)
 			, FreeRadar(false)
 			, ForceRadar(false)
+			, PlayerAutoRepair(true)
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding) const;

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -2,7 +2,11 @@
 
 #include <Ext/Aircraft/Body.h>
 #include <Ext/Scenario/Body.h>
-#include <Ext/Building/Body.h>
+#include "Ext/Techno/Body.h"
+#include "Ext/Building/Body.h"
+#include <Ext/Event/Body.h>
+
+#include <unordered_map>
 
 // Trigger power recalculation on gain/loss of any techno, not just buildings.
 DEFINE_HOOK_AGAIN(0x5025F0, HouseClass_RegisterGain, 0x5) // RegisterLoss
@@ -545,3 +549,58 @@ DEFINE_HOOK(0x50BF60, HouseClass_CalculateCostMultipliers, 0x5)
 
 	return SkipGameCode;
 }
+
+#pragma region PlayerAutoRepair
+
+DEFINE_HOOK(0x536FA0, ToggleRepariModeCommandClass_Execute_PlayerAutoRepair, 0x7)
+{
+	if (!RulesExt::Global()->ExtendedPlayerRepair)
+		return 0;
+
+	EventExt::RaiseTogglePlayerAutoRepair();
+	return 0x536FAC;
+}
+
+DEFINE_HOOK(0x6A78F6, SidebarClass_Update_ToggleRepair, 0x9)
+{
+	if (!RulesExt::Global()->ExtendedPlayerRepair)
+		MapClass::Instance.SetRepairMode(-1);
+	else
+		EventExt::RaiseTogglePlayerAutoRepair();
+	return 0x6A78FF;
+}
+
+DEFINE_HOOK(0x6A7AE1, SidebarClass_Update_RepairButton, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedPlayerRepair)
+		return 0;
+
+	R->AL(HouseExt::ExtMap.Find(HouseClass::CurrentPlayer)->PlayerAutoRepair);
+	return 0x6A7AE7;
+}
+
+DEFINE_HOOK(0x45063F, BuildingClass_UpdateRepairSell_PlayerAutoRepair, 0x6)
+{
+	enum { CanAutoRepair = 0x450659, CanNotAutoRepair = 0x450813 };
+
+	if (!RulesExt::Global()->ExtendedPlayerRepair)
+		return 0;
+
+	GET(BuildingClass*, pThis, ESI);
+
+	if (!pThis->Owner->IsControlledByHuman())
+		return 0;
+
+	if (HouseExt::ExtMap.Find(pThis->Owner)->PlayerAutoRepair)
+	{
+		return CanAutoRepair;
+	}
+	else
+	{
+		if (pThis->IsBeingRepaired)
+			pThis->SetRepairState(0);
+		return CanNotAutoRepair;
+	}
+}
+
+#pragma endregion

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -552,6 +552,20 @@ DEFINE_HOOK(0x50BF60, HouseClass_CalculateCostMultipliers, 0x5)
 
 #pragma region PlayerAutoRepair
 
+DEFINE_HOOK(0x6A5395, SidebarClass_InitIO_InitRepairButton, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedPlayerRepair)
+		return 0;
+
+	if (HouseExt::ExtMap.Find(HouseClass::CurrentPlayer)->PlayerAutoRepair)
+	{
+		SidebarClass::Instance.SidebarNeedsRedraw = true;
+		SidebarClass::ToggelRepairButton.IsOn = true;
+	}
+
+	return 0;
+}
+
 DEFINE_HOOK(0x536FA0, ToggleRepariModeCommandClass_Execute_PlayerAutoRepair, 0x7)
 {
 	if (!RulesExt::Global()->ExtendedPlayerRepair)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -1,4 +1,4 @@
-#include "Body.h"
+﻿#include "Body.h"
 
 #include <Ext/TechnoType/Body.h>
 #include <New/Type/RadTypeClass.h>
@@ -394,6 +394,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->ShipLocomotorMakesWake.Read(exINI, GameStrings::AudioVisual, "ShipLocomotionClassMakesWake");
 	
 	this->FiringAnim_Update.Read(exINI, GameStrings::AudioVisual, "FiringAnim.Update");
+	this->ExtendedPlayerRepair.Read(exINI, GameStrings::General, "ExtendedPlayerRepair");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -716,6 +717,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->HoverLocomotorMakesWake)
 		.Process(this->ShipLocomotorMakesWake)
 		.Process(this->FiringAnim_Update)
+		.Process(this->ExtendedPlayerRepair)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <RulesClass.h>
 #include <Utilities/Container.h>
@@ -313,6 +313,7 @@ public:
 		Valueable<bool> ApplyPerTargetEffectsOnDetonate;
 
 		Valueable<bool> FiringAnim_Update;
+		Valueable<bool> ExtendedPlayerRepair;
 		
 		Valueable<bool> AutoTarget_NoThreatBuildings;
 		Valueable<bool> AutoTargetAI_NoThreatBuildings;
@@ -627,6 +628,7 @@ public:
 			, HoverLocomotorMakesWake { true }
 			, ShipLocomotorMakesWake { true }
 			, FiringAnim_Update { false }
+			, ExtendedPlayerRepair { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Allow replacing vanilla repairing with togglable auto repairing

- Now you can replace the vanilla repair method with a togglable auto-repair.
  - Pressing repair button or hotkey will no longer change your mouse, but will toggle your auto-repair state on/off.
  - When auto-repair state is toggled off, buildings will stop repairing.

  In `rulesmd.ini`:
```ini
[General]
ExtendedPlayerRepair=false    ; boolean
```