### PR TITLE
Vanilla Fix - Sell Unit Exploit 

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -17,7 +17,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that temporaryed unit cannot be erased correctly and no longer raise an error.
 - Fixed building and defense tab hotkeys not enabling the placement mode after *Cannot build here.* triggered and the placement mode cancelled.
 - Fixed buildings with `UndeployInto` playing `EVA_NewRallypointEstablished` on undeploying.
-- Fixed ambiguous sell-target selection when clicking overlapping objects. Sell action now prefers a building on the clicked cell, preventing accidental selling of units/aircraft when the cursor overlaps non-building objects.
+- Vehicles overlapping wall overlaytypes are no longer sellable through exploits.
 - Fixed buildings with `Naval=yes` ignoring `WaterBound=no` to be forced to place onto water.
 - Fixed AI Aircraft docks bug when Ares tag `[GlobalControls] -> AllowParallelAIQueues=no` is set.
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -17,6 +17,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that temporaryed unit cannot be erased correctly and no longer raise an error.
 - Fixed building and defense tab hotkeys not enabling the placement mode after *Cannot build here.* triggered and the placement mode cancelled.
 - Fixed buildings with `UndeployInto` playing `EVA_NewRallypointEstablished` on undeploying.
+- Fixed ambiguous sell-target selection when clicking overlapping objects. Sell action now prefers a building on the clicked cell, preventing accidental selling of units/aircraft when the cursor overlaps non-building objects.
 - Fixed buildings with `Naval=yes` ignoring `WaterBound=no` to be forced to place onto water.
 - Fixed AI Aircraft docks bug when Ares tag `[GlobalControls] -> AllowParallelAIQueues=no` is set.
 - Fixed laser drawing code to allow for thicker lasers in house color draw mode.

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -237,6 +237,33 @@ DEFINE_HOOK(0x702299, TechnoClass_ReceiveDamage_Debris, 0xA)
 // Author: Uranusian
 DEFINE_JUMP(LJMP, 0x4ABBD5, 0x4ABBD5 + 7); // DisplayClass_MouseLeftRelease_HotkeyFix
 
+// Fixes ambiguous sell-target selection when cursor overlap picks a non-building object first.
+// In Action::Sell path, force target to a building on clicked cell (if any) so SellUnit=false cannot
+// accidentally sell unit/aircraft via building-sell action.
+// Author: EJ, RAZER
+DEFINE_HOOK(0x4AC15A, DisplayClass_LeftMouseButtonUp_SellAction_RetargetBuilding, 0x4)
+{
+	enum { Continue = 0, SellCell = 0x4AC19A, SkipSellEvent = 0x4AC20C };
+
+	GET(ObjectClass*, pSellTarget, ESI);
+	const bool hadObjectTarget = (pSellTarget != nullptr);
+
+	if (pSellTarget && pSellTarget->WhatAmI() != AbstractType::Building)
+	{
+		GET_STACK(const CellStruct*, pClickedCell, 0x94);
+
+		pSellTarget = MapClass::Instance.GetCellAt(*pClickedCell)->GetBuilding();
+		R->ESI(pSellTarget);
+
+		// Ambiguous overlap case with object target but no building under clicked cell:
+		// do not emit Sell / SellCell events from this path.
+		if (!pSellTarget && hadObjectTarget)
+			return SkipSellEvent;
+	}
+
+	return pSellTarget ? Continue : SellCell;
+}
+
 DEFINE_HOOK(0x4FB2DE, HouseClass_PlaceObject_HotkeyFix, 0x6)
 {
 	GET(TechnoClass*, pObject, ESI);
@@ -2724,7 +2751,7 @@ DEFINE_HOOK(0x5218C2, InfantryClass_UnmarkAllOccupationBits_ResetOwnerIdx, 0x6)
 	const auto pExt = CellExt::ExtMap.Find(pCell);
 	pExt->InfantryCount--;
 
-	// Vanilla check only the flag to decide if the InfantryOwnerIndex should be reset. 
+	// Vanilla check only the flag to decide if the InfantryOwnerIndex should be reset.
 	// But the tree take one of the flag bit. So if a infantry walk through a cell with a tree, the InfantryOwnerIndex won't be reset.
 	return (newFlag & 0x1C) == 0 || pExt->InfantryCount == 0 ? Reset : NoReset;
 }

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -237,33 +237,6 @@ DEFINE_HOOK(0x702299, TechnoClass_ReceiveDamage_Debris, 0xA)
 // Author: Uranusian
 DEFINE_JUMP(LJMP, 0x4ABBD5, 0x4ABBD5 + 7); // DisplayClass_MouseLeftRelease_HotkeyFix
 
-// Fixes ambiguous sell-target selection when cursor overlap picks a non-building object first.
-// In Action::Sell path, force target to a building on clicked cell (if any) so SellUnit=false cannot
-// accidentally sell unit/aircraft via building-sell action.
-// Author: EJ, RAZER
-DEFINE_HOOK(0x4AC15A, DisplayClass_LeftMouseButtonUp_SellAction_RetargetBuilding, 0x4)
-{
-	enum { Continue = 0, SellCell = 0x4AC19A, SkipSellEvent = 0x4AC20C };
-
-	GET(ObjectClass*, pSellTarget, ESI);
-	const bool hadObjectTarget = (pSellTarget != nullptr);
-
-	if (pSellTarget && pSellTarget->WhatAmI() != AbstractType::Building)
-	{
-		GET_STACK(const CellStruct*, pClickedCell, 0x94);
-
-		pSellTarget = MapClass::Instance.GetCellAt(*pClickedCell)->GetBuilding();
-		R->ESI(pSellTarget);
-
-		// Ambiguous overlap case with object target but no building under clicked cell:
-		// do not emit Sell / SellCell events from this path.
-		if (!pSellTarget && hadObjectTarget)
-			return SkipSellEvent;
-	}
-
-	return pSellTarget ? Continue : SellCell;
-}
-
 DEFINE_HOOK(0x4FB2DE, HouseClass_PlaceObject_HotkeyFix, 0x6)
 {
 	GET(TechnoClass*, pObject, ESI);
@@ -2974,6 +2947,19 @@ DEFINE_HOOK(0x65DE82, TeamTypeClass_CreateTeamMembers_Veterancy, 0x6)
 	GET(TechnoTypeClass*, pTechnoType, EDI);
 
 	return pTechnoType->Trainable ? 0 : SkipVeterancy;
+}
+
+// Disallow sell action on wall overlays if mouse cursor is hovering on another object.
+DEFINE_HOOK(0x692AD6, ScrollClass_ChooseAction_SellWall, 0x6)
+{
+	enum { NoSell = 0x692AFE };
+
+	GET(ObjectClass*, pObject, ESI);
+
+	if (pObject)
+		return NoSell;
+
+	return 0;
 }
 
 // Fixed the issue where non-repairer units needed sensors to attack cloaked friendly units.

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1,4 +1,5 @@
 #include <AircraftTrackerClass.h>
+#include <EventClass.h>
 #include <JumpjetLocomotionClass.h>
 #include <TunnelLocomotionClass.h>
 
@@ -2958,6 +2959,19 @@ DEFINE_HOOK(0x692AD6, ScrollClass_ChooseAction_SellWall, 0x6)
 
 	if (pObject)
 		return NoSell;
+
+	return 0;
+}
+
+// Disallow sell action on wall overlays at event/network level if there's an object on the cell.
+DEFINE_HOOK(0x4C6FCE, HouseClass_SellOverlay_ObjectCheck, 0x5)
+{
+	enum { SkipSellOverlay = 0x4C6FD3 };
+
+	GET(EventClass*, pEvent, ESI);
+
+	if (MapClass::Instance.GetCellAt(pEvent->SellCell.Location)->GetContent())
+		return SkipSellOverlay;
 
 	return 0;
 }


### PR DESCRIPTION
Improvements to sell-target selection:

* Added a hook in `src/Misc/Hooks.BugFixes.cpp` (`ScrollClass_ChooseAction_SellWall`) to disallow the sell action on wall overlays if the mouse cursor is hovering over another object, ensuring the correct target is selected.
* Added a hook in `src/Misc/Hooks.BugFixes.cpp` (`HouseClass_SellOverlay_ObjectCheck`) to prevent the sell action on wall overlays at the event/network level if there is another object present on the cell.

Supporting changes:

* Included the `EventClass.h` header in `src/Misc/Hooks.BugFixes.cpp` to support the new event-level sell overlay logic.