### PR TITLE
Extended auto-targeting

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -749,6 +749,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow replacing vanilla repairing with togglable auto repairing
   - Fix an issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions
   - Framework for dynamic sight
+  - Extended auto-targeting
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1727,6 +1727,20 @@ RateDown.Cover.Value=0        ; integer
 RateDown.Cover.AmmoBelow=-2   ; integer
 ```
 
+### Extended auto-targeting
+
+- Now you can activate multiple auto-targeting optimizations by setting `ExtendedAutoTargeting=true`. These include:
+  - When using stop, guard, or mouse commands, refresh the auto-targeting cooldown.
+  - When the target becomes invalid, refresh the auto-targeting cooldown (In vanilla, this cooldown will be reduced to less than 10 frames).
+  - When a unit is on a task that allows auto-targeting but already has a target, it will still auto-target. If a target with a threat level higher than the original target by more than `ExtendedAutoTargeting.SwitchTargetThreshold` is found, switch the target.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ExtendedAutoTargeting=false                        ; boolean
+ExtendedAutoTargeting.SwitchTargetThreshold=1000   ; integer
+```
+
 ### Extra threat
 
 - Now you can adjust the techno's evaluation of the threat posed by the target in more ways. This will help the techno in auto - targeting.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -573,6 +573,7 @@ New:
 - [Allow replacing vanilla repairing with togglable auto repairing](User-Interface.md#allow-replacing-vanilla-repairing-with-togglable-auto-repairing) (by TaranDahl)
 - Use `OpenTopped.AllowFiringIfAttackedByLocomotor` to control whether the passengers of a non-building transport unit can fire when the unit is being attacked by a weapon whose warhead has `IsLocomotor=true` (by Noble_Fish)
 - Framework for dynamic sight (by TaranDahl)
+- [Extended auto-targeting](New-or-Enhanced-Logics.md#extended-auto-targeting) (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -1,4 +1,4 @@
-#include "Body.h"
+﻿#include "Body.h"
 
 #include <Ext/TechnoType/Body.h>
 #include <New/Type/RadTypeClass.h>
@@ -396,6 +396,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	
 	this->FiringAnim_Update.Read(exINI, GameStrings::AudioVisual, "FiringAnim.Update");
 	this->ExtendedPlayerRepair.Read(exINI, GameStrings::General, "ExtendedPlayerRepair");
+	this->ExtendedAutoTargeting.Read(exINI, GameStrings::General, "ExtendedAutoTargeting");
+	this->ExtendedAutoTargeting_SwitchTargetThreshold.Read(exINI, GameStrings::General, "ExtendedAutoTargeting.SwitchTargetThreshold");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -720,6 +722,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ShipLocomotorMakesWake)
 		.Process(this->FiringAnim_Update)
 		.Process(this->ExtendedPlayerRepair)
+		.Process(this->ExtendedAutoTargeting)
+		.Process(this->ExtendedAutoTargeting_SwitchTargetThreshold)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -325,6 +325,8 @@ public:
 		Valueable<bool> DefaultToGuardArea;
 
 		Valueable<bool> DisableOveroptimizationInTargeting;
+		Valueable<bool> ExtendedAutoTargeting;
+		Valueable<int> ExtendedAutoTargeting_SwitchTargetThreshold;
     
 		Valueable<bool> CylinderRangefinding;
 
@@ -631,6 +633,8 @@ public:
 			, ShipLocomotorMakesWake { true }
 			, FiringAnim_Update { false }
 			, ExtendedPlayerRepair { false }
+			, ExtendedAutoTargeting { false }
+			, ExtendedAutoTargeting_SwitchTargetThreshold { 1000 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Targeting.cpp
+++ b/src/Ext/Techno/Hooks.Targeting.cpp
@@ -75,3 +75,255 @@ DEFINE_HOOK(0x6F9AF4, TechnoClass_SelectAutoTarget_DisableStupid, 0x6)
 {
 	return RulesExt::Global()->DisableOveroptimizationInTargeting ? 0x6F9B1B : 0;
 }
+
+#pragma region ExtendedAutoTargeting
+
+namespace ExtendedAutoTargetingContext
+{
+	AbstractClass* OldTarget = nullptr;
+	int OldThreat = -1;
+
+	AbstractClass* NewTarget = nullptr;
+	int NewThreat = -1;
+
+	void Clear()
+	{
+		OldTarget = nullptr;
+		OldThreat = -1;
+		NewTarget = nullptr;
+		NewThreat = -1;
+	}
+}
+
+// Record old target
+DEFINE_HOOK(0x6FA6C9, TechnoClass_Update_RecordOldTarget, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(TechnoClass*, pThis, ESI);
+
+	auto pOldTarget = pThis->Target;
+
+	if (pOldTarget && (pOldTarget->AbstractFlags & AbstractFlags::Techno) != AbstractFlags::None && pThis->IsCloseEnoughToAttack(pOldTarget) && pThis->ShouldLoseTargetNow) // OpportunityFire, in-range only
+	{
+		auto crd = pThis->GetCoords();
+		ExtendedAutoTargetingContext::OldTarget = pOldTarget;
+		ExtendedAutoTargetingContext::OldThreat = (int)pThis->ThreatCoeffients(static_cast<ObjectClass*>(pOldTarget), &crd);
+		pThis->Target = 0;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x4DF3A0, TechnoClass_UpdateAttackMove_RecordOldTarget1, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(FootClass*, pThis, ECX);
+
+	auto pOldTarget = pThis->Target;
+
+	if (pOldTarget && (pOldTarget->AbstractFlags & AbstractFlags::Techno) != AbstractFlags::None && pThis->InAuxiliarySearchRange(pOldTarget)) // AttackMove has its own range checking
+	{
+		auto crd = pThis->GetCoords();
+		ExtendedAutoTargetingContext::OldTarget = pOldTarget;
+		ExtendedAutoTargetingContext::OldThreat = (int)pThis->ThreatCoeffients(static_cast<ObjectClass*>(pOldTarget), &crd);
+		pThis->Target = 0;
+		pThis->HaveAttackMoveTarget = false;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x4DF42A, TechnoClass_UpdateAttackMove_SkipCheck, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	enum { SkipCheck = 0x4DF462, FuncEnd = 0x4DF4AB };
+
+	GET(FootClass*, pThis, ESI);
+
+	return pThis->MegaTarget ? SkipCheck : FuncEnd;
+}
+
+DEFINE_HOOK(0x4D6ED1, TechnoClass_MissionAreaGuard_RecordOldTarget, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(TechnoClass*, pThis, ESI);
+
+	auto pOldTarget = pThis->Target;
+
+	if (pOldTarget && (pOldTarget->AbstractFlags & AbstractFlags::Techno) != AbstractFlags::None && pThis->CanPassiveAcquireTargets() && pThis->TargetingTimerFinished() && pThis->DistanceFrom(pOldTarget) <= pThis->GetGuardRange(1)) // AreaGuard, use GetGuardRange
+	{
+		auto crd = pThis->ArchiveTarget->GetCoords();
+		ExtendedAutoTargetingContext::OldTarget = pOldTarget;
+		ExtendedAutoTargetingContext::OldThreat = (int)pThis->ThreatCoeffients(static_cast<ObjectClass*>(pOldTarget), &crd);
+		pThis->Target = 0;
+	}
+
+	return 0;
+}
+
+// Use old target when targeting
+DEFINE_HOOK(0x6F8E1F, TechnoClass_SelectAutoTarget_UseContext, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	R->Stack(STACK_OFFSET(0x6C, -0x4C), ExtendedAutoTargetingContext::OldTarget);
+	R->Stack(STACK_OFFSET(0x6C, -0x50), ExtendedAutoTargetingContext::OldThreat);
+	return 0;
+}
+
+// Record new target
+DEFINE_HOOK(0x6F936F, TechnoClass_SelectAutoTarget_RecordNew1, 0x8)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(AbstractClass*, pBestTarget, EBP);
+	GET(int, bestThreat, EAX);
+
+	if (ExtendedAutoTargetingContext::OldTarget)
+	{
+		ExtendedAutoTargetingContext::NewTarget = pBestTarget;
+		ExtendedAutoTargetingContext::NewThreat = bestThreat;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x6F955B, TechnoClass_SelectAutoTarget_RecordNew2, 0x8)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(AbstractClass*, pBestTarget, EDX);
+	GET(int, bestThreat, EAX);
+
+	if (ExtendedAutoTargetingContext::OldTarget)
+	{
+		ExtendedAutoTargetingContext::NewTarget = pBestTarget;
+		ExtendedAutoTargetingContext::NewThreat = bestThreat;
+	}
+
+	return 0;
+}
+
+// Check if new target has enough threat
+DEFINE_HOOK(0x709938, TechnoClass_TargetAndEstimateDamage_CheckContext, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(TechnoClass*, pThis, ESI);
+
+	if (ExtendedAutoTargetingContext::OldTarget && ExtendedAutoTargetingContext::NewTarget && ExtendedAutoTargetingContext::OldTarget != ExtendedAutoTargetingContext::NewTarget)
+	{
+		auto crd = pThis->GetCoords();
+		//if (ExtendedAutoTargetingContext::NewThreat < ExtendedAutoTargetingContext::OldThreat + RulesExt::Global()->ExtendedAutoTargeting_SwitchTargetThreshold)
+		if (pThis->ThreatCoeffients(static_cast<ObjectClass*>(ExtendedAutoTargetingContext::NewTarget), &crd) < ExtendedAutoTargetingContext::OldThreat + RulesExt::Global()->ExtendedAutoTargeting_SwitchTargetThreshold)
+			R->EAX(ExtendedAutoTargetingContext::OldTarget);
+	}
+
+	return 0;
+}
+
+// Reset context
+DEFINE_HOOK_AGAIN(0x6FA6F5, ExtendedAutoTargetingContext_Clear, 0x5); // Update
+DEFINE_HOOK_AGAIN(0x4DF4AB, ExtendedAutoTargetingContext_Clear, 0x5); // UpdateAttackMove
+DEFINE_HOOK(0x4DF41E, ExtendedAutoTargetingContext_Clear, 0x7) // UpdateAttackMove
+{
+	ExtendedAutoTargetingContext::Clear();
+	return 0;
+}
+
+DEFINE_HOOK(0x6FA6E6, TechnoClass_Update_SetIsOpportunityTarget, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(TechnoClass*, pThis, ESI);
+
+	// This field indicate that the target is acquired by OpportunityFire, thus should be cleared if out of range.
+	// Must set it manually because the SetTarget in TargetAndEstimateDamage will reset it.
+	if (pThis->Target == ExtendedAutoTargetingContext::OldTarget)
+		pThis->ShouldLoseTargetNow = true;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x4D6F0C, FootClass_MissionAreaGuard_AfterTargeting, 0x6) // AreaGuard
+{
+	GET(FootClass*, pThis, ESI);
+
+	if (pThis->Target)
+		pThis->ApproachTarget(0);
+
+	ExtendedAutoTargetingContext::Clear();
+	return 0;
+}
+
+// Stop command
+DEFINE_HOOK(0x4C757D, EventClass_RespondToEvent_IDLE_ClearTargetingTimer, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(TechnoClass*, pThis, ESI);
+	pThis->TargetingTimer.Start(0);
+	return 0;
+}
+
+// Clicked mission
+DEFINE_HOOK(0x4C72E8, EventClass_RespondToEvent_MegaMission_ClearTargetingTimer, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(TechnoClass*, pThis, EDI);
+	pThis->TargetingTimer.Start(0);
+	return 0;
+}
+
+// Target expired.
+DEFINE_HOOK(0x7079D1, TechnoClass_PointerExpired_ClearTargetingTimer, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	GET(TechnoClass*, pThis, ESI);
+	pThis->TargetingTimer.Start(0);
+
+	if (pThis->MegaMissionIsAttackMove())
+		pThis->UpdateTimer.Start(0);
+
+	return 0;
+}
+
+// ContinueMegaMission
+DEFINE_HOOK(0x4DF320, FootClass_ContinueMegaMission_Start, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedAutoTargeting)
+		return 0;
+
+	enum { RETN = 0x4DF395 };
+
+	GET(FootClass*, pThis, ECX);
+
+	if (!pThis->Target)
+	{
+		pThis->HaveAttackMoveTarget = 0;
+		pThis->HaveAttackMoveTarget = pThis->TargetAndEstimateDamage(pThis->Location, ThreatType::Range);
+		return pThis->HaveAttackMoveTarget ? RETN : 0;
+	}
+
+	return 0;
+}
+
+#pragma endregion


### PR DESCRIPTION
### Extended auto-targeting

- Now you can activate multiple auto-targeting optimizations by setting `ExtendedAutoTargeting=true`. These include:
  - When using stop, guard, or mouse commands, refresh the auto-targeting cooldown.
  - When the target becomes invalid, refresh the auto-targeting cooldown (In vanilla, this cooldown will be reduced to less than 10 frames).
  - When a unit is on a task that allows auto-targeting but already has a target, it will still auto-target. If a target with a threat level higher than the original target by more than `ExtendedAutoTargeting.SwitchTargetThreshold` is found, switch the target.

In `rulesmd.ini`:
```ini
[General]
ExtendedAutoTargeting=false                        ; boolean
ExtendedAutoTargeting.SwitchTargetThreshold=1000   ; integer
```