### PR TITLE
[Phobos Fix] Fix the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -485,6 +485,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize size for mind controlled unit
   - Fix the issue that weapon selection don't check if secondary's warhead has `IsLocomotor=yes`
   - Fix the issue that warhead with `IsLocomotor=yes` can be used to vehicles who is in tank bunker
+  - Fix the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -291,6 +291,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the issue that warhead with `IsLocomotor=yes` can be used to vehicles who is in tank bunker.
 - Fixed an issue where miners affected by `Passengers/DeployFire` were unable to unload minerals.
 - Fixed an issue where mining vehicles could not move after leaving a tank bunker.
+- Fixed the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -600,6 +600,7 @@ Phobos fixes:
 - LimboDelivery buildings cannot be selected (by FlyStar)
 - Fixed the positive value of `Reveal` on warhead (by NetsuNegi)
 - Fixed the bug that weapon cannot used to intercept on gound bullet if it's projectile has `AG=no` (by NetsuNegi)
+- Fixed the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly (by NetsuNegi)
 
 Fixes / interactions with other extensions:
 <!--  - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)  -->

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -1625,6 +1625,12 @@ void TechnoExt::KillSelf(TechnoClass* pThis, AutoDeathBehavior deathOption, cons
 	{
 		AnimExt::CreateRandomAnim(pVanishAnimation, pThis->GetCoords(), pThis, nullptr, true);
 
+		if (const auto pBuilding = abstract_cast<BuildingClass*, true>(pThis))
+		{
+			if (pThis->BunkerLinkedItem)
+				pBuilding->UnloadBunker();
+		}
+
 		pThis->KillPassengers(pThis);
 		pThis->Stun();
 		pThis->Limbo();


### PR DESCRIPTION
- Fix the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly
- 修复如果坦克碉堡里有坦克，使用vanish自动死亡会导致坦克卡住并且游戏会迅速崩溃的bug.