### PR TITLE
[Vanilla Enhancement] Allow draw SuperWeapon timer as percentage

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -497,6 +497,7 @@ This page lists all the individual contributions to the project by their author.
   - Penetrates damage on transporter
   - Add amount limit of `LimboKill`
   - Spawns particle when spawns tiberium by terrain
+  - Allow draw SuperWeapon timer as percentage
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -397,8 +397,11 @@ ShowTimer.Priority=0  ; integer
 
 In `rulesmd.ini`:
 ```ini
+[AudioVisual]
+SuperWeaponTimer.Percentage=false  ; boolean
+
 [SOMESW]              ; SuperWeaponType, with ShowTimer=yes
-ShowTimer.Percentage=false  ; boolean
+ShowTimer.Percentage=     ; boolean
 ```
 
 ### Task subtitles display in the middle of the screen

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -391,6 +391,16 @@ In `rulesmd.ini`:
 ShowTimer.Priority=0  ; integer
 ```
 
+### Allow draw SuperWeapon timer as percentage
+
+- Superweapon cd timer can now draw as percentage.
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]              ; SuperWeaponType, with ShowTimer=yes
+ShowTimer.Percentage=false  ; boolean
+```
+
 ### Task subtitles display in the middle of the screen
 
 ![Message Display In Center](_static/images/messagedisplayincenter.gif)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -541,6 +541,7 @@ New:
 - [Customizations for techno type target scan/guard range](Fixed-or-Improved-Logics.md#target-scan-guard-range-customizations) (by Starkku)
 - Spawns particle when spawns tiberium by terrain (by NetsuNegi)
 - Allow jumpjet climbing ignore building height (by TaranDahl)
+- Allow draw SuperWeapon timer as percentage (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -112,6 +112,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->PlacementPreview.Read(exINI, GameStrings::AudioVisual, "PlacementPreview");
 	this->PlacementPreview_Translucency.Read(exINI, GameStrings::AudioVisual, "PlacementPreview.Translucency");
 
+	this->SuperWeaponTimer_Percentage.Read(exINI, GameStrings::AudioVisual, "SuperWeaponTimer.Percentage");
 	this->SuperWeaponSidebar_AllowByDefault.Read(exINI, GameStrings::AudioVisual, "SuperWeaponSidebar.AllowByDefault");
 
 	this->ConditionYellow_Terrain.Read(exINI, GameStrings::AudioVisual, "ConditionYellow.Terrain");
@@ -473,6 +474,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->PlacementGrid_TranslucencyWithPreview)
 		.Process(this->PlacementPreview)
 		.Process(this->PlacementPreview_Translucency)
+		.Process(this->SuperWeaponTimer_Percentage)
 		.Process(this->SuperWeaponSidebar_AllowByDefault)
 		.Process(this->ConditionYellow_Terrain)
 		.Process(this->Shield_ConditionYellow)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <RulesClass.h>
 #include <Utilities/Container.h>
@@ -63,6 +63,7 @@ public:
 		Valueable<bool> PlacementPreview;
 		TranslucencyLevel PlacementPreview_Translucency;
 
+		Valueable<bool> SuperWeaponTimer_Percentage;
 		Valueable<bool> SuperWeaponSidebar_AllowByDefault;
 
 		Nullable<double> ConditionYellow_Terrain;
@@ -353,6 +354,7 @@ public:
 			, PlacementPreview { false }
 			, PlacementPreview_Translucency { 75 }
 
+			, SuperWeaponTimer_Percentage { false }
 			, SuperWeaponSidebar_AllowByDefault { false }
 
 			, Shield_ConditionYellow { }

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -69,6 +69,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_Next_RandomWeightsData)
 		.Process(this->SW_Next_RollChances)
 		.Process(this->ShowTimer_Priority)
+		.Process(this->ShowTimer_Percentage)
 		.Process(this->Convert_Pairs)
 		.Process(this->ShowDesignatorRange)
 		.Process(this->TabIndex)
@@ -152,6 +153,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SW_Next_RollChances.Read(exINI, pSection, "SW.Next.RollChances");
 
 	this->ShowTimer_Priority.Read(exINI, pSection, "ShowTimer.Priority");
+	this->ShowTimer_Percentage.Read(exINI, pSection, "ShowTimer.Percentage");
 
 	this->EMPulse_WeaponIndex.Read(exINI, pSection, "EMPulse.WeaponIndex");
 	this->EMPulse_SuspendOthers.Read(exINI, pSection, "EMPulse.SuspendOthers");

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -65,6 +65,7 @@ public:
 		ValueableVector<float> SW_Next_RollChances;
 
 		Valueable<int> ShowTimer_Priority;
+		Valueable<bool> ShowTimer_Percentage;
 
 		Valueable<WarheadTypeClass*> Detonate_Warhead;
 		Valueable<WeaponTypeClass*> Detonate_Weapon;
@@ -158,6 +159,7 @@ public:
 			, SW_Next_RollChances {}
 			, SW_Next_RandomWeightsData {}
 			, ShowTimer_Priority { 0 }
+			, ShowTimer_Percentage { false }
 			, Convert_Pairs {}
 			, ShowDesignatorRange { true }
 			, TabIndex { 1 }

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -65,7 +65,7 @@ public:
 		ValueableVector<float> SW_Next_RollChances;
 
 		Valueable<int> ShowTimer_Priority;
-		Valueable<bool> ShowTimer_Percentage;
+		Nullable<bool> ShowTimer_Percentage;
 
 		Valueable<WarheadTypeClass*> Detonate_Warhead;
 		Valueable<WeaponTypeClass*> Detonate_Weapon;

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -599,10 +599,6 @@ TextPrintType flag,
 		}
 	}
 
-	// Fix text position
-	location.X += 2;
-	location.Y += 1;
-
 	return Fancy_Text_Print_Wide(retBuffer, pText, pSurface, bounds, location, pForeScheme, pBackScheme, flag);
 }
 DEFINE_FUNCTION_JUMP(CALL, 0x6D4D42, TacticalClass_DrawTimer_Print_Wide)// UIName

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -537,7 +537,7 @@ DEFINE_HOOK(0x6D4A10, TacticalClass_Render_DrawSuperTimer_PercentageTimer, 0x6)
 	const int timeLeft = pSuper->RechargeTimer.GetTimeLeft();
 	const auto pSWTypeExt = SWTypeExt::ExtMap.Find(pSuper->Type);
 
-	if (pSWTypeExt->ShowTimer_Percentage)
+	if (pSWTypeExt->ShowTimer_Percentage.Get(RulesExt::Global()->SuperWeaponTimer_Percentage))
 	{
 		DrawTimerTemp::IsPercentage = true;
 		const int recharge = pSuper->GetRechargeTime();

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -502,3 +502,110 @@ DEFINE_HOOK(0x55F1F8, MPDebugPrint_CheckDrawFlag, 0x8)
 {
     return Game::DrawMPDebugStats ? 0 : 0x55F280;
 }
+
+#pragma region Draw Timer
+
+namespace DrawTimerTemp
+{
+	bool AdjustLocation = false;
+	bool IsPercentage = false;
+	double Percentage = 0.0;
+	int TimeLeft = 0;
+}
+
+DEFINE_HOOK(0x6D3D10, TacticalClass_Render_BeforeAll, 0x6)
+{
+	using namespace DrawTimerTemp;
+	AdjustLocation = false;
+	IsPercentage = false;
+	return 0;
+}
+
+DEFINE_HOOK(0x6D4992, TacticalClass_Render_DrawMissionTimer_TimeLeft, 0x6)
+{
+	DrawTimerTemp::TimeLeft = R->EDX<int>();
+	return 0;
+}
+
+DEFINE_HOOK(0x6D4A10, TacticalClass_Render_DrawSuperTimer_PercentageTimer, 0x6)
+{
+	enum { SkipGetTimeLeft = 0x6D4A35 };
+
+	GET(SuperClass*, pSuper, ECX);
+
+	DrawTimerTemp::IsPercentage = false;
+	const int timeLeft = pSuper->RechargeTimer.GetTimeLeft();
+	const auto pSWTypeExt = SWTypeExt::ExtMap.Find(pSuper->Type);
+
+	if (pSWTypeExt->ShowTimer_Percentage)
+	{
+		DrawTimerTemp::IsPercentage = true;
+		const int recharge = pSuper->GetRechargeTime();
+		const double percentage = DrawTimerTemp::Percentage = std::min(static_cast<double>(recharge - timeLeft) / recharge, 1.0);
+		R->ESI(percentage >= 1.0 ? 0 : 15);
+	}
+	else
+	{
+		DrawTimerTemp::TimeLeft = timeLeft / 15;
+		R->ESI(timeLeft);
+	}
+
+	return SkipGetTimeLeft;
+}
+
+DEFINE_HOOK(0x6D4B03, TacticalClass_Render_DrawBlackoutTimer_TimeLeft, 0x5)
+{
+	DrawTimerTemp::TimeLeft = R->EDX<int>();
+	return 0;
+}
+
+static int __fastcall TacticalClass_DrawTimer_swprintf(wchar_t* pBuffer, size_t bufferCount, wchar_t* pFormat, ...)
+{
+	using namespace DrawTimerTemp;
+
+	if (IsPercentage)
+		return swprintf(pBuffer, bufferCount, L"%.2lf%s", Percentage * 100, L"%%");
+	else
+		return swprintf(pBuffer, bufferCount, L"%02d:%02d", TimeLeft / 60 % 60, TimeLeft % 60);
+}
+DEFINE_FUNCTION_JUMP(CALL, 0x6D4C4C, TacticalClass_DrawTimer_swprintf)
+
+static Point2D* __fastcall TacticalClass_DrawTimer_Print_Wide
+(
+Point2D& retBuffer,
+const wchar_t* pText,
+Surface* pSurface,
+const RectangleStruct& bounds,
+Point2D& location,
+ColorScheme* pForeScheme,
+ColorScheme* pBackScheme,
+TextPrintType flag,
+...
+)
+{
+	using namespace DrawTimerTemp;
+	AdjustLocation = !AdjustLocation;
+
+	if (AdjustLocation)
+	{
+		if (IsPercentage)
+		{
+			IsPercentage = false;
+			location.X += 8;
+		}
+		else
+		{
+			location.X -= 2;
+		}
+	}
+
+	// Fix text position
+	location.X += 2;
+	location.Y += 1;
+
+	return Fancy_Text_Print_Wide(retBuffer, pText, pSurface, bounds, location, pForeScheme, pBackScheme, flag);
+}
+DEFINE_FUNCTION_JUMP(CALL, 0x6D4D42, TacticalClass_DrawTimer_Print_Wide)// UIName
+DEFINE_FUNCTION_JUMP(CALL, 0x6D4D9A, TacticalClass_DrawTimer_Print_Wide)// Time
+
+#pragma endregion


### PR DESCRIPTION
- Superweapon cd timer can now draw as percentage.
- 超级武器的CD倒计时现在可以以百分比形式显示了.

In `rulesmd.ini`:
```ini
[AudioVisual]
SuperWeaponTimer.Percentage=false  ; boolean

[SOMESW]              ; SuperWeaponType, with ShowTimer=yes
ShowTimer.Percentage=     ; boolean
```