### PR TITLE
Audio logging improvements

### DIFF
--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -28,6 +28,10 @@ This page describes every change in Phobos that wasn't categorized into a proper
 - There's a [new hotkey](User-Interface.md#toggle-frame-by-frame-mode) to execute the game frame by frame for development usage.
   - You can switch to frame by frame mode and then use frame step in command to forward 1, 5, 10, 15, 30 or 60 frames by one hit.
 
+### Logging missing audio files (samples)
+
+- While parsing `soundmd.ini`, Phobos prints information in debug log about any missing audio files (samples).
+
 ### Save variables to file
 
 - There's a [new hotkey](User-Interface.md#save-variables) to write all local variables to `locals.ini` and all global variables to `globals.ini`. Available only if `DebugKeysEnabled` under `[GlobalControls]` is set to true in `rulesmd.ini`.

--- a/src/Utilities/Debug.cpp
+++ b/src/Utilities/Debug.cpp
@@ -233,6 +233,10 @@ void Console::PatchLog(DWORD dwAddr, void* fakeFunc, DWORD* pdwRealFunc)
 	VirtualProtect((LPVOID)dwAddr, 5, dwOldFlag, NULL);
 }
 
+// Patch out sound buffer size etc. logging calls.
+DEFINE_JUMP(LJMP, 0x40A55D, 0x40A562);
+DEFINE_JUMP(LJMP, 0x40A5BC, 0x40A5C1);
+
 DEFINE_HOOK(0x7504C9, VocClass_ReadINI_LogMissingSamples, 0x5)
 {
 	GET(VocClass*, pThis, ECX);

--- a/src/Utilities/Debug.cpp
+++ b/src/Utilities/Debug.cpp
@@ -4,6 +4,8 @@
 #include <YRPPCore.h>
 #include <MessageListClass.h>
 #include <CRT.h>
+#include <CCFileClass.h>
+#include <VocClass.h>
 
 char Debug::StringBuffer[0x1000];
 char Debug::FinalStringBuffer[0x1000];
@@ -229,4 +231,31 @@ void Console::PatchLog(DWORD dwAddr, void* fakeFunc, DWORD* pdwRealFunc)
 	pInst->offset = reinterpret_cast<DWORD>(fakeFunc) - dwAddr - 5;
 
 	VirtualProtect((LPVOID)dwAddr, 5, dwOldFlag, NULL);
+}
+
+DEFINE_HOOK(0x7504C9, VocClass_ReadINI_LogMissingSamples, 0x5)
+{
+	GET(VocClass*, pThis, ECX);
+	GET(const char*, pSampleName, EDX);
+
+	// Skip prefixes from sample names.
+	while (*pSampleName == '$' || *pSampleName == '#')
+		++pSampleName;
+
+	int sampleIndex = pThis->SampleIndex[pThis->NumSamples - 1];
+	bool validSample = sampleIndex != -1 && pThis->SamplesOK;
+
+	// Ares loose audio file handling. If sample index >= 65536 it is a pointer to sample name string for loose files.
+	if (validSample && sampleIndex >= 0x10000)
+	{
+		char filename[0x100];
+		_snprintf_s(filename, _TRUNCATE, "%s.wav", pSampleName);
+		CCFileClass file{ filename };
+		validSample = file.Exists();
+	}
+
+	if (!validSample)
+		Debug::Log("[Developer warning] VocClass [%s] has missing sample '%s'\n", pThis->Name, pSampleName);
+
+	return 0;
 }


### PR DESCRIPTION
- Patch out sound buffer size log calls due to them polluting the debug log disproportionately while being of questionable use.
- Output developer warnings for missing audio samples f.ex `VocClass [VO_FuryMove] has missing sample 'vo_regu_mov07'`.