### PR TITLE
Fix desync caused by inconsistent shroud state

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -736,4 +736,6 @@ This page lists all the individual contributions to the project by their author.
 - **Damfoos** - extensive and thorough testing
 - **Dmitry Volkov** - extensive and thorough testing
 - **Rise of the East community** - extensive playtesting of in-dev features
-- **11EJDE11** - Prevent mpdebug number from being drawn when visibility toggled off
+- **11EJDE11**:
+  - Prevent mpdebug number from being drawn when visibility toggled off
+  - Fixed a desync caused by inconsistent shroud state

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -297,6 +297,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allow the default value of `DefaultToGuardArea` to be defined by `[General] -> DefaultToGuardArea`.
 - Fixed the bug that cause technos teleport to cell 0,0 by ChronoSphere superweapon.
 - Fixed the bug that techno in attack move will move to target if it cannot attack it.
+- Fixed a desync caused by inconsistent shroud state.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -592,6 +592,7 @@ Vanilla fixes:
 - Fixed the issue where units recruited by a team with `AreTeamMembersRecruitable=false` cannot be recruited even if they have been liberated by that team (by TaranDahl)
 - Fixed the bug that cause technos teleport to cell 0,0 by ChronoSphere superweapon (by NetsuNegi)
 - Fixed the bug that techno in attack move will move to target if it cannot attack it (by NetsuNegi)
+- Fixed a desync caused by inconsistent shroud state (By 11EJDE11)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2999,3 +2999,7 @@ DEFINE_HOOK(0x6EA870, TeamClass_LiberateMember_Start, 0x6)
 	pMember->RecruitableB = true;
 	return 0;
 }
+
+// Fixes a desync caused by a check for shrouding at a specific cell
+// Sets Session.MPGameMode->SkipCheatCheck() to true
+DEFINE_PATCH(0x5C0E30, 0xB0, 0x01)


### PR DESCRIPTION
When Session.MPGameMode->SkipCheatCheck is active, there are two probes to check a hardcoded cell's shroud state (ShroudCounter != 1 || AltFlags & 0x18 at main loop around 0055ddc1 and HouseClass::AI around 004f88a1). If it passes the checks, the synced random gets advanced. 
Because Clear_Shroud skips the cell check but Reset_Shroud does not, a gap generator cycling near the top-left corner of the map (where the cell check falls) can leave the cell's shroud state inconsistent between players which causes a desync.

To fix, we're just setting that SkipCheatCheck to true so it never runs. In v1.006 they removed the check entirely.

Here is a test map. One player at top left. Both deploy, top left player sells powers and undeploys mcv > desync (note mcv gives power on this map, hence the undeploy).
[desynctest.zip](https://github.com/user-attachments/files/25455974/desynctest.zip)

Thanks to Razer for the map, Kerbiter and ZivDero for confirming and providing additional information.