### PR TITLE
Disable the Build workflow for PRs with the `No test needed` label.

### DIFF
--- a/.github/workflows/pr-nightly-comment.yml
+++ b/.github/workflows/pr-nightly-comment.yml
@@ -5,7 +5,10 @@ on:
     types: [completed]
 jobs:
   pr_comment:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: |
+      github.event.workflow_run.event == 'pull_request' && 
+      github.event.workflow_run.conclusion == 'success' &&
+      !contains(fromJson(github.event.workflow_run.pull_requests).*.labels.*.name, 'no test needed')
     runs-on: ubuntu-latest
     steps:
       - name: Get the PR number

--- a/.github/workflows/pr-nightly.yml
+++ b/.github/workflows/pr-nightly.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no test needed') }}
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
These changes are used to skip the `Pull Request Nightly Build / build (pull_request)` and its associated git bot auto-comments for Pull Requests that have the `No test needed` label added.

> [!Note]
> ## No test needed
> This PR is simple enough, or changes no in-game logic, so no in-game testing is required.