### PR TITLE
Vanilla Fix for Vehicle salesmen

### DIFF
--- a/src/Ext/Building/Hooks.Selling.cpp
+++ b/src/Ext/Building/Hooks.Selling.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
 
 #include <Misc/FlyingStrings.h>
+#include <Ext/Rules/Body.h>
 
 // SellSound and EVA dehardcode
 DEFINE_HOOK(0x4D9F7B, FootClass_Sell, 0x6)
@@ -8,7 +9,19 @@ DEFINE_HOOK(0x4D9F7B, FootClass_Sell, 0x6)
 	enum { ReadyToVanish = 0x4D9FCB };
 	GET(FootClass*, pThis, ESI);
 
-	const int money = pThis->GetRefund();
+	// Check if this is a vehicle and UnitsUnsellable is enabled
+	// If so, set refund to 0 (units being sold normally, not grinded)
+	int money = pThis->GetRefund();
+	
+	if (RulesExt::Global()->UnitsUnsellable.Get())
+	{
+		// Only apply to vehicles (not buildings, not infantry)
+		if (auto pUnit = abstract_cast<UnitClass*>(pThis))
+		{
+			money = 0;
+		}
+	}
+	
 	const auto pOwner = pThis->Owner;
 	pOwner->GiveMoney(money);
 

--- a/src/Ext/Building/Hooks.Selling.cpp
+++ b/src/Ext/Building/Hooks.Selling.cpp
@@ -9,10 +9,10 @@ DEFINE_HOOK(0x4D9F7B, FootClass_Sell, 0x6)
 	enum { ReadyToVanish = 0x4D9FCB };
 	GET(FootClass*, pThis, ESI);
 
-	// Check if this is a vehicle and UnitsUnsellable is enabled
+	// Check if this is a vehicletype
 	// If so, set refund to 0 (units being sold normally, not grinded)
 	int money = pThis->GetRefund();
-	
+
 	if (RulesExt::Global()->UnitsUnsellable.Get())
 	{
 		// Only apply to vehicles (not buildings, not infantry)
@@ -21,7 +21,7 @@ DEFINE_HOOK(0x4D9F7B, FootClass_Sell, 0x6)
 			money = 0;
 		}
 	}
-	
+
 	const auto pOwner = pThis->Owner;
 	pOwner->GiveMoney(money);
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -346,6 +346,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->AutoTarget_NoThreatBuildings.Read(exINI, GameStrings::General, "AutoTarget.NoThreatBuildings");
 	this->AutoTargetAI_NoThreatBuildings.Read(exINI, GameStrings::General, "AutoTargetAI.NoThreatBuildings");
+	this->UnitsUnsellable.Read(exINI, GameStrings::General, "UnitsUnsellable");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -634,6 +635,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ExtraRange_Prefiring_IncludeBurst)
 		.Process(this->AutoTarget_NoThreatBuildings)
 		.Process(this->AutoTargetAI_NoThreatBuildings)
+		.Process(this->UnitsUnsellable)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -296,6 +296,8 @@ public:
 		
 		Valueable<bool> AutoTarget_NoThreatBuildings;
 		Valueable<bool> AutoTargetAI_NoThreatBuildings;
+		
+		Valueable<bool> UnitsUnsellable;
     
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -538,6 +540,7 @@ public:
 
 			, AutoTarget_NoThreatBuildings { false }
 			, AutoTargetAI_NoThreatBuildings { true }
+			, UnitsUnsellable { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
<!-- Please manually add a label named [No Documentation Needed] if this change should not be mentioned in documentation, what's new and no credit needs to be given.
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches. -->

Are you tired of people abusing the sell mechanic on tanks when they're not supposed to? 

Are you tired of constantly being harassed by streamers abusing this bug? 



Look no further!!! 



With this pull request the functionality is still enabled but it's enforced to sell any vehicletype for 0 credits!


https://github.com/user-attachments/assets/ba297895-d672-4a7b-8182-878cf8195daf

Imagine the video above but the user gets 0 credits!! That's what happens when this PR gets accepted. Also free donuts. Don't ask. Just merge.

https://youtu.be/uPEFi4cte4U