### PR TITLE
Customizations for Ares' SW.AITargeting modes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -308,6 +308,7 @@ This page lists all the individual contributions to the project by their author.
   - Tank Bunker improvements
   - `ProjectileRange` weapon range modifiers interaction fix
   - Berzerk duration stacking behaviour customization
+  - AI superweapon targeting improvements
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -391,6 +391,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allowed customizing the default value of `[Warhead] -> PreventScatter` via `[CombatDamage] -> Warhead.PreventScatter`.
 - Allowed `SW.ShowCameo` and `SW.ManualFire` to work independently of `SW.AutoFire`.
 - Fixed the bug that Ares tunnel-type buildings cannot unload via the Deploy hotkey or command bar button.
+- `SW.AITargeting=PsychicDominator` superweapons now ignore `Insignificant=true` as well as owned by `MultiplayPassive=true` house targets.
 
 ## Newly added global settings
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1290,6 +1290,29 @@ In `rulesmd.ini`:
 AISuperWeaponDelay=  ; integer, game frames
 ```
 
+### AI Superweapon targeting customizations
+
+- There are several customizations available for AI superweapon targeting, currently restricted to controlling Ares' `SW.AITargeting` modes.
+- For `SW.AITargeting=PsychicDominator`:
+    - If `SW.AITargeting.PsyDom.SkipChecks` is set to true targets with `ImmuneToPsionics=yes` will be considered and `SW.AITargeting.PsyDom.AllowAir` and `SW.AITargeting.PsyDom.AllowInvulnerable` will be available to customize whether or not targets in air or those affected by Iron Curtain/Force Shield, respectively, will be considered.
+    - `SW.AIRequiresTarget` and `SW.AIRequiresHouse` will be considered if explicitly set, with latter overriding previously hardcoded check to only allow enemy house targets to be considered.
+    - `SW.AITargeting.PsyDom.AllowTypes` and `SW.AITargeting.PsyDom.DisallowTypes` can be used to white/blacklist specific TechnoTypes.
+- For `SW.AITargeting=LightningRandom`:
+    - If `SW.AITargeting.Random.SnapOnDesignators` is set to true, instead of picking random cells and hoping they have designators on them it will only consider cells with active designators on them. If all designators are within range of inhibitors, it attempts to look for a valid cell within designator's range but outside inhibitor's range. If `SW.AITargeting.Random.PickFirstDesignator` is also set to true first eligible cell is picked, otherwise it is chosen at random.
+      - Use caution when using in conjunction with `SW.Inhibitors` and large `DesignatorRange` as the fallback of looking for cells outside inhibitor range in a large radius can degrade performance.
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]                                         ; SuperWeaponType
+SW.AITargeting.PsyDom.SkipChecks=false           ; boolean
+SW.AITargeting.PsyDom.AllowAir=false             ; boolean
+SW.AITargeting.PsyDom.AllowInvulnerable=false    ; boolean
+SW.AITargeting.PsyDom.AllowTypes=                ; List of TechnoTypes
+SW.AITargeting.PsyDom.DisallowTypes=             ; List of TechnoTypes
+SW.AITargeting.Random.SnapOnDesignators=false    ; boolean
+SW.AITargeting.Random.PickFirstDesignator=false  ; boolean
+```
+
 ### Aux technos and TechLevel requirement of superweapon
 
 - `SW.AuxTechnos` specifies the auxiliary technos without which this super weapon cannot become available. The player has to own at least one techno of any of these types to get access to this super weapon.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -883,12 +883,13 @@ HideShakeEffects=false           ; boolean
 - Removed the restriction that prohibits InfantryTypes from using the InitialPayload logic (by Noble_Fish)
 - `ProjectileRange` now has weapon range modifiers applied to it if greater than 0 (by Starkku)
 - Allowed customizing the default value of `[Warhead] -> PreventScatter` via `[CombatDamage] -> Warhead.PreventScatter` (by Noble_Fish)
+- `SW.AITargeting=PsychicDominator` superweapons now ignore `Insignificant=true` as well as owned by `MultiplayPassive=true` house targets (by Starkku)
+- [Additional customizations for certain AI superweapon targeting modes](New-or-Enhanced-Logics.md#ai-superweapon-targeting-customizations) (by Starkku)
 ```
 
 ```{dropdown} Pre-release changes
 
 #### 0.5-alpha1
-
 ```
 
 ### 0.4.0.3

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -3,6 +3,7 @@
 #include "NewSWType/NewSWType.h"
 
 SWTypeExt::ExtContainer SWTypeExt::ExtMap;
+SuperClass* SWTypeExt::CurrentAIEvaluatedSW = nullptr;
 
 void SWTypeExt::Initialize()
 {
@@ -24,6 +25,13 @@ void SWTypeExt::Serialize(T& Stm)
 		.Process(this->EVA_Impatient)
 		.Process(this->EVA_InsufficientFunds)
 		.Process(this->EVA_SelectTarget)
+		.Process(this->SW_AITargeting_PsyDom_SkipChecks)
+		.Process(this->SW_AITargeting_PsyDom_AllowAir)
+		.Process(this->SW_AITargeting_PsyDom_AllowInvulnerable)
+		.Process(this->SW_AITargeting_PsyDom_AllowTypes)
+		.Process(this->SW_AITargeting_PsyDom_DisallowTypes)
+		.Process(this->SW_AITargeting_Random_SnapOnDesignators)
+		.Process(this->SW_AITargeting_Random_PickFirstDesignator)
 		.Process(this->SW_UseAITargeting)
 		.Process(this->SW_AutoFire)
 		.Process(this->SW_ManualFire)
@@ -48,6 +56,8 @@ void SWTypeExt::Serialize(T& Stm)
 		.Process(this->SW_PostDependent)
 		.Process(this->SW_MaxCount)
 		.Process(this->SW_Shots)
+		.Process(this->SW_AIRequiresTarget)
+		.Process(this->SW_AIRequiresHouse)
 		.Process(this->Message_CannotFire)
 		.Process(this->Message_InsufficientFunds)
 		.Process(this->Message_ColorScheme)
@@ -122,6 +132,13 @@ void SWTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->EVA_Impatient.Read(exINI, pSection, "EVA.Impatient");
 	this->EVA_InsufficientFunds.Read(exINI, pSection, "EVA.InsufficientFunds");
 	this->EVA_SelectTarget.Read(exINI, pSection, "EVA.SelectTarget");
+	this->SW_AITargeting_PsyDom_SkipChecks.Read(exINI, pSection, "SW.AITargeting.PsyDom.SkipChecks");
+	this->SW_AITargeting_PsyDom_AllowAir.Read(exINI, pSection, "SW.AITargeting.PsyDom.AllowAir");
+	this->SW_AITargeting_PsyDom_AllowInvulnerable.Read(exINI, pSection, "SW.AITargeting.PsyDom.AllowInvulnerable");
+	this->SW_AITargeting_PsyDom_AllowTypes.Read(exINI, pSection, "SW.AITargeting.PsyDom.AllowTypes");
+	this->SW_AITargeting_PsyDom_DisallowTypes.Read(exINI, pSection, "SW.AITargeting.PsyDom.DisallowTypes");
+	this->SW_AITargeting_Random_SnapOnDesignators.Read(exINI, pSection, "SW.AITargeting.Random.SnapOnDesignators");
+	this->SW_AITargeting_Random_PickFirstDesignator.Read(exINI, pSection, "SW.AITargeting.Random.PickFirstDesignator");
 	this->SW_UseAITargeting.Read(exINI, pSection, "SW.UseAITargeting");
 	this->SW_AutoFire.Read(exINI, pSection, "SW.AutoFire");
 	this->SW_ManualFire.Read(exINI, pSection, "SW.ManualFire");
@@ -146,6 +163,8 @@ void SWTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->SW_PostDependent.Read(exINI, pSection, "SW.PostDependent");
 	this->SW_MaxCount.Read(exINI, pSection, "SW.MaxCount");
 	this->SW_Shots.Read(exINI, pSection, "SW.Shots");
+	this->SW_AIRequiresTarget.Read(exINI, pSection, "SW.AIRequiresTarget");
+	this->SW_AIRequiresHouse.Read(exINI, pSection, "SW.AIRequiresHouse");
 
 	this->Message_CannotFire.Read(exINI, pSection, "Message.CannotFire");
 	this->Message_InsufficientFunds.Read(exINI, pSection, "Message.InsufficientFunds");

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -30,6 +30,13 @@ public:
 	ValueableIdx<VoxClass> EVA_InsufficientFunds;
 	ValueableIdx<VoxClass> EVA_SelectTarget;
 	Valueable<bool> SW_UseAITargeting;
+	Valueable<bool> SW_AITargeting_PsyDom_SkipChecks;
+	Valueable<bool> SW_AITargeting_PsyDom_AllowAir;
+	Valueable<bool> SW_AITargeting_PsyDom_AllowInvulnerable;
+	ValueableVector<TechnoTypeClass*> SW_AITargeting_PsyDom_AllowTypes;
+	ValueableVector<TechnoTypeClass*> SW_AITargeting_PsyDom_DisallowTypes;
+	Valueable<bool> SW_AITargeting_Random_SnapOnDesignators;
+	Valueable<bool> SW_AITargeting_Random_PickFirstDesignator;
 	Valueable<bool> SW_AutoFire;
 	Valueable<bool> SW_ManualFire;
 	Valueable<bool> SW_ShowCameo;
@@ -43,6 +50,8 @@ public:
 	Valueable<double> SW_RangeMinimum;
 	Valueable<double> SW_RangeMaximum;
 	Valueable<int> SW_Shots;
+	Nullable<AffectedTarget> SW_AIRequiresTarget;
+	Nullable<AffectedHouse> SW_AIRequiresHouse;
 
 	DWORD SW_RequiredHouses;
 	DWORD SW_ForbiddenHouses;
@@ -131,6 +140,13 @@ public:
 		, EVA_Impatient { -1 }
 		, EVA_InsufficientFunds { -1 }
 		, EVA_SelectTarget { -1 }
+		, SW_AITargeting_PsyDom_SkipChecks { false }
+		, SW_AITargeting_PsyDom_AllowAir { false }
+		, SW_AITargeting_PsyDom_AllowInvulnerable { false }
+		, SW_AITargeting_PsyDom_AllowTypes {}
+		, SW_AITargeting_PsyDom_DisallowTypes {}
+		, SW_AITargeting_Random_SnapOnDesignators { false }
+		, SW_AITargeting_Random_PickFirstDesignator { false }
 		, SW_UseAITargeting { false }
 		, SW_AutoFire { false }
 		, SW_ManualFire { true }
@@ -155,6 +171,8 @@ public:
 		, SW_PostDependent {}
 		, SW_MaxCount { -1 }
 		, SW_Shots { -1 }
+		, SW_AIRequiresTarget {}
+		, SW_AIRequiresHouse {}
 		, Message_CannotFire {}
 		, Message_InsufficientFunds {}
 		, Message_ColorScheme { -1 }
@@ -242,6 +260,8 @@ public:
 	void ApplyActivatedMessage(SuperClass* pSW) const;
 	void ApplyActivatedEva(SuperClass* pSW) const;
 
+	bool PickDesignatorCell(HouseClass* pOwner, bool pickFirst, CellStruct& targetCell, bool& isSuccessful) const;
+
 	virtual void LoadFromINIFile(CCINIClass* pINI) override;
 	virtual void Initialize() override;
 
@@ -264,6 +284,8 @@ public:
 		~ExtContainer();
 	};
 
+	static SuperClass* CurrentAIEvaluatedSW;
+
 	static void FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell);
 
 	static ExtContainer ExtMap;
@@ -282,6 +304,7 @@ public:
 
 	static bool Activate(SuperClass* pSuper, CellStruct cell, bool isPlayer);
 	static SuperClass* __stdcall IsSuperAvailable(int swIdx, HouseClass* pHouse);
-
+	static bool EligibleTargetForPsyDomSW(TechnoClass* pTechno);
+	static bool HandleAITargetingOverrides(SuperClass* pSuper, SuperWeaponAITargetingMode aiTargetingType, CellStruct& targetCell, bool& isSuccessful);
 };
 

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -288,3 +288,21 @@ DEFINE_HOOK(0x53B276, PsyDom_Fire_Select, 0x6)
 
 	return SkipGameCode;
 }
+
+// Only used if Ares is not available.
+DEFINE_HOOK(0x509952, HouseClass_SuperWeapon_AI_Set, 0x6)
+{
+	GET(SuperClass*, pSuper, EAX);
+
+	SWTypeExt::CurrentAIEvaluatedSW = pSuper;
+
+	return 0;
+}
+
+// Only used if Ares is not available.
+DEFINE_HOOK(0x509AD2, HouseClass_SuperWeapon_AI_Unset, 0x6)
+{
+	SWTypeExt::CurrentAIEvaluatedSW = nullptr;
+
+	return 0;
+}

--- a/src/Ext/SWType/SWHelpers.cpp
+++ b/src/Ext/SWType/SWHelpers.cpp
@@ -337,3 +337,181 @@ SuperClass* __stdcall SWTypeExt::IsSuperAvailable(int swIdx, HouseClass* pHouse)
 
 	return nullptr;
 }
+
+// Replaces Ares Psychic Dominator SW target eligibility checks if Ares is present.
+bool SWTypeExt::EligibleTargetForPsyDomSW(TechnoClass* pTechno)
+{
+	auto const pTechnoType = pTechno->GetTechnoType();
+
+	// Always ignore Insignificant or civilian-house owned targets - change from Ares and vanilla behaviour.
+	if (pTechnoType->Insignificant || pTechno->Owner->Type->MultiplayPassive)
+		return false;
+
+	if (auto const pSuper = SWTypeExt::CurrentAIEvaluatedSW)
+	{
+		auto const pTypeExt = SWTypeExt::ExtMap.Find(pSuper->Type);
+		auto const pOwner = pSuper->Owner;
+		auto const pTargetHouse = pTechno->Owner;
+
+		// If SW.AIRequiresHouse is explicitly set use that instead of restricting to enemies only.
+		if (pTypeExt->SW_AIRequiresHouse.isset())
+		{
+			if (!EnumFunctions::CanTargetHouse(pTypeExt->SW_AIRequiresHouse, pOwner, pTargetHouse))
+				return false;
+		}
+		else if (pOwner->IsAlliedWith(pTargetHouse))
+		{
+			return false;
+		}
+
+		// If SW.AIRequiresTarget is explicitly set check that here as well.
+		if (pTypeExt->SW_AIRequiresTarget.isset() && !EnumFunctions::IsTechnoEligible(pTechno, pTypeExt->SW_AIRequiresTarget))
+			return false;
+
+		if (pTypeExt->SW_AITargeting_PsyDom_AllowTypes.size() > 0 && !pTypeExt->SW_AITargeting_PsyDom_AllowTypes.Contains(pTechnoType))
+			return false;
+
+		if (pTypeExt->SW_AITargeting_PsyDom_DisallowTypes.size() > 0 && pTypeExt->SW_AITargeting_PsyDom_DisallowTypes.Contains(pTechnoType))
+			return false;
+
+		// Skip normal MC immunity etc. checks and only check air & invulnerability separately with toggles to turn them off.
+		if (pTypeExt->SW_AITargeting_PsyDom_SkipChecks)
+		{
+			if (pTechno->IsInAir() && !pTypeExt->SW_AITargeting_PsyDom_AllowAir)
+				return false;
+
+			if (pTechno->IsIronCurtained() && !pTypeExt->SW_AITargeting_PsyDom_AllowInvulnerable)
+				return false;
+
+			return true;
+		}
+	}
+
+	return pTechno->CanBePermaMindControlled();
+}
+
+// Override Ares' SW AI targeting behaviour based in AI targeting type or whatever else.
+bool SWTypeExt::HandleAITargetingOverrides(SuperClass* pSuper, SuperWeaponAITargetingMode aiTargetingType, CellStruct& targetCell, bool& isSuccessful)
+{
+	// Fix LightningRandom behaving suboptimally with explicit Designators.
+	if (aiTargetingType == SuperWeaponAITargetingMode::LightningRandom)
+	{
+		auto const pTypeExt = SWTypeExt::ExtMap.Find(pSuper->Type);
+
+		if (pTypeExt->SW_AITargeting_Random_SnapOnDesignators)
+			return pTypeExt->PickDesignatorCell(pSuper->Owner, pTypeExt->SW_AITargeting_Random_PickFirstDesignator, targetCell, isSuccessful);
+	}
+
+	return false;
+}
+
+// Overrides target cell with a cell of designator or one in designator range not affected by inhibitor.
+bool SWTypeExt::ExtData::PickDesignatorCell(HouseClass* pOwner, bool pickFirst, CellStruct& targetCell, bool& isSuccessful) const
+{
+	if (!this->SW_Designators.empty())
+	{
+		std::vector<TechnoClass*> inhibited;
+		std::vector<CellStruct> designatorCells;
+
+		// Evaluate technos for designators.
+		for (auto* pTechno : TechnoClass::Array)
+		{
+			if (this->IsDesignator(pOwner, pTechno))
+			{
+				auto const cell = pTechno->GetMapCoords();
+
+				if (this->HasInhibitor(pOwner, cell))
+				{
+					inhibited.push_back(pTechno); // Designator is in inhibitor range, defer evaluation.
+				}
+				else
+				{
+					// Bail out early if we're picking first match.
+					if (pickFirst)
+					{
+						targetCell = cell;
+						isSuccessful = true;
+						return true;
+					}
+
+					designatorCells.push_back(cell);
+				}
+			}
+		}
+
+		// Pick random cell from found designators.
+		if (!designatorCells.empty())
+		{
+			int index = ScenarioClass::Instance->Random.RandomRanged(0, designatorCells.size() - 1);
+			targetCell = designatorCells[index];
+			isSuccessful = true;
+			return true;
+		}
+
+		// Evaluate designators in inhibitor range.
+		if (!inhibited.empty())
+		{
+			// Scramble list of designators if we're not always picking first one.
+			if (!pickFirst)
+			{
+				size_t n = inhibited.size();
+
+				for (size_t i = n - 1; i > 0; --i)
+				{
+					size_t j = ScenarioClass::Instance->Random.RandomRanged(0, static_cast<int>(i));
+					std::swap(inhibited[i], inhibited[j]);
+				}
+			}
+
+			// Find first cell not within inhibitor range but still within designator's range.
+			for (auto const* pTechno : inhibited)
+			{
+				auto cell = pTechno->GetMapCoords();
+				auto const pType = pTechno->GetTechnoType();
+				auto const pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+				short maxDistance = static_cast<short>(pTechnoTypeExt->DesignatorRange.Get(pType->Sight) + 0.5);
+
+				for (short dist = 1; dist <= maxDistance; ++dist)
+				{
+					for (short dx = -dist; dx <= dist; ++dx)
+					{
+						for (int sign : {-1, 1})
+						{
+							short x = cell.X + dx;
+							short y = cell.Y + static_cast<short>(sign) * dist;
+
+							if (!this->HasInhibitor(pOwner, { x, y }))
+							{
+								targetCell = { x, y };
+								isSuccessful = true;
+								return true;
+							}
+						}
+					}
+
+					for (short dy = -dist + 1; dy <= dist - 1; ++dy)
+					{
+						for (int sign : {-1, 1})
+						{
+							short x = cell.X + static_cast<short>(sign) * dist;
+							short y = cell.Y + dy;
+
+							if (!this->HasInhibitor(pOwner, { x, y }))
+							{
+								targetCell = { x, y };
+								isSuccessful = true;
+								return true;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		targetCell = CellStruct::Empty;
+		isSuccessful = false;
+		return true;
+	}
+
+	return false;
+}

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -13,6 +13,7 @@
 #include <Ext/Rules/Body.h>
 
 #include <New/Entity/Ares/RadarJammerClass.h>
+#include <Utilities/AresFunctions.h>
 
 // Remember that we still don't fix Ares "issues" a priori. Extensions as well.
 // Patches presented here are exceptions rather that the rule. They must be short, concise and correct.
@@ -253,6 +254,24 @@ DEFINE_HOOK(0x440580, BuildingClass_Unlimbo_UnitDeliveryFix, 0x5)
 	return 0;
 }
 
+static AresSWTargetResult* __stdcall PickSuperWeaponTarget(AresSWTargetResult* result, AresSWTargetInfo* info)
+{
+	SWTypeExt::CurrentAIEvaluatedSW = info->SW;
+	auto const aiTargetingType = *(SuperWeaponAITargetingMode*)((char*)info->Ext + 0x210); // Ares' SW.AITargetingType
+
+	if (SWTypeExt::HandleAITargetingOverrides(info->SW, aiTargetingType, result->TargetCell, result->WasSuccessful))
+		return result;
+
+	result = AresFunctions::PickSuperWeaponTarget(result, info);
+	SWTypeExt::CurrentAIEvaluatedSW = nullptr;
+	return result;
+}
+
+static bool __fastcall CanBePermaMindControlled(TechnoClass* pTechno)
+{
+	return SWTypeExt::EligibleTargetForPsyDomSW(pTechno);
+}
+
 _GET_FUNCTION_ADDRESS(RadarJammerClass::Update, AresRadarJammerClass_Update_GetAddr)
 
 static DWORD _cdecl AresPreventScatter_Override(REGISTERS* R)
@@ -383,6 +402,15 @@ void Apply_Ares3_0_Patches()
 
 	// Ares' `KeepAlive` adds global tags.
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x21F70, GET_OFFSET(AresHouseExt_UpdateKeepAlive));
+
+	// Redirect Ares' SW target picker to our wrapper.
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x38356, &PickSuperWeaponTarget);
+
+	// Redirect Ares' Psychic Dominator target evaluation checks to our wrapper.
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x38177, &CanBePermaMindControlled);
+
+	// Skip checking house alliances in Ares' Psychic Dominator target evaluation checks, check them elsewhere later.
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x38137, AresHelper::AresBaseAddress + 0x38175);
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -504,4 +532,13 @@ void Apply_Ares3_0p1_Patches()
 
 	// Ares' `KeepAlive` adds global tags.
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x229F0, GET_OFFSET(AresHouseExt_UpdateKeepAlive));
+
+	// Redirect Ares' SW target picker to our wrapper.
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x38DF6, &PickSuperWeaponTarget);
+
+	// Redirect Ares' Psychic Dominator target evaluation checks to our wrapper.
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x38C17, &CanBePermaMindControlled);
+
+	// Skip checks in Ares' Psychic Dominator target evaluation checks, check them elsewhere later.
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x38BD7, AresHelper::AresBaseAddress + 0x38C15);
 }

--- a/src/Utilities/AresAddressInit.cpp
+++ b/src/Utilities/AresAddressInit.cpp
@@ -14,6 +14,7 @@ decltype(AresFunctions::SetSpotlight) AresFunctions::SetSpotlight = nullptr;
 decltype(AresFunctions::ApplyPermaMC) AresFunctions::ApplyPermaMC = nullptr;
 decltype(AresFunctions::DetailsCurrentlyEnabled) AresFunctions::DetailsCurrentlyEnabled = nullptr;
 decltype(AresFunctions::SendPDPlane) AresFunctions::SendPDPlane = nullptr;
+decltype(AresFunctions::PickSuperWeaponTarget) AresFunctions::PickSuperWeaponTarget = nullptr;
 std::function<AresSWTypeExtData* (SuperWeaponTypeClass*)> AresFunctions::SWTypeExtMap_Find;
 PhobosMap<ObjectClass*, AlphaShapeClass*>* AresFunctions::AlphaExtMap = nullptr;
 PhobosMap<BombClass*, WeaponTypeClass**>* AresFunctions::BombExtMap = nullptr;
@@ -59,6 +60,8 @@ void AresFunctions::InitAres3_0()
 	NOTE_ARES_FUN(DetailsCurrentlyEnabled, 0x02A6C0);
 
 	NOTE_ARES_FUN(SendPDPlane, 0x0741A0);
+
+	NOTE_ARES_FUN(PickSuperWeaponTarget, 0x038640);
 
 	NOTE_ARES_FUN(_SWTypeExtMapFind, 0x57C70);
 	NOTE_ARES_FUN(_SWTypeExtMap, 0xC1C54);
@@ -109,6 +112,8 @@ void AresFunctions::InitAres3_0p1()
 	NOTE_ARES_FUN(DetailsCurrentlyEnabled, 0x02B1C0);
 
 	NOTE_ARES_FUN(SendPDPlane, 0x075250);
+
+	NOTE_ARES_FUN(PickSuperWeaponTarget, 0x0390E0);
 
 	NOTE_ARES_FUN(_SWTypeExtMapFind, 0x58900);
 	NOTE_ARES_FUN(_SWTypeExtMap, 0xC2C50);

--- a/src/Utilities/AresFunctions.h
+++ b/src/Utilities/AresFunctions.h
@@ -19,6 +19,25 @@ class AresTechnoTypeExtData;
 class AresHouseExtData;
 class AresSWTypeExtData;
 
+// Wrapper of values passed to Ares' SW target picker.
+class AresSWTargetInfo
+{
+public:
+	SuperClass* SW;
+	HouseClass* Owner;
+	void* Ext;  // Ares' SWTypeExt
+	void* Unk1; // Unknown
+	void* Unk2; // Unknown
+};
+
+// What Ares' SW target picker sets and returns.
+class AresSWTargetResult
+{
+public:
+	CellStruct TargetCell;
+	bool WasSuccessful;
+};
+
 class AresFunctions
 {
 public:
@@ -47,6 +66,8 @@ public:
 	static bool (*DetailsCurrentlyEnabled)();
 
 	static void(*SendPDPlane)(HouseClass* pOwner, CellClass* pDestination, AircraftTypeClass* pPlaneType, Iterator<TechnoTypeClass*> Types, Iterator<int> Nums);
+
+	static AresSWTargetResult*(__stdcall* PickSuperWeaponTarget)(AresSWTargetResult*, AresSWTargetInfo*);
 
 	static std::function<AresSWTypeExtData* (SuperWeaponTypeClass*)> SWTypeExtMap_Find;
 

--- a/src/Utilities/Enum.h
+++ b/src/Utilities/Enum.h
@@ -63,7 +63,13 @@ enum class SuperWeaponAITargetingMode
 	Base = 11,
 	MultiMissile = 12,
 	HunterSeeker = 13,
-	EnemyBase = 14
+	EnemyBase = 14,
+	IronCurtain = 15,
+	Attack = 16,
+	LowPower = 17,
+	LowPowerAttack = 18,
+	DropPod = 19,
+	LightningRandom = 20
 };
 
 enum class LandTypeFlags : unsigned short


### PR DESCRIPTION
`SW.AITargeting=PsychicDominator` superweapons now ignore `Insignificant=true` as well as owned by `MultiplayPassive=true` house targets.

------------------------

### AI Superweapon targeting customizations

- There are several customizations available for AI superweapon targeting, currently restricted to controlling Ares' `SW.AITargeting` modes.
- For `SW.AITargeting=PsychicDominator`:
    - If `SW.AITargeting.PsyDom.SkipChecks` is set to true targets with `ImmuneToPsionics=yes` will be considered and `SW.AITargeting.PsyDom.AllowAir` and `SW.AITargeting.PsyDom.AllowInvulnerable` will be available to customize whether or not targets in air or those affected by Iron Curtain/Force Shield, respectively, will be considered.
    - `SW.AIRequiresTarget` and `SW.AIRequiresHouse` will be considered if explicitly set, with latter overriding previously hardcoded check to only allow enemy house targets to be considered.
    - `SW.AITargeting.PsyDom.AllowTypes` and `SW.AITargeting.PsyDom.DisallowTypes` can be used to white/blacklist specific TechnoTypes.
- For `SW.AITargeting=LightningRandom`:
    - If `SW.AITargeting.Random.SnapOnDesignators` is set to true, instead of picking random cells and hoping they have designators on them it will only consider cells with active designators on them. If all designators are within range of inhibitors, it attempts to look for a valid cell within designator's range but outside inhibitor's range. If `SW.AITargeting.Random.PickFirstDesignator` is also set to true first eligible cell is picked, otherwise it is chosen at random.
      - Use caution when using in conjunction with `SW.Inhibitors` and large `DesignatorRange` as the fallback of looking for cells outside inhibitor range in a large radius can degrade performance.

In `rulesmd.ini`:
```ini
[SOMESW]                                         ; SuperWeaponType
SW.AITargeting.PsyDom.SkipChecks=false           ; boolean
SW.AITargeting.PsyDom.AllowAir=false             ; boolean
SW.AITargeting.PsyDom.AllowInvulnerable=false    ; boolean
SW.AITargeting.PsyDom.AllowTypes=                ; List of TechnoTypes
SW.AITargeting.PsyDom.DisallowTypes=             ; List of TechnoTypes
SW.AITargeting.Random.SnapOnDesignators=false    ; boolean
SW.AITargeting.Random.PickFirstDesignator=false  ; boolean
```