### PR TITLE
Additional AITriggerType conditions (# of Tech Buildings / Bridge Repair Huts)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -308,6 +308,7 @@ This page lists all the individual contributions to the project by their author.
   - Tank Bunker improvements
   - `ProjectileRange` weapon range modifiers interaction fix
   - Berzerk duration stacking behaviour customization
+  - AI trigger condition type extension
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -48,6 +48,9 @@
     <ClCompile Include="src\Commands\ToggleMessageList.cpp" />
     <ClCompile Include="src\Commands\ToggleSWSidebar.cpp" />
     <!-- src\Ext -->
+    <!-- src\Ext\AITriggerType -->
+    <ClCompile Include="src\Ext\AITriggerType\Body.cpp" />
+    <ClCompile Include="src\Ext\AITriggerType\Hooks.cpp" />
     <!-- src\Ext\Aircraft -->
     <ClCompile Include="src\Ext\Aircraft\Body.cpp" />
     <ClCompile Include="src\Ext\Aircraft\Hooks.cpp" />
@@ -326,6 +329,7 @@
     <ClInclude Include="src\Commands\ToggleMessageList.h" />
     <ClInclude Include="src\Commands\ToggleSWSidebar.h" />
     <!-- src\Ext -->
+    <ClInclude Include="src\Ext\AITriggerType\Body.h" />
     <ClInclude Include="src\Ext\Aircraft\Body.h" />
     <ClInclude Include="src\Ext\Anim\Body.h" />
     <ClInclude Include="src\Ext\AnimType\Body.h" />

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -548,6 +548,25 @@ x=i,n             ; where 18048 <= i <= 18071, n is made up of two parts, the lo
 
 This category is empty for now.
 
+## AI Trigger Condition Types
+
+Phobos adds new AI trigger condition types. AI trigger's condition type is defined as the number in fifth comma-separated parameter in `AITriggerType` declaration.
+
+F.ex
+```ini
+ID=Name,Team1,OwnerHouse,TechLevel,ConditionType,ConditionObject,Comparator,StartingWeight,MinimumWeight,MaximumWeight,IsForSkirmish,unused,Side,IsBaseDefense,Team2,EnabledInE,EnabledInM,EnabledInH
+```
+
+Some condition types operate on or with `ConditionObject` and `Comperator` as well. More information on defining AITriggerTypes can be found on [ModEnc](https://modenc.renegadeprojects.com/AITriggerTypes).
+
+### `8` Amount of Capturable Tech Buildings Exists
+
+Trigger can spring if a number of `Capturable=true` + `NeedsEngineer=true` buildings owned in total by all houses the trigger owner is not allied with satisfies `Comparator`.
+
+### `9` Amount of Bridge Repair Huts Exists
+
+Trigger can spring if a number of `BridgeRepairHut=true` buildings linked to broken bridges owned by first house belonging to `Civilian` side satisfies `Comparator`.
+
 ## Trigger Actions
 
 ### `500` Save Game

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -720,6 +720,7 @@ HideShakeEffects=false           ; boolean
 - [Disable AlphaImage during Buildup](Fixed-or-Improved-Logics.md#disable-alphaimage-during-buildup) (by Noble_Fish)
 - [Reload speed adjustment on promotion](New-or-Enhanced-Logics.md#reload-speed-adjustment-on-promotion) (by Nuke)
 - Allowed `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys (by Noble_Fish)
+- [New AITriggerType conditions for tech buildings & bridge repair huts](AI-Scripting-and-Mapping.md#ai-trigger-condition-types) (by Starkku)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/AITriggerType/Body.cpp
+++ b/src/Ext/AITriggerType/Body.cpp
@@ -1,0 +1,129 @@
+#include "Body.h"
+
+AITriggerTypeExt::ExtContainer AITriggerTypeExt::ExtMap;
+
+int AITriggerTypeExt::CheckConditions(AITriggerTypeClass* pThis, HouseClass* pOwner, HouseClass* pEnemy)
+{
+	int condition = (int)pThis->ConditionType;
+
+	if (condition < -1) // Invalid, bail out early.
+		return 0;
+	else if (condition < (int)PhobosAITriggerConditions::NumberOfTechBuildingsExist) // Not Phobos condition
+		return -1;
+
+	bool success = false;
+
+	switch ((PhobosAITriggerConditions)condition)
+	{
+	case PhobosAITriggerConditions::NumberOfTechBuildingsExist:
+		success = AITriggerTypeExt::NumberOfTechBuildingsExist(pThis, pOwner);
+		break;
+	case PhobosAITriggerConditions::NumberOfBridgeRepairHutsExist:
+		success = AITriggerTypeExt::NumberOfBridgeRepairHutsExist(pThis);
+		break;
+	}
+
+	return success;
+}
+
+bool AITriggerTypeExt::GetComparatorResult(int operand1, AITriggerConditionComparatorType operatorType, int operand2)
+{
+	switch (operatorType)
+	{
+	case AITriggerConditionComparatorType::Less:
+		return operand1 < operand2;
+		break;
+	case AITriggerConditionComparatorType::LessOrEqual:
+		return operand1 <= operand2;
+		break;
+	case AITriggerConditionComparatorType::Equal:
+		return operand1 == operand2;
+		break;
+	case AITriggerConditionComparatorType::GreaterOrEqual:
+		return operand1 >= operand2;
+		break;
+	case AITriggerConditionComparatorType::Greater:
+		return operand1 > operand2;
+		break;
+	case AITriggerConditionComparatorType::NotEqual:
+		return operand1 != operand2;
+		break;
+	default:
+		return false;
+		break;
+	}
+}
+
+bool AITriggerTypeExt::NumberOfTechBuildingsExist(AITriggerTypeClass* pThis, HouseClass* pOwner)
+{
+	int count = 0;
+
+	for (auto const pHouse : HouseClass::Array)
+	{
+		if (pHouse->IsAlliedWith(pOwner))
+			continue;
+
+		// Could possibly be optimized with bespoke tracking but
+		// it didn't seem to make much of a difference in testing.
+		for (auto const pBuilding : pHouse->Buildings)
+		{
+			if (!pBuilding->IsAlive || pBuilding->InLimbo)
+				continue;
+
+			auto const pType = pBuilding->Type;
+
+			if (pType->NeedsEngineer && pType->Capturable)
+				count++;
+		}
+	}
+
+	return AITriggerTypeExt::GetComparatorResult(count, pThis->Conditions[0].ComparatorType, pThis->Conditions[0].ComparatorOperand);
+}
+
+bool AITriggerTypeExt::NumberOfBridgeRepairHutsExist(AITriggerTypeClass* pThis)
+{
+	int count = 0;
+	auto const pHouse = HouseClass::FindCivilianSide();
+
+	for (auto const pBuilding : pHouse->Buildings)
+	{
+		if (!pBuilding->IsAlive || pBuilding->InLimbo)
+			continue;
+
+		auto const pType = pBuilding->Type;
+
+		if (pType->BridgeRepairHut && MapClass::Instance.IsLinkedBridgeDestroyed(pBuilding->GetMapCoords()))
+			count++;
+	}
+
+	return AITriggerTypeExt::GetComparatorResult(count, pThis->Conditions[0].ComparatorType, pThis->Conditions[0].ComparatorOperand);
+}
+
+// =============================
+// load / save
+
+template <typename T>
+void AITriggerTypeExt::Serialize(T& Stm)
+{
+	//Stm;
+}
+
+void AITriggerTypeExt::LoadFromStream(PhobosStreamReader& Stm)
+{
+	AbstractTypeExt::LoadFromStream(Stm);
+	this->Serialize(Stm);
+}
+
+void AITriggerTypeExt::SaveToStream(PhobosStreamWriter& Stm)
+{
+	AbstractTypeExt::SaveToStream(Stm);
+	this->Serialize(Stm);
+}
+
+// container
+
+AITriggerTypeExt::ExtContainer::ExtContainer() : Container("AITriggerTypeClass") {}
+AITriggerTypeExt::ExtContainer::~ExtContainer() = default;
+
+// =============================
+// container hooks

--- a/src/Ext/AITriggerType/Body.h
+++ b/src/Ext/AITriggerType/Body.h
@@ -1,0 +1,66 @@
+#pragma once
+#include <AITriggerTypeClass.h>
+
+#include <Ext/AbstractType/Body.h>
+#include <Utilities/Container.h>
+
+// Vanilla game ones range from -1 to 7, see AITriggerCondition in GeneralDefinitions.h in YRpp.
+enum class PhobosAITriggerConditions : unsigned int
+{
+	NumberOfTechBuildingsExist = 8,
+	NumberOfBridgeRepairHutsExist = 9,
+};
+
+class AITriggerTypeExt final : public AbstractTypeExt
+{
+public:
+	using base_type = AITriggerTypeClass;
+
+	static constexpr DWORD Canary = 0x9B9B9B9B;
+
+public:
+	// Nothing yet
+
+	AITriggerTypeClass* OwnerObject() const
+	{
+		return static_cast<AITriggerTypeClass*>(this->GetAttachedObject());
+	}
+
+	explicit AITriggerTypeExt(AITriggerTypeClass* const OwnerObject) : AbstractTypeExt(OwnerObject)
+		// Nothing yet
+	{}
+
+	virtual ~AITriggerTypeExt() = default;
+
+	static int CheckConditions(AITriggerTypeClass* pThis, HouseClass* pOwner, HouseClass* pEnemy);
+	static bool GetComparatorResult(int operand1, AITriggerConditionComparatorType operatorType, int operand2);
+	static bool NumberOfTechBuildingsExist(AITriggerTypeClass* pThis, HouseClass* pOwner);
+	static bool NumberOfBridgeRepairHutsExist(AITriggerTypeClass* pThis);
+
+public:
+	class ExtContainer final : public Container<AITriggerTypeExt>
+	{
+	public:
+		ExtContainer();
+		~ExtContainer();
+	};
+
+	static ExtContainer ExtMap;
+
+	static AITriggerTypeExt* Fetch(const AITriggerTypeClass* pThis)
+	{
+		return AbstractExt::Fetch<AITriggerTypeExt>(pThis);
+	}
+
+	static AITriggerTypeExt* TryFetch(const AITriggerTypeClass* pThis)
+	{
+		return AbstractExt::TryFetch<AITriggerTypeExt>(pThis);
+	}
+
+	virtual void LoadFromStream(PhobosStreamReader& Stm) override;
+	virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+private:
+	template <typename T>
+	void Serialize(T& Stm);
+};

--- a/src/Ext/AITriggerType/Hooks.cpp
+++ b/src/Ext/AITriggerType/Hooks.cpp
@@ -1,0 +1,26 @@
+#include <Ext/AITriggerType/Body.h>
+#include <Helpers/Macro.h>
+
+DEFINE_HOOK(0x41E8FF, AITriggerTypeClass_NewTeam_CheckConditions, 0x9) // ConditionMet() in YRpp
+{
+	enum { ContinueGameChecks = 0x41E908, ReturnFromFunction = 0x41E9E1, Success = 0x41E9EA };
+
+	GET(AITriggerTypeClass*, pThis, ESI);
+	GET(HouseClass*, pOwner, EDI);
+	GET(HouseClass*, pEnemy, EBX);
+
+	int result = AITriggerTypeExt::CheckConditions(pThis, pOwner, pEnemy);
+
+	switch (result)
+	{
+	case 0:
+		return ReturnFromFunction;
+		break;
+	case 1:
+		return Success;
+		break;
+	default:
+		return ContinueGameChecks;
+		break;
+	}
+}

--- a/src/Phobos.Ext.cpp
+++ b/src/Phobos.Ext.cpp
@@ -3,6 +3,7 @@
 #include <LoadOptionsClass.h>
 
 #include <Ext/Aircraft/Body.h>
+#include <Ext/AITriggerType/Body.h>
 #include <Ext/Anim/Body.h>
 #include <Ext/Infantry/Body.h>
 #include <Ext/Unit/Body.h>
@@ -280,6 +281,7 @@ using PhobosTypeRegistry = TypeRegistry <
 	// Ext classes
 	AircraftExt,
 	AircraftTypeExt,
+	AITriggerTypeExt,
 	AnimTypeExt,
 	AnimExt,
 	BuildingExt,


### PR DESCRIPTION
This PR adds framework for adding new AITriggerType conditions in similar vein to what Phobos already does with script actions. In addition it adds two new conditiontypes checking tech buildings and bridge repair huts.

---------------

## AI Trigger Condition Types

Phobos adds new AI trigger condition types. AI trigger's condition type is defined as the number in fifth comma-separated parameter in `AITriggerType` declaration.

F.ex
```ini
ID=Name,Team1,OwnerHouse,TechLevel,ConditionType,ConditionObject,Comparator,StartingWeight,MinimumWeight,MaximumWeight,IsForSkirmish,unused,Side,IsBaseDefense,Team2,EnabledInE,EnabledInM,EnabledInH
```

Some condition types operate on or with `ConditionObject` and `Comperator` as well. More information on defining AITriggerTypes can be found on [ModEnc](https://modenc.renegadeprojects.com/AITriggerTypes).

### `8` Amount of Capturable Tech Buildings Exists

Trigger can spring if a number of `Capturable=true` + `NeedsEngineer=true` buildings owned in total by all houses the trigger owner is not allied with satisfies `Comparator`.

### `9` Amount of Bridge Repair Huts Exists

Trigger can spring if a number of `BridgeRepairHut=true` buildings linked to broken bridges owned by first house belonging to `Civilian` side satisfies `Comparator`.
