### PR TITLE
Update the projectile immediately after firing to reduce useless firing

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -760,6 +760,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow replacing vanilla repairing with togglable auto repairing
   - Fix an issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions
   - Framework for dynamic sight
+  - Update the projectile immediately after firing to reduce useless firing
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1076,6 +1076,25 @@ ReturnWeapon=                           ; WeaponType
 ReturnWeapon.ApplyFirepowerMult=false   ; boolean
 ```
 
+### Update the projectile immediately after firing to reduce useless firing
+
+- In vanilla, newly created projectiles are added to the end of the update list. This will result in some useless firing.
+  - For example: If two snipers aim at an infantry simultaneously (and either of them can kill the infantry), they will still fire together in the same frame. Because when the sniper who fires later shoots, the projectile of the sniper who fires first has not exploded yet, so the target infantry is still alive.
+- Now you can update the projectile once when it is fired through the following flag, so as to avoid the above situation.
+
+In `rulesmd.ini`:
+```ini
+[General]
+UpdateInvisoImmediately=false    ; boolean
+
+[SOMEPROJECTILE]                 ; Projectile
+UpdateImmediately=               ; boolean, default to (`[General] -> UpdateInvisoImmediately` && `Inviso=yes`)
+```
+
+```{note}
+- Interfering with the update sequence may cause problems. Please use this feature with caution. If you encounter any issues, please provide feedback.
+```
+
 ## Super Weapons
 
 ### AI Superweapon delay timer

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -581,6 +581,7 @@ New:
 - [Electric bolt Z-adjust](Fixed-or-Improved-Logics.md#electric-bolt-z-adjust) (by Noble_Fish)
 - Allow disabling the processing of the Z-depth of EBolt drawn by BuildingType being clamped to non-positive numbers (by Noble_Fish)
 - Add the `Bolt.ZAdjust` setting item to the LaserTrailType with `DrawType=ebolt` (by Noble_Fish)
+- [Update the projectile immediately after firing to reduce useless firing](New-or-Enhanced-Logics.md#update-the-projectile-immediately-after-firing-to-reduce-useless-firing) (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
+++ b/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
@@ -1,4 +1,4 @@
-#include "StraightTrajectory.h"
+﻿#include "StraightTrajectory.h"
 #include "BombardTrajectory.h"
 #include "ParabolaTrajectory.h"
 
@@ -587,6 +587,15 @@ DEFINE_HOOK(0x468B72, BulletClass_Unlimbo_Trajectories, 0x5)
 		pExt->Trajectory = pTypeExt->TrajectoryType->CreateInstance();
 		pExt->Trajectory->OnUnlimbo(pThis, pCoord, pVelocity);
 	}
-
+	
+	// Parasite=yes will make the bullet MoveTo twice, and may cause some issue.
+	// Before we know how to deal with it, just exclude it.
+	if ((!pThis->WeaponType || !pThis->WeaponType->Warhead->Parasite)
+		&& !pThis->WH->Parasite
+		&& pTypeExt->UpdateImmediately.Get(pThis->Type->Inviso && RulesExt::Global()->UpdateInvisoImmediately))
+	{
+		pThis->Update();
+	}
+	
 	return 0;
 }

--- a/src/Ext/BulletType/Body.cpp
+++ b/src/Ext/BulletType/Body.cpp
@@ -78,6 +78,7 @@ void BulletTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Parachuted_MaxFallRate.Read(exINI, pSection, "Parachuted.MaxFallRate");
 	this->BombParachute.Read(exINI, pSection, "BombParachute");
 	this->AU.Read(exINI, pSection, "AU");
+	this->UpdateImmediately.Read(exINI, pSection, "UpdateImmediately");
 
 	// Ares 0.7
 	this->BallisticScatter_Min.Read(exINI, pSection, "BallisticScatter.Min");
@@ -180,6 +181,7 @@ void BulletTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Parachuted_MaxFallRate)
 		.Process(this->BombParachute)
 		.Process(this->AU)
+		.Process(this->UpdateImmediately)
 
 		.Process(this->TrajectoryType) // just keep this shit at last
 		;

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -77,6 +77,8 @@ public:
 
 		Valueable<bool> AU;
 
+		Nullable<bool> UpdateImmediately;
+
 		// Ares 0.7
 		Nullable<Leptons> BallisticScatter_Min;
 		Nullable<Leptons> BallisticScatter_Max;
@@ -132,6 +134,7 @@ public:
 			, Parachuted_MaxFallRate {}
 			, BombParachute {}
 			, AU { false }
+			, UpdateImmediately {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -1,4 +1,4 @@
-#include "Body.h"
+﻿#include "Body.h"
 
 #include <Ext/TechnoType/Body.h>
 #include <New/Type/RadTypeClass.h>
@@ -408,6 +408,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->ExtendedPlayerRepair.Read(exINI, GameStrings::General, "ExtendedPlayerRepair");
 
 	this->Shrapnel_IgnoreHitBuildings.Read(exINI, GameStrings::CombatDamage, "Shrapnel.IgnoreHitBuildings");
+	this->UpdateInvisoImmediately.Read(exINI, GameStrings::General, "UpdateInvisoImmediately");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -737,6 +738,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->FiringAnim_Update)
 		.Process(this->ExtendedPlayerRepair)
 		.Process(this->Shrapnel_IgnoreHitBuildings)
+		.Process(this->UpdateInvisoImmediately)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <RulesClass.h>
 #include <Utilities/Container.h>
@@ -320,6 +320,7 @@ public:
 
 		Valueable<bool> FiringAnim_Update;
 		Valueable<bool> ExtendedPlayerRepair;
+		Valueable<bool> UpdateInvisoImmediately;
 		
 		Valueable<bool> AutoTarget_NoThreatBuildings;
 		Valueable<bool> AutoTargetAI_NoThreatBuildings;
@@ -643,6 +644,7 @@ public:
 			, FiringAnim_Update { false }
 			, ExtendedPlayerRepair { false }
 			, Shrapnel_IgnoreHitBuildings { false }
+			, UpdateInvisoImmediately { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Update the projectile immediately after firing to reduce useless firing

- In vanilla, newly created projectiles are added to the end of the update list. This will result in some useless firing.
  - For example: If two snipers aim at an infantry simultaneously (and either of them can kill the infantry), they will still fire together in the same frame. Because when the sniper who fires later shoots, the projectile of the sniper who fires first has not exploded yet, so the target infantry is still alive.
- Now you can update the projectile once when it is fired through the following flag, so as to avoid the above situation.

In `rulesmd.ini`:
```ini
[General]
UpdateInvisoImmediately=false    ; boolean

[SOMEPROJECTILE]                 ; Projectile
UpdateImmediately=               ; boolean, default to (`[General] -> UpdateInvisoImmediately` && `Inviso=yes`)
```

```{note}
- Interfering with the update sequence may cause problems. Please use this feature with caution. If you encounter any issues, please provide feedback.
```