### PR TITLE
Buildable-upon OverlayTypes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -308,6 +308,7 @@ This page lists all the individual contributions to the project by their author.
   - Tank Bunker improvements
   - `ProjectileRange` weapon range modifiers interaction fix
   - Berzerk duration stacking behaviour customization
+  - Buildable-upon OverlayTypes
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1568,15 +1568,19 @@ ProneSpeed=                   ; floating point value, multiplier, by default, us
 - It is now possible to make OverlayTypes allow buildings to be placed on them by setting `CanBeBuiltOn` to true. This still requires the tile's landtype (which is changed to overlay's land type unless OverlayType has `NoUseTileLandType=false`) to allow buildings to be placed.
   - If `CanBeBuiltOn.Remove=true`, the overlay will be removed (if it is a wall owned by the player placing the building, it is sold) upon the building being placed. If this is not set to true, buildings with `Wall=true` cannot be placed on the overlay and neither does overlay with `Wall=true` allow buildings to be placed on itself regardless of other settings.
   - `Tiberium.CanBeBuiltOn` can be used to set the global default value for overlays with `Tiberium=true`.
+  - `Wall.CanBeBuiltOn` can be used to set the global default value for overlays with `Wall=true`. This is checked after `Tiberium.CanBeBuiltOn`.
+  - `Rock.CanBeBuiltOn` can be used to set the global default value for overlays with `IsARock=true`. This is checked after `Tiberium.CanBeBuiltOn` and `Wall.CanBeBuiltOn`.
 
 In `rulesmd.ini`:
 ```ini
 [General]
 Tiberium.CanBeBuiltOn=false     ; boolean
+Wall.CanBeBuiltOn=false         ; boolean
+Rock.CanBeBuiltOn=false         ; boolean
 CanBeBuiltOnOverlay.Remove=true ; boolean
 
 [SOMEOVERLAY]                   ; OverlayType
-CanBeBuiltOn=                   ; boolean, default to [General] -> Tiberium.CanBeBuiltOn if it has Tiberium=true, and false otherwise
+CanBeBuiltOn=                   ; boolean, default to [General] -> Tiberium/Wall/Rock.CanBeBuiltOn depends on the overlay settings, and false otherwise
 CanBeBuiltOn.Remove=            ; boolean, default to [General] -> CanBeBuiltOnOverlay.Remove
 ```
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -114,10 +114,10 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Objects with `Palette` set now have their color tint adjusted accordingly by superweapons, map retint actions etc. if they belong to a house using any color scheme instead of only those from the first half of `[Colors]` list.
 - Fixed `DeployToFire` not considering building placement rules for `DeploysInto` buildings and as a result not working properly with `WaterBound` buildings.
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy.
-- `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`.
+- `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`, default to `[CombatDamage] -> Arcing.AllowElevationInaccuracy`.
 - Wall overlays are now drawn with the custom palette defined in `Palette` in `artmd.ini` if possible.
-- Setting `ReloadInTransport` to true on units with `Ammo` will allow the ammo to be reloaded according to `Reload` or `EmptyReload` timers even while the unit is inside a transport.
-- It is now possible to enable `Verses` and `PercentAtMax` to be applied on negative damage by setting `ApplyModifiersOnNegativeDamage` to true on the Warhead.
+- Setting `ReloadInTransport` to true on units with `Ammo` will allow the ammo to be reloaded according to `Reload` or `EmptyReload` timers even while the unit is inside a transport. Can also be defined at `[General] -> ReloadInTransport` for a global default value.
+- It is now possible to enable `Verses` and `PercentAtMax` to be applied on negative damage by setting `ApplyModifiersOnNegativeDamage` to true on the Warhead, default to `[General] -> ApplyModifiersOnNegativeDamage`.
 - Attached animations on flying units now have their layer updated immediately after the parent unit, if on same layer they always draw above the parent.
 - Fixed an issue where the powered anims of `Powered` / `PoweredSpecial` buildings cease to update when being captured by enemies.
 - Fixed a glitch related to incorrect target setting for spawned missiles. Notice that this will affect the center of missile explosion, set `[CombatDamage] -> MissileSpawnAttackCell` to false to disable the fix.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -114,10 +114,16 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Objects with `Palette` set now have their color tint adjusted accordingly by superweapons, map retint actions etc. if they belong to a house using any color scheme instead of only those from the first half of `[Colors]` list.
 - Fixed `DeployToFire` not considering building placement rules for `DeploysInto` buildings and as a result not working properly with `WaterBound` buildings.
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy.
+<<<<<<< HEAD
 - `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`, default to `[CombatDamage] -> Arcing.AllowElevationInaccuracy`.
 - Wall overlays are now drawn with the custom palette defined in `Palette` in `artmd.ini` if possible.
 - Setting `ReloadInTransport` to true on units with `Ammo` will allow the ammo to be reloaded according to `Reload` or `EmptyReload` timers even while the unit is inside a transport. Can also be defined at `[General] -> ReloadInTransport` for a global default value.
 - It is now possible to enable `Verses` and `PercentAtMax` to be applied on negative damage by setting `ApplyModifiersOnNegativeDamage` to true on the Warhead, default to `[General] -> ApplyModifiersOnNegativeDamage`.
+=======
+- `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`.
+- Setting `ReloadInTransport` to true on units with `Ammo` will allow the ammo to be reloaded according to `Reload` or `EmptyReload` timers even while the unit is inside a transport.
+- It is now possible to enable `Verses` and `PercentAtMax` to be applied on negative damage by setting `ApplyModifiersOnNegativeDamage` to true on the Warhead.
+>>>>>>> a788ad7b1 (Add toggle to allow building on overlays)
 - Attached animations on flying units now have their layer updated immediately after the parent unit, if on same layer they always draw above the parent.
 - Fixed an issue where the powered anims of `Powered` / `PoweredSpecial` buildings cease to update when being captured by enemies.
 - Fixed a glitch related to incorrect target setting for spawned missiles. Notice that this will affect the center of missile explosion, set `[CombatDamage] -> MissileSpawnAttackCell` to false to disable the fix.
@@ -1563,14 +1569,38 @@ ProneSpeed=                   ; floating point value, multiplier, by default, us
 
 - Game now supports more than 255 distinct OverlayTypes, up to 65535. For map file/editor support, see [Increased Overlay Limit](AI-Scripting-and-Mapping.md#increased-overlay-limit).
 
-### `ZAdjust` for OverlayTypes
+### Buildable-upon OverlayTypes
 
-- OverlayTypes now read and use `ZAdjust` if specified in their `artmd.ini` entry.
+- It is now possible to make OverlayTypes allow buildings to be placed on them by setting `CanBeBuiltOn` to true. This still requires the tile's landtype (which is changed to overlay's land type unless OverlayType has `NoUseTileLandType=false`) to allow buildings to be placed.
+  - If `CanBeBuiltOn.Remove=true`, the overlay will be removed (if it is a wall owned by the player placing the building, it is sold) upon the building being placed. If this is not set to true, buildings with `Wall=true` cannot be placed on the overlay and neither does overlay with `Wall=true` allow buildings to be placed on itself regardless of other settings.
+
+In `rulesmd.ini`:
+```ini
+[SOMEOVERLAY]             ; OverlayType
+CanBeBuiltOn=false        ; boolean
+
+### More than 255 OverlayTypes
+
+- Game now supports more than 255 distinct OverlayTypes, up to 65535. For map file/editor support, see [Increased Overlay Limit](AI-Scripting-and-Mapping.md#increased-overlay-limit).
+
+### Custom palette
+
+- You can now specify custom palette for OverlayTypes in similar manner as TechnoTypes can.
 
 In `artmd.ini`:
 ```ini
-[SOMEOVERLAY]  ; OverlayType Image
-ZAdjust=0      ; integer
+[SOMETERRAINTYPE]  ; TerrainType
+Palette=           ; filename - excluding .pal extension and three-character theater-specific suffix
+```
+
+### ZAdjust
+
+- OverlayTypes now read and use `ZAdjust`.
+
+In `artmd.ini`:
+```ini
+[SOMEOVERLAY]  ; OverlayType image
+ZAdjust=0
 ```
 
 ## Particle systems

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -214,6 +214,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that infantry ignored `Passengers` and `SizeLimit` when entering buildings.
 - Fixed `VoiceDeploy` not played, when deployed through hot-key/command bar.
 - Fixed the bug that ships can travel on elevated bridges.
+- Dehardcoded 255 limit of `OverlayType`.
 - Fixed an issue where airstrike flare line drawn to target at lower elevation would clip.
 - Elite technos no longer scatter by default, behaviour is controlled by `SCATTER` veterancy ability now.
 - Second weapon with `ElectricAssault=yes` will not unconditionally attack your building with `Overpowerable=yes`.
@@ -1574,38 +1575,24 @@ ProneSpeed=                   ; floating point value, multiplier, by default, us
 In `rulesmd.ini`:
 ```ini
 [General]
-Tiberium.CanBeBuiltOn=false     ; boolean
-Wall.CanBeBuiltOn=false         ; boolean
-Rock.CanBeBuiltOn=false         ; boolean
-CanBeBuiltOnOverlay.Remove=true ; boolean
+Tiberium.CanBeBuiltOn=false      ; boolean
+Wall.CanBeBuiltOn=false          ; boolean
+Rock.CanBeBuiltOn=false          ; boolean
+CanBeBuiltOnOverlay.Remove=true  ; boolean
 
-[SOMEOVERLAY]                   ; OverlayType
-CanBeBuiltOn=                   ; boolean, default to [General] -> Tiberium/Wall/Rock.CanBeBuiltOn depends on the overlay settings, and false otherwise
-CanBeBuiltOn.Remove=            ; boolean, default to [General] -> CanBeBuiltOnOverlay.Remove
+[SOMEOVERLAY]                    ; OverlayType
+CanBeBuiltOn=                    ; boolean, default to [General] -> Tiberium/Wall/Rock.CanBeBuiltOn depends on the overlay settings, and false otherwise
+CanBeBuiltOn.Remove=             ; boolean, default to [General] -> CanBeBuiltOnOverlay.Remove
 ```
 
-### More than 255 OverlayTypes
+### `ZAdjust` for OverlayTypes
 
-- Game now supports more than 255 distinct OverlayTypes, up to 65535. For map file/editor support, see [Increased Overlay Limit](AI-Scripting-and-Mapping.md#increased-overlay-limit).
-
-### Custom palette
-
-- You can now specify custom palette for OverlayTypes in similar manner as TechnoTypes can.
+- OverlayTypes now read and use `ZAdjust` if specified in their `artmd.ini` entry.
 
 In `artmd.ini`:
 ```ini
-[SOMETERRAINTYPE]  ; TerrainType
-Palette=           ; filename - excluding .pal extension and three-character theater-specific suffix
-```
-
-### ZAdjust
-
-- OverlayTypes now read and use `ZAdjust`.
-
-In `artmd.ini`:
-```ini
-[SOMEOVERLAY]  ; OverlayType image
-ZAdjust=0
+[SOMEOVERLAY]  ; OverlayType Image
+ZAdjust=0      ; integer
 ```
 
 ## Particle systems

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -114,16 +114,10 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Objects with `Palette` set now have their color tint adjusted accordingly by superweapons, map retint actions etc. if they belong to a house using any color scheme instead of only those from the first half of `[Colors]` list.
 - Fixed `DeployToFire` not considering building placement rules for `DeploysInto` buildings and as a result not working properly with `WaterBound` buildings.
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy.
-<<<<<<< HEAD
-- `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`, default to `[CombatDamage] -> Arcing.AllowElevationInaccuracy`.
-- Wall overlays are now drawn with the custom palette defined in `Palette` in `artmd.ini` if possible.
-- Setting `ReloadInTransport` to true on units with `Ammo` will allow the ammo to be reloaded according to `Reload` or `EmptyReload` timers even while the unit is inside a transport. Can also be defined at `[General] -> ReloadInTransport` for a global default value.
-- It is now possible to enable `Verses` and `PercentAtMax` to be applied on negative damage by setting `ApplyModifiersOnNegativeDamage` to true on the Warhead, default to `[General] -> ApplyModifiersOnNegativeDamage`.
-=======
 - `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`.
+- Wall overlays are now drawn with the custom palette defined in `Palette` in `artmd.ini` if possible.
 - Setting `ReloadInTransport` to true on units with `Ammo` will allow the ammo to be reloaded according to `Reload` or `EmptyReload` timers even while the unit is inside a transport.
 - It is now possible to enable `Verses` and `PercentAtMax` to be applied on negative damage by setting `ApplyModifiersOnNegativeDamage` to true on the Warhead.
->>>>>>> a788ad7b1 (Add toggle to allow building on overlays)
 - Attached animations on flying units now have their layer updated immediately after the parent unit, if on same layer they always draw above the parent.
 - Fixed an issue where the powered anims of `Powered` / `PoweredSpecial` buildings cease to update when being captured by enemies.
 - Fixed a glitch related to incorrect target setting for spawned missiles. Notice that this will affect the center of missile explosion, set `[CombatDamage] -> MissileSpawnAttackCell` to false to disable the fix.
@@ -1573,11 +1567,18 @@ ProneSpeed=                   ; floating point value, multiplier, by default, us
 
 - It is now possible to make OverlayTypes allow buildings to be placed on them by setting `CanBeBuiltOn` to true. This still requires the tile's landtype (which is changed to overlay's land type unless OverlayType has `NoUseTileLandType=false`) to allow buildings to be placed.
   - If `CanBeBuiltOn.Remove=true`, the overlay will be removed (if it is a wall owned by the player placing the building, it is sold) upon the building being placed. If this is not set to true, buildings with `Wall=true` cannot be placed on the overlay and neither does overlay with `Wall=true` allow buildings to be placed on itself regardless of other settings.
+  - `Tiberium.CanBeBuiltOn` can be used to set the global default value for overlays with `Tiberium=true`.
 
 In `rulesmd.ini`:
 ```ini
-[SOMEOVERLAY]             ; OverlayType
-CanBeBuiltOn=false        ; boolean
+[General]
+Tiberium.CanBeBuiltOn=false     ; boolean
+CanBeBuiltOnOverlay.Remove=true ; boolean
+
+[SOMEOVERLAY]                   ; OverlayType
+CanBeBuiltOn=                   ; boolean, default to [General] -> Tiberium.CanBeBuiltOn if it has Tiberium=true, and false otherwise
+CanBeBuiltOn.Remove=            ; boolean, default to [General] -> CanBeBuiltOnOverlay.Remove
+```
 
 ### More than 255 OverlayTypes
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -720,6 +720,7 @@ HideShakeEffects=false           ; boolean
 - [Disable AlphaImage during Buildup](Fixed-or-Improved-Logics.md#disable-alphaimage-during-buildup) (by Noble_Fish)
 - [Reload speed adjustment on promotion](New-or-Enhanced-Logics.md#reload-speed-adjustment-on-promotion) (by Nuke)
 - Allowed `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys (by Noble_Fish)
+- [Buildable-upon OverlayTypes](Fixed-or-Improved-Logics.md#buildable-upon-overlaytypes) (by Starkku)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/OverlayType/Body.cpp
+++ b/src/Ext/OverlayType/Body.cpp
@@ -1,5 +1,7 @@
 #include "Body.h"
 
+#include <Ext/Rules/Body.h>
+
 OverlayTypeExt::ExtContainer OverlayTypeExt::ExtMap;
 
 bool OverlayTypeExt::CanPlaceBuildingOnOverlay(int overlayTypeIndex, BuildingTypeClass* pBuildingType, bool requireToBeRemovable)
@@ -7,13 +9,15 @@ bool OverlayTypeExt::CanPlaceBuildingOnOverlay(int overlayTypeIndex, BuildingTyp
 	auto const pOverlayType = OverlayTypeClass::Array[overlayTypeIndex];
 	auto const pTypeExt = OverlayTypeExt::Fetch(pOverlayType);
 
-	if (!pTypeExt->CanBeBuiltOn)
+	if (!pTypeExt->CanBeBuiltOn.Get(pOverlayType->Tiberium ? RulesExt::Global()->Tiberium_CanBeBuiltOn : false))
 		return false;
 
-	if (((pBuildingType && pBuildingType->Wall) || pOverlayType->Wall) && !pTypeExt->CanBeBuiltOn_Remove)
+	const bool remove = pTypeExt->CanBeBuiltOn_Remove.Get(RulesExt::Global()->CanBeBuiltOnOverlay_Remove);
+
+	if (((pBuildingType && pBuildingType->Wall) || pOverlayType->Wall) && !remove)
 		return false;
 
-	return requireToBeRemovable ? pTypeExt->CanBeBuiltOn_Remove : true;
+	return requireToBeRemovable ? remove : true;
 }
 
 void OverlayTypeExt::RemoveOverlayFromCell(int overlayTypeIndex, CellClass* pCell, HouseClass* pSource)

--- a/src/Ext/OverlayType/Body.cpp
+++ b/src/Ext/OverlayType/Body.cpp
@@ -9,8 +9,13 @@ bool OverlayTypeExt::CanPlaceBuildingOnOverlay(int overlayTypeIndex, BuildingTyp
 	auto const pOverlayType = OverlayTypeClass::Array[overlayTypeIndex];
 	auto const pTypeExt = OverlayTypeExt::Fetch(pOverlayType);
 
-	if (!pTypeExt->CanBeBuiltOn.Get(pOverlayType->Tiberium ? RulesExt::Global()->Tiberium_CanBeBuiltOn : false))
+	if (!pTypeExt->CanBeBuiltOn.Get(pOverlayType->Tiberium ? RulesExt::Global()->Tiberium_CanBeBuiltOn
+		: pOverlayType->Wall ? RulesExt::Global()->Wall_CanBeBuiltOn
+		: pOverlayType->IsARock ? RulesExt::Global()->Rock_CanBeBuiltOn
+		: false))
+	{
 		return false;
+	}
 
 	const bool remove = pTypeExt->CanBeBuiltOn_Remove.Get(RulesExt::Global()->CanBeBuiltOnOverlay_Remove);
 

--- a/src/Ext/OverlayType/Body.cpp
+++ b/src/Ext/OverlayType/Body.cpp
@@ -2,6 +2,37 @@
 
 OverlayTypeExt::ExtContainer OverlayTypeExt::ExtMap;
 
+bool OverlayTypeExt::CanPlaceBuildingOnOverlay(int overlayTypeIndex, BuildingTypeClass* pBuildingType, bool requireToBeRemovable)
+{
+	auto const pOverlayType = OverlayTypeClass::Array[overlayTypeIndex];
+	auto const pTypeExt = OverlayTypeExt::Fetch(pOverlayType);
+
+	if (!pTypeExt->CanBeBuiltOn)
+		return false;
+
+	if (((pBuildingType && pBuildingType->Wall) || pOverlayType->Wall) && !pTypeExt->CanBeBuiltOn_Remove)
+		return false;
+
+	return requireToBeRemovable ? pTypeExt->CanBeBuiltOn_Remove : true;
+}
+
+void OverlayTypeExt::RemoveOverlayFromCell(int overlayTypeIndex, CellClass* pCell, HouseClass* pSource)
+{
+	if (overlayTypeIndex != -1 && OverlayTypeClass::Array[overlayTypeIndex]->Wall)
+	{
+		if (pSource && pCell->WallOwnerIndex == pSource->ArrayIndex)
+			pSource->SellWall(pCell->MapCoords, true);
+		else
+			pCell->DamageWall(-1);
+	}
+	else
+	{
+		pCell->OverlayTypeIndex = -1;
+		pCell->OverlayData = 0;
+		pCell->RecalcAttributes(-1);
+	}
+}
+
 // =============================
 // load / save
 
@@ -9,6 +40,8 @@ template <typename T>
 void OverlayTypeExt::Serialize(T& Stm)
 {
 	Stm
+		.Process(this->CanBeBuiltOn)
+		.Process(this->CanBeBuiltOn_Remove)
 		.Process(this->ZAdjust)
 		.Process(this->PaletteFile)
 		;
@@ -18,12 +51,15 @@ void OverlayTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 {
 	auto pThis = this->OwnerObject();
 
-	//const char* pSection = pThis->ID;
-	//
-	//if (!pINI->GetSection(pSection))
-	//	return;
-	//
-	//INI_EX exINI(pINI);
+	const char* pSection = pThis->ID;
+	
+	if (!pINI->GetSection(pSection))
+		return;
+
+	INI_EX exINI(pINI);
+
+	this->CanBeBuiltOn.Read(exINI, pSection, "CanBeBuiltOn");
+	this->CanBeBuiltOn_Remove.Read(exINI, pSection, "CanBeBuiltOn.Remove");
 
 	auto pArtSection = pThis->ImageFile;
 	INI_EX exArtINI(&CCINIClass::INI_Art);

--- a/src/Ext/OverlayType/Body.h
+++ b/src/Ext/OverlayType/Body.h
@@ -22,15 +22,15 @@ public:
 		return static_cast<OverlayTypeClass*>(this->GetAttachedObject());
 	}
 
-	Valueable<bool> CanBeBuiltOn;
-	Valueable<bool> CanBeBuiltOn_Remove;
+	Nullable<bool> CanBeBuiltOn;
+	Nullable<bool> CanBeBuiltOn_Remove;
 	Valueable<int> ZAdjust;
 	PhobosFixedString<32u> PaletteFile;
 	DynamicVectorClass<ColorScheme*>* Palette; // Intentionally not serialized - rebuilt from the palette file on load.
 
 	OverlayTypeExt(OverlayTypeClass* OwnerObject) : ObjectTypeExt(OwnerObject)
-		, CanBeBuiltOn { false }
-		, CanBeBuiltOn_Remove { true }
+		, CanBeBuiltOn {}
+		, CanBeBuiltOn_Remove {}
 		, ZAdjust { 0 }
 		, PaletteFile {}
 		, Palette {}

--- a/src/Ext/OverlayType/Body.h
+++ b/src/Ext/OverlayType/Body.h
@@ -22,11 +22,15 @@ public:
 		return static_cast<OverlayTypeClass*>(this->GetAttachedObject());
 	}
 
+	Valueable<bool> CanBeBuiltOn;
+	Valueable<bool> CanBeBuiltOn_Remove;
 	Valueable<int> ZAdjust;
 	PhobosFixedString<32u> PaletteFile;
 	DynamicVectorClass<ColorScheme*>* Palette; // Intentionally not serialized - rebuilt from the palette file on load.
 
 	OverlayTypeExt(OverlayTypeClass* OwnerObject) : ObjectTypeExt(OwnerObject)
+		, CanBeBuiltOn { false }
+		, CanBeBuiltOn_Remove { true }
 		, ZAdjust { 0 }
 		, PaletteFile {}
 		, Palette {}
@@ -65,5 +69,8 @@ public:
 
 	static bool LoadGlobals(PhobosStreamReader& Stm);
 	static bool SaveGlobals(PhobosStreamWriter& Stm);
+
+	static bool CanPlaceBuildingOnOverlay(int overlayTypeIndex, BuildingTypeClass* pBuildingType, bool requireToBeRemovable);
+	static void RemoveOverlayFromCell(int overlayTypeIndex, CellClass* pCell, HouseClass* pSource);
 };
 

--- a/src/Ext/OverlayType/Hooks.cpp
+++ b/src/Ext/OverlayType/Hooks.cpp
@@ -54,7 +54,7 @@ DEFINE_HOOK(0x47C9A7, CellClass_IsClearToBuild_Overlays, 0x5)
 	GET(CellClass*, pThis, EDI);
 	GET_STACK(BuildingTypeClass*, pBuildingType, STACK_OFFSET(0x18, 0x8));
 
-	int overlayTypeIndex = pThis->OverlayTypeIndex;
+	const int overlayTypeIndex = pThis->OverlayTypeIndex;
 
 	if (overlayTypeIndex != -1)
 	{
@@ -70,7 +70,7 @@ DEFINE_HOOK(0x45EF11, BuildingTypeClass_FlushForPlacement_Overlays, 0x6)
 	enum { Continue = 0x45EF2C };
 
 	GET(BuildingTypeClass*, pThis, EBX);
-	GET(int, overlayTypeIndex, ECX);
+	GET(const int, overlayTypeIndex, ECX);
 
 	if (OverlayTypeExt::CanPlaceBuildingOnOverlay(overlayTypeIndex, pThis, false))
 		return Continue;

--- a/src/Ext/OverlayType/Hooks.cpp
+++ b/src/Ext/OverlayType/Hooks.cpp
@@ -44,3 +44,38 @@ DEFINE_HOOK(0x47F974, CellClass_DrawOverlay_Walls, 0x5)
 
 	return SkipGameCode;
 }
+
+#pragma region CanBeBuiltOn
+
+DEFINE_HOOK(0x47C9A7, CellClass_IsClearToBuild_Overlays, 0x5)
+{
+	enum { ReturnFromFunction = 0x47C6D1, CheckTileLandType = 0x47C9CD };
+
+	GET(CellClass*, pThis, EDI);
+	GET_STACK(BuildingTypeClass*, pBuildingType, STACK_OFFSET(0x18, 0x8));
+
+	int overlayTypeIndex = pThis->OverlayTypeIndex;
+
+	if (overlayTypeIndex != -1)
+	{
+		if (OverlayTypeExt::CanPlaceBuildingOnOverlay(overlayTypeIndex, pBuildingType, false))
+			return CheckTileLandType;
+	}
+
+	return ReturnFromFunction;
+}
+
+DEFINE_HOOK(0x45EF11, BuildingTypeClass_FlushForPlacement_Overlays, 0x6)
+{
+	enum { Continue = 0x45EF2C };
+
+	GET(BuildingTypeClass*, pThis, EBX);
+	GET(int, overlayTypeIndex, ECX);
+
+	if (OverlayTypeExt::CanPlaceBuildingOnOverlay(overlayTypeIndex, pThis, false))
+		return Continue;
+
+	return 0;
+}
+
+#pragma endregion

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -457,6 +457,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Terrain_CanBeBuiltOn.Read(exINI, GameStrings::General, "Terrain.CanBeBuiltOn");
 	this->Tibtree_CanBeBuiltOn.Read(exINI, GameStrings::General, "Tibtree.CanBeBuiltOn");
 	this->Tiberium_CanBeBuiltOn.Read(exINI, GameStrings::General, "Tiberium.CanBeBuiltOn");
+	this->Wall_CanBeBuiltOn.Read(exINI, GameStrings::General, "Wall.CanBeBuiltOn");
+	this->Rock_CanBeBuiltOn.Read(exINI, GameStrings::General, "Rock.CanBeBuiltOn");
 	this->CanBeBuiltOnOverlay_Remove.Read(exINI, GameStrings::General, "CanBeBuiltOnOverlay.Remove");
 
 	this->Sinkable.Read(exINI, GameStrings::General, "Sinkable");
@@ -1016,6 +1018,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Terrain_CanBeBuiltOn)
 		.Process(this->Tibtree_CanBeBuiltOn)
 		.Process(this->Tiberium_CanBeBuiltOn)
+		.Process(this->Wall_CanBeBuiltOn)
+		.Process(this->Rock_CanBeBuiltOn)
 		.Process(this->CanBeBuiltOnOverlay_Remove)
 		.Process(this->Sinkable)
 		.Process(this->Sinkable_SquidGrab)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -456,6 +456,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Tibtree_IsPassable.Read(exINI, GameStrings::General, "Tibtree.IsPassable");
 	this->Terrain_CanBeBuiltOn.Read(exINI, GameStrings::General, "Terrain.CanBeBuiltOn");
 	this->Tibtree_CanBeBuiltOn.Read(exINI, GameStrings::General, "Tibtree.CanBeBuiltOn");
+	this->Tiberium_CanBeBuiltOn.Read(exINI, GameStrings::General, "Tiberium.CanBeBuiltOn");
+	this->CanBeBuiltOnOverlay_Remove.Read(exINI, GameStrings::General, "CanBeBuiltOnOverlay.Remove");
 
 	this->Sinkable.Read(exINI, GameStrings::General, "Sinkable");
 	this->Sinkable_SquidGrab.Read(exINI, GameStrings::General, "Sinkable.SquidGrab");
@@ -1013,6 +1015,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Tibtree_IsPassable)
 		.Process(this->Terrain_CanBeBuiltOn)
 		.Process(this->Tibtree_CanBeBuiltOn)
+		.Process(this->Tiberium_CanBeBuiltOn)
+		.Process(this->CanBeBuiltOnOverlay_Remove)
 		.Process(this->Sinkable)
 		.Process(this->Sinkable_SquidGrab)
 		.Process(this->SinkSpeed)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -389,6 +389,8 @@ public:
 		Valueable<bool> Terrain_CanBeBuiltOn;
 		Valueable<bool> Tibtree_CanBeBuiltOn;
 		Valueable<bool> Tiberium_CanBeBuiltOn;
+		Valueable<bool> Wall_CanBeBuiltOn;
+		Valueable<bool> Rock_CanBeBuiltOn;
 		Valueable<bool> CanBeBuiltOnOverlay_Remove;
 
 		Nullable<bool> Sinkable;
@@ -888,6 +890,8 @@ public:
 			, Terrain_CanBeBuiltOn { false }
 			, Tibtree_CanBeBuiltOn { false }
 			, Tiberium_CanBeBuiltOn { false }
+			, Wall_CanBeBuiltOn { false }
+			, Rock_CanBeBuiltOn { false }
 			, CanBeBuiltOnOverlay_Remove { true }
 
 			, Sinkable {}

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -388,6 +388,8 @@ public:
 		Valueable<bool> Tibtree_IsPassable;
 		Valueable<bool> Terrain_CanBeBuiltOn;
 		Valueable<bool> Tibtree_CanBeBuiltOn;
+		Valueable<bool> Tiberium_CanBeBuiltOn;
+		Valueable<bool> CanBeBuiltOnOverlay_Remove;
 
 		Nullable<bool> Sinkable;
 		Valueable<bool> Sinkable_SquidGrab;
@@ -885,6 +887,8 @@ public:
 			, Tibtree_IsPassable { false }
 			, Terrain_CanBeBuiltOn { false }
 			, Tibtree_CanBeBuiltOn { false }
+			, Tiberium_CanBeBuiltOn { false }
+			, CanBeBuiltOnOverlay_Remove { true }
 
 			, Sinkable {}
 			, Sinkable_SquidGrab { true }

--- a/src/Ext/TerrainType/Hooks.Passable.cpp
+++ b/src/Ext/TerrainType/Hooks.Passable.cpp
@@ -267,8 +267,11 @@ DEFINE_HOOK(0x586780, MapClass_IsAreaFree, 0x7)
 				? (pCell->Passability != PassabilityType::Passable && pCell->Passability != PassabilityType::HasFreeSpots)
 				: (pCell->Passability != PassabilityType::Passable);
 
+			// Check if cell has overlay and if it is buildable on.
+			const bool invalidOverlay = pCell->OverlayTypeIndex != -1 && !OverlayTypeExt::CanPlaceBuildingOnOverlay(pCell->OverlayTypeIndex, nullptr, false);
+
 			if ((pCell->BaseSpacerOfHouses & mask) != 0
-				|| pCell->OverlayTypeIndex != -1
+				|| invalidOverlay
 				|| invalidPassability
 				|| pCell->SlopeIndex
 				|| pCell->GetBuilding())

--- a/src/Ext/TerrainType/Hooks.Passable.cpp
+++ b/src/Ext/TerrainType/Hooks.Passable.cpp
@@ -1,4 +1,5 @@
 #include "Body.h"
+#include <Ext/OverlayType/Body.h>
 
 #include <Ext/Rules/Body.h>
 
@@ -141,6 +142,16 @@ DEFINE_HOOK(0x5684B1, MapClass_PlaceDown_BuildableTerrain, 0x6)
 				pCell->RemoveContent(pTerrain, false);
 				TerrainTypeExt::Remove(pTerrain);
 			}
+		}
+
+		int overlayTypeIndex = pCell->OverlayTypeIndex;
+
+		if (overlayTypeIndex != -1)
+		{
+			auto const pBuildingType = static_cast<BuildingTypeClass*>(pObject->GetType());
+
+			if (OverlayTypeExt::CanPlaceBuildingOnOverlay(overlayTypeIndex, pBuildingType, true))
+				OverlayTypeExt::RemoveOverlayFromCell(overlayTypeIndex, pCell, pObject->GetOwningHouse());
 		}
 	}
 

--- a/src/Ext/TerrainType/Hooks.Passable.cpp
+++ b/src/Ext/TerrainType/Hooks.Passable.cpp
@@ -144,7 +144,7 @@ DEFINE_HOOK(0x5684B1, MapClass_PlaceDown_BuildableTerrain, 0x6)
 			}
 		}
 
-		int overlayTypeIndex = pCell->OverlayTypeIndex;
+		const int overlayTypeIndex = pCell->OverlayTypeIndex;
 
 		if (overlayTypeIndex != -1)
 		{


### PR DESCRIPTION
### Buildable-upon OverlayTypes

- It is now possible to make OverlayTypes allow buildings to be placed on them by setting `CanBeBuiltOn` to true. This still requires the tile's landtype (which is changed to overlay's land type unless OverlayType has `NoUseTileLandType=false`) to allow buildings to be placed.
  - If `CanBeBuiltOn.Remove=true`, the overlay will be removed (if it is a wall owned by the player placing the building, it is sold) upon the building being placed. If this is not set to true, buildings with `Wall=true` cannot be placed on the overlay and neither does overlay with `Wall=true` allow buildings to be placed on itself regardless of other settings.
  - `Tiberium.CanBeBuiltOn` can be used to set the global default value for overlays with `Tiberium=true`.
  - `Wall.CanBeBuiltOn` can be used to set the global default value for overlays with `Wall=true`. This is checked after `Tiberium.CanBeBuiltOn`.
  - `Rock.CanBeBuiltOn` can be used to set the global default value for overlays with `IsARock=true`. This is checked after `Tiberium.CanBeBuiltOn` and `Wall.CanBeBuiltOn`.

In `rulesmd.ini`:
```ini
[General]
Tiberium.CanBeBuiltOn=false     ; boolean
Wall.CanBeBuiltOn=false         ; boolean
Rock.CanBeBuiltOn=false         ; boolean
CanBeBuiltOnOverlay.Remove=true ; boolean

[SOMEOVERLAY]                   ; OverlayType
CanBeBuiltOn=                   ; boolean, default to [General] -> Tiberium/Wall/Rock.CanBeBuiltOn depends on the overlay settings, and false otherwise
CanBeBuiltOn.Remove=            ; boolean, default to [General] -> CanBeBuiltOnOverlay.Remove
```