### PR TITLE
Fix the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -487,6 +487,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the issue that warhead with `IsLocomotor=yes` can be used to vehicles who is in tank bunker
   - Fix the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly
   - Customize whether warhead can be used to targeting ironcurtained technos or not
+  - Keep select techno when use permanent mindcontrol or psychic dominator superweapon to instead normal mindcontrol
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -487,7 +487,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the issue that warhead with `IsLocomotor=yes` can be used to vehicles who is in tank bunker
   - Fix the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly
   - Customize whether warhead can be used to targeting ironcurtained technos or not
-  - Keep select techno when use permanent mindcontrol or psychic dominator superweapon to instead normal mindcontrol
+  - Fixed the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -487,7 +487,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the issue that warhead with `IsLocomotor=yes` can be used to vehicles who is in tank bunker
   - Fix the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly
   - Customize whether warhead can be used to targeting ironcurtained technos or not
-  - Fixed the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon
+  - Fix the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -293,7 +293,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue where mining vehicles could not move after leaving a tank bunker.
 - Fixed the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly.
 - `ProductionAnim` is now available for `Factory=InfantryType` as well as non-`ConstructionYard=true` `Factory=BuildingType` buildings. `IdleAnim` will cease to play for its duration normally as well.
-- Keep select techno when use permanent mindcontrol or psychic dominator superweapon to instead normal mindcontrol.
+- Fixed the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -293,6 +293,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue where mining vehicles could not move after leaving a tank bunker.
 - Fixed the bug that if there's a tank in tank bunker, tank bunker use auto death by vanish will cause tank get stuck and game will crash quickly.
 - `ProductionAnim` is now available for `Factory=InfantryType` as well as non-`ConstructionYard=true` `Factory=BuildingType` buildings. `IdleAnim` will cease to play for its duration normally as well.
+- Keep select techno when use permanent mindcontrol or psychic dominator superweapon to instead normal mindcontrol.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -581,7 +581,7 @@ Vanilla fixes:
 - Fixed the issue that warhead with `IsLocomotor=yes` can be used to vehicles who is in tank bunker (by NetsuNegi)
 - Fixed an issue where miners affected by `Passengers/DeployFire` were unable to unload minerals (by FlyStar)
 - Fixed an issue where mining vehicles could not move after leaving a tank bunker (by FlyStar)
-- Keep select techno when use permanent mindcontrol or psychic dominator superweapon to instead normal mindcontrol (by NetsuNegi)
+- Fixed the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon (by NetsuNegi)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -581,6 +581,7 @@ Vanilla fixes:
 - Fixed the issue that warhead with `IsLocomotor=yes` can be used to vehicles who is in tank bunker (by NetsuNegi)
 - Fixed an issue where miners affected by `Passengers/DeployFire` were unable to unload minerals (by FlyStar)
 - Fixed an issue where mining vehicles could not move after leaving a tank bunker (by FlyStar)
+- Keep select techno when use permanent mindcontrol or psychic dominator superweapon to instead normal mindcontrol (by NetsuNegi)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Ext/SWType/Hooks.cpp
+++ b/src/Ext/SWType/Hooks.cpp
@@ -263,3 +263,28 @@ DEFINE_HOOK(0x6AC67A, SidebarClass_6AC5F0_TabIndex, 0x5)
 
 DEFINE_JUMP(LJMP, 0x6A8D07, 0x6A8D17) // Skip tabIndex check
 #pragma endregion
+
+DEFINE_HOOK(0x53B276, PsyDom_Fire_Select, 0x6)
+{
+	enum { SkipGameCode = 0x53B29E };
+
+	GET(TechnoClass*, pTechno, ESI);
+	const bool selected = pTechno->IsSelected;
+
+	if (const auto pController = pTechno->MindControlledBy)
+	{
+		if (const auto pManager = pController->CaptureManager)
+			pManager->FreeUnit(pTechno);
+	}
+
+	pTechno->SetOwningHouse(PsyDom::Owner);
+
+	if (selected && pTechno->Owner->IsCurrentPlayer())
+	{
+		const bool moveFeedBack = std::exchange(Unsorted::MoveFeedback, false);
+		pTechno->Select();
+		Unsorted::MoveFeedback = moveFeedBack;
+	}
+
+	return SkipGameCode;
+}

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -61,6 +61,31 @@ static bool __fastcall CameoIsVeteran(TechnoTypeClass** pTypeExt_Ares, void*, Ho
 	return TechnoTypeExt::ExtMap.Find(*pTypeExt_Ares)->CameoIsVeteran(pHouse);
 }
 
+namespace PermaMCTemp
+{
+	bool Selected = false;
+}
+
+static bool __fastcall PermaMC_FreeUnit_SetContext(CaptureManagerClass* pManager, void*, TechnoClass* pTechno)
+{
+	PermaMCTemp::Selected = pTechno->IsSelected;
+	return pManager->FreeUnit(pTechno);
+}
+
+static bool __fastcall PermaMC_SetOwningHouse_Select(TechnoClass* pTechno, void*, HouseClass* pHouse, bool announce)
+{
+	const bool result = pTechno->SetOwningHouse(pHouse, announce);
+
+	if (std::exchange(PermaMCTemp::Selected, false) && pTechno->Owner->IsCurrentPlayer())
+	{
+		const bool moveFeedBack = std::exchange(Unsorted::MoveFeedback, false);
+		pTechno->Select();
+		Unsorted::MoveFeedback = moveFeedBack;
+	}
+
+	return result;
+}
+
 _GET_FUNCTION_ADDRESS(RadarJammerClass::Update, AresRadarJammerClass_Update_GetAddr)
 
 void Apply_Ares3_0_Patches()
@@ -127,6 +152,13 @@ void Apply_Ares3_0_Patches()
 
 	// Redirect Ares's return address in ImmuneToBerserk related checks
 	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4AB37, { 0x1F, 0x1D });
+
+	// Handle select of PsyDom
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x36107, &PermaMC_FreeUnit_SetContext);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x36115, &PermaMC_SetOwningHouse_Select);
+	// Handle select of MindControl.Permanent
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x45EAF, &PermaMC_FreeUnit_SetContext);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x45EBE, &PermaMC_SetOwningHouse_Select);
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -195,4 +227,11 @@ void Apply_Ares3_0p1_Patches()
 
 	// Redirect Ares's return address in ImmuneToBerserk related checks
 	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4B797, { 0x1F, 0x1D });
+
+	// Handle select of PsyDom
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x36BA7, &PermaMC_FreeUnit_SetContext);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x36BB5, &PermaMC_SetOwningHouse_Select);
+	// Handle select of MindControl.Permanent
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x46A1F, &PermaMC_FreeUnit_SetContext);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x46A2E, &PermaMC_SetOwningHouse_Select);
 }


### PR DESCRIPTION
- In vanilla, if you use psychic dominator superweapon to control a techno which has beed controlled in yours, the techno will always deselect. Now it should keep select (if it is selected before you use superweapon).
- 在原版游戏中，如果你使用心灵控制超级武器去控制一个已经被你控制的科技类型，那这个科技类型总是会被取消选择。现在它应当会保持选中了（如果在使用超级武器前它已经被选中）.
- It is also same of Ares's `MindControl.Permanent`.
- 这对于Ares的 `MindControl.Permanent` 也有同样的问题和修复方案.