### PR TITLE
Customize effects range of power plant enhancer

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -522,6 +522,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the initial direction of building placed by Ares's UnitDelivery superweapon
   - Customize default mirage disguises per vehicletypes
   - Allow customize jumpjet properties on warhead
+  - Customize effects range of power plant enhancer
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -672,6 +672,7 @@ In `rulesmd.ini`:
 ```ini
 [SOMEBUILDING]                     ; BuildingType
 PowerPlantEnhancer.PowerPlants=    ; List of BuildingTypes
+PowerPlantEnhancer.Range=0         ; integer, in leptons
 PowerPlantEnhancer.Amount=0        ; integer
 PowerPlantEnhancer.Factor=1.0      ; floating point value
 PowerPlantEnhancer.MaxCount=-1     ; integer

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -467,6 +467,22 @@ DisplayIncome.Houses=     ; Affected House Enumeration, defaults to [AudioVisual
 DisplayIncome.Offset=0,0  ; X,Y, pixels relative to default
 ```
 
+### Show power plant enhancer range
+
+- It is possible to show range of power plant enhancer when placing a building.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+ShowPowerPlantEnhancerRange=true   ; boolean
+```
+
+In `RA2MD.INI`:
+```ini
+[Phobos]
+ShowPowerPlantEnhancerRange=false  ; boolean
+```
+
 ## Hotkey Commands
 
 ### `[ ]` Display Damage Numbers

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -560,6 +560,7 @@ New:
 - Allow the [use of more precise calculation of repair costs](Fixed-or-Improved-Logics.md#use-more-precise-calculation-of-repair-costs) (by NetsuNegi)
 - [Customize default mirage disguises per vehicletypes](New-or-Enhanced-Logics.md#default-mirage-disguise-for-individual-vehicletypes) (by NetsuNegi)
 - [Allow customize jumpjet properties on warhead](Fixed-or-Improved-Logics.md#customizing-locomotor-warhead) (by NetsuNegi)
+- Customize effects range of power plant enhancer (by NetsuNegi)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1715,6 +1715,11 @@ msgid ""
 msgstr ""
 "允许在弹头上自定义 Jumpjet 属性"
 
+msgid ""
+"Customize effects range of power plant enhancer"
+msgstr ""
+"自定义电厂增幅器的效果范围"
+
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/User-Interface.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/User-Interface.po
@@ -807,6 +807,13 @@ msgid ""
 "credits when selling a unit on a repair bay."
 msgstr "`[AudioVisual] -> DisplayIncome` 还允许在维修厂出售单位时显示资金点数。"
 
+msgid "Show power plant enhancer range"
+msgstr "显示电厂增幅器的范围"
+
+msgid ""
+"It is possible to show range of power plant enhancer when placing a building."
+msgstr "现在可以在摆放建筑物时显示电厂增幅器的作用范围了。"
+
 msgid "Hotkey Commands"
 msgstr "快捷键命令"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -1788,6 +1788,10 @@ msgstr ""
 "[允许在弹头上自定义 Jumpjet 属性](Fixed-or-Improved-"
 "Logics.md#customizing-locomotor-warhead)（by NetsuNegi）"
 
+msgid ""
+"Customize effects range of power plant enhancer (by NetsuNegi)"
+msgstr "自定义电厂增幅器的效果范围（by NetsuNegi）"
+
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："
 

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -359,6 +359,51 @@ DEFINE_HOOK(0x4511D6, BuildingClass_AnimationAI_SellBuildup, 0x7)
 	return BuildingTypeExt::ExtMap.Find(pThis->Type)->SellBuildupLength == pThis->Animation.Value ? Continue : Skip;
 }
 
+#pragma region PowerPlantEnhancer
+
+DEFINE_HOOK(0x441553, BuildingClass_Unlimbo_AddOwned, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+	const auto pTypeExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+	const auto pOwnerExt = HouseExt::ExtMap.Find(pThis->Owner);
+
+	if (!pTypeExt->PowerPlantEnhancer_Buildings.empty() && (pTypeExt->PowerPlantEnhancer_Amount != 0 || pTypeExt->PowerPlantEnhancer_Factor != 1.0f))
+		pOwnerExt->PowerPlantEnhancers.push_back(pThis);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x448A78, BuildingClass_SetOwningHouse_RemoveOwned, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+	GET(HouseClass*, pOwner, EBX);
+	const auto pTypeExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+	const auto pOwnerExt = HouseExt::ExtMap.Find(pOwner);
+
+	if (!pTypeExt->PowerPlantEnhancer_Buildings.empty() && (pTypeExt->PowerPlantEnhancer_Amount != 0 || pTypeExt->PowerPlantEnhancer_Factor != 1.0f))
+	{
+		auto& vec = pOwnerExt->PowerPlantEnhancers;
+		vec.erase(std::remove(vec.begin(), vec.end(), pThis), vec.end());
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x449197, BuildingClass_SetOwningHouse_AddOwned, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+	GET(HouseClass*, pNewOwner, EBP);
+	const auto pTypeExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+	const auto pNewOwnerExt = HouseExt::ExtMap.Find(pNewOwner);
+
+	if (!pTypeExt->PowerPlantEnhancer_Buildings.empty() && (pTypeExt->PowerPlantEnhancer_Amount != 0 || pTypeExt->PowerPlantEnhancer_Factor != 1.0f))
+		pNewOwnerExt->PowerPlantEnhancers.push_back(pThis);
+
+	return 0;
+}
+
+#pragma endregion
+
 #pragma region FactoryPlant
 
 DEFINE_HOOK(0x441501, BuildingClass_Unlimbo_FactoryPlant, 0x6)

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1070,3 +1070,20 @@ DEFINE_HOOK(0x444D11, BuildingClass_ExitObject_ProductionAnimForInfantryFactory,
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x45670D, BuildingClass_GetRadialIndicatorRange_Extras, 0x7)
+{
+	enum { ApplyRange = 0x45674B, ApplyTurretWeapon = 0x456714 };
+
+	GET(BuildingClass*, pThis, ESI);
+	const auto pTypeExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+
+	if (!pTypeExt->PowerPlantEnhancer_Buildings.empty() && (pTypeExt->PowerPlantEnhancer_Amount != 0 || pTypeExt->PowerPlantEnhancer_Factor != 1.0f))
+	{
+		R->EAX(pTypeExt->PowerPlantEnhancer_Range.Get() / Unsorted::LeptonsPerCell);
+		return ApplyRange;
+	}
+
+	R->EAX(pThis->TechnoClass::GetTurretWeapon());
+	return ApplyTurretWeapon;
+}

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -40,7 +40,7 @@ int BuildingTypeExt::ExtData::GetSuperWeaponIndex(const int index) const
 	return -1;
 }
 
-std::pair<int, int> BuildingTypeExt::GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse, const CoordStruct* pCoords)
+std::pair<int, int> BuildingTypeExt::GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse, BuildingClass* pPowerPlant)
 {
 	const auto pHouseExt = HouseExt::ExtMap.Find(pHouse);
 	int amount = 0;
@@ -58,13 +58,10 @@ std::pair<int, int> BuildingTypeExt::GetEnhancedPower(BuildingTypeClass* pBuildi
 		if (!pEnhancerTypeExt->PowerPlantEnhancer_Buildings.Contains(pBuilding))
 			continue;
 
-		if (pCoords)
-		{
-			const int range = pEnhancerTypeExt->PowerPlantEnhancer_Range.Get();
+		const int range = pEnhancerTypeExt->PowerPlantEnhancer_Range.Get();
 
-			if (range > 0 && static_cast<int>(pCoords->DistanceFrom(pEnhancer->GetCoords())) > range)
-				continue;
-		}
+		if (range > 0 && (!pPowerPlant || pPowerPlant->DistanceFrom(pEnhancer) > range))
+			continue;
 
 		const int max = pEnhancerTypeExt->PowerPlantEnhancer_MaxCount;
 

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -40,22 +40,45 @@ int BuildingTypeExt::ExtData::GetSuperWeaponIndex(const int index) const
 	return -1;
 }
 
-std::pair<int, int> BuildingTypeExt::GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse)
+std::pair<int, int> BuildingTypeExt::GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse, const CoordStruct* pCoords)
 {
+	const auto pHouseExt = HouseExt::ExtMap.Find(pHouse);
 	int amount = 0;
 	float factor = 1.0f;
+	std::map<int, int> applied; // index, count
 
-	const auto pHouseExt = HouseExt::ExtMap.Find(pHouse);
-
-	for (const auto& [typeIdx, count] : pHouseExt->PowerPlantEnhancers)
+	for (const auto pEnhancer : pHouseExt->PowerPlantEnhancers)
 	{
-		const auto pTypeExt = BuildingTypeExt::ExtMap.Find(BuildingTypeClass::Array[typeIdx]);
+		if (!TechnoExt::IsActive(pEnhancer) || pEnhancer->InLimbo || !pEnhancer->HasPower)
+			continue;
 
-		if (pTypeExt->PowerPlantEnhancer_Buildings.Contains(pBuilding))
+		const auto pEnhancerType = pEnhancer->Type;
+		const auto pEnhancerTypeExt = BuildingTypeExt::ExtMap.Find(pEnhancerType);
+
+		if (!pEnhancerTypeExt->PowerPlantEnhancer_Buildings.Contains(pBuilding))
+			continue;
+
+		if (pCoords)
 		{
-			factor *= std::powf(pTypeExt->PowerPlantEnhancer_Factor, static_cast<float>(count));
-			amount += pTypeExt->PowerPlantEnhancer_Amount * count;
+			const int range = pEnhancerTypeExt->PowerPlantEnhancer_Range.Get();
+
+			if (range > 0 && static_cast<int>(pCoords->DistanceFrom(pEnhancer->GetCoords())) > range)
+				continue;
 		}
+
+		const int max = pEnhancerTypeExt->PowerPlantEnhancer_MaxCount;
+
+		if (max > 0)
+		{
+			const auto it = applied.find(pEnhancerType->ArrayIndex);
+
+			if (it != applied.cend() && it->second >= max)
+				continue;
+		}
+
+		factor *= pEnhancerTypeExt->PowerPlantEnhancer_Factor;
+		amount += pEnhancerTypeExt->PowerPlantEnhancer_Amount;
+		++applied[pEnhancerType->ArrayIndex];
 	}
 
 	return std::make_pair(static_cast<int>(std::round(output * factor)), amount);
@@ -138,6 +161,7 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->PowersUp_Buildings.Read(exINI, pSection, "PowersUp.Buildings");
 	this->PowerPlant_DamageFactor.Read(exINI, pSection, "PowerPlant.DamageFactor");
 	this->PowerPlantEnhancer_Buildings.Read(exINI, pSection, "PowerPlantEnhancer.PowerPlants");
+	this->PowerPlantEnhancer_Range.Read(exINI, pSection, "PowerPlantEnhancer.Range");
 	this->PowerPlantEnhancer_Amount.Read(exINI, pSection, "PowerPlantEnhancer.Amount");
 	this->PowerPlantEnhancer_Factor.Read(exINI, pSection, "PowerPlantEnhancer.Factor");
 	this->PowerPlantEnhancer_MaxCount.Read(exINI, pSection, "PowerPlantEnhancer.MaxCount");
@@ -291,6 +315,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PowersUp_Buildings)
 		.Process(this->PowerPlant_DamageFactor)
 		.Process(this->PowerPlantEnhancer_Buildings)
+		.Process(this->PowerPlantEnhancer_Range)
 		.Process(this->PowerPlantEnhancer_Amount)
 		.Process(this->PowerPlantEnhancer_Factor)
 		.Process(this->PowerPlantEnhancer_MaxCount)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -60,7 +60,7 @@ std::pair<int, int> BuildingTypeExt::GetEnhancedPower(BuildingTypeClass* pBuildi
 
 		const int range = pEnhancerTypeExt->PowerPlantEnhancer_Range.Get();
 
-		if (range > 0 && (!pPowerPlant || pPowerPlant->DistanceFrom(pEnhancer) > range))
+		if (range > 0 && (!pPowerPlant || pEnhancer->DistanceFrom(pPowerPlant) > range))
 			continue;
 
 		const int max = pEnhancerTypeExt->PowerPlantEnhancer_MaxCount;

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -19,6 +19,7 @@ public:
 
 		Valueable<double> PowerPlant_DamageFactor;
 		ValueableVector<BuildingTypeClass*> PowerPlantEnhancer_Buildings;
+		Valueable<Leptons> PowerPlantEnhancer_Range;
 		Valueable<int> PowerPlantEnhancer_Amount;
 		Nullable<float> PowerPlantEnhancer_Factor;
 		Valueable<int> PowerPlantEnhancer_MaxCount;
@@ -118,6 +119,7 @@ public:
 			, PowersUp_Buildings {}
 			, PowerPlant_DamageFactor { 1.0 }
 			, PowerPlantEnhancer_Buildings {}
+			, PowerPlantEnhancer_Range { Leptons(0) }
 			, PowerPlantEnhancer_Amount { 0 }
 			, PowerPlantEnhancer_Factor { 1.0f }
 			, PowerPlantEnhancer_MaxCount { -1 }
@@ -229,7 +231,7 @@ public:
 
 	static void PlayBunkerSound(BuildingClass const* pThis, bool buildUp = false);
 
-	static std::pair<int, int> GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse);
+	static std::pair<int, int> GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse, const CoordStruct* pCoords = nullptr);
 	static bool CanUpgrade(BuildingClass* pBuilding, BuildingTypeClass* pUpgradeType, HouseClass* pUpgradeOwner);
 	static int CountOwnedNowWithDeployOrUpgrade(BuildingTypeClass* pBuilding, HouseClass* pHouse);
 	static int GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass* pHouse);

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -231,7 +231,7 @@ public:
 
 	static void PlayBunkerSound(BuildingClass const* pThis, bool buildUp = false);
 
-	static std::pair<int, int> GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse, const CoordStruct* pCoords = nullptr);
+	static std::pair<int, int> GetEnhancedPower(BuildingTypeClass* pBuilding, int output, HouseClass* pHouse, BuildingClass* pPowerPlant = nullptr);
 	static bool CanUpgrade(BuildingClass* pBuilding, BuildingTypeClass* pUpgradeType, HouseClass* pUpgradeOwner);
 	static int CountOwnedNowWithDeployOrUpgrade(BuildingTypeClass* pBuilding, HouseClass* pHouse);
 	static int GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass* pHouse);

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -432,8 +432,7 @@ DEFINE_HOOK(0x44E826, BuildingClass_GetPowerOutput_Enhancer, 0x6)
 		return ReturnZero;
 
 	const auto pOwner = pThis->Owner;
-	const auto coords = pThis->GetCoords();
-	auto [power, extraPower] = BuildingTypeExt::GetEnhancedPower(pThis->Type, R->EDI<int>(), pOwner, &coords);
+	auto [power, extraPower] = BuildingTypeExt::GetEnhancedPower(pThis->Type, R->EDI<int>(), pOwner, pThis);
 	 
 	if (pThis->UpgradeLevel)
 	{
@@ -441,7 +440,7 @@ DEFINE_HOOK(0x44E826, BuildingClass_GetPowerOutput_Enhancer, 0x6)
 		{
 			if (pUpgrade)
 			{
-				const auto [upgradePower, extraUpgradePower] = BuildingTypeExt::GetEnhancedPower(pUpgrade, pUpgrade->PowerBonus, pOwner, &coords);
+				const auto [upgradePower, extraUpgradePower] = BuildingTypeExt::GetEnhancedPower(pUpgrade, pUpgrade->PowerBonus, pOwner, pThis);
 				power += upgradePower;
 				extraPower += extraUpgradePower;
 			}

--- a/src/Ext/BuildingType/Hooks.cpp
+++ b/src/Ext/BuildingType/Hooks.cpp
@@ -432,7 +432,8 @@ DEFINE_HOOK(0x44E826, BuildingClass_GetPowerOutput_Enhancer, 0x6)
 		return ReturnZero;
 
 	const auto pOwner = pThis->Owner;
-	auto [power, extraPower] = BuildingTypeExt::GetEnhancedPower(pThis->Type, R->EDI<int>(), pOwner);
+	const auto coords = pThis->GetCoords();
+	auto [power, extraPower] = BuildingTypeExt::GetEnhancedPower(pThis->Type, R->EDI<int>(), pOwner, &coords);
 	 
 	if (pThis->UpgradeLevel)
 	{
@@ -440,7 +441,7 @@ DEFINE_HOOK(0x44E826, BuildingClass_GetPowerOutput_Enhancer, 0x6)
 		{
 			if (pUpgrade)
 			{
-				const auto [upgradePower, extraUpgradePower] = BuildingTypeExt::GetEnhancedPower(pUpgrade, pUpgrade->PowerBonus, pOwner);
+				const auto [upgradePower, extraUpgradePower] = BuildingTypeExt::GetEnhancedPower(pUpgrade, pUpgrade->PowerBonus, pOwner, &coords);
 				power += upgradePower;
 				extraPower += extraUpgradePower;
 			}

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -740,27 +740,32 @@ bool HouseExt::SaveGlobals(PhobosStreamWriter& Stm)
 
 void HouseExt::ExtData::InvalidatePointer(void* ptr, bool bRemoved)
 {
-	AnnounceInvalidPointer(Factory_BuildingType, ptr);
-	AnnounceInvalidPointer(Factory_InfantryType, ptr);
-	AnnounceInvalidPointer(Factory_VehicleType, ptr);
-	AnnounceInvalidPointer(Factory_NavyType, ptr);
-	AnnounceInvalidPointer(Factory_AircraftType, ptr);
+	AnnounceInvalidPointer(this->Factory_BuildingType, ptr);
+	AnnounceInvalidPointer(this->Factory_InfantryType, ptr);
+	AnnounceInvalidPointer(this->Factory_VehicleType, ptr);
+	AnnounceInvalidPointer(this->Factory_NavyType, ptr);
+	AnnounceInvalidPointer(this->Factory_AircraftType, ptr);
 
 	if (ptr != nullptr)
 	{
-		if (!OwnedLimboDeliveredBuildings.empty())
+		if (!this->PowerPlantEnhancers.empty())
+		{
+			auto& vec = this->PowerPlantEnhancers;
+			vec.erase(std::remove(vec.begin(), vec.end(), reinterpret_cast<BuildingClass*>(ptr)), vec.end());
+		}
+
+		if (!this->OwnedLimboDeliveredBuildings.empty())
 		{
 			auto& vec = this->OwnedLimboDeliveredBuildings;
 			vec.erase(std::remove(vec.begin(), vec.end(), reinterpret_cast<BuildingClass*>(ptr)), vec.end());
 		}
 
-		if (!RestrictedFactoryPlants.empty())
+		if (!this->RestrictedFactoryPlants.empty())
 		{
 			auto& vec = this->RestrictedFactoryPlants;
 			vec.erase(std::remove(vec.begin(), vec.end(), reinterpret_cast<BuildingClass*>(ptr)), vec.end());
 		}
 	}
-
 }
 
 // =============================

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -16,7 +16,7 @@ public:
 	class ExtData final : public Extension<HouseClass>
 	{
 	public:
-		std::map<int, int> PowerPlantEnhancers;
+		std::vector<BuildingClass*> PowerPlantEnhancers;
 		std::vector<BuildingClass*> OwnedLimboDeliveredBuildings;
 		std::vector<TechnoClass*> OwnedCountedHarvesters;
 		bool ForceOnlyTargetHouseEnemy;

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -4,34 +4,6 @@
 #include <Ext/Scenario/Body.h>
 #include <Ext/Building/Body.h>
 
-DEFINE_HOOK(0x508C30, HouseClass_UpdatePower_UpdateCounter, 0x5)
-{
-	GET(HouseClass*, pThis, ECX);
-	auto const pHouseExt = HouseExt::ExtMap.Find(pThis);
-
-	pHouseExt->PowerPlantEnhancers.clear();
-
-	// This pre-iterating ensure our process to be done in O(NM) instead of O(N^2),
-	// as M should be much less than N, this will be a great improvement. - secsome
-	for (auto const pBld : pThis->Buildings)
-	{
-		if (TechnoExt::IsActive(pBld) && pBld->IsOnMap && pBld->HasPower)
-		{
-			const auto pType = pBld->Type;
-			const auto pExt = BuildingTypeExt::ExtMap.Find(pType);
-
-			if (pExt->PowerPlantEnhancer_Buildings.size()
-				&& (pExt->PowerPlantEnhancer_Amount != 0 || pExt->PowerPlantEnhancer_Factor != 1.0f)
-				&& (pExt->PowerPlantEnhancer_MaxCount < 0 || pHouseExt->PowerPlantEnhancers[pType->ArrayIndex] < pExt->PowerPlantEnhancer_MaxCount))
-			{
-				++pHouseExt->PowerPlantEnhancers[pType->ArrayIndex];
-			}
-		}
-	}
-
-	return 0;
-}
-
 // Trigger power recalculation on gain/loss of any techno, not just buildings.
 DEFINE_HOOK_AGAIN(0x5025F0, HouseClass_RegisterGain, 0x5) // RegisterLoss
 DEFINE_HOOK(0x502A80, HouseClass_RegisterGain, 0x8)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -146,6 +146,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AnimRemapDefaultColorScheme.Read(exINI, GameStrings::AudioVisual, "AnimRemapDefaultColorScheme");
 	this->TimerBlinkColorScheme.Read(exINI, GameStrings::AudioVisual, "TimerBlinkColorScheme");
 	this->ShowDesignatorRange.Read(exINI, GameStrings::AudioVisual, "ShowDesignatorRange");
+	this->ShowPowerPlantEnhancerRange.Read(exINI, GameStrings::AudioVisual, "ShowPowerPlantEnhancerRange");
+
 	Nullable<double>AirShadowBaseScale;
 	AirShadowBaseScale.Read(exINI, GameStrings::AudioVisual, "AirShadowBaseScale");
 	if (AirShadowBaseScale.isset() && AirShadowBaseScale.Get() > 0)
@@ -576,6 +578,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->VisualScatter_Min)
 		.Process(this->VisualScatter_Max)
 		.Process(this->ShowDesignatorRange)
+		.Process(this->ShowPowerPlantEnhancerRange)
 		.Process(this->DropPodTrailer)
 		.Process(this->DropPodDefaultTrailer)
 		.Process(this->PodImage)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -168,6 +168,7 @@ public:
 		Valueable<Leptons> VisualScatter_Max;
 
 		Valueable<bool> ShowDesignatorRange;
+		Valueable<bool> ShowPowerPlantEnhancerRange;
 		Valueable<bool> IsVoiceCreatedGlobal;
 		Valueable<int> SelectionFlashDuration;
 		Nullable<AnimTypeClass*> DropPodTrailer;
@@ -463,6 +464,7 @@ public:
 			, VisualScatter_Min { Leptons(8) }
 			, VisualScatter_Max { Leptons(32) }
 			, ShowDesignatorRange { true }
+			, ShowPowerPlantEnhancerRange { true }
 			, DropPodTrailer { }
 			, DropPodDefaultTrailer { }
 			, PodImage { }

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -122,6 +122,10 @@ static inline void LimboCreate(BuildingTypeClass* pType, HouseClass* pOwner, int
 		auto const pBuildingExt = BuildingExt::ExtMap.Find(pBuilding);
 		auto const pOwnerExt = HouseExt::ExtMap.Find(pOwner);
 
+		if (!pBuildingExt->TypeExtData->PowerPlantEnhancer_Buildings.empty()
+			&& (pBuildingExt->TypeExtData->PowerPlantEnhancer_Amount != 0 || pBuildingExt->TypeExtData->PowerPlantEnhancer_Factor != 1.0f))
+			pOwnerExt->PowerPlantEnhancers.push_back(pBuilding);
+
 		if (pType->FactoryPlant)
 		{
 			if (pBuildingExt->TypeExtData->FactoryPlant_AllowTypes.size() > 0 || pBuildingExt->TypeExtData->FactoryPlant_DisallowTypes.size() > 0)

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -605,3 +605,40 @@ DEFINE_FUNCTION_JUMP(CALL, 0x6D4D42, TacticalClass_DrawTimer_Print_Wide)// UINam
 DEFINE_FUNCTION_JUMP(CALL, 0x6D4D9A, TacticalClass_DrawTimer_Print_Wide)// Time
 
 #pragma endregion
+
+DEFINE_HOOK(0x6DBEA3, TacticalClass_DrawRadialIndicator_Building_Extras, 0x7)
+{
+	enum { ContinueAfter = 0x6DBEAA };
+
+	GET(BuildingClass*, pCurrentBuilding, EBX);
+
+	if (Phobos::Config::ShowPowerPlantEnhancerRange && RulesExt::Global()->ShowPowerPlantEnhancerRange)
+	{
+		const auto pCurrentExt = HouseExt::ExtMap.Find(HouseClass::CurrentPlayer);
+		const auto center = DisplayClass::Instance.CurrentFoundation_CenterCell;
+
+		for (const auto pEnhancer : pCurrentExt->PowerPlantEnhancers)
+		{
+			if (!TechnoExt::IsActive(pEnhancer) || pEnhancer->InLimbo || !pEnhancer->HasPower)
+				continue;
+
+			const auto pEnhancerTypeExt = BuildingTypeExt::ExtMap.Find(pEnhancer->Type);
+			const int range = pEnhancerTypeExt->PowerPlantEnhancer_Range.Get() / Unsorted::LeptonsPerCell;
+
+			if (range <= 0 || !pEnhancerTypeExt->PowerPlantEnhancer_Buildings.Contains(pCurrentBuilding->Type))
+				continue;
+
+			CoordStruct enhancerCoords = pEnhancer->GetCoords();
+
+			if (center.DistanceFrom(CellClass::Coord2Cell(enhancerCoords)) > range * 1.5)
+				continue;
+
+			enhancerCoords.Z = MapClass::Instance.GetCellFloorHeight(enhancerCoords);
+			const auto& color = pEnhancer->Owner->Color;
+			Game::DrawRadialIndicator(false, true, enhancerCoords, color, range, false, true);
+		}
+	}
+
+	R->EAX(pCurrentBuilding->GetRadialIndicatorRange());
+	return ContinueAfter;
+}

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -65,6 +65,7 @@ bool Phobos::Config::RealTimeTimers_Adaptive = false;
 int Phobos::Config::CampaignDefaultGameSpeed = 2;
 bool Phobos::Config::SkirmishUnlimitedColors = false;
 bool Phobos::Config::ShowDesignatorRange = false;
+bool Phobos::Config::ShowPowerPlantEnhancerRange = false;
 bool Phobos::Config::SaveVariablesOnScenarioEnd = false;
 bool Phobos::Config::SaveGameOnScenarioStart = true;
 bool Phobos::Config::ShowBriefing = true;
@@ -128,6 +129,7 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 	}
 
 	Phobos::Config::ShowDesignatorRange = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "ShowDesignatorRange", false);
+	Phobos::Config::ShowPowerPlantEnhancerRange = CCINIClass::INI_RA2MD.ReadBool(phobosSection, "ShowPowerPlantEnhancerRange", false);
 
 	CCINIClass ini_uimd {};
 	ini_uimd.LoadFromFile(GameStrings::UIMD_INI);

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -100,6 +100,7 @@ public:
 		static int CampaignDefaultGameSpeed;
 		static bool SkirmishUnlimitedColors;
 		static bool ShowDesignatorRange;
+		static bool ShowPowerPlantEnhancerRange;
 		static bool SaveVariablesOnScenarioEnd;
 		static bool SaveGameOnScenarioStart;
 		static bool ShowBriefing;


### PR DESCRIPTION
In `rulesmd.ini`:
```ini
[AudioVisual]
ShowPowerPlantEnhancerRange=true   ; boolean

[SOMEBUILDING]                     ; BuildingType
PowerPlantEnhancer.Range=0         ; integer, in leptons
```

In `RA2MD.INI`:
```ini
[Phobos]
ShowPowerPlantEnhancerRange=false  ; boolean
```