### PR TITLE
Allow custom FPS values for each GameSpeed index

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -736,4 +736,6 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
-- **11EJDE11** - Prevent mpdebug number from being drawn when visibility toggled off
+- **11EJDE11**:
+  - Prevent mpdebug number from being drawn when visibility toggled off
+  - Allow customising FPS values

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -95,26 +95,9 @@ InsigniaType.PassengersN=                ; InsigniaType
 
 ## Game Speed
 
-### Single player game speed
+### Campaign default game speed
 
 - It is now possible to change the default (GS4/Fast/30FPS) campaign game speed with `CampaignDefaultGameSpeed`.
-- It is now possible to change the *values* of single player game speed, by inputing a pair of values. This feature must be enabled with `CustomGS=true`. **Only values between 10 and 60 FPS can be consistently achieved.**
-  - Custom game speed is achieved by periodically manipulating the delay between game frames, thus increasing or decreasing FPS.
-  - `CustomGSN.ChangeInterval` describes the frame interval between applying the effect. A value of 2 means "every other frame", 3 means "every 3 frames" etc. Increase of speedup/slowdown is approximately logarithmic.
-  - `CustomGSN.ChangeDelay` sets the delay (game speed number) to use every `CustomGSN.ChangeInterval` frames.
-  - `CustomGSN.DefaultDelay` sets the delay (game speed number) to use on other frames.
-  - Using game speed 6 (Fastest) in either `CustomGSN.ChangeDelay` or `CustomGSN.DefaultDelay` allows to set FPS above 60.
-    - **However, the resulting FPS may vary on different machines.**
-
-In `rulesmd.ini`:
-```ini
-[General]
-CustomGS=false              ; boolean
-CustomGSN.ChangeInterval=-1 ; integer >= 1
-CustomGSN.ChangeDelay=N     ; integer between 0 and 6
-CustomGSN.DefaultDelay=N    ; integer between 0 and 6
-; where N = 0, 1, 2, 3, 4, 5, 6
-```
 
 In `RA2MD.INI`:
 ```ini
@@ -122,68 +105,26 @@ In `RA2MD.INI`:
 CampaignDefaultGameSpeed=4  ; integer
 ```
 
-```{note}
-Currently there is no way to set desired FPS directly. Use the generator below to get required values. The generator supports values from 10 to 60.
+### Custom game speed
+
+- Each of the 7 game speed slider positions (GameSpeed 0-6) can have a custom target FPS set independently. A value of `0` keeps that position at its vanilla FPS.
+- Works in skirmish, campaign, and multiplayer.
+- Per-speed keys (`CustomGameSpeedFPS.N`) set individual positions.
+- Practical maximum is ~1000 FPS (limited by `timeGetTime()` resolution).
+
+In `rulesmd.ini`:
+```ini
+[General]
+EnableCustomFPS=true             ; boolean
+CustomGameSpeedFPS.0=140         ; integer, GameSpeed 0 target FPS
+CustomGameSpeedFPS.1=120         ; integer, GameSpeed 1 target FPS
+CustomGameSpeedFPS.2=100         ; integer, GameSpeed 2 target FPS
+CustomGameSpeedFPS.3=90          ; integer, GameSpeed 3 target FPS
+CustomGameSpeedFPS.4=80          ; integer, GameSpeed 4 target FPS
+CustomGameSpeedFPS.5=70          ; integer, GameSpeed 5 target FPS
+CustomGameSpeedFPS.6=0           ; integer, GameSpeed 6 target FPS (0 = default)
 ```
 
-```{dropdown} Click to show the generator
-Enter desired FPS
-<div>
-<input id="customGameSpeedIn" type=number oninput="onInput()" style="width:100%";>
-</div>
-
-Results (remember to replace N with your game speed number!):
-
-<div>
-</p>
-<div id="codeBlockHere1"></div>
-</div>
-```
-
-<script>
-makeINICodeBlock(document.getElementById("codeBlockHere1"), "customGameSpeedOut", 400);
-let fpsArray = [];
-for (let d = 0; d <= 5; d++) {
-	for (let c = 0; c <= 5; c++) {
-		for (let i = 1; i <= 40; i++) {
-			fpsArray.push(Math.round(formula(c, d, i)));
-		}
-	}
-}
-function formula(c, d, i) {
-	return (60/(6-c)+60/(6-d)*((i-1)/(6-c)))/(1+(i-1)/(6-c));
-}
-function onInput() {
-	let fps = document.getElementById("customGameSpeedIn");
-	let out = document.getElementById("customGameSpeedOut");
-	out.textContent = ''; // remove all children
-	out.appendChild(document.createElement("span"));
-	let j = 0;
-	let foundAny = false;
-	while (true) {
-		j = fpsArray.indexOf(parseInt(fps.value), j);
-		if (j == -1) {
-			break;
-		}
-		d = Math.floor(j / 240);
-		c = Math.floor(j % 240 / 40);
-		i = j % 40 + 1;
-		j += 1;
-		let content = [];
-		if (foundAny) {
-			content.push({key: null, value: null, comment: "// -- Or -- "});
-		}
-		content.push({key: "CustomGSN.DefaultDelay", value: d, comment: null});
-		content.push({key: "CustomGSN.ChangeDelay", value: c, comment: null});
-		content.push({key: "CustomGSN.ChangeInterval", value: i, comment: null});
-		content.forEach(line => addINILine(out, line));
-		foundAny = true;
-	}
-	if (!foundAny) {
-		addINILine(out, {key: null, value: null, comment: "// Sorry, couldn't find anything!  本工具无能为力"});
-	}
-}
-</script>
 
 ## INI
 

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -115,14 +115,14 @@ CampaignDefaultGameSpeed=4  ; integer
 In `rulesmd.ini`:
 ```ini
 [General]
-EnableCustomFPS=true             ; boolean
-CustomGameSpeedFPS.0=140         ; integer, GameSpeed 0 target FPS
-CustomGameSpeedFPS.1=120         ; integer, GameSpeed 1 target FPS
-CustomGameSpeedFPS.2=100         ; integer, GameSpeed 2 target FPS
-CustomGameSpeedFPS.3=90          ; integer, GameSpeed 3 target FPS
-CustomGameSpeedFPS.4=80          ; integer, GameSpeed 4 target FPS
-CustomGameSpeedFPS.5=70          ; integer, GameSpeed 5 target FPS
-CustomGameSpeedFPS.6=0           ; integer, GameSpeed 6 target FPS (0 = default)
+EnableCustomFPS=false            ; boolean (default: false)
+CustomGameSpeedFPS.0=0           ; integer, GameSpeed 0 target FPS (default: 0 = vanilla 60 FPS)
+CustomGameSpeedFPS.1=0           ; integer, GameSpeed 1 target FPS (default: 0 = vanilla 45 FPS)
+CustomGameSpeedFPS.2=0           ; integer, GameSpeed 2 target FPS (default: 0 = vanilla 30 FPS)
+CustomGameSpeedFPS.3=0           ; integer, GameSpeed 3 target FPS (default: 0 = vanilla 20 FPS)
+CustomGameSpeedFPS.4=0           ; integer, GameSpeed 4 target FPS (default: 0 = vanilla 15 FPS)
+CustomGameSpeedFPS.5=0           ; integer, GameSpeed 5 target FPS (default: 0 = vanilla 12 FPS)
+CustomGameSpeedFPS.6=0           ; integer, GameSpeed 6 target FPS (default: 0 = vanilla 10 FPS)
 ```
 
 

--- a/docs/Miscellanous.md
+++ b/docs/Miscellanous.md
@@ -108,7 +108,7 @@ CampaignDefaultGameSpeed=4  ; integer
 ### Custom game speed
 
 - Each of the 7 game speed slider positions (GameSpeed 0-6) can have a custom target FPS set independently. A value of `0` keeps that position at its vanilla FPS.
-- Works in skirmish, campaign, and multiplayer.
+- When used, **game speeds are unified across all game modes** - skirmish, campaign, and multiplayer all use the same FPS values for each speed position.
 - Per-speed keys (`CustomGameSpeedFPS.N`) set individual positions.
 - Practical maximum is ~1000 FPS (limited by `timeGetTime()` resolution).
 

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -288,9 +288,8 @@ ShowPlacementPreview=yes   ; boolean
 ### Real time timers
 
 - Timers can now display values in real time, taking game speed into account. This can be enabled with `RealTimeTimers=true`.
-- By default, time is calculated relative to desired framerate. Enabling `RealTimeTimers.Adaptive` (always true for unlimited FPS and custom speeds) will calculate time relative to *current* FPS, accounting for lag.
-  - When playing with unlimited FPS (or custom speed above 60 FPS), the timers might constantly change value because of the unstable nature.
-- This option respects custom game speeds.
+- By default, time is calculated relative to the desired framerate for the current GameSpeed. Enabling `RealTimeTimers.Adaptive` (always forced on when GameSpeed is 0/Fastest or a custom game speed is active) will calculate time relative to *current* FPS, accounting for lag.
+  - When playing with a custom FPS above 60, the timers might constantly fluctuate due to frame-to-frame variance.
 
 - This behavior is designed to be toggleable by users. For now you can only do that externally via client or manually.
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -32,6 +32,7 @@ You can use the migration utility (can be found on [Phobos supplementaries repo]
 
 #### From post-0.3 devbuilds
 
+- `CustomGS` and related keys (`CustomGSN.ChangeInterval`, `CustomGSN.ChangeDelay`, `CustomGSN.DefaultDelay`) have been deprecated and replaced by the new direct FPS control system. Use `EnableCustomFPS=true` and `CustomGameSpeedFPS.N` keys instead to set target FPS for each game speed position. The new system works across skirmish, campaign, and multiplayer modes. See [Custom game speed](Miscellanous.md#custom-game-speed) for details.
 - Ivan bombs no longer automatically center on building when attached. Set `[CombatDamage] -> IvanBombAttachToCenter` to true to restore this behaviour. Due to technical constraints this cannot be customized per WeaponType.
 - `AlternateFLH` no longer affects vehicle passengers by default. To re-enable it, set `AlternateFLH.ApplyVehicle=true` on the transport unit.
 - Parsing priority of `ShowBriefing` and `BriefingTheme` between map file and `missionmd.ini` has been switched (from latter taking priority over former to vice-versa) due to technical limitations and compatibility issues with spawner DLL.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -535,6 +535,7 @@ New:
 - Option to scale `PowerSurplus` setting if enabled to current power drain with `PowerSurplus.ScaleToDrainAmount` (by Starkku)
 - Global default value for `DefaultToGuardArea` (by TaranDahl)
 - [Weapon range finding in cylinder](New-or-Enhanced-Logics.md#range-finding-in-cylinder) (by TaranDahl)
+- [Enhanced custom game speed with direct FPS control and multiplayer support](Miscellanous.md#custom-game-speed) (by 11EJDE11)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -1,12 +1,8 @@
 #include <Phobos.h>
-#include <Helpers/Macro.h>
+#include <Utilities/Macro.h>
+#include <algorithm>
 #include <SessionClass.h>
 #include <GameOptionsClass.h>
-
-namespace GameSpeedTemp
-{
-	static int counter = 0;
-}
 
 DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 {
@@ -14,84 +10,122 @@ DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 	return 0x69BAF1;
 }
 
-DEFINE_REFERENCE(CDTimerClass, FrameTimer, 0x887348)
+// For custom game speeds:
+// Add to rulesmd.ini under [General]:
+//   EnableCustomFPS=yes              ; Enable/disable custom FPS (default: yes)
+//   CustomGameSpeedFPS.0=120         ; Per-speed FPS. 0 = vanilla. Vanilla: 0=60, 1=45, 2=30, 3=20, 4=15, 5=12, 6=10
+//
+//   -Each speed slot with a non-zero CustomGameSpeedFPS.N runs at that target FPS
+//   -Slots with 0 (or unset) use vanilla FPS for that position
+//   -Practical max is ~1000 FPS (timeGetTime() resolution)
 
-DEFINE_HOOK(0x55E160, SyncDelay_Start, 0x6)
+// Queue_AI_Multiplayer
+// Patch v26 to INT_MAX disables the 60fps cap on multiplayer.
+DEFINE_PATCH(0x647C28, 0xBE, 0xFF, 0xFF, 0xFF, 0x7F); // mov esi, INT_MAX
+
+// Queue_AI_Multiplayer
+// Override the GameSpeed-to-fps calculation in multiplayer.
+DEFINE_HOOK(0x647C4D, Queue_AI_Multiplayer_CustomFPSCalculation, 0x1F)
 {
-	//DEFINE_NONSTATIC_REFERENCE(CDTimerClass, NFTTimer, 0x887328);
-	if (!Phobos::Misc::CustomGS || SessionClass::IsMultiplayer())
-		return 0;
-	if ((Phobos::Misc::CustomGS_ChangeInterval[FrameTimer.TimeLeft] > 0)
-		&& (GameSpeedTemp::counter % Phobos::Misc::CustomGS_ChangeInterval[FrameTimer.TimeLeft] == 0))
+	int gameSpeed = GameOptionsClass::Instance.GameSpeed;
+	int calculatedFPS;
+
+	if (Phobos::Misc::EnableCustomFPS && Phobos::Misc::CustomGameSpeedFPS[gameSpeed] > 0)
 	{
-		FrameTimer.TimeLeft = Phobos::Misc::CustomGS_ChangeDelay[FrameTimer.TimeLeft];
-		GameSpeedTemp::counter = 1;
+		calculatedFPS = Phobos::Misc::CustomGameSpeedFPS[gameSpeed];
+	}
+	else if (gameSpeed == 0)
+	{
+		// Vanilla: GameSpeed 0 = 60 FPS
+		calculatedFPS = 60;
+	}
+	else if (gameSpeed == 1)
+	{
+		// Vanilla: GameSpeed 1 = 45 FPS
+		calculatedFPS = 45;
 	}
 	else
 	{
-		FrameTimer.TimeLeft = Phobos::Misc::CustomGS_DefaultDelay[FrameTimer.TimeLeft];
-		GameSpeedTemp::counter++;
+		// Vanilla: GameSpeed 2+ = 60 / GameSpeed
+		calculatedFPS = 60 / gameSpeed;
 	}
 
-	return 0;
+	R->EAX(calculatedFPS);
+
+	return 0x647C6C;
 }
 
-DEFINE_HOOK(0x55E33B, SyncDelay_End, 0x6)
+struct NFTTimerStruct
 {
-	if (Phobos::Misc::CustomGS && SessionClass::IsSingleplayer())
-		FrameTimer.TimeLeft = GameOptionsClass::Instance.GameSpeed;
-	return 0;
-}
+	DWORD StartTime;
+	DWORD CurrentTime;
+	int   TimeLeft;
+};
+DEFINE_REFERENCE(NFTTimerStruct, NFTTimer, 0x887328);
 
-// note: currently vanilla code, doesn't do anything, changing PrecalcDesiredFrameRate doesn't effect anything either
-/*
-void SetNetworkFrameRate()
+struct FrameTimerStruct
 {
-	DEFINE_REFERENCE(int, PrecalcDesiredFrameRate, 0xA8B550u)
-	switch (GameOptionsClass::Instance.GameSpeed)
+	DWORD StartTime;
+	DWORD CurrentTime;
+	int   DelayTime;
+};
+DEFINE_REFERENCE(FrameTimerStruct, GameFrameTimer, 0x887348);
+
+// Hook MainLoop skirmish/campaign FPS calculation
+// The normal route FrameTimer.DelayTime rounds to 0 for >60 FPS (tick-based timeGetTime >> 4),
+// NFTTimer (ms-based timeGetTime) provides the frame timing that SyncDelay's NFTTimer loop uses.
+// We need to set up NFTTimer like multiplayer mode does for >60 FPS support.
+DEFINE_HOOK(0x55D7B6, MainLoop_SkirmishFPSFix, 0xC)
+{
+	const DWORD timerValue = R->ECX();
+	const int gameSpeed = R->ESI();
+
+	const bool shouldUseCustomFPS = Phobos::Misc::EnableCustomFPS
+		&& Phobos::Misc::CustomGameSpeedFPS[gameSpeed] > 0
+		&& (SessionClass::IsSkirmish() || SessionClass::IsCampaign());
+
+	if (!shouldUseCustomFPS)
 	{
-	case 0:
-		Game::Network.MaxAhead = 40;
-		PrecalcDesiredFrameRate = 60;
-		Game::Network.FrameSendRate = 10;
-		break;
-	case 1:
-		Game::Network.MaxAhead = 40;
-		PrecalcDesiredFrameRate = 45;
-		Game::Network.FrameSendRate = 10;
-		break;
-	case 2:
-		Game::Network.MaxAhead = 30;
-		PrecalcDesiredFrameRate = 30;
-		break;
-	case 3:
-		Game::Network.MaxAhead = 20;
-		PrecalcDesiredFrameRate = 20;
-		break;
-	case 4:
-		Game::Network.MaxAhead = 20;
-		PrecalcDesiredFrameRate = 15;
-		break;
-	case 5:
-		Game::Network.MaxAhead = 20;
-		PrecalcDesiredFrameRate = 12;
-		break;
-	default:
-		Game::Network.MaxAhead = 10;
-		PrecalcDesiredFrameRate = 10;
-		break;
+		// Use vanilla behavior
+		GameFrameTimer.CurrentTime = timerValue;
+		GameFrameTimer.DelayTime = gameSpeed;
+		return 0x55D7C2;
 	}
+
+	const int customFPS = Phobos::Misc::CustomGameSpeedFPS[gameSpeed];
+
+	// calc frame timings
+	const int targetFrameDelayTicks = 60 / customFPS;
+	const int targetFrameTimeMs = std::max(1, 1000 / customFPS); // 1ms floor = ~1000 FPS ceiling
+
+	const DWORD currentTime = timeGetTime();
+
+	// just in case
+	GameFrameTimer.CurrentTime = timerValue;
+	GameFrameTimer.DelayTime = targetFrameDelayTicks;
+
+	// SyncDelay compares elapsed time since CurrentTime against TimeLeft.
+	NFTTimer.StartTime = currentTime;
+	NFTTimer.CurrentTime = currentTime;
+	NFTTimer.TimeLeft = targetFrameTimeMs;
+
+	// "Requested FPS"
+	SessionClass::Instance.DesiredFrameRate = customFPS;
+
+	return 0x55D7C2; // Past the two MOVs we replaced
 }
 
-DEFINE_HOOK(0x5C49A7, MPCooperative_5C46E0_FPS, 0x9)
+// SyncDelay
+// Redirect skirmish/campaign to the NFTTimer path
+DEFINE_HOOK(0x55E1B6, SyncDelay_RedirectSkirmishToNFTTimer, 0x6)
 {
-	SetNetworkFrameRate();
-	return 0x5C4A40;
-}
+	if (SessionClass::IsSkirmish() || SessionClass::IsCampaign())
+	{
+		if (Phobos::Misc::EnableCustomFPS && Phobos::Misc::CustomGameSpeedFPS[GameOptionsClass::Instance.GameSpeed] > 0)
+			return 0x55E1BC; // Custom FPS: use NFTTimer path like multiplayer
 
-DEFINE_HOOK(0x794F7E, Start_Game_Now_FPS, 0x8)
-{
-	SetNetworkFrameRate();
-	return 0x79501F;
+		return 0x55E2B4; // Vanilla FrameTimer path
+	}
+
+	return 0x55E1BC;
 }
-*/

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -55,26 +55,10 @@ DEFINE_HOOK(0x647C4D, Queue_AI_Multiplayer_CustomFPSCalculation, 0x1F)
 	return 0x647C6C;
 }
 
-struct NFTTimerStruct
-{
-	DWORD StartTime;
-	DWORD CurrentTime;
-	int   TimeLeft;
-};
-DEFINE_REFERENCE(NFTTimerStruct, NFTTimer, 0x887328);
-
-struct FrameTimerStruct
-{
-	DWORD StartTime;
-	DWORD CurrentTime;
-	int   DelayTime;
-};
-DEFINE_REFERENCE(FrameTimerStruct, GameFrameTimer, 0x887348);
-
 // Hook MainLoop skirmish/campaign FPS calculation
-// The normal route FrameTimer.DelayTime rounds to 0 for >60 FPS (tick-based timeGetTime >> 4),
-// NFTTimer (ms-based timeGetTime) provides the frame timing that SyncDelay's NFTTimer loop uses.
-// We need to set up NFTTimer like multiplayer mode does for >60 FPS support.
+// The normal route FrameTimer.TimeLeft rounds to 0 for >60 FPS (tick-based timeGetTime >> 4),
+// NetworkFrameTimer (ms-based timeGetTime) provides the frame timing that SyncDelay's NetworkFrameTimer loop uses.
+// We need to set up NetworkFrameTimer like multiplayer mode does for >60 FPS support.
 DEFINE_HOOK(0x55D7B6, MainLoop_SkirmishFPSFix, 0xC)
 {
 	const DWORD timerValue = R->ECX();
@@ -87,8 +71,8 @@ DEFINE_HOOK(0x55D7B6, MainLoop_SkirmishFPSFix, 0xC)
 	if (!shouldUseCustomFPS)
 	{
 		// Use vanilla behavior
-		GameFrameTimer.CurrentTime = timerValue;
-		GameFrameTimer.DelayTime = gameSpeed;
+		Unsorted::GameFrameTimer.CurrentTime = timerValue;
+		Unsorted::GameFrameTimer.TimeLeft = gameSpeed;
 		return 0x55D7C2;
 	}
 
@@ -101,13 +85,13 @@ DEFINE_HOOK(0x55D7B6, MainLoop_SkirmishFPSFix, 0xC)
 	const DWORD currentTime = timeGetTime();
 
 	// just in case
-	GameFrameTimer.CurrentTime = timerValue;
-	GameFrameTimer.DelayTime = targetFrameDelayTicks;
+	Unsorted::GameFrameTimer.CurrentTime = timerValue;
+	Unsorted::GameFrameTimer.TimeLeft = targetFrameDelayTicks;
 
 	// SyncDelay compares elapsed time since CurrentTime against TimeLeft.
-	NFTTimer.StartTime = currentTime;
-	NFTTimer.CurrentTime = currentTime;
-	NFTTimer.TimeLeft = targetFrameTimeMs;
+	Unsorted::NetworkFrameTimer.StartTime = currentTime;
+	Unsorted::NetworkFrameTimer.CurrentTime = currentTime;
+	Unsorted::NetworkFrameTimer.TimeLeft = targetFrameTimeMs;
 
 	// "Requested FPS"
 	SessionClass::Instance.DesiredFrameRate = customFPS;
@@ -116,13 +100,13 @@ DEFINE_HOOK(0x55D7B6, MainLoop_SkirmishFPSFix, 0xC)
 }
 
 // SyncDelay
-// Redirect skirmish/campaign to the NFTTimer path
-DEFINE_HOOK(0x55E1B6, SyncDelay_RedirectSkirmishToNFTTimer, 0x6)
+// Redirect skirmish/campaign to the NetworkFrameTimer path
+DEFINE_HOOK(0x55E1B6, SyncDelay_RedirectSkirmishToNetworkFrameTimer, 0x6)
 {
 	if (SessionClass::IsSkirmish() || SessionClass::IsCampaign())
 	{
 		if (Phobos::Misc::EnableCustomFPS && Phobos::Misc::CustomGameSpeedFPS[GameOptionsClass::Instance.GameSpeed] > 0)
-			return 0x55E1BC; // Custom FPS: use NFTTimer path like multiplayer
+			return 0x55E1BC; // Custom FPS: use NetworkFrameTimer path like multiplayer
 
 		return 0x55E2B4; // Vanilla FrameTimer path
 	}

--- a/src/Misc/Hooks.Gamespeed.cpp
+++ b/src/Misc/Hooks.Gamespeed.cpp
@@ -12,7 +12,7 @@ DEFINE_HOOK(0x69BAE7, SessionClass_Resume_CampaignGameSpeed, 0xA)
 
 // For custom game speeds:
 // Add to rulesmd.ini under [General]:
-//   EnableCustomFPS=yes              ; Enable/disable custom FPS (default: yes)
+//   EnableCustomFPS=yes              ; Enable/disable custom FPS
 //   CustomGameSpeedFPS.0=120         ; Per-speed FPS. 0 = vanilla. Vanilla: 0=60, 1=45, 2=30, 3=20, 4=15, 5=12, 6=10
 //
 //   -Each speed slot with a non-zero CustomGameSpeedFPS.N runs at that target FPS

--- a/src/Misc/Hooks.Timers.cpp
+++ b/src/Misc/Hooks.Timers.cpp
@@ -18,7 +18,7 @@ DEFINE_HOOK(0x6D4B50, PrintTimerOnTactical_Start, 0x6)
 
 	if (Phobos::Config::RealTimeTimers_Adaptive
 		|| GameOptionsClass::Instance.GameSpeed == 0
-		|| (Phobos::Misc::CustomGS && !SessionClass::IsMultiplayer()))
+		|| (Phobos::Misc::EnableCustomFPS && Phobos::Misc::CustomGameSpeedFPS[GameOptionsClass::Instance.GameSpeed] > 0))
 	{
 		value = (int)((double)value / (std::max((double)FPSCounter::CurrentFrameRate, 1.0) / 15.0));
 		return 0;

--- a/src/Misc/PhobosToolTip.cpp
+++ b/src/Misc/PhobosToolTip.cpp
@@ -109,7 +109,7 @@ inline static int TickTimeToSeconds(int tickTime)
 
 	if (Phobos::Config::RealTimeTimers_Adaptive
 		|| GameOptionsClass::Instance.GameSpeed == 0
-		|| (Phobos::Misc::CustomGS && !SessionClass::IsMultiplayer()))
+		|| (Phobos::Misc::EnableCustomFPS && Phobos::Misc::CustomGameSpeedFPS[GameOptionsClass::Instance.GameSpeed] > 0))
 	{
 		return tickTime / std::max((int)FPSCounter::CurrentFrameRate, 1);
 	}

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -249,7 +249,7 @@ DEFINE_HOOK(0x52D21F, InitRules_ThingsThatShouldntBeSerailized, 0x6)
 	Phobos::Config::UnitPowerDrain = pINI_RULESMD->ReadBool(GameStrings::General, "UnitPowerDrain", false);
 
 	// Custom FPS settings
-	Phobos::Misc::EnableCustomFPS = pINI_RULESMD->ReadBool(GameStrings::General, "EnableCustomFPS", true);
+	Phobos::Misc::EnableCustomFPS = pINI_RULESMD->ReadBool(GameStrings::General, "EnableCustomFPS", false);
 
 	char tempBuffer[32];
 	for (int i = 0; i < 7; ++i)

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -77,10 +77,8 @@ bool Phobos::Config::ShowFlashOnSelecting = false;
 bool Phobos::Config::UnitPowerDrain = false;
 int Phobos::Config::SuperWeaponSidebar_RequiredSignificance = 0;
 
-bool Phobos::Misc::CustomGS = false;
-int Phobos::Misc::CustomGS_ChangeInterval[7] = { -1, -1, -1, -1, -1, -1, -1 };
-int Phobos::Misc::CustomGS_ChangeDelay[7] = { 0, 1, 2, 3, 4, 5, 6 };
-int Phobos::Misc::CustomGS_DefaultDelay[7] = { 0, 1, 2, 3, 4, 5, 6 };
+bool Phobos::Misc::EnableCustomFPS = false;
+int Phobos::Misc::CustomGameSpeedFPS[7] = { 0, 0, 0, 0, 0, 0, 0 };
 
 DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 {
@@ -250,26 +248,16 @@ DEFINE_HOOK(0x52D21F, InitRules_ThingsThatShouldntBeSerailized, 0x6)
 	Phobos::Config::ArtImageSwap = pINI_RULESMD->ReadBool(GameStrings::General, "ArtImageSwap", false);
 	Phobos::Config::UnitPowerDrain = pINI_RULESMD->ReadBool(GameStrings::General, "UnitPowerDrain", false);
 
-	Phobos::Misc::CustomGS = pINI_RULESMD->ReadBool(GameStrings::General, "CustomGS", false);
+	// Custom FPS settings
+	Phobos::Misc::EnableCustomFPS = pINI_RULESMD->ReadBool(GameStrings::General, "EnableCustomFPS", true);
 
-	char tempBuffer[26];
-	for (size_t i = 0; i <= 6; ++i)
+	char tempBuffer[32];
+	for (int i = 0; i < 7; ++i)
 	{
-		int temp;
-		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.ChangeDelay", 6 - i);
-		temp = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, -1);
-		if (temp >= 0 && temp <= 6)
-			Phobos::Misc::CustomGS_ChangeDelay[i] = 6 - temp;
-
-		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.DefaultDelay", 6 - i);
-		temp = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, -1);
-		if (temp >= 1)
-			Phobos::Misc::CustomGS_DefaultDelay[i] = 6 - temp;
-
-		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGS%d.ChangeInterval", 6 - i);
-		temp = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, -1);
-		if (temp >= 1)
-			Phobos::Misc::CustomGS_ChangeInterval[i] = temp;
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "CustomGameSpeedFPS.%d", i);
+		Phobos::Misc::CustomGameSpeedFPS[i] = pINI_RULESMD->ReadInteger(GameStrings::General, tempBuffer, Phobos::Misc::CustomGameSpeedFPS[i]);
+		if (Phobos::Misc::CustomGameSpeedFPS[i] < 0)
+			Phobos::Misc::CustomGameSpeedFPS[i] = 0;
 	}
 
 	if (pINI_RULESMD->ReadBool(GameStrings::General, "FixTransparencyBlitters", true))

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -117,10 +117,8 @@ public:
 	class Misc
 	{
 	public:
-		static bool CustomGS;
-		static int CustomGS_ChangeInterval[7];
-		static int CustomGS_ChangeDelay[7];
-		static int CustomGS_DefaultDelay[7];
+		static int CustomGameSpeedFPS[7];
+		static bool EnableCustomFPS;
 	};
 
 	class Optimizations


### PR DESCRIPTION
- Deprecates `CustomGS ini` keys
- Adds `EnableCustomFPS` and `CustomGameSpeedFPS`

Add to `RulesMD.ini`
```ini
;note: use 0 for the game's default fps for that index
[General]
EnableCustomFPS=True
CustomGameSpeedFPS.0=100
CustomGameSpeedFPS.1=90
CustomGameSpeedFPS.2=80
CustomGameSpeedFPS.3=70
CustomGameSpeedFPS.4=60
CustomGameSpeedFPS.5=0 ;default
CustomGameSpeedFPS.6=0 ;default
```


This PR allows for custom FPS values for each of the `GameSpeed` indices. Applies to Campaign, Skirmish, and Multiplayer.

For multiplayer we hook into `Queue_AI_Multiplayer` to override the hardcoded 60fps cap, and override the `GameSpeed` index to fps calculation.

For Skirmish and Campaign, we hook in main loop to set up the `NFTTimer` that is used in multiplayer. We then hook into `SyncDelay` and force skirmish/campaign down the multiplayer path instead.

