### PR TITLE
Add amount limit of `LimboKill`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -490,6 +490,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon
   - Fix the bug that building with `Explodes=yes` use Ares's rubble logic will cause it's owner cannot defeat normally
   - Customizable disk drain logic
+  - Add amount limit of `LimboKill`
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1182,6 +1182,7 @@ LimboDelivery.RollChances=      ; List of percentages.
 LimboDelivery.RandomWeightsN=   ; List of integers.
 LimboKill.AffectsHouse=self     ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
 LimboKill.IDs=                  ; List of numeric IDs.
+LimboKill.Counts=               ; List of counts
 ```
 
 ```{warning}

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1156,6 +1156,7 @@ EMPulse.SuspendOthers=false  ; boolean
 - Created buildings are not affected by any on-map threats. The only way to remove them from the game is by using a Superweapon with `LimboKill.IDs` set.
   - `LimboKill.AffectsHouse` sets which houses are affected by this feature.
   - `LimboKill.IDs` lists IDs that will be targeted. Buildings with these IDs will be removed from the game instantly.
+  - `LimboKill.Counts` sets how many buildings of each type will be removed. Value from position matching the position from `LimboKill.IDs` is used if found, or no limitation if not found. If list is empty, there's no limitation for all types.
 
 - Delivery can be made random with these optional tags. The game will randomly choose only a single building from the list for each roll chance provided.
   - `LimboDelivery.RollChances` lists chances of each "dice roll" happening. Valid values range from 0% (never happens) to 100% (always happens). Defaults to a single sure roll.
@@ -1177,12 +1178,12 @@ In `rulesmd.ini`:
 ```ini
 [SOMESW]                        ; SuperWeaponType
 LimboDelivery.Types=            ; List of BuildingTypes
-LimboDelivery.IDs=              ; List of numeric IDs. -1 cannot be used.
-LimboDelivery.RollChances=      ; List of percentages.
-LimboDelivery.RandomWeightsN=   ; List of integers.
+LimboDelivery.IDs=              ; List of numeric IDs, -1 cannot be used
+LimboDelivery.RollChances=      ; List of percentages
+LimboDelivery.RandomWeightsN=   ; List of integers
 LimboKill.AffectsHouse=self     ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)
-LimboKill.IDs=                  ; List of numeric IDs.
-LimboKill.Counts=               ; List of counts
+LimboKill.IDs=                  ; List of numeric IDs
+LimboKill.Counts=               ; List of integers
 ```
 
 ```{warning}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -533,6 +533,7 @@ New:
 - Customizable disk drain logic (by NetsuNegi)
 - [Customizable paradropped unit missions](Fixed-or-Improved-Logics.md#customizable-paradrop-missions) (by Starkku)
 - Option to scale `PowerSurplus` setting if enabled to current power drain with `PowerSurplus.ScaleToDrainAmount` (by Starkku)
+- Added amount limit of `LimboKill` (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -55,6 +55,7 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->LimboDelivery_RollChances)
 		.Process(this->LimboKill_AffectsHouse)
 		.Process(this->LimboKill_IDs)
+		.Process(this->LimboKill_Counts)
 		.Process(this->RandomBuffer)
 		.Process(this->Detonate_Warhead)
 		.Process(this->Detonate_Weapon)
@@ -143,6 +144,7 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->LimboDelivery_RollChances.Read(exINI, pSection, "LimboDelivery.RollChances");
 	this->LimboKill_AffectsHouse.Read(exINI, pSection, "LimboKill.AffectsHouse");
 	this->LimboKill_IDs.Read(exINI, pSection, "LimboKill.IDs");
+	this->LimboKill_Counts.Read(exINI, pSection, "LimboKill.Counts");
 	this->SW_Next.Read(exINI, pSection, "SW.Next");
 	this->SW_Next_RealLaunch.Read(exINI, pSection, "SW.Next.RealLaunch");
 	this->SW_Next_IgnoreInhibitors.Read(exINI, pSection, "SW.Next.IgnoreInhibitors");

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -56,6 +56,7 @@ public:
 		ValueableVector<float> LimboDelivery_RollChances;
 		Valueable<AffectedHouse> LimboKill_AffectsHouse;
 		ValueableVector<int> LimboKill_IDs;
+		ValueableVector<int> LimboKill_Counts;
 		Valueable<double> RandomBuffer;
 		ValueableIdxVector<SuperWeaponTypeClass> SW_Next;
 		Valueable<bool> SW_Next_RealLaunch;
@@ -143,6 +144,7 @@ public:
 			, LimboDelivery_RandomWeightsData {}
 			, LimboKill_AffectsHouse { AffectedHouse::Owner }
 			, LimboKill_IDs {}
+			, LimboKill_Counts {}
 			, RandomBuffer { 0.0 }
 			, Detonate_Warhead {}
 			, Detonate_Weapon {}

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -4,6 +4,9 @@
 #include <Ext/WarheadType/Body.h>
 #include <Ext/WeaponType/Body.h>
 #include <Ext/Scenario/Body.h>
+#include <Utilities/Helpers.Alex.h>
+
+#include <unordered_set>
 
 // ============= New SuperWeapon Effects================
 
@@ -193,41 +196,61 @@ void SWTypeExt::ExtData::ApplyLimboDelivery(HouseClass* pHouse)
 
 void SWTypeExt::ExtData::ApplyLimboKill(HouseClass* pHouse)
 {
-	for (int limboKillID : this->LimboKill_IDs)
+	const int idAmount = static_cast<int>(this->LimboKill_IDs.size());
+
+	if (!idAmount)
+		return;
+
+	std::vector<BuildingClass*> limboKills;
+
+	for (const auto pTargetHouse : HouseClass::Array)
 	{
-		for (HouseClass* pTargetHouse : HouseClass::Array)
+		if (!EnumFunctions::CanTargetHouse(this->LimboKill_AffectsHouse, pHouse, pTargetHouse))
+			continue;
+
+		const auto pHouseExt = HouseExt::ExtMap.Find(pTargetHouse);
+		auto& buildings = pHouseExt->OwnedLimboDeliveredBuildings;
+
+		if (buildings.empty())
+			continue;
+
+		std::unordered_set<int> removedID;
+		std::unordered_set<BuildingClass*> removes;
+
+		for (int idx = 0; idx < idAmount; ++idx)
 		{
-			if (EnumFunctions::CanTargetHouse(this->LimboKill_AffectsHouse, pHouse, pTargetHouse))
-			{
-				auto const pHouseExt = HouseExt::ExtMap.Find(pTargetHouse);
-				auto& vec = pHouseExt->OwnedLimboDeliveredBuildings;
+			const int id = this->LimboKill_IDs[idx];
 
-				for (auto it = vec.begin(); it != vec.end(); )
-				{
-					BuildingClass* const pBuilding = *it;
-					auto const pBuildingExt = BuildingExt::ExtMap.Find(pBuilding);
+			if (removedID.contains(id))
+				continue;
 
-					if (pBuildingExt->LimboID == limboKillID)
-					{
-						it = vec.erase(it);
-						auto const pBldType = pBuilding->Type;
+			const int maxCount = idx < static_cast<int>(this->LimboKill_Counts.size()) ? this->LimboKill_Counts[idx] : std::numeric_limits<int>::max();
+			auto IsEligible = [id](BuildingClass* pBuilding) { return BuildingExt::ExtMap.Find(pBuilding)->LimboID == id; };
 
-						// Remove limbo buildings' tracking here because their are not truely InLimbo
-						if (!pBldType->Insignificant && !pBldType->DontScore)
-							HouseExt::ExtMap.Find(pBuilding->Owner)->RemoveFromLimboTracking(pBldType);
+			Helpers::Alex::for_each_if_n(buildings.begin(), buildings.end(), maxCount, IsEligible, [&limboKills, &removes](BuildingClass* pBuilding) {
+				limboKills.emplace_back(pBuilding);
+				removes.emplace(pBuilding);
+			});
 
-						pBuilding->Stun();
-						pBuilding->Limbo();
-						pBuilding->RegisterDestruction(nullptr);
-						pBuilding->UnInit();
-					}
-					else
-					{
-						++it;
-					}
-				}
-			}
+			removedID.emplace(id);
 		}
+
+		if (!buildings.empty())
+			std::erase_if(buildings, [&removes](BuildingClass* pBuilding) { return removes.contains(pBuilding); });
+	}
+
+	for (const auto pBuilding : limboKills)
+	{
+		const auto pBuildingType = pBuilding->Type;
+
+		// Remove limbo buildings' tracking here because their are not truely InLimbo
+		if (!pBuildingType->Insignificant && !pBuildingType->DontScore)
+			HouseExt::ExtMap.Find(pBuilding->Owner)->RemoveFromLimboTracking(pBuildingType);
+
+		pBuilding->Stun();
+		pBuilding->Limbo();
+		pBuilding->RegisterDestruction(nullptr);
+		pBuilding->UnInit();
 	}
 }
 


### PR DESCRIPTION
`LimboKill.Counts` sets how many buildings of each type will be removed. Value from position matching the position from `LimboKill.IDs` is used if found, or no limitation if not found. If list is empty, there's no limitation for all types.

In `rulesmd.ini`:
```ini
[SOMESW]                        ; SuperWeaponType
LimboKill.Counts=               ; List of counts
```