### PR TITLE
Fixed the issue where the AI's regular targeting would also target garrisonable buildings

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -705,6 +705,7 @@ This page lists all the individual contributions to the project by their author.
   - Global default value for `DefaultToGuardArea`
   - Weapon range finding in cylinder
   - Allow jumpjet climbing ignore building height
+  - Fix an issue where the AI's regular targeting would also target garrisonable buildings
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -301,6 +301,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Buildings with `NeedsEngineer=true` are now considered to have threat value of 0 under ownership of `MultiplayPassive=true` houses regardless of their `ThreatPosed` value.
 - Vehicles overlapping `Wall=true` OverlayTypes no longer display sell cursor and cannot be sold.
 - Fixed vehicles disguised as trees incorrectly displaying veterancy insignia when they shouldn't.
+- Fixed the issue where the AI's regular targeting would also target garrisonable buildings.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -1253,6 +1253,7 @@ Vanilla fixes:
 - Fixed building `TargetCoordOffset` not being taken into accord for several things like fire angle calculations and target lines (by Starkku)
 - Allowed observers to see a selected building's radial indicator (by Trsdy)
 - Allow voxel projectiles to use `AnimPalette` and `FirersPalette` (by NetsuNegi)
+- Fixed the issue where the AI's regular targeting would also target garrisonable buildings (by TaranDahl)
 
 Phobos fixes:
 - Fixed shields being able to take damage when the parent TechnoType was under effects of a `Temporal` Warhead (by Starkku)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3077,3 +3077,16 @@ DEFINE_HOOK(0x6EA870, TeamClass_LiberateMember_Start, 0x6)
 	pMember->RecruitableB = true;
 	return 0;
 }
+
+DEFINE_HOOK_AGAIN(0x6F845D, TechnoClass_CanAutoTargetObject_Garrisonable, 0x6);
+DEFINE_HOOK(0x6F833E, TechnoClass_CanAutoTargetObject_Garrisonable, 0x6)
+{
+	GET(TechnoClass*, pThis, EDI);
+	GET(bool, garrisonable, EAX);
+	GET_BASE(ThreatType, flags, 0x4);
+
+	bool isAttackMove = pThis->MegaMissionIsAttackMove(); // Attack move is allowed because it can switch to Mission::Attack
+	bool isFullMap = (flags & (ThreatType)3) == ThreatType::Normal; // Mission::Hunt and script is allowed
+	R->AL(garrisonable && (isAttackMove || isFullMap));
+	return 0;
+}

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3082,11 +3082,10 @@ DEFINE_HOOK_AGAIN(0x6F845D, TechnoClass_CanAutoTargetObject_Garrisonable, 0x6);
 DEFINE_HOOK(0x6F833E, TechnoClass_CanAutoTargetObject_Garrisonable, 0x6)
 {
 	GET(TechnoClass*, pThis, EDI);
-	GET(bool, garrisonable, EAX);
-	GET_BASE(ThreatType, flags, 0x4);
+	GET(const bool, garrisonable, EAX);
+	GET_BASE(const ThreatType, flags, 0x4);
 
-	bool isAttackMove = pThis->MegaMissionIsAttackMove(); // Attack move is allowed because it can switch to Mission::Attack
-	bool isFullMap = (flags & (ThreatType)3) == ThreatType::Normal; // Mission::Hunt and script is allowed
-	R->AL(garrisonable && (isAttackMove || isFullMap));
+	const bool isFullMap = (flags & (ThreatType)3) == ThreatType::Normal; // Mission::Hunt and script is allowed
+	R->AL(garrisonable && (isFullMap || pThis->MegaMissionIsAttackMove())); // Attack move is allowed because it can switch to Mission::Attack
 	return 0;
 }

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3083,7 +3083,7 @@ DEFINE_HOOK(0x6F833E, TechnoClass_CanAutoTargetObject_Garrisonable, 0x6)
 {
 	GET(TechnoClass*, pThis, EDI);
 	GET(const bool, garrisonable, EAX);
-	GET_BASE(const ThreatType, flags, 0x4);
+	GET_STACK(const ThreatType, flags, STACK_OFFSET(0x3C, 0x4));
 
 	const bool isFullMap = (flags & (ThreatType)3) == ThreatType::Normal; // Mission::Hunt and script is allowed
 	R->AL(garrisonable && (isFullMap || pThis->MegaMissionIsAttackMove())); // Attack move is allowed because it can switch to Mission::Attack


### PR DESCRIPTION
When an AI infantry unit is executing an attack or a hunt mission, it will automatically enter a garrisonable building. At the same time, AI units will automatically search for garrisonable buildings, thus achieving automatic garrisoning.
Missing checks have been added to prevent AI infantry from attacking garrisonable buildings during other missions.