### PR TITLE
Add low priority deploy filtering

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -284,6 +284,7 @@ This page lists all the individual contributions to the project by their author.
   - Owner change during buildup bugfix
   - Subterranean harvester pathfinding fix
   - Toggle to exclude technos from base center calculations
+  - Deploy priority filtering
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1811,6 +1811,24 @@ AutoDeath.TechnosExist.Houses=owner            ; Affected House Enumeration (non
 Please notice that if the object is a unit which carries passengers, they will not be released even with the `kill` option **if you are not using Ares 3.0+**.
 ```
 
+### Low priority for deploy
+
+- You can now set lower priority for TechnoType deploying which means it will be excluded from deploy command if selected together with other units. This will not affect the cursor action which requires no other objects to be selected in the first place.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]             ; TechnoType
+LowDeployPriority=false  ; boolean
+```
+
+- This behavior is designed to be toggleable by users. For now you can only do that externally via client or manually.
+
+In `RA2MD.INI`:
+```ini
+[Phobos]
+PriorityDeployFiltering=true  ; boolean
+```
+
 ### Mind Control enhancement
 
 ![image](_static/images/mindcontrol-max-range-01.gif)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -132,6 +132,7 @@ ShowBriefing=true                ; boolean
 DigitalDisplay.Enable=false      ; boolean
 ShowDesignatorRange=false        ; boolean
 PrioritySelectionFiltering=true  ; boolean
+PriorityDeployFiltering=true     ; boolean
 ShowPlacementPreview=yes         ; boolean
 RealTimeTimers=false             ; boolean
 RealTimeTimers.Adaptive=false    ; boolean
@@ -516,6 +517,7 @@ New:
 - [Weapons now support `AttackFriendlies` and `AttackCursorOnFriendlies`](Fixed-or-Improved-Logics.md#can-attack-allies) (by FlyStar)
 - [Attack non-threatening structures extensions](New-or-Enhanced-Logics.md#attack-non-threatening-structures-techno) (by FlyStar)
 - [Customize size for mind controlled unit](New-or-Enhanced-Logics.md#mind-control-enhancement) (by NetsuNegi)
+- [Deploy priority filtering](New-or-Enhanced-Logics.md#low-priority-for-deploy) (by Starkku)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -826,14 +826,25 @@ DEFINE_HOOK(0x730D0F, ProcessDeployCommand_LowDeployPriority, 0x6)
 {
 	enum { SkipDeploy = 0x730D24 };
 
-	if (Phobos::Config::PriorityDeployFiltering && ObjectClass::CurrentObjects.Count > 1)
+	GET_STACK(const int, selectedObjectCount, STACK_OFFSET(0x18, -0x4));
+
+	if (Phobos::Config::PriorityDeployFiltering && selectedObjectCount > 1)
 	{
 		GET(TechnoClass* const, pTechno, ESI);
 
 		auto const pExt = TechnoExt::ExtMap.Find(pTechno);
 
 		if (pExt->TypeExtData->LowDeployPriority)
-			return SkipDeploy;
+		{
+			for (const auto pObject : ObjectClass::CurrentObjects)
+			{
+				if ((pObject->AbstractFlags & AbstractFlags::Techno) != AbstractFlags::None)
+				{
+					if (!TechnoExt::ExtMap.Find(static_cast<TechnoClass*>(pObject))->TypeExtData->LowDeployPriority)
+						return SkipDeploy;
+				}
+			}
+		}
 	}
 
 	return 0;
@@ -841,9 +852,9 @@ DEFINE_HOOK(0x730D0F, ProcessDeployCommand_LowDeployPriority, 0x6)
 
 DEFINE_HOOK(0x730D1F, ProcessDeployCommand_VoiceDeploy, 0x5)
 {
-	GET_STACK(const int, unitsToDeploy, STACK_OFFSET(0x18, -0x4));
+	GET_STACK(const int, selectedObjectCount, STACK_OFFSET(0x18, -0x4));
 
-	if (unitsToDeploy != 1)
+	if (selectedObjectCount != 1)
 		return 0;
 
 	GET(TechnoClass* const, pTechno, ESI);

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -822,16 +822,33 @@ DEFINE_HOOK(0x70FB73, FootClass_IsBunkerableNow_Dehardcode, 0x6)
 	return pTypeExt->BunkerableAnyway ? CanEnter : 0;
 }
 
-DEFINE_HOOK(0x730D1F, DeployCommandClass_Execute_VoiceDeploy, 0x5)
+DEFINE_HOOK(0x730D0F, ProcessDeployCommand_LowDeployPriority, 0x6)
+{
+	enum { SkipDeploy = 0x730D24 };
+
+	if (Phobos::Config::PriorityDeployFiltering && ObjectClass::CurrentObjects.Count > 1)
+	{
+		GET(TechnoClass* const, pTechno, ESI);
+
+		auto const pExt = TechnoExt::ExtMap.Find(pTechno);
+
+		if (pExt->TypeExtData->LowDeployPriority)
+			return SkipDeploy;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x730D1F, ProcessDeployCommand_VoiceDeploy, 0x5)
 {
 	GET_STACK(const int, unitsToDeploy, STACK_OFFSET(0x18, -0x4));
 
 	if (unitsToDeploy != 1)
 		return 0;
 
-	GET(TechnoClass* const, pThis, ESI);
+	GET(TechnoClass* const, pTechno, ESI);
 
-	pThis->VoiceDeploy();
+	pTechno->VoiceDeploy();
 
 	return 0;
 }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -728,6 +728,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->HealthBar_Permanent_PipScale.Read(exINI, pSection, "HealthBar.Permanent.PipScale");
 	this->UIDescription.Read(exINI, pSection, "UIDescription");
 	this->LowSelectionPriority.Read(exINI, pSection, "LowSelectionPriority");
+	this->LowDeployPriority.Read(exINI, pSection, "LowDeployPriority");
 
 	if (pThis->Gunner)
 	{
@@ -1407,6 +1408,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->HealthBar_Permanent_PipScale)
 		.Process(this->UIDescription)
 		.Process(this->LowSelectionPriority)
+		.Process(this->LowDeployPriority)
 		.Process(this->MindControlRangeLimit)
 		.Process(this->MindControl_IgnoreSize)
 		.Process(this->MindControlSize)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -32,6 +32,7 @@ public:
 		Valueable<bool> HealthBar_Permanent_PipScale;
 		Valueable<CSFText> UIDescription;
 		Valueable<bool> LowSelectionPriority;
+		Valueable<bool> LowDeployPriority;
 		PhobosFixedString<0x20> GroupAs;
 		std::vector<PhobosFixedString<0x20>> WeaponGroupAs;
 		Valueable<int> RadarJamRadius;
@@ -464,6 +465,7 @@ public:
 			, HealthBar_Permanent_PipScale { false }
 			, UIDescription {}
 			, LowSelectionPriority { false }
+			, LowDeployPriority { false }
 			, GroupAs { NONE_STR }
 			, WeaponGroupAs {}
 			, RadarJamRadius { 0 }

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -46,6 +46,7 @@ bool Phobos::UI::AnchoredToolTips = false;
 bool Phobos::Config::ToolTipDescriptions = true;
 bool Phobos::Config::ToolTipBlur = false;
 bool Phobos::Config::PrioritySelectionFiltering = true;
+bool Phobos::Config::PriorityDeployFiltering = true;
 bool Phobos::Config::DevelopmentCommands = true;
 bool Phobos::Config::SuperWeaponSidebarCommands = false;
 bool Phobos::Config::ShowPlanningPath = false;
@@ -88,6 +89,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	Phobos::Config::ToolTipDescriptions = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "ToolTipDescriptions", true);
 	Phobos::Config::ToolTipBlur = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "ToolTipBlur", false);
 	Phobos::Config::PrioritySelectionFiltering = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "PrioritySelectionFiltering", true);
+	Phobos::Config::PriorityDeployFiltering = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "PriorityDeployFiltering", true);
 	Phobos::Config::ShowPlacementPreview = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "ShowPlacementPreview", true);
 	Phobos::Config::MessageApplyHoverState = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "MessageApplyHoverState", false);
 	Phobos::Config::MessageDisplayInCenter = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "MessageDisplayInCenter", false);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -81,6 +81,7 @@ public:
 		static bool ToolTipDescriptions;
 		static bool ToolTipBlur;
 		static bool PrioritySelectionFiltering;
+		static bool PriorityDeployFiltering;
 		static bool DevelopmentCommands;
 		static bool SuperWeaponSidebarCommands;
 		static bool ArtImageSwap;


### PR DESCRIPTION
### Low priority for deploy

- You can now set lower priority for TechnoType deploying which means it will be excluded from deploy command if selected together with other units. This will not affect the cursor action which requires no other objects to be selected in the first place.

In `rulesmd.ini`:
```ini
[SOMETECHNO]             ; TechnoType
LowDeployPriority=false  ; boolean
```

- This behavior is designed to be toggleable by users. For now you can only do that externally via client or manually.

In `RA2MD.INI`:
```ini
[Phobos]
PriorityDeployFiltering=true  ; boolean
```