### PR TITLE
Decouple the calculations of `TurretOffset` and `HeightShadowScaling`

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -651,6 +651,7 @@ Phobos fixes:
 - `RealTimeTimers` now support independent gamespeed index values for Multiplayer and Skirmish (by RAZER)
 - Fixed the bug that the upgrade building's power-enhancing effect depends only on its parent building and is not related to the upgrade building itself (by NetsuNegi)
 - Fixed an issue where hover vehicles could not be destroyed after malfunctioning on water surfaces (by FlyStar)
+- Fixed an issue where shadow matrix scaling was incorrectly applied to `TurretOffset` causing turret shadow misplacement (by Noble_Fish)
 
 Fixes / interactions with other extensions:
 <!--  - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)  -->

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2260,6 +2260,12 @@ msgid ""
 "malfunctioning on water surfaces (by FlyStar)"
 msgstr "修复了悬浮载具在水面上失灵后无法被摧毁的问题（by FlyStar）"
 
+msgid ""
+"Fixed an issue where shadow matrix scaling was incorrectly applied to "
+"`TurretOffset` causing turret shadow misplacement (by Noble_Fish)"
+msgstr ""
+"修复了一个影子矩阵缩放错误地应用于 `TurretOffset` 而导致炮塔影子错位的问题（by Noble_Fish）"
+
 msgid "Fixes / interactions with other extensions:"
 msgstr "其他扩展引擎相关的修复／交互："
 

--- a/src/Ext/TechnoType/Hooks.MatrixOp.cpp
+++ b/src/Ext/TechnoType/Hooks.MatrixOp.cpp
@@ -564,6 +564,8 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 	const auto height = pThis->GetHeight();
 	const double baseScale_log = RulesExt::Global()->AirShadowBaseScale_log;
 
+	double currentScale = 1.0;
+
 	if (RulesExt::Global()->HeightShadowScaling && height > 0)
 	{
 		const double minScale = RulesExt::Global()->HeightShadowScaling_MinScale;
@@ -573,7 +575,9 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 
 			if (cHeight > 0)
 			{
-				shadowMatrix.Scale((float)std::max(Pade2_2(baseScale_log * height / cHeight), minScale));
+				double scale = std::max(Pade2_2(baseScale_log * height / cHeight), minScale);
+				shadowMatrix.Scale((float)scale);
+				currentScale = scale;
 
 				if (jjloco->State != JumpjetLocomotionClass::State::Hovering)
 					vxlIndexKey.Invalidate();
@@ -585,14 +589,16 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 
 			if (cHeight > 0 && height > 208)
 			{
-				shadowMatrix.Scale((float)std::max(Pade2_2(baseScale_log * (height - 208) / cHeight), minScale));
+				double scale = std::max(Pade2_2(baseScale_log * (height - 208) / cHeight), minScale);
 				vxlIndexKey.Invalidate();
 			}
 		}
 	}
 	else if (!RulesExt::Global()->HeightShadowScaling && pThis->Type->ConsideredAircraft)
 	{
-		shadowMatrix.Scale((float)Pade2_2(baseScale_log));
+		double scale = Pade2_2(baseScale_log);
+		shadowMatrix.Scale((float)scale);
+		currentScale = scale;
 	}
 
 	auto GetMainVoxel = [&]()
@@ -742,7 +748,8 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 		return nullptr;
 	};
 
-	pDrawTypeExt->ApplyTurretOffset(&mtx, Pixel_Per_Lepton);
+	double adjustedFactor = Pixel_Per_Lepton / currentScale;
+	pDrawTypeExt->ApplyTurretOffset(&mtx, adjustedFactor);
 	mtx.RotateZ(static_cast<float>(pThis->SecondaryFacing.Current().GetRadian<32>() - pThis->PrimaryFacing.Current().GetRadian<32>()));
 
 	const bool inRecoil = pDrawType->TurretRecoil && pThis->TurretRecoil.State != RecoilData::RecoilState::Inactive;

--- a/src/Ext/TechnoType/Hooks.MatrixOp.cpp
+++ b/src/Ext/TechnoType/Hooks.MatrixOp.cpp
@@ -575,9 +575,8 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 
 			if (cHeight > 0)
 			{
-				double scale = std::max(Pade2_2(baseScale_log * height / cHeight), minScale);
-				shadowMatrix.Scale((float)scale);
-				currentScale = scale;
+				currentScale = std::max(Pade2_2(baseScale_log * height / cHeight), minScale);
+				shadowMatrix.Scale((float)currentScale);
 
 				if (jjloco->State != JumpjetLocomotionClass::State::Hovering)
 					vxlIndexKey.Invalidate();
@@ -589,18 +588,16 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 
 			if (cHeight > 0 && height > 208)
 			{
-				double scale = std::max(Pade2_2(baseScale_log * (height - 208) / cHeight), minScale);
-				shadowMatrix.Scale((float)scale);
-				currentScale = scale;
+				currentScale = std::max(Pade2_2(baseScale_log * (height - 208) / cHeight), minScale);
+				shadowMatrix.Scale((float)currentScale);
 				vxlIndexKey.Invalidate();
 			}
 		}
 	}
 	else if (!RulesExt::Global()->HeightShadowScaling && pThis->Type->ConsideredAircraft)
 	{
-		double scale = Pade2_2(baseScale_log);
-		shadowMatrix.Scale((float)scale);
-		currentScale = scale;
+		currentScale = Pade2_2(baseScale_log);
+		shadowMatrix.Scale((float)currentScale);
 	}
 
 	auto GetMainVoxel = [&]()

--- a/src/Ext/TechnoType/Hooks.MatrixOp.cpp
+++ b/src/Ext/TechnoType/Hooks.MatrixOp.cpp
@@ -273,7 +273,7 @@ DEFINE_HOOK(0x4CF68D, FlyLocomotionClass_DrawMatrix_OnAirport, 0x5)
 		mat = Matrix3D::VoxelRampMatrix[slope_idx] * mat;
 		const float ars = pThis->AngleRotatedSideways;
 		const float arf = pThis->AngleRotatedForwards;
-		if (std::abs(ars) > 0.005 || std::abs(arf) > 0.005)
+		if (std::abs(ars) > 0.005f || std::abs(arf) > 0.005f)
 		{
 			const auto pType = pThis->Type;
 			mat.TranslateZ(float(std::abs(Math::sin(ars)) * pType->VoxelScaleX
@@ -315,7 +315,7 @@ static Matrix3D* __stdcall JumpjetLocomotionClass_Draw_Matrix(ILocomotion* iloco
 	size_t arfFace = 0;
 	size_t arsFace = 0;
 
-	if (std::abs(ars) >= 0.005 || std::abs(arf) >= 0.005)
+	if (std::abs(ars) >= 0.005f || std::abs(arf) >= 0.005f)
 	{
 		if (key)
 			key->Base.Invalidate();
@@ -447,7 +447,7 @@ static Matrix3D* __stdcall TeleportLocomotionClass_Draw_Matrix(ILocomotion* iloc
 	const float arf = linked->AngleRotatedForwards;
 	const float ars = linked->AngleRotatedSideways;
 
-	if (std::abs(ars) >= 0.005 || std::abs(arf) >= 0.005)
+	if (std::abs(ars) >= 0.005f || std::abs(arf) >= 0.005f)
 	{
 		if (pIndex)
 			pIndex->Invalidate();
@@ -622,7 +622,7 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 	float arf = pThis->AngleRotatedForwards;
 	float ars = pThis->AngleRotatedSideways;
 	// lazy, don't want to hook inside Shadow_Matrix
-	if (std::abs(ars) >= 0.005 || std::abs(arf) >= 0.005)
+	if (std::abs(ars) >= 0.005f || std::abs(arf) >= 0.005f)
 	{
 		// index key should have been already invalid, so it won't hurt to invalidate again
 		vxlIndexKey.Invalidate();
@@ -657,7 +657,7 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 				* JumpjetTiltReference::SidewaysBaseTilt), -JumpjetTiltReference::MaxTilt, JumpjetTiltReference::MaxTilt);
 		}
 
-		if (std::abs(ars) >= 0.005 || std::abs(arf) >= 0.005)
+		if (std::abs(ars) >= 0.005f || std::abs(arf) >= 0.005f)
 		{
 			vxlIndexKey.Invalidate();
 			shadowMatrix.RotateX(ars);
@@ -746,8 +746,8 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 
 		return nullptr;
 	};
-	double adjustedFactor = Pixel_Per_Lepton / currentScale;
 
+	const double adjustedFactor = Pixel_Per_Lepton / currentScale;
 	pDrawTypeExt->ApplyTurretOffset(&mtx, adjustedFactor);
 	mtx.RotateZ(static_cast<float>(pThis->SecondaryFacing.Current().GetRadian<32>() - pThis->PrimaryFacing.Current().GetRadian<32>()));
 
@@ -860,12 +860,13 @@ DEFINE_HOOK(0x4147F9, AircraftClass_Draw_Shadow, 0x6)
 		double arf = pThis->AngleRotatedForwards;
 		if (flyLoco->CurrentSpeed > pAircraftType->PitchSpeed)
 			arf += pAircraftType->PitchAngle;
-		float ars = pThis->AngleRotatedSideways;
-		if (key.Is_Valid_Key() && (std::abs(arf) > 0.005 || std::abs(ars) > 0.005))
+		const float newArf = (float)arf;
+		const float ars = pThis->AngleRotatedSideways;
+		if (key.Is_Valid_Key() && (std::abs(newArf) > 0.005f || std::abs(ars) > 0.005f))
 			key.Invalidate();
 
 		shadow_mtx.RotateX(ars);
-		shadow_mtx.RotateY((float)arf);
+		shadow_mtx.RotateY(newArf);
 	}
 	else if (height > 0)
 	{

--- a/src/Ext/TechnoType/Hooks.MatrixOp.cpp
+++ b/src/Ext/TechnoType/Hooks.MatrixOp.cpp
@@ -590,6 +590,8 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 			if (cHeight > 0 && height > 208)
 			{
 				double scale = std::max(Pade2_2(baseScale_log * (height - 208) / cHeight), minScale);
+				shadowMatrix.Scale((float)scale);
+				currentScale = scale;
 				vxlIndexKey.Invalidate();
 			}
 		}
@@ -747,8 +749,8 @@ DEFINE_HOOK(0x73C47A, UnitClass_DrawAsVXL_Shadow, 0x5)
 
 		return nullptr;
 	};
-
 	double adjustedFactor = Pixel_Per_Lepton / currentScale;
+
 	pDrawTypeExt->ApplyTurretOffset(&mtx, adjustedFactor);
 	mtx.RotateZ(static_cast<float>(pThis->SecondaryFacing.Current().GetRadian<32>() - pThis->PrimaryFacing.Current().GetRadian<32>()));
 


### PR DESCRIPTION
When drawing the shadow of an airborne unit, TurretOffset is applied to a transformation matrix that has already been scaled for height, causing the turret shadow's offset to be scaled as well and resulting in a misalignment with the actual turret image position.

> [!Note]
> Example reproduction steps:
> 1. Duplicate a `[DISK]` unit  
>    - It flies in the air while its shadow is on the ground, making it easy to observe.
> 2. Set `ShadowIndex=-1` on both to hide the body shadow  
>    - Leaving only the turret shadow visible for clarity.
> 3. Apply a `TurretOffset` to one of them to displace the turret by a certain distance  
>    - Preferably a multiple of cell distance, e.g., `512` leptons as in the image below.
> 4. Place both units at the same altitude and separate them horizontally by the same amount as the `TurretOffset` value. Check if the two turret shadows overlap.

Before:
![Shadow](https://github.com/user-attachments/assets/1f1f9af4-4c2b-4997-894b-5fe0d55adb0c)

After:
![Fixed](https://github.com/user-attachments/assets/03ec4bf1-8762-4e2f-a2a4-56eb19d01f02)
