### PR TITLE
Extra threat

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -735,6 +735,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug where non-Teleporter miners would not return to work after minerals are depleted and then regenerated
   - Miners back to work when ore regenerated
   - Allow disable an over-optimization in targeting
+  - Extra threat
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1397,6 +1397,17 @@ In `rulesmd.ini`:
 DisableOveroptimizationInTargeting=false  ; boolean
 ```
 
+### Allow techno type considered as other type when recruiting techno for teams
+
+- It is now possible to make techno type considered as other type when recruiting techno for teams, both for AI team recruitment and `Create Team` action.
+  - Only affect techno that's presented on the map. Cannot make AI produce this type of techno if it doesn't have any.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                      ; TechnoType
+TeamMember.ConsideredAs=          ; List of TechnoTypes
+```
+
 ### Alternate FLH customizations
 
 - `AlternateFLH.OnTurret` can be used to customize whether or not `AlternateFLH` used for `OpenTopped` transport firing coordinates, multiple mind control link offsets etc. is calculated relative to the unit's turret if available or body.
@@ -1947,17 +1958,6 @@ HeightShadowScaling.MinScale=0.0  ; floating point value
 
 [SOMETECHNO]                      ; TechnoType
 ShadowSizeCharacteristicHeight=   ; integer, height in leptons
-```
-
-### Allow techno type considered as other type when recruiting techno for teams
-
-- It is now possible to make techno type considered as other type when recruiting techno for teams, both for AI team recruitment and `Create Team` action.
-  - Only affect techno that's presented on the map. Cannot make AI produce this type of techno if it doesn't have any.
-
-In `rulesmd.ini`:
-```ini
-[SOMETECHNO]                      ; TechnoType
-TeamMember.ConsideredAs=          ; List of TechnoTypes
 ```
 
 ## Terrains

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1725,6 +1725,40 @@ RateDown.Cover.Value=0        ; integer
 RateDown.Cover.AmmoBelow=-2   ; integer
 ```
 
+### Extra threat
+
+- Now you can adjust the techno's evaluation of the threat posed by the target in more ways. This will help the techno in auto - targeting.
+  - When the target poses a threat to the techno, it will receive an additional threat value defined by `ExtraThreat.IsThreat`.
+    - Generally speaking, "Posing a threat" means the target can fire at the techno.
+    - Using `AlwaysConsideredThreat` makes the target always considered to be a threat.
+  - When the target is within the techno's range, it will receive an additional threat value defined by `ExtraThreat.InRange`.
+  - When the target is within the techno's range, it will receive an additional threat value equal to `ExtraThreatCoefficient.InRangeDistance` multiplied by the distance (in cells) from the target to the techno.
+    - Only considering in-range is because the vanilla flag `TargetDistanceCoefficientDefault` only considers outside-range. This flag is complementary to that.
+  - The target will receive an additional threat value equal to `ExtraThreatCoefficient.Facing` multiplied by the difference in facing from the techno's current firing-facing to the target's facing.
+    - "Firing-facing" refers to the facing the techno uses to check if it "is already facing the target and can fire". Infantry doesn't check the facing when firing, so this is also invalid for infantry.
+    - The unit of facing is the in-game internal numerical scale. A full circle corresponds to 65536.
+  - The target will receive an additional threat value equal to `ExtraThreatCoefficient.DistanceToLastTarget` multiplied by the distance (in cells) from the target to the techno's last target.
+    - Each techno will record its current target as the "last target" per frame. This record will be retained for at most 15 frames after the target becomes invalid.
+    - If the techno doesn't have a "last target", then this will not take effect.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ExtraThreat.IsThreat=0.0                            ; double
+ExtraThreat.InRange=0.0                             ; double
+ExtraThreatCoefficient.InRangeDistance=0.0          ; double
+ExtraThreatCoefficient.Facing=0.0                   ; double
+ExtraThreatCoefficient.DistanceToLastTarget=0.0     ; double
+
+[SOMETECHNO]                                        ; TechnoType
+AlwaysConsideredThreat=false
+ExtraThreat.IsThreat=                               ; double, default to the flag in [General] with same name
+ExtraThreat.InRange=                                ; double, default to the flag in [General] with same name
+ExtraThreatCoefficient.InRangeDistance=             ; double, default to the flag in [General] with same name
+ExtraThreatCoefficient.Facing=                      ; double, default to the flag in [General] with same name
+ExtraThreatCoefficient.DistanceToLastTarget=        ; double, default to the flag in [General] with same name
+```
+
 ### Firing offsets for specific Burst shots
 
 - You can now specify separate firing offsets for each of the shots fired by weapon with `Burst` via using `(Elite)(Prone/Deployed)PrimaryFire|SecondaryFire|WeaponX|FLH.BurstN` keys, depending on which weapons your TechnoType makes use of. *N* in `BurstN` is zero-based burst shot index, and the values are parsed sequentially until no value for either regular or elite weapon is present, with elite weapon defaulting to regular weapon FLH if only it is missing. If no burst-index specific value is available, value from the base key (f.ex `PrimaryFireFLH`) is used.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -636,6 +636,7 @@ Vanilla fixes:
 - Fixed the bug where non-Teleporter miners would not return to work after minerals are depleted and then regenerated (by TaranDahl)
 - Miners back to work when ore regenerated (by TaranDahl)
 - [Allow disable an over-optimization in targeting](Fixed-or-Improved-Logics.md#allow-disable-an-over-optimization-in-targeting) (by TaranDahl)
+- Extra threat (by TaranDahl)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -379,6 +379,11 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DisableOveroptimizationInTargeting.Read(exINI, GameStrings::General, "DisableOveroptimizationInTargeting");
 
 	this->DriverKilled_KillPassengers.Read(exINI, GameStrings::CombatDamage, "DriverKilled.KillPassengers");
+	this->ExtraThreat_IsThreat.Read(exINI, GameStrings::General, "ExtraThreat.IsThreat");
+	this->ExtraThreat_InRange.Read(exINI, GameStrings::General, "ExtraThreat.InRange");
+	this->ExtraThreatCoefficient_InRangeDistance.Read(exINI, GameStrings::General, "ExtraThreatCoefficient.InRangeDistance");
+	this->ExtraThreatCoefficient_Facing.Read(exINI, GameStrings::General, "ExtraThreatCoefficient.Facing");
+	this->ExtraThreatCoefficient_DistanceToLastTarget.Read(exINI, GameStrings::General, "ExtraThreatCoefficient.DistanceToLastTarget");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -689,6 +694,11 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->UnitsUnsellable)
 		.Process(this->DriverKilled_KillPassengers)
 		.Process(this->DisableOveroptimizationInTargeting)
+		.Process(this->ExtraThreat_IsThreat)
+		.Process(this->ExtraThreat_InRange)
+		.Process(this->ExtraThreatCoefficient_InRangeDistance)
+		.Process(this->ExtraThreatCoefficient_Facing)
+		.Process(this->ExtraThreatCoefficient_DistanceToLastTarget)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -328,6 +328,11 @@ public:
 		Valueable<bool> UnitsUnsellable;
 
 		Valueable<bool> DriverKilled_KillPassengers;
+		Valueable<double> ExtraThreat_IsThreat;
+		Valueable<double> ExtraThreat_InRange;
+		Valueable<double> ExtraThreatCoefficient_InRangeDistance;
+		Valueable<double> ExtraThreatCoefficient_Facing;
+		Valueable<double> ExtraThreatCoefficient_DistanceToLastTarget;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -599,6 +604,11 @@ public:
 
 			, DriverKilled_KillPassengers { false }
 			, DisableOveroptimizationInTargeting { false }
+			, ExtraThreat_IsThreat { 0.0 }
+			, ExtraThreat_InRange { 0.0 }
+			, ExtraThreatCoefficient_InRangeDistance { 0.0 }
+			, ExtraThreatCoefficient_Facing { 0.0 }
+			, ExtraThreatCoefficient_DistanceToLastTarget { 0.0 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -39,6 +39,8 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 
 	if (this->AttackMoveFollowerTempCount)
 		this->AttackMoveFollowerTempCount--;
+
+	this->UpdateLastTargetCrd();
 }
 
 void TechnoExt::ExtData::ApplyInterceptor()
@@ -2167,5 +2169,31 @@ void TechnoExt::ExtData::UpdateTintValues()
 	{
 		auto const pShieldType = this->Shield->GetType();
 		calculateTint(Drawing::RGB_To_Int(pShieldType->Tint_Color), static_cast<int>(pShieldType->Tint_Intensity * 1000), pShieldType->Tint_VisibleToHouses);
+	}
+}
+
+void TechnoExt::ExtData::UpdateLastTargetCrd()
+{
+	if (!this->TypeExtData->ExtraThreat_Enabled)
+		return;
+
+	auto const pThis = this->OwnerObject();
+	auto pTimer = &this->LastTargetCrdClearTimer;
+
+	if (pThis->Target)
+	{
+		this->LastTargetCrd = pThis->Target->GetCoords();
+		pTimer->Stop();
+	}
+	else
+	{
+		if (!pTimer->IsTicking())
+			pTimer->Start(15);
+
+		if (pTimer->Completed())
+		{
+			this->LastTargetCrd = CoordStruct::Empty;
+			pTimer->Stop();
+		}
 	}
 }

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -2188,7 +2188,7 @@ void TechnoExt::ExtData::UpdateLastTargetCrd()
 	else
 	{
 		if (!pTimer->IsTicking())
-			pTimer->Start(15);
+			pTimer->Start(45);
 
 		if (pTimer->Completed())
 		{

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1,4 +1,4 @@
-#include "Body.h"
+﻿#include "Body.h"
 
 #include <JumpjetLocomotionClass.h>
 
@@ -1223,6 +1223,8 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetStraightAscend)
 		.Process(this->OnParachuted)
 		.Process(this->HoverShutdown)
+		.Process(this->LastTargetCrd)
+		.Process(this->LastTargetCrdClearTimer)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <Ext/TechnoType/Body.h>
 #include <Utilities/Container.h>
@@ -103,6 +103,8 @@ public:
 
 		bool OnParachuted; // This is just a temporary patch. TODO: fully check HasParachuted and correct its maintenance method.
 		bool HoverShutdown;
+		CoordStruct LastTargetCrd;
+		CDTimerClass LastTargetCrdClearTimer;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
@@ -173,6 +175,8 @@ public:
 			, JumpjetStraightAscend { false }
 			, OnParachuted { false }
 			, HoverShutdown { false }
+			, LastTargetCrd { CoordStruct::Empty }
+			, LastTargetCrdClearTimer {}
 		{ }
 
 		void OnEarlyUpdate();
@@ -213,6 +217,7 @@ public:
 		void UpdateTintValues();
 
 		void AmmoAutoConvertActions();
+		void UpdateLastTargetCrd();
 
 		virtual ~ExtData() override;
 		virtual void InvalidatePointer(void* ptr, bool bRemoved) override;

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -378,3 +378,136 @@ static Action __fastcall InfantryClass__WhatAction_Wrapper(InfantryClass* pThis,
 DEFINE_FUNCTION_JUMP(VTABLE, 0x7EB0CC, InfantryClass__WhatAction_Wrapper)
 
 #pragma endregion
+
+#pragma region ThreatEvaluation
+
+// Current target may hurt me.
+static inline bool IsAThreatToMe(TechnoClass* const pTechno, AbstractClass* const pTarget, int weaponIndex = -1)
+{
+	if (const auto pTechnoTarget = abstract_cast<TechnoClass*>(pTarget))
+	{
+		auto pTypeExt = TechnoExt::ExtMap.Find(pTechnoTarget)->TypeExtData;
+
+		if (pTypeExt->AlwaysConsideredThreat)
+			return true;
+
+		if (weaponIndex < 0)
+			weaponIndex = pTechnoTarget->SelectWeapon(pTechno);
+
+		if (!pTechnoTarget->GetWeapon(weaponIndex)->WeaponType)
+			return false;
+
+		const auto error = pTechnoTarget->GetFireError(pTechno, weaponIndex, true);
+		return pTechnoTarget->WhatAmI() == AbstractType::Building ? (error != FireError::ILLEGAL) && (error != FireError::RANGE) : (error != FireError::ILLEGAL);
+	}
+
+	return false;
+}
+
+// Decide the facing to check for firing.
+static inline FacingClass* GetFireFacing(TechnoClass* const pTechno)
+{
+	if (!pTechno)
+		return nullptr;
+
+	switch (pTechno->WhatAmI())
+	{
+		case AbstractType::Building:
+			return &pTechno->PrimaryFacing;
+		case AbstractType::Unit:
+		{
+			if (pTechno->GetTechnoType()->Turret)
+				return &pTechno->SecondaryFacing;
+			else
+				return &pTechno->PrimaryFacing;
+		}
+		case AbstractType::Infantry:
+			return nullptr;
+		case AbstractType::Aircraft:
+			return &pTechno->SecondaryFacing;
+		default:
+			return nullptr;
+	}
+}
+
+DEFINE_HOOK(0x70CF87, TechnoClass_ThreatCoefficient_CanAttackMeThreatBonus, 0x9)
+{
+	GET(TechnoClass* const, pThis, EDI);
+	GET(TechnoClass* const, pTarget, ESI);
+	REF_STACK(double, totalThreat, STACK_OFFSET(0x58, -0x48));
+
+	auto pExt = TechnoExt::ExtMap.Find(pThis);
+	auto pTypeExt = pExt->TypeExtData;
+
+	if (!pTypeExt->ExtraThreat_Enabled)
+		return 0;
+
+	auto ApplyIsThreatBonus = [pTypeExt, pThis, pTarget, &totalThreat]()
+		{
+			double bonus = pTypeExt->ExtraThreat_IsThreat.Get(RulesExt::Global()->ExtraThreat_IsThreat);
+
+			if (bonus == 0.0)
+				return;
+
+			if (!IsAThreatToMe(pThis, pTarget))
+				return;
+
+			totalThreat += bonus;
+		};
+	ApplyIsThreatBonus();
+
+	auto ApplyInRangeBonus = [pTypeExt, pThis, pTarget, &totalThreat]()
+		{
+			double bonus1 = pTypeExt->ExtraThreat_InRange.Get(RulesExt::Global()->ExtraThreat_InRange);
+			double dist = pThis->DistanceFrom(pTarget) / 256.0;
+			double bonus2 = dist * pTypeExt->ExtraThreatCoefficient_InRangeDistance.Get(RulesExt::Global()->ExtraThreatCoefficient_InRangeDistance);
+			double bonus = bonus1 + bonus2;
+
+			if (bonus == 0.0)
+				return;
+
+			if (!pThis->IsCloseEnoughToAttack(pTarget))
+				return;
+
+			totalThreat += bonus;
+		};
+	ApplyInRangeBonus();
+
+	auto ApplyFacingBonus = [pTypeExt, pThis, pTarget, &totalThreat]()
+		{
+			auto pFacing = GetFireFacing(pThis);
+
+			if (!pFacing)
+				return;
+
+			double bonus = pTypeExt->ExtraThreatCoefficient_Facing.Get(RulesExt::Global()->ExtraThreatCoefficient_Facing);
+
+			if (bonus == 0.0)
+				return;
+
+			DirStruct dir = DirStruct();
+			int deltaFacing = std::abs(pThis->GetTargetDirection(&dir, pTarget)->Raw - pFacing->Current().Raw);
+			totalThreat += deltaFacing * bonus;
+		};
+	ApplyFacingBonus();
+
+	auto ApplyLastTargetDistanceBonus = [pExt, pTypeExt, pThis, pTarget, &totalThreat]()
+		{
+			double bonus = pTypeExt->ExtraThreatCoefficient_DistanceToLastTarget.Get(RulesExt::Global()->ExtraThreatCoefficient_DistanceToLastTarget);
+
+			if (bonus == 0.0)
+				return;
+
+			if (pExt->LastTargetCrd == CoordStruct::Empty)
+				return;
+
+			double distToLastTarget = pTarget->GetCoords().DistanceFrom(pExt->LastTargetCrd) / 256.0;
+			totalThreat += distToLastTarget * bonus;
+		};
+	ApplyLastTargetDistanceBonus();
+
+	return 0;
+}
+
+
+#pragma endregion

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -486,7 +486,7 @@ DEFINE_HOOK(0x70CF87, TechnoClass_ThreatCoefficient_CanAttackMeThreatBonus, 0x9)
 				return;
 
 			DirStruct dir = DirStruct();
-			int deltaFacing = std::abs(pThis->GetTargetDirection(&dir, pTarget)->Raw - pFacing->Current().Raw);
+			int deltaFacing = std::abs(pThis->GetTargetDirection(&dir, pTarget)->Raw - pFacing->Current().Raw) % 65536;
 			totalThreat += deltaFacing * bonus;
 		};
 	ApplyFacingBonus();

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -486,7 +486,7 @@ DEFINE_HOOK(0x70CF87, TechnoClass_ThreatCoefficient_CanAttackMeThreatBonus, 0x9)
 				return;
 
 			DirStruct dir = DirStruct();
-			int deltaFacing = std::abs(pThis->GetTargetDirection(&dir, pTarget)->Raw - pFacing->Current().Raw) % 65536;
+			int deltaFacing = 32768 - std::abs(std::abs(pThis->GetTargetDirection(&dir, pTarget)->Raw - pFacing->Current().Raw) - 32768);
 			totalThreat += deltaFacing * bonus;
 		};
 	ApplyFacingBonus();

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1,4 +1,4 @@
-#include "Body.h"
+﻿#include "Body.h"
 
 #include <JumpjetLocomotionClass.h>
 
@@ -1179,6 +1179,19 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->JumpjetClimbIgnoreBuilding.Read(exINI, pSection, "JumpjetClimbIgnoreBuilding");
 	
+
+	this->ExtraThreat_IsThreat.Read(exINI, pSection, "ExtraThreat.IsThreat");
+	this->AlwaysConsideredThreat.Read(exINI, pSection, "AlwaysConsideredThreat");
+	this->ExtraThreat_InRange.Read(exINI, pSection, "ExtraThreat.InRange");
+	this->ExtraThreatCoefficient_InRangeDistance.Read(exINI, pSection, "ExtraThreatCoefficient.InRangeDistance");
+	this->ExtraThreatCoefficient_Facing.Read(exINI, pSection, "ExtraThreatCoefficient.Facing");
+	this->ExtraThreatCoefficient_DistanceToLastTarget.Read(exINI, pSection, "ExtraThreatCoefficient.DistanceToLastTarget");
+	this->ExtraThreat_Enabled = ExtraThreat_IsThreat.Get(RulesExt::Global()->ExtraThreat_IsThreat) != 0
+		|| !ExtraThreat_InRange.Get(RulesExt::Global()->ExtraThreat_InRange) != 0
+		|| ExtraThreatCoefficient_InRangeDistance.Get(RulesExt::Global()->ExtraThreatCoefficient_InRangeDistance) != 0
+		|| ExtraThreatCoefficient_Facing.Get(RulesExt::Global()->ExtraThreatCoefficient_Facing) != 0
+		|| ExtraThreatCoefficient_DistanceToLastTarget.Get(RulesExt::Global()->ExtraThreatCoefficient_DistanceToLastTarget) != 0;
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1907,6 +1920,13 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Unsellable)
 
 		.Process(this->TurretShape)
+		.Process(this->ExtraThreat_Enabled)
+		.Process(this->ExtraThreat_IsThreat)
+		.Process(this->AlwaysConsideredThreat)
+		.Process(this->ExtraThreat_InRange)
+		.Process(this->ExtraThreatCoefficient_InRangeDistance)
+		.Process(this->ExtraThreatCoefficient_Facing)
+		.Process(this->ExtraThreatCoefficient_DistanceToLastTarget)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
 
@@ -493,6 +493,13 @@ public:
 		Nullable<bool> JumpjetClimbIgnoreBuilding;
 
 		Valueable<bool> HoverDrownable;
+		bool ExtraThreat_Enabled;
+		Nullable<double> ExtraThreat_IsThreat;
+		Valueable<bool> AlwaysConsideredThreat;
+		Nullable<double> ExtraThreat_InRange;
+		Nullable<double> ExtraThreatCoefficient_InRangeDistance;
+		Nullable<double> ExtraThreatCoefficient_Facing;
+		Nullable<double> ExtraThreatCoefficient_DistanceToLastTarget;
 
 		Nullable<bool> Unsellable; // Ares 3.0
 
@@ -948,6 +955,13 @@ public:
 			, Unsellable {}
 
 			, TurretShape { nullptr }
+			, ExtraThreat_Enabled { false }
+			, ExtraThreat_IsThreat {}
+			, AlwaysConsideredThreat { false }
+			, ExtraThreat_InRange {}
+			, ExtraThreatCoefficient_InRangeDistance {}
+			, ExtraThreatCoefficient_Facing {}
+			, ExtraThreatCoefficient_DistanceToLastTarget {}
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Extra threat

- Now you can adjust the techno's evaluation of the threat posed by the target in more ways. This will help the techno in auto - targeting.
  - When the target poses a threat to the techno, it will receive an additional threat value defined by `ExtraThreat.IsThreat`.
    - Generally speaking, "Posing a threat" means the target can fire at the techno.
    - Using `AlwaysConsideredThreat` makes the target always considered to be a threat.
  - When the target is within the techno's range, it will receive an additional threat value defined by `ExtraThreat.InRange`.
  - When the target is within the techno's range, it will receive an additional threat value equal to `ExtraThreatCoefficient.InRangeDistance` multiplied by the distance (in cells) from the target to the techno.
    - Only considering in-range is because the vanilla flag `TargetDistanceCoefficientDefault` only considers outside-range. This flag is complementary to that.
  - The target will receive an additional threat value equal to `ExtraThreatCoefficient.Facing` multiplied by the difference in facing from the techno's current firing-facing to the target's facing.
    - "Firing-facing" refers to the facing the techno uses to check if it "is already facing the target and can fire". Infantry doesn't check the facing when firing, so this is also invalid for infantry.
    - The unit of facing is the in-game internal numerical scale. A full circle corresponds to 65536.
  - The target will receive an additional threat value equal to `ExtraThreatCoefficient.DistanceToLastTarget` multiplied by the distance (in cells) from the target to the techno's last target.
    - Each techno will record its current target as the "last target" per frame. This record will be retained for at most 15 frames after the target becomes invalid.
    - If the techno doesn't have a "last target", then this will not take effect.

In `rulesmd.ini`:
```ini
[General]
ExtraThreat.IsThreat=0.0                            ; double
ExtraThreat.InRange=0.0                             ; double
ExtraThreatCoefficient.InRangeDistance=0.0          ; double
ExtraThreatCoefficient.Facing=0.0                   ; double
ExtraThreatCoefficient.DistanceToLastTarget=0.0     ; double

[SOMETECHNO]                                        ; TechnoType
AlwaysConsideredThreat=false
ExtraThreat.IsThreat=                               ; double, default to the flag in [General] with same name
ExtraThreat.InRange=                                ; double, default to the flag in [General] with same name
ExtraThreatCoefficient.InRangeDistance=             ; double, default to the flag in [General] with same name
ExtraThreatCoefficient.Facing=                      ; double, default to the flag in [General] with same name
ExtraThreatCoefficient.DistanceToLastTarget=        ; double, default to the flag in [General] with same name
```