### PR TITLE
[Minor] Fixed some minor bugs

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -547,6 +547,7 @@ Phobos fixes:
 - Fixed an issue that caused Ares's `Battery.KeepOnline` cannot keep defense buildings works fine (by NetsuNegi)
 - Map Event 601 should return true only when exists in the map like other similar map events (by FS-21)
 - Fixed OverlayType `ZAdjust` as well as some shield & AttachEffect variables not being correctly saved & loaded (by Ollerus)
+- LimboDelivery buildings cannot be selected (by FlyStar)
 
 Fixes / interactions with other extensions:
 <!--  - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)  -->

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -526,5 +526,6 @@ DEFINE_HOOK(0x508E17, HouseClass_UpdateRadar_FreeRadar, 0x8)
 		return ForceRadar;
 	}
 
+	R->Stack(STACK_OFFSET(0x1C, -0xC), false);
 	return Continue;
 }

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -428,6 +428,8 @@ bool TActionExt::UndeployToWaypoint(TActionClass* const pThis, HouseClass* const
 
 	const auto& limboDelivereds = HouseExt::ExtMap.Find(vHouse)->OwnedLimboDeliveredBuildings;
 	const bool existLimboBuilding = !limboDelivereds.empty();
+	const auto vectorBegin = limboDelivereds.begin();
+	const auto vectorEnd = limboDelivereds.end();
 
 	// Thanks to chaserli for the relevant code!
 	// There should be a more perfect way to do this, but I don't know how.
@@ -445,13 +447,10 @@ bool TActionExt::UndeployToWaypoint(TActionClass* const pThis, HouseClass* const
 		}
 
 		// verify whether the building's source is LimboDelivery.
-		if (existLimboBuilding)
+		if (existLimboBuilding
+			&& std::find(vectorBegin, vectorEnd, pBuilding) != vectorEnd)
 		{
-			for (auto const pLimboBuilding : limboDelivereds)
-			{
-				if (pLimboBuilding == pBuilding)
-					return false;
-			}
+			return false;
 		}
 
 		if (pType->ConstructionYard)

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1489,3 +1489,23 @@ DEFINE_HOOK(0x6F9398, TechnoClass_SelectAutoTarget_Scan_FallingDown, 0x9)
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x6FBFA3, TechnoClass_Select_SkipLimboDelivery, 0x6)
+{
+	enum { SkipSelect = 0x6FC029 };
+
+	GET(TechnoClass* const, pThis, ESI);
+
+	if (auto const pBuilding = abstract_cast<BuildingClass*, true>(pThis))
+	{
+		auto const pHouseExt = HouseExt::ExtMap.Find(pBuilding->Owner);
+
+		for (auto const pItem : pHouseExt->OwnedLimboDeliveredBuildings)
+		{
+			if (pItem == pBuilding)
+				return SkipSelect;
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1498,13 +1498,11 @@ DEFINE_HOOK(0x6FBFA3, TechnoClass_Select_SkipLimboDelivery, 0x6)
 
 	if (auto const pBuilding = abstract_cast<BuildingClass*, true>(pThis))
 	{
-		auto const pHouseExt = HouseExt::ExtMap.Find(pBuilding->Owner);
+		const auto& limboDelivereds = HouseExt::ExtMap.Find(pBuilding->Owner)->OwnedLimboDeliveredBuildings;
+		const auto vectorEnd = limboDelivereds.end();
 
-		for (auto const pItem : pHouseExt->OwnedLimboDeliveredBuildings)
-		{
-			if (pItem == pBuilding)
-				return SkipSelect;
-		}
+		if (std::find(limboDelivereds.begin(), vectorEnd, pBuilding) != vectorEnd)
+			return SkipSelect;
 	}
 
 	return 0;


### PR DESCRIPTION
Fixed an issue where the radar shutdown sound effect would trigger incorrectly after constructing power buildings.
 - 修复雷达关闭音效在电力建筑建造后错误触发的问题。

Fixed an issue where LimboDelivery buildings could be selected, causing them to be undeployed along with other units.
 - 修复虚拟投放建筑可以被选中导致一同反部署的问题。