### PR TITLE
Group retaliate

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -692,6 +692,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue where units recruited by a team with `AreTeamMembersRecruitable=false` cannot be recruited even if they have been liberated by that team
   - Global default value for `DefaultToGuardArea`
   - Weapon range finding in cylinder
+  - Group retaliate
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1766,7 +1766,7 @@ InitialSpawnsNumber=      ; integer
 
 In `rulesmd.ini`:
 ```ini
-[General]
+[CombatDamage]
 GroupRetaliate.AllowAI=false             ; boolean
 GroupRetaliate.AllowPlayer=false         ; boolean
 GroupRetaliate.ThreatThreshold=1000.0    ; float, range in cell

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1745,12 +1745,41 @@ Note that this logic is used for [Passenger](https://modenc.renegadeprojects.com
 ```
 
 ### Initial spawns number
+
 - It is now possible to set the initial amount of spawnees for a spawner, instead of always being filled. Won't work if it's larger than `SpawnsNumber`.
 
 In `rulesmd.ini`:
 ```ini
 [SOMETECHNO]              ; TechnoType
 InitialSpawnsNumber=      ; integer
+```
+
+### Group retaliate
+
+- In vanilla, only the unit itself will counter - attack when it takes damage. This often makes units stupidly lured away one by one and eliminated.
+- Now you can make units "seek support from nearby friendly units" when they take damage. They will retaliate the attacker together with the victim.
+  - `GroupRetaliate.AllowAI` and `GroupRetaliate.AllowPlayer` control whether this effect applies to AI units and player units respectively.
+  - The attacker's threat must be higher than the `GroupRetaliate.ThreatThreshold` of the unit's current target to trigger retaliation.
+  - `GroupRetaliate.GroupRange` controls the range within which the victim can call for friendly forces.
+  - `GroupRetaliate.TraceExtraRange` controls the distance for retaliating against the attacker. When the attacker is farther from the unit than the unit's guard range + TraceExtraRange, retaliation will not be triggered.
+- An additional option `DisableVanillaRetaliateBehavior` is provided to turn off the vanilla retaliation behavior.
+
+In `rulesmd.ini`:
+```ini
+[General]
+GroupRetaliate.AllowAI=false             ; boolean
+GroupRetaliate.AllowPlayer=false         ; boolean
+GroupRetaliate.ThreatThreshold=1000.0    ; float, range in cell
+GroupRetaliate.GroupRange=7.0            ; float, range in cell
+GroupRetaliate.TraceExtraRange=20.0      ; float, range in cell
+DisableVanillaRetaliateBehavior=false    ; boolean
+
+[SOMETECHNO]                             ; TechnoType
+GroupRetaliate.GroupRange=               ; float, range in cell, default to [General] -> GroupRetaliate.GroupRange
+```
+
+```{note}
+The unit must be able to trigger the vanilla retaliation behavior in order to trigger group retaliate.
 ```
 
 ### Initial strength for TechnoTypes and cloned infantry

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -535,6 +535,7 @@ New:
 - Option to scale `PowerSurplus` setting if enabled to current power drain with `PowerSurplus.ScaleToDrainAmount` (by Starkku)
 - Global default value for `DefaultToGuardArea` (by TaranDahl)
 - [Weapon range finding in cylinder](New-or-Enhanced-Logics.md#range-finding-in-cylinder) (by TaranDahl)
+- [Group retaliate](New-or-Enhanced-Logics.md#group-retaliate) (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -369,6 +369,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->GroupRetaliate_ThreatThreshold.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.ThreatThreshold");
 	this->GroupRetaliate_GroupRange.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.GroupRange");
 	this->GroupRetaliate_TraceExtraRange.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.TraceExtraRange");
+	this->GroupRetaliate_Delay.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.Delay");
 
 	this->DisableVanillaRetaliateBehavior.Read(exINI, GameStrings::CombatDamage, "DisableVanillaRetaliateBehavior");
 
@@ -676,6 +677,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->GroupRetaliate_ThreatThreshold)
 		.Process(this->GroupRetaliate_GroupRange)
 		.Process(this->GroupRetaliate_TraceExtraRange)
+		.Process(this->GroupRetaliate_Delay)
 		.Process(this->DisableVanillaRetaliateBehavior)
 		;
 }

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -1,4 +1,4 @@
-#include "Body.h"
+﻿#include "Body.h"
 
 #include <Ext/TechnoType/Body.h>
 #include <New/Type/RadTypeClass.h>
@@ -364,6 +364,14 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->CylinderRangefinding.Read(exINI, GameStrings::General, "CylinderRangefinding");
 	
+	this->GroupRetaliate_AllowAI.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.AllowAI");
+	this->GroupRetaliate_AllowPlayer.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.AllowPlayer");
+	this->GroupRetaliate_ThreatThreshold.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.ThreatThreshold");
+	this->GroupRetaliate_GroupRange.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.GroupRange");
+	this->GroupRetaliate_TraceExtraRange.Read(exINI, GameStrings::CombatDamage, "GroupRetaliate.TraceExtraRange");
+
+	this->DisableVanillaRetaliateBehavior.Read(exINI, GameStrings::CombatDamage, "DisableVanillaRetaliateBehavior");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -663,6 +671,12 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AIParadropMission)
 		.Process(this->DefaultToGuardArea)
 		.Process(this->CylinderRangefinding)
+		.Process(this->GroupRetaliate_AllowAI)
+		.Process(this->GroupRetaliate_AllowPlayer)
+		.Process(this->GroupRetaliate_ThreatThreshold)
+		.Process(this->GroupRetaliate_GroupRange)
+		.Process(this->GroupRetaliate_TraceExtraRange)
+		.Process(this->DisableVanillaRetaliateBehavior)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -318,6 +318,7 @@ public:
 		Valueable<double> GroupRetaliate_ThreatThreshold;
 		Valueable<Leptons> GroupRetaliate_GroupRange;
 		Valueable<Leptons> GroupRetaliate_TraceExtraRange;
+		Valueable<int> GroupRetaliate_Delay;
 
 		Valueable<bool> DisableVanillaRetaliateBehavior;
 
@@ -582,6 +583,7 @@ public:
 			, GroupRetaliate_ThreatThreshold { 1000.0 }
 			, GroupRetaliate_GroupRange { Leptons(7 * Unsorted::LeptonsPerCell) }
 			, GroupRetaliate_TraceExtraRange { Leptons(20 * Unsorted::LeptonsPerCell) }
+			, GroupRetaliate_Delay { 15 }
 
 			, DisableVanillaRetaliateBehavior { false }
 		{ }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -313,6 +313,13 @@ public:
 		Valueable<bool> DefaultToGuardArea;
     
 		Valueable<bool> CylinderRangefinding;
+		Valueable<bool> GroupRetaliate_AllowAI;
+		Valueable<bool> GroupRetaliate_AllowPlayer;
+		Valueable<double> GroupRetaliate_ThreatThreshold;
+		Valueable<Leptons> GroupRetaliate_GroupRange;
+		Valueable<Leptons> GroupRetaliate_TraceExtraRange;
+
+		Valueable<bool> DisableVanillaRetaliateBehavior;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -570,6 +577,13 @@ public:
 			, DefaultToGuardArea { false }
 			
 			, CylinderRangefinding { false }
+			, GroupRetaliate_AllowAI { false }
+			, GroupRetaliate_AllowPlayer { false }
+			, GroupRetaliate_ThreatThreshold { 1000.0 }
+			, GroupRetaliate_GroupRange { Leptons(7 * Unsorted::LeptonsPerCell) }
+			, GroupRetaliate_TraceExtraRange { Leptons(20 * Unsorted::LeptonsPerCell) }
+
+			, DisableVanillaRetaliateBehavior { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1052,6 +1052,10 @@ void TechnoExt::ApplyGroupRetaliate(TechnoClass* pThis, ObjectClass* pAttacker, 
 			if (pTechno->Target == pAttacker)
 				return false;
 
+			// Check timer
+			if (!TechnoExt::ExtMap.Find(pTechno)->GroupRetaliateTimer.Expired())
+				return false;
+
 			// IsAI chcek
 			if (pTechno->Owner->IsControlledByHuman())
 			{
@@ -1100,12 +1104,13 @@ void TechnoExt::ApplyGroupRetaliate(TechnoClass* pThis, ObjectClass* pAttacker, 
 		};
 	auto callForHelp = [pThis, pAttacker, pWH, range, missionAllowRangeSearch](TechnoClass* pTechno) -> void
 		{
+			TechnoExt::ExtMap.Find(pTechno)->GroupRetaliateTimer.Start(RulesExt::Global()->GroupRetaliate_Delay);
 			pTechno->SetTarget(pAttacker);
 
 			if (pTechno->MegaMissionIsAttackMove())
 			{
 				pTechno->QueueMission(Mission::Attack, true);
-				pTechno->SetDestination(nullptr, true);
+				//pTechno->SetDestination(nullptr, true);
 				((FootClass*)pTechno)->HaveAttackMoveTarget = true;
 			}
 			else if (missionAllowRangeSearch(pTechno->GetCurrentMission()))
@@ -1193,6 +1198,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->SpecialTracked)
 		.Process(this->FallingDownTracked)
 		.Process(this->JumpjetStraightAscend)
+		.Process(this->GroupRetaliateTimer)
 		;
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -8,6 +8,7 @@
 #include <Ext/WeaponType/Body.h>
 
 #include <Utilities/AresFunctions.h>
+#include <Utilities/Helpers.Alex.h>
 
 TechnoExt::ExtContainer TechnoExt::ExtMap;
 UnitClass* TechnoExt::Deployer = nullptr;
@@ -980,6 +981,145 @@ bool TechnoExt::EjectSurvivor(FootClass* pSurvivor, CoordStruct coords, bool sel
 		pSurvivor->Select();
 
 	return true;
+}
+
+void TechnoExt::ApplyGroupRetaliate(TechnoClass* pThis, ObjectClass* pAttacker, WarheadTypeClass* pWH)
+{
+	auto range = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType())->GroupRetaliate_GroupRange.Get(RulesExt::Global()->GroupRetaliate_GroupRange);
+
+	if (range <= 0)
+		return;
+
+	auto canApproachTarget = [](TechnoClass* pTechno) -> bool
+		{
+			if ((pTechno->AbstractFlags & AbstractFlags::Foot) == AbstractFlags::None)
+				return false;
+
+			auto mission = pTechno->GetCurrentMission();
+			if (mission == Mission::Sticky)
+				return false;
+
+			if (pTechno->DrainTarget)
+				return false;
+
+			auto pUnit = abstract_cast<UnitClass*>(pTechno);
+			if (pUnit && TechnoExt::CannotMove(pUnit))
+				return false;
+
+			if (!pTechno->GetTechnoType()->CanApproachTarget)
+				return false;
+
+			if (pTechno->BunkerLinkedItem)
+				return false;
+
+			if (pTechno->InOpenToppedTransport)
+				return false;
+
+			return true;
+		};
+	auto missionAllowAreaSearch = [](Mission mission)
+		{
+			switch (mission)
+			{
+			case Mission::Patrol:
+			case Mission::Hunt:
+			case Mission::Area_Guard:
+			case Mission::Rescue:
+				return true;
+			default :
+				return false;
+			}
+		};
+	auto missionAllowRangeSearch = [](Mission mission)
+		{
+			switch (mission)
+			{
+			case Mission::Move:
+			case Mission::Guard:
+			case Mission::Harvest:
+				return true;
+			default:
+				return false;
+			}
+		};
+	auto canRespondGroupRetaliate = [pThis, pAttacker, pWH, range, canApproachTarget, missionAllowAreaSearch, missionAllowRangeSearch](TechnoClass* pTechno) -> bool
+		{
+			// Must be ally
+			if (!pTechno->Owner->IsAlliedWith(pThis))
+				return false;
+
+			// Skip if same target
+			if (pTechno->Target == pAttacker)
+				return false;
+
+			// IsAI chcek
+			if (pTechno->Owner->IsControlledByHuman())
+			{
+				if (!RulesExt::Global()->GroupRetaliate_AllowPlayer)
+					return false;
+			}
+			else
+			{
+				if (!RulesExt::Global()->GroupRetaliate_AllowAI)
+					return false;
+			}
+
+			// Has less important target
+			if (auto pTarget = pTechno->Target)
+			{
+				auto attackerThreat = pTechno->ThreatCoeffients(pAttacker, &CoordStruct::Empty);
+				auto currentThreat = (pTechno->Target->AbstractFlags & AbstractFlags::Object) != AbstractFlags::None ? pTechno->ThreatCoeffients(static_cast<ObjectClass*>(pTechno->Target), &CoordStruct::Empty) : 0.0;
+
+				if (attackerThreat - currentThreat < RulesExt::Global()->GroupRetaliate_ThreatThreshold)
+					return false;
+			}
+
+			// Must check mission
+			bool closeEnough = pTechno->IsCloseEnoughToAttack(pAttacker);
+			auto mission = pTechno->GetCurrentMission();
+			bool attackMove = pTechno->MegaMissionIsAttackMove() && pTechno->InAuxiliarySearchRange(pAttacker);
+			bool canApproach = missionAllowAreaSearch(mission) && canApproachTarget(pTechno); // TODO : && InAreaStrayRange
+			bool canRangeFire = missionAllowRangeSearch(mission) && closeEnough;
+
+			if (!attackMove && !canApproach && !canRangeFire)
+				return false;
+
+			// Check simple can retaliate
+			if (!pTechno->CanRetaliateToAttacker(pAttacker, pWH))
+				return false;
+
+			// In search range
+			if (pThis->DistanceFrom(pTechno) > range)
+				return false;
+
+			// Attacker not too far
+			if (pAttacker->DistanceFrom(pTechno) > (int)RulesExt::Global()->GroupRetaliate_TraceExtraRange.Get() + pTechno->GetGuardRange(0))
+				return false;
+
+			return true;
+		};
+	auto callForHelp = [pThis, pAttacker, pWH, range, missionAllowRangeSearch](TechnoClass* pTechno) -> void
+		{
+			pTechno->SetTarget(pAttacker);
+
+			if (pTechno->MegaMissionIsAttackMove())
+			{
+				pTechno->QueueMission(Mission::Attack, true);
+				pTechno->SetDestination(nullptr, true);
+				((FootClass*)pTechno)->HaveAttackMoveTarget = true;
+			}
+			else if (missionAllowRangeSearch(pTechno->GetCurrentMission()))
+			{
+				pTechno->ShouldLoseTargetNow = true;
+			}
+		};
+
+	auto list = Helpers::Alex::getCellSpreadItems(pThis->GetCoords(), (double)range / Unsorted::LeptonsPerCell, true);
+	for (auto techno : list)
+	{
+		if (canRespondGroupRetaliate(techno))
+			callForHelp(techno);
+	}
 }
 
 // =============================

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -311,4 +311,6 @@ public:
 	static void ApplyKillWeapon(TechnoClass* pThis, TechnoClass* pSource, WarheadTypeClass* pWH);
 	static void ApplyRevengeWeapon(TechnoClass* pThis, TechnoClass* pSource, WarheadTypeClass* pWH);
 	static bool MultiWeaponCanFire(TechnoClass* const pThis, AbstractClass* const pTarget, WeaponTypeClass* const pWeaponType);
+
+	static void ApplyGroupRetaliate(TechnoClass* pThis, ObjectClass* pAttacker, WarheadTypeClass* pWH);
 };

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -100,6 +100,8 @@ public:
 
 		bool JumpjetStraightAscend; // Is set to true jumpjet units will ascend straight and do not adjust rotation or position during it.
 
+		CDTimerClass GroupRetaliateTimer;
+
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
 			, Shield {}
@@ -166,6 +168,7 @@ public:
 			, SpecialTracked { false }
 			, FallingDownTracked { false }
 			, JumpjetStraightAscend { false }
+			, GroupRetaliateTimer {}
 		{ }
 
 		void OnEarlyUpdate();

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -435,6 +435,13 @@ DEFINE_HOOK(0x701CFC, TechnoClass_ReceiveDamage_AllowBerzerkOnAllies, 0x5)
 	return RulesExt::Global()->AllowBerzerkOnAllies ? IgnoreOwnerCheckFailed : 0;
 }
 
+#pragma region GroupRetaliate
+
+namespace GroupRetaliateContext
+{
+	bool Processing = false;
+}
+
 DEFINE_HOOK(0x702A31, TechnoClass_ReceiveDamage_GroupRetaliate, 0x7)
 {
 	if (!RulesExt::Global()->GroupRetaliate_AllowAI && !RulesExt::Global()->GroupRetaliate_AllowPlayer)
@@ -443,14 +450,25 @@ DEFINE_HOOK(0x702A31, TechnoClass_ReceiveDamage_GroupRetaliate, 0x7)
 	GET_STACK(WarheadTypeClass*, pWH, STACK_OFFSET(0xC4, 0xC));
 	GET_STACK(ObjectClass*, pAttacker, STACK_OFFSET(0xC4, 0x10));
 	GET(TechnoClass*, pThis, ESI);
-
+	GroupRetaliateContext::Processing = true;
 	if (pAttacker)
 		TechnoExt::ApplyGroupRetaliate(pThis, pAttacker, pWH);
+	GroupRetaliateContext::Processing = false;
 	return 0;
+}
+
+// Skip mission check in vanilla checker. We'll check it by ourselves.
+DEFINE_HOOK(0x708A13, TechnoClass_CanRetaliateToAttacker_GroupRetaliate1, 0x6)
+{
+	return GroupRetaliateContext::Processing ? 0x708A2C : 0;
 }
 
 DEFINE_HOOK(0x702A58, TechnoClass_ReceiveDamage_DisableVanilla, 0x5)
 {
 	enum { SkipGameCode = 0x702B47 };
-	return RulesExt::Global()->DisableVanillaRetaliateBehavior ? SkipGameCode : 0;
+	GET(TechnoClass*, pThis, ESI);
+	bool canGroupRetaliate = pThis->Owner->IsControlledByHuman() ? RulesExt::Global()->GroupRetaliate_AllowPlayer : RulesExt::Global()->GroupRetaliate_AllowAI;
+	return RulesExt::Global()->DisableVanillaRetaliateBehavior && canGroupRetaliate ? SkipGameCode : 0;
 }
+
+#pragma endregion

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -434,3 +434,23 @@ DEFINE_HOOK(0x701CFC, TechnoClass_ReceiveDamage_AllowBerzerkOnAllies, 0x5)
 	enum { IgnoreOwnerCheckFailed = 0x701D0B };
 	return RulesExt::Global()->AllowBerzerkOnAllies ? IgnoreOwnerCheckFailed : 0;
 }
+
+DEFINE_HOOK(0x702A31, TechnoClass_ReceiveDamage_GroupRetaliate, 0x7)
+{
+	if (!RulesExt::Global()->GroupRetaliate_AllowAI && !RulesExt::Global()->GroupRetaliate_AllowPlayer)
+		return 0;
+
+	GET_STACK(WarheadTypeClass*, pWH, STACK_OFFSET(0xC4, 0xC));
+	GET_STACK(ObjectClass*, pAttacker, STACK_OFFSET(0xC4, 0x10));
+	GET(TechnoClass*, pThis, ESI);
+
+	if (pAttacker)
+		TechnoExt::ApplyGroupRetaliate(pThis, pAttacker, pWH);
+	return 0;
+}
+
+DEFINE_HOOK(0x702A58, TechnoClass_ReceiveDamage_DisableVanilla, 0x5)
+{
+	enum { SkipGameCode = 0x702B47 };
+	return RulesExt::Global()->DisableVanillaRetaliateBehavior ? SkipGameCode : 0;
+}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1,4 +1,4 @@
-#include "Body.h"
+﻿#include "Body.h"
 
 #include <JumpjetLocomotionClass.h>
 
@@ -1150,6 +1150,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ParadropMission.Read(exINI, pSection, "ParadropMission");
 	this->AIParadropMission.Read(exINI, pSection, "AIParadropMission");
 
+	this->GroupRetaliate_GroupRange.Read(exINI, pSection, "GroupRetaliate.GroupRange");
+	
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1851,6 +1853,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->ParadropMission)
 		.Process(this->AIParadropMission)
+
+		.Process(this->GroupRetaliate_GroupRange)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
 
@@ -474,6 +474,7 @@ public:
 
 		Nullable<Mission> ParadropMission;
 		Nullable<Mission> AIParadropMission;
+		Nullable<Leptons> GroupRetaliate_GroupRange;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -903,6 +904,7 @@ public:
 
 			, ParadropMission {}
 			, AIParadropMission {}
+			, GroupRetaliate_GroupRange {}
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Group retaliate

- In vanilla, only the unit itself will counter - attack when it takes damage. This often makes units stupidly lured away one by one and eliminated.
- Now you can make units "seek support from nearby friendly units" when they take damage. They will retaliate the attacker together with the victim.
  - `GroupRetaliate.AllowAI` and `GroupRetaliate.AllowPlayer` control whether this effect applies to AI units and player units respectively.
  - The attacker's threat must be higher than the `GroupRetaliate.ThreatThreshold` of the unit's current target to trigger retaliation.
  - `GroupRetaliate.GroupRange` controls the range within which the victim can call for friendly forces.
  - `GroupRetaliate.TraceExtraRange` controls the distance for retaliating against the attacker. When the attacker is farther from the unit than the unit's guard range + TraceExtraRange, retaliation will not be triggered.
- An additional option `DisableVanillaRetaliateBehavior` is provided to turn off the vanilla retaliation behavior.

In `rulesmd.ini`:
```ini
[General]
GroupRetaliate.AllowAI=false             ; boolean
GroupRetaliate.AllowPlayer=false         ; boolean
GroupRetaliate.ThreatThreshold=1000.0    ; float, range in cell
GroupRetaliate.GroupRange=7.0            ; float, range in cell
GroupRetaliate.TraceExtraRange=20.0      ; float, range in cell
DisableVanillaRetaliateBehavior=false    ; boolean

[SOMETECHNO]                             ; TechnoType
GroupRetaliate.GroupRange=               ; float, range in cell, default to [General] -> GroupRetaliate.GroupRange
```

```{note}
The unit must be able to trigger the vanilla retaliation behavior in order to trigger group retaliate.
```