### PR TITLE
[Vanilla Enhancement] Customizable disk drain logic

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -489,6 +489,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize whether weapon can be used to targeting ironcurtained technos or not
   - Fix the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon
   - Fix the bug that building with `Explodes=yes` use Ares's rubble logic will cause it's owner cannot defeat normally
+  - Customizable disk drain logic
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2155,25 +2155,28 @@ WarpOutWeapon=                          ; WeaponType
 ### Customizable disk drain logic
 
 - It is possible to set properties of drain logic per technotypes.
-  - `DrainMoneyDisplay.AtFirer` and `DrainMoneyDisplay.AtTarget` determine whether drain money will be displayed at firer (get money) and target (lose money) respectively.
+  - `DrainMoneyDisplay` and `DrainMoneyDisplay.OnTarget` determine whether drain money will be displayed at firer and target respectively.
+  - `DrainMoneyDisplay.Houses` determines which houses can see the credits display on firer.
+  - `DrainMoneyDisplay.Offset` is additional pixel offset for the center of the credits display, by default `0,0` at firer's center.
+  - `DrainMoneyDisplay.OnTarget.UseDisplayIncome` determines whether drain money display on target will use its `DisplayIncome.Houses` and `DisplayIncome.Offset` settings. If set to false, it'll respect the firer's `DrainMoneyDisplay.Houses` and `DrainMoneyDisplay.Offset` settings instead.
 
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
-DrainMoneyDisplay=false            ; boolean
-DrainMoneyDisplay.House=all        ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
-DrainMoneyDisplay.AtFirer=true     ; boolean
-DrainMoneyDisplay.AtTarget=true    ; boolean
+DrainMoneyDisplay=false                             ; boolean
+DrainMoneyDisplay.Houses=all                        ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+DrainMoneyDisplay.OnTarget=false                    ; boolean
+DrainMoneyDisplay.OnTarget.UseDisplayIncome=true    ; boolean
 
-[SOMETECHNO]                       ; TechnoType
-DrainMoneyFrameDelay=              ; integer, default to [CombatDamage] -> DrainMoneyFrameDelay
-DrainMoneyAmount=                  ; integer, default to [CombatDamage] -> DrainMoneyAmount
-DrainAnimationType=                ; AnimationType, default to [CombatDamage] -> DrainAnimationType
-DrainMoneyDisplay=                 ; boolean, default to [AudioVisual] -> DrainMoneyDisplay
-DrainMoneyDisplay.House=           ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all), default to [AudioVisual] -> DrainMoneyDisplay.House
-DrainMoneyDisplay.AtFirer=         ; boolean, default to [AudioVisual] -> DrainMoneyDisplay.AtFirer
-DrainMoneyDisplay.AtTarget=        ; boolean, default to [AudioVisual] -> DrainMoneyDisplay.AtTarget
-DrainMoneyDisplay.Offset=0,0       ; X,Y, pixels relative to default
+[SOMETECHNO]                                        ; TechnoType
+DrainMoneyFrameDelay=                               ; integer, default to [CombatDamage] -> DrainMoneyFrameDelay
+DrainMoneyAmount=                                   ; integer, default to [CombatDamage] -> DrainMoneyAmount
+DrainAnimationType=                                 ; AnimationType, default to [CombatDamage] -> DrainAnimationType
+DrainMoneyDisplay=                                  ; boolean, default to [AudioVisual] -> DrainMoneyDisplay
+DrainMoneyDisplay.Houses=                           ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all), default to [AudioVisual] -> DrainMoneyDisplay.Houses
+DrainMoneyDisplay.Offset=0,0                        ; X,Y, pixels relative to default
+DrainMoneyDisplay.OnTarget=                         ; boolean, default to [AudioVisual] -> DrainMoneyDisplay.OnTarget
+DrainMoneyDisplay.OnTarget.UseDisplayIncome=        ; boolean
 ```
 
 ## Terrain

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2155,17 +2155,25 @@ WarpOutWeapon=                          ; WeaponType
 ### Customizable disk drain logic
 
 - It is possible to set properties of drain logic per technotypes.
+  - `DrainMoneyDisplay.AtFirer` and `DrainMoneyDisplay.AtTarget` determine whether drain money will be displayed at firer (get money) and target (lose money) respectively.
 
 In `rulesmd.ini`:
 ```ini
-[SOMETECHNO]                            ; TechnoType
-DrainMoneyFrameDelay=               ; integer
-DrainMoneyAmount=                       ; integer
-DrainAnimationType=                     ; AnimationType
-DrainMoney.Display=false            ; boolean
-DrainMoney.Display.House=all        ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
-DrainMoney.Display.AtFirer=true         ; boolean
-DrainMoney.Display.Offset=0,0           ; integer - X, Y
+[AudioVisual]
+DrainMoneyDisplay=false            ; boolean
+DrainMoneyDisplay.House=all        ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+DrainMoneyDisplay.AtFirer=true     ; boolean
+DrainMoneyDisplay.AtTarget=true    ; boolean
+
+[SOMETECHNO]                       ; TechnoType
+DrainMoneyFrameDelay=              ; integer, default to [CombatDamage] -> DrainMoneyFrameDelay
+DrainMoneyAmount=                  ; integer, default to [CombatDamage] -> DrainMoneyAmount
+DrainAnimationType=                ; AnimationType, default to [CombatDamage] -> DrainAnimationType
+DrainMoneyDisplay=                 ; boolean, default to [AudioVisual] -> DrainMoneyDisplay
+DrainMoneyDisplay.House=           ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all), default to [AudioVisual] -> DrainMoneyDisplay.House
+DrainMoneyDisplay.AtFirer=         ; boolean, default to [AudioVisual] -> DrainMoneyDisplay.AtFirer
+DrainMoneyDisplay.AtTarget=        ; boolean, default to [AudioVisual] -> DrainMoneyDisplay.AtTarget
+DrainMoneyDisplay.Offset=0,0       ; X,Y, pixels relative to default
 ```
 
 ## Terrain

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2152,6 +2152,22 @@ WarpInWeapon.UseDistanceAsDamage=false  ; boolean
 WarpOutWeapon=                          ; WeaponType
 ```
 
+### Customizable disk drain logic
+
+- It is possible to set properties of drain logic per technotypes.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                            ; TechnoType
+DrainMoneyFrameDelay=               ; integer
+DrainMoneyAmount=                       ; integer
+DrainAnimationType=                     ; AnimationType
+DrainMoney.Display=false            ; boolean
+DrainMoney.Display.House=all        ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
+DrainMoney.Display.AtFirer=true         ; boolean
+DrainMoney.Display.Offset=0,0           ; integer - X, Y
+```
+
 ## Terrain
 
 ### Destroy animation & sound

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -529,6 +529,7 @@ New:
 - [Return warhead](New-or-Enhanced-Logics.md#return-warhead) (by Ollerus)
 - [`AllowBerzerkOnAllies`](Fixed-or-Improved-Logics.md#berzerk-on-allies) (by TaranDahl)
 - [Customize whether weapon can be used to targeting ironcurtained technos or not](New-or-Enhanced-Logics.md#customize-whether-weapon-can-target-iron-curtained-technos) (by NetsuNegi)
+- Customizable disk drain logic (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -200,6 +200,11 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DisplayIncome_Houses.Read(exINI, GameStrings::AudioVisual, "DisplayIncome.Houses");
 	this->DisplayIncome_AllowAI.Read(exINI, GameStrings::AudioVisual, "DisplayIncome.AllowAI");
 
+	this->DrainMoneyDisplay.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay");
+	this->DrainMoneyDisplay_House.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.House");
+	this->DrainMoneyDisplay_AtFirer.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.AtFirer");
+	this->DrainMoneyDisplay_AtTarget.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.AtTarget");
+
 	this->IsVoiceCreatedGlobal.Read(exINI, GameStrings::AudioVisual, "IsVoiceCreatedGlobal");
 	this->SelectionFlashDuration.Read(exINI, GameStrings::AudioVisual, "SelectionFlashDuration");
 	this->DrawInsignia_OnlyOnSelected.Read(exINI, GameStrings::AudioVisual, "DrawInsignia.OnlyOnSelected");
@@ -520,6 +525,10 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->DisplayIncome)
 		.Process(this->DisplayIncome_AllowAI)
 		.Process(this->DisplayIncome_Houses)
+		.Process(this->DrainMoneyDisplay)
+		.Process(this->DrainMoneyDisplay_House)
+		.Process(this->DrainMoneyDisplay_AtFirer)
+		.Process(this->DrainMoneyDisplay_AtTarget)
 		.Process(this->CrateOnlyOnLand)
 		.Process(this->UnitCrateVehicleCap)
 		.Process(this->FreeMCV_CreditsThreshold)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -201,9 +201,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DisplayIncome_AllowAI.Read(exINI, GameStrings::AudioVisual, "DisplayIncome.AllowAI");
 
 	this->DrainMoneyDisplay.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay");
-	this->DrainMoneyDisplay_House.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.House");
-	this->DrainMoneyDisplay_AtFirer.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.AtFirer");
-	this->DrainMoneyDisplay_AtTarget.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.AtTarget");
+	this->DrainMoneyDisplay_Houses.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.Houses");
+	this->DrainMoneyDisplay_OnTarget.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.OnTarget");
+	this->DrainMoneyDisplay_OnTarget_UseDisplayIncome.Read(exINI, GameStrings::AudioVisual, "DrainMoneyDisplay.OnTarget.UseDisplayIncome");
 
 	this->IsVoiceCreatedGlobal.Read(exINI, GameStrings::AudioVisual, "IsVoiceCreatedGlobal");
 	this->SelectionFlashDuration.Read(exINI, GameStrings::AudioVisual, "SelectionFlashDuration");
@@ -526,9 +526,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->DisplayIncome_AllowAI)
 		.Process(this->DisplayIncome_Houses)
 		.Process(this->DrainMoneyDisplay)
-		.Process(this->DrainMoneyDisplay_House)
-		.Process(this->DrainMoneyDisplay_AtFirer)
-		.Process(this->DrainMoneyDisplay_AtTarget)
+		.Process(this->DrainMoneyDisplay_Houses)
+		.Process(this->DrainMoneyDisplay_OnTarget)
+		.Process(this->DrainMoneyDisplay_OnTarget_UseDisplayIncome)
 		.Process(this->CrateOnlyOnLand)
 		.Process(this->UnitCrateVehicleCap)
 		.Process(this->FreeMCV_CreditsThreshold)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -116,6 +116,11 @@ public:
 		Valueable<bool> DisplayIncome_AllowAI;
 		Valueable<AffectedHouse> DisplayIncome_Houses;
 
+		Valueable<bool> DrainMoneyDisplay;
+		Valueable<AffectedHouse> DrainMoneyDisplay_House;
+		Valueable<bool> DrainMoneyDisplay_AtFirer;
+		Valueable<bool> DrainMoneyDisplay_AtTarget;
+
 		Valueable<bool> AllowDeployControlledMCV;
 
 		Valueable<bool> TypeSelectUseIFVMode;
@@ -407,6 +412,10 @@ public:
 			, DisplayIncome { false }
 			, DisplayIncome_AllowAI { true }
 			, DisplayIncome_Houses { AffectedHouse::All }
+			, DrainMoneyDisplay { false }
+			, DrainMoneyDisplay_House { AffectedHouse::All }
+			, DrainMoneyDisplay_AtFirer { true }
+			, DrainMoneyDisplay_AtTarget { true }
 			, CrateOnlyOnLand { false }
 			, UnitCrateVehicleCap { 50 }
 			, FreeMCV_CreditsThreshold { 1500 }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -117,9 +117,9 @@ public:
 		Valueable<AffectedHouse> DisplayIncome_Houses;
 
 		Valueable<bool> DrainMoneyDisplay;
-		Valueable<AffectedHouse> DrainMoneyDisplay_House;
-		Valueable<bool> DrainMoneyDisplay_AtFirer;
-		Valueable<bool> DrainMoneyDisplay_AtTarget;
+		Valueable<AffectedHouse> DrainMoneyDisplay_Houses;
+		Valueable<bool> DrainMoneyDisplay_OnTarget;
+		Valueable<bool> DrainMoneyDisplay_OnTarget_UseDisplayIncome;
 
 		Valueable<bool> AllowDeployControlledMCV;
 
@@ -413,9 +413,9 @@ public:
 			, DisplayIncome_AllowAI { true }
 			, DisplayIncome_Houses { AffectedHouse::All }
 			, DrainMoneyDisplay { false }
-			, DrainMoneyDisplay_House { AffectedHouse::All }
-			, DrainMoneyDisplay_AtFirer { true }
-			, DrainMoneyDisplay_AtTarget { true }
+			, DrainMoneyDisplay_Houses { AffectedHouse::All }
+			, DrainMoneyDisplay_OnTarget { false }
+			, DrainMoneyDisplay_OnTarget_UseDisplayIncome { true }
 			, CrateOnlyOnLand { false }
 			, UnitCrateVehicleCap { 50 }
 			, FreeMCV_CreditsThreshold { 1500 }

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -908,6 +908,17 @@ DEFINE_HOOK(0x6FF29E, TechnoClass_FireAt_ChargeTurret2, 0x6)
 
 #pragma endregion
 
+DEFINE_HOOK(0x70FDF5, TechnoClass_DrawDrainAnimation_Custom, 0x6)
+{
+	enum { SkipGameCode = 0x70FDFB };
+
+	GET(TechnoClass*, pThis, ESI);
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+
+	R->EDX(pTypeExt->DrainAnimationType.Get(RulesClass::Instance->DrainAnimationType));
+	return SkipGameCode;
+}
+
 #pragma region TechnoClass_GetFLH
 
 namespace GetFLHTemp

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -913,7 +913,7 @@ DEFINE_HOOK(0x70FDF5, TechnoClass_DrawDrainAnimation_Custom, 0x6)
 	enum { SkipGameCode = 0x70FDFB };
 
 	GET(TechnoClass*, pThis, ESI);
-	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+	const auto pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
 
 	R->EDX(pTypeExt->DrainAnimationType.Get(RulesClass::Instance->DrainAnimationType));
 	return SkipGameCode;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -168,7 +168,7 @@ DEFINE_HOOK(0x6FA167, TechnoClass_AI_DrainMoney, 0x5)
 
 	GET(TechnoClass*, pThis, ESI);
 	const auto pSource = pThis->DrainingMe;
-	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pSource->GetTechnoType());
+	const auto pTypeExt = TechnoExt::ExtMap.Find(pSource)->TypeExtData;
 
 	if (Unsorted::CurrentFrame % pTypeExt->DrainMoneyFrameDelay.Get(RulesClass::Instance->DrainMoneyFrameDelay))
 		return SkipGameCode;
@@ -189,15 +189,15 @@ DEFINE_HOOK(0x6FA167, TechnoClass_AI_DrainMoney, 0x5)
 	pThis->Owner->TransactMoney(-amount);
 	pSource->Owner->TransactMoney(amount);
 
-	if (pTypeExt->DrainMoney_Display)
+	if (pTypeExt->DrainMoneyDisplay.Get(RulesExt::Global()->DrainMoneyDisplay))
 	{
-		const auto displayAt = pTypeExt->DrainMoney_Display_AtFirer ? pSource : pThis;
+		const auto displayTo = pTypeExt->DrainMoneyDisplay_House.Get(RulesExt::Global()->DrainMoneyDisplay_House);
 
-		if (displayAt->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
-		{
-			const int displayAmount = pTypeExt->DrainMoney_Display_AtFirer ? amount : -amount;
-			FlyingStrings::AddMoneyString(displayAmount, pSource, pSource->Owner, pTypeExt->DrainMoney_Display_House, displayAt->Location, pTypeExt->DrainMoney_Display_Offset);
-		}
+		if (pTypeExt->DrainMoneyDisplay_AtFirer.Get(RulesExt::Global()->DrainMoneyDisplay_AtFirer) && pSource->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
+			FlyingStrings::AddMoneyString(amount, pSource, pSource->Owner, displayTo, pSource->Location, pTypeExt->DrainMoneyDisplay_Offset);
+
+		if (pTypeExt->DrainMoneyDisplay_AtTarget.Get(RulesExt::Global()->DrainMoneyDisplay_AtTarget) && pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
+			FlyingStrings::AddMoneyString(-amount, pThis, pThis->Owner, displayTo, pThis->Location, pTypeExt->DrainMoneyDisplay_Offset);
 	}
 
 	return SkipGameCode;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -189,15 +189,27 @@ DEFINE_HOOK(0x6FA167, TechnoClass_AI_DrainMoney, 0x5)
 	pThis->Owner->TransactMoney(-amount);
 	pSource->Owner->TransactMoney(amount);
 
-	if (pTypeExt->DrainMoneyDisplay.Get(RulesExt::Global()->DrainMoneyDisplay))
+	if (pTypeExt->DrainMoneyDisplay.Get(RulesExt::Global()->DrainMoneyDisplay) && pSource->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
 	{
-		const auto displayTo = pTypeExt->DrainMoneyDisplay_House.Get(RulesExt::Global()->DrainMoneyDisplay_House);
+		const auto displayTo = pTypeExt->DrainMoneyDisplay_Houses.Get(RulesExt::Global()->DrainMoneyDisplay_Houses);
+		FlyingStrings::AddMoneyString(amount, pSource, pSource->Owner, displayTo, pSource->Location, pTypeExt->DrainMoneyDisplay_Offset);
+	}
 
-		if (pTypeExt->DrainMoneyDisplay_AtFirer.Get(RulesExt::Global()->DrainMoneyDisplay_AtFirer) && pSource->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
-			FlyingStrings::AddMoneyString(amount, pSource, pSource->Owner, displayTo, pSource->Location, pTypeExt->DrainMoneyDisplay_Offset);
-
-		if (pTypeExt->DrainMoneyDisplay_AtTarget.Get(RulesExt::Global()->DrainMoneyDisplay_AtTarget) && pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
-			FlyingStrings::AddMoneyString(-amount, pThis, pThis->Owner, displayTo, pThis->Location, pTypeExt->DrainMoneyDisplay_Offset);
+	if (pTypeExt->DrainMoneyDisplay_OnTarget.Get(RulesExt::Global()->DrainMoneyDisplay_OnTarget) && pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
+	{
+		if (!pTypeExt->DrainMoneyDisplay_OnTarget_UseDisplayIncome.Get(RulesExt::Global()->DrainMoneyDisplay_OnTarget_UseDisplayIncome))
+		{
+			const auto displayTo = pTypeExt->DrainMoneyDisplay_Houses.Get(RulesExt::Global()->DrainMoneyDisplay_Houses);
+			// use firer for owner check
+			FlyingStrings::AddMoneyString(-amount, pThis, pSource->Owner, displayTo, pThis->GetRenderCoords(), pTypeExt->DrainMoneyDisplay_Offset);
+		}
+		else if (const auto pBld = abstract_cast<BuildingClass*, true>(pThis))
+		{
+			const auto pBldTypeExt = BuildingTypeExt::ExtMap.Find(pBld->Type);
+			const auto displayTo = pBldTypeExt->DisplayIncome_Houses.Get(RulesExt::Global()->DisplayIncome_Houses);
+			// use target for owner check
+			FlyingStrings::AddMoneyString(-amount, pThis, pThis->Owner, displayTo, pThis->GetRenderCoords(), pBldTypeExt->DisplayIncome_Offset);
+		}
 	}
 
 	return SkipGameCode;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -194,7 +194,10 @@ DEFINE_HOOK(0x6FA167, TechnoClass_AI_DrainMoney, 0x5)
 		const auto displayAt = pTypeExt->DrainMoney_Display_AtFirer ? pSource : pThis;
 
 		if (displayAt->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
-			FlyingStrings::AddMoneyString(amount, pSource, pSource->Owner, pTypeExt->DrainMoney_Display_House, displayAt->Location, pTypeExt->DrainMoney_Display_Offset);
+		{
+			const int displayAmount = pTypeExt->DrainMoney_Display_AtFirer ? amount : -amount;
+			FlyingStrings::AddMoneyString(displayAmount, pSource, pSource->Owner, pTypeExt->DrainMoney_Display_House, displayAt->Location, pTypeExt->DrainMoney_Display_Offset);
+		}
 	}
 
 	return SkipGameCode;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -12,6 +12,7 @@
 #include <Utilities/Helpers.Alex.h>
 #include <Utilities/AresHelper.h>
 #include <Utilities/AresFunctions.h>
+#include <Misc/FlyingStrings.h>
 
 #pragma region GetTechnoType
 
@@ -158,6 +159,44 @@ DEFINE_HOOK(0x6FA07A, TechnoClass_AI_PromoteAnim, 0x5)
 
 	// Restore overridden instructions.
 	R->EAX(pVet->GetRemainingLevel());
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x6FA167, TechnoClass_AI_DrainMoney, 0x5)
+{
+	enum { SkipGameCode = 0x6FA1C5 };
+
+	GET(TechnoClass*, pThis, ESI);
+	const auto pSource = pThis->DrainingMe;
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pSource->GetTechnoType());
+
+	if (Unsorted::CurrentFrame % pTypeExt->DrainMoneyFrameDelay.Get(RulesClass::Instance->DrainMoneyFrameDelay))
+		return SkipGameCode;
+
+	int amount = pTypeExt->DrainMoneyAmount.Get(RulesClass::Instance->DrainMoneyAmount);
+
+	if (!amount)
+		return SkipGameCode;
+
+	if (amount > 0)
+		amount = Math::min(amount, pThis->Owner->Available_Money());
+	else
+		amount = Math::max(amount, -pSource->Owner->Available_Money());
+
+	if (!amount)
+		return SkipGameCode;
+
+	pThis->Owner->TransactMoney(-amount);
+	pSource->Owner->TransactMoney(amount);
+
+	if (pTypeExt->DrainMoney_Display)
+	{
+		const auto displayAt = pTypeExt->DrainMoney_Display_AtFirer ? pSource : pThis;
+
+		if (displayAt->IsClearlyVisibleTo(HouseClass::CurrentPlayer))
+			FlyingStrings::AddMoneyString(amount, pSource, pSource->Owner, pTypeExt->DrainMoney_Display_House, displayAt->Location, pTypeExt->DrainMoney_Display_Offset);
+	}
+
 	return SkipGameCode;
 }
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1142,10 +1142,10 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DrainMoneyAmount.Read(exINI, pSection, "DrainMoneyAmount");
 	this->DrainAnimationType.Read(exINI, pSection, "DrainAnimationType");
 	this->DrainMoneyDisplay.Read(exINI, pSection, "DrainMoneyDisplay");
-	this->DrainMoneyDisplay_House.Read(exINI, pSection, "DrainMoneyDisplay.House");
-	this->DrainMoneyDisplay_AtFirer.Read(exINI, pSection, "DrainMoneyDisplay.AtFirer");
-	this->DrainMoneyDisplay_AtTarget.Read(exINI, pSection, "DrainMoneyDisplay.AtTarget");
+	this->DrainMoneyDisplay_Houses.Read(exINI, pSection, "DrainMoneyDisplay.Houses");
 	this->DrainMoneyDisplay_Offset.Read(exINI, pSection, "DrainMoneyDisplay.Offset");
+	this->DrainMoneyDisplay_OnTarget.Read(exINI, pSection, "DrainMoneyDisplay.OnTarget");
+	this->DrainMoneyDisplay_OnTarget_UseDisplayIncome.Read(exINI, pSection, "DrainMoneyDisplay.OnTarget.UseDisplayIncome");
 	
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1841,10 +1841,10 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DrainMoneyAmount)
 		.Process(this->DrainAnimationType)
 		.Process(this->DrainMoneyDisplay)
-		.Process(this->DrainMoneyDisplay_House)
-		.Process(this->DrainMoneyDisplay_AtFirer)
-		.Process(this->DrainMoneyDisplay_AtTarget)
+		.Process(this->DrainMoneyDisplay_Houses)
 		.Process(this->DrainMoneyDisplay_Offset)
+		.Process(this->DrainMoneyDisplay_OnTarget)
+		.Process(this->DrainMoneyDisplay_OnTarget_UseDisplayIncome)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1141,10 +1141,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DrainMoneyFrameDelay.Read(exINI, pSection, "DrainMoneyFrameDelay");
 	this->DrainMoneyAmount.Read(exINI, pSection, "DrainMoneyAmount");
 	this->DrainAnimationType.Read(exINI, pSection, "DrainAnimationType");
-	this->DrainMoney_Display.Read(exINI, pSection, "DrainMoney.Display");
-	this->DrainMoney_Display_House.Read(exINI, pSection, "DrainMoney.Display.House");
-	this->DrainMoney_Display_AtFirer.Read(exINI, pSection, "DrainMoney.Display.AtFirer");
-	this->DrainMoney_Display_Offset.Read(exINI, pSection, "DrainMoney.Display.Offset");
+	this->DrainMoneyDisplay.Read(exINI, pSection, "DrainMoneyDisplay");
+	this->DrainMoneyDisplay_House.Read(exINI, pSection, "DrainMoneyDisplay.House");
+	this->DrainMoneyDisplay_AtFirer.Read(exINI, pSection, "DrainMoneyDisplay.AtFirer");
+	this->DrainMoneyDisplay_AtTarget.Read(exINI, pSection, "DrainMoneyDisplay.AtTarget");
+	this->DrainMoneyDisplay_Offset.Read(exINI, pSection, "DrainMoneyDisplay.Offset");
 	
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1839,10 +1840,11 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DrainMoneyFrameDelay)
 		.Process(this->DrainMoneyAmount)
 		.Process(this->DrainAnimationType)
-		.Process(this->DrainMoney_Display)
-		.Process(this->DrainMoney_Display_House)
-		.Process(this->DrainMoney_Display_AtFirer)
-		.Process(this->DrainMoney_Display_Offset)
+		.Process(this->DrainMoneyDisplay)
+		.Process(this->DrainMoneyDisplay_House)
+		.Process(this->DrainMoneyDisplay_AtFirer)
+		.Process(this->DrainMoneyDisplay_AtTarget)
+		.Process(this->DrainMoneyDisplay_Offset)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1137,6 +1137,14 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->InfantryAutoDeploy.Read(exINI, pSection, "InfantryAutoDeploy");
 
 	this->TeamMember_ConsideredAs.Read(exINI, pSection, "TeamMember.ConsideredAs");
+
+	this->DrainMoneyFrameDelay.Read(exINI, pSection, "DrainMoneyFrameDelay");
+	this->DrainMoneyAmount.Read(exINI, pSection, "DrainMoneyAmount");
+	this->DrainAnimationType.Read(exINI, pSection, "DrainAnimationType");
+	this->DrainMoney_Display.Read(exINI, pSection, "DrainMoney.Display");
+	this->DrainMoney_Display_House.Read(exINI, pSection, "DrainMoney.Display.House");
+	this->DrainMoney_Display_AtFirer.Read(exINI, pSection, "DrainMoney.Display.AtFirer");
+	this->DrainMoney_Display_Offset.Read(exINI, pSection, "DrainMoney.Display.Offset");
 	
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1827,6 +1835,14 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Deploy_SkipPassengerUnload)
 		.Process(this->Deploy_NoPassenger)
 		.Process(this->Deploy_NoTiberium)
+		
+		.Process(this->DrainMoneyFrameDelay)
+		.Process(this->DrainMoneyAmount)
+		.Process(this->DrainAnimationType)
+		.Process(this->DrainMoney_Display)
+		.Process(this->DrainMoney_Display_House)
+		.Process(this->DrainMoney_Display_AtFirer)
+		.Process(this->DrainMoney_Display_Offset)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -466,10 +466,11 @@ public:
 		Nullable<int> DrainMoneyFrameDelay;
 		Nullable<int> DrainMoneyAmount;
 		Nullable<AnimTypeClass*> DrainAnimationType;
-		Valueable<bool> DrainMoney_Display;
-		Valueable<AffectedHouse> DrainMoney_Display_House;
-		Valueable<bool> DrainMoney_Display_AtFirer;
-		Valueable<Point2D> DrainMoney_Display_Offset;
+		Nullable<bool> DrainMoneyDisplay;
+		Nullable<AffectedHouse> DrainMoneyDisplay_House;
+		Nullable<bool> DrainMoneyDisplay_AtFirer;
+		Nullable<bool> DrainMoneyDisplay_AtTarget;
+		Valueable<Point2D> DrainMoneyDisplay_Offset;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -891,10 +892,11 @@ public:
 			, DrainMoneyFrameDelay {}
 			, DrainMoneyAmount {}
 			, DrainAnimationType {}
-			, DrainMoney_Display { false }
-			, DrainMoney_Display_House { AffectedHouse::All }
-			, DrainMoney_Display_AtFirer { true }
-			, DrainMoney_Display_Offset { Point2D::Empty }
+			, DrainMoneyDisplay {}
+			, DrainMoneyDisplay_House {}
+			, DrainMoneyDisplay_AtFirer {}
+			, DrainMoneyDisplay_AtTarget {}
+			, DrainMoneyDisplay_Offset { Point2D::Empty }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -467,10 +467,10 @@ public:
 		Nullable<int> DrainMoneyAmount;
 		Nullable<AnimTypeClass*> DrainAnimationType;
 		Nullable<bool> DrainMoneyDisplay;
-		Nullable<AffectedHouse> DrainMoneyDisplay_House;
-		Nullable<bool> DrainMoneyDisplay_AtFirer;
-		Nullable<bool> DrainMoneyDisplay_AtTarget;
+		Nullable<AffectedHouse> DrainMoneyDisplay_Houses;
 		Valueable<Point2D> DrainMoneyDisplay_Offset;
+		Nullable<bool> DrainMoneyDisplay_OnTarget;
+		Nullable<bool> DrainMoneyDisplay_OnTarget_UseDisplayIncome;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -893,10 +893,10 @@ public:
 			, DrainMoneyAmount {}
 			, DrainAnimationType {}
 			, DrainMoneyDisplay {}
-			, DrainMoneyDisplay_House {}
-			, DrainMoneyDisplay_AtFirer {}
-			, DrainMoneyDisplay_AtTarget {}
+			, DrainMoneyDisplay_Houses {}
 			, DrainMoneyDisplay_Offset { Point2D::Empty }
+			, DrainMoneyDisplay_OnTarget {}
+			, DrainMoneyDisplay_OnTarget_UseDisplayIncome {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -463,6 +463,14 @@ public:
 		Valueable<bool> Deploy_NoPassenger;
 		Valueable<bool> Deploy_NoTiberium;
 
+		Nullable<int> DrainMoneyFrameDelay;
+		Nullable<int> DrainMoneyAmount;
+		Nullable<AnimTypeClass*> DrainAnimationType;
+		Valueable<bool> DrainMoney_Display;
+		Valueable<AffectedHouse> DrainMoney_Display_House;
+		Valueable<bool> DrainMoney_Display_AtFirer;
+		Valueable<Point2D> DrainMoney_Display_Offset;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, HealthBar_HidePips { false }
@@ -879,6 +887,14 @@ public:
 			, Deploy_SkipPassengerUnload { false }
 			, Deploy_NoPassenger { false }
 			, Deploy_NoTiberium { false }
+
+			, DrainMoneyFrameDelay {}
+			, DrainMoneyAmount {}
+			, DrainAnimationType {}
+			, DrainMoney_Display { false }
+			, DrainMoney_Display_House { AffectedHouse::All }
+			, DrainMoney_Display_AtFirer { true }
+			, DrainMoney_Display_Offset { Point2D::Empty }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- It is possible to set properties of drain logic per technotypes.
  - `DrainMoneyDisplay` and `DrainMoneyDisplay.OnTarget` determine whether drain money will be displayed at firer and target respectively.
  - `DrainMoneyDisplay.Houses` determines which houses can see the credits display on firer.
  - `DrainMoneyDisplay.Offset` is additional pixel offset for the center of the credits display, by default `0,0` at firer's center.
  - `DrainMoneyDisplay.OnTarget.UseDisplayIncome` determines whether drain money display on target will use its `DisplayIncome.Houses` and `DisplayIncome.Offset` settings. If set to false, it'll respect the firer's `DrainMoneyDisplay.Houses` and `DrainMoneyDisplay.Offset` settings instead.

In `rulesmd.ini`:
```ini
[AudioVisual]
DrainMoneyDisplay=false                             ; boolean
DrainMoneyDisplay.Houses=all                        ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
DrainMoneyDisplay.OnTarget=false                    ; boolean
DrainMoneyDisplay.OnTarget.UseDisplayIncome=true    ; boolean

[SOMETECHNO]                                        ; TechnoType
DrainMoneyFrameDelay=                               ; integer, default to [CombatDamage] -> DrainMoneyFrameDelay
DrainMoneyAmount=                                   ; integer, default to [CombatDamage] -> DrainMoneyAmount
DrainAnimationType=                                 ; AnimationType, default to [CombatDamage] -> DrainAnimationType
DrainMoneyDisplay=                                  ; boolean, default to [AudioVisual] -> DrainMoneyDisplay
DrainMoneyDisplay.Houses=                           ; List of Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all), default to [AudioVisual] -> DrainMoneyDisplay.Houses
DrainMoneyDisplay.Offset=0,0                        ; X,Y, pixels relative to default
DrainMoneyDisplay.OnTarget=                         ; boolean, default to [AudioVisual] -> DrainMoneyDisplay.OnTarget
DrainMoneyDisplay.OnTarget.UseDisplayIncome=       ; boolean
```