### PR TITLE
Extend the Harvester counter color definition and standardize the variable names

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -638,10 +638,10 @@ MissingCameo=XXICON.SHP  ; filename - including the .shp/.pcx extension
 In `uimd.ini`:
 ```ini
 [Sidebar]
-HarvesterCounter.Show=false           ; boolean
-HarvesterCounter.Label=<none>         ; CSF entry key
-HarvesterCounter.ConditionYellow=99%  ; floating point value, percents
-HarvesterCounter.ConditionRed=50%     ; floating point value, percents
+HarvesterCounter.Show=false                     ; boolean
+HarvesterCounter.Label=<none>                   ; CSF entry key
+HarvesterCounter.ConditionYellow=99%            ; floating point value, percents
+HarvesterCounter.ConditionRed=50%               ; floating point value, percents
 ```
 
 In `rulesmd.ini`:
@@ -651,6 +651,7 @@ Harvester.Counted=                              ; boolean
 
 [SOMESIDE]                                      ; Side
 Sidebar.HarvesterCounter.Offset=0,0             ; X,Y, pixels relative to default
+Sidebar.HarvesterCounter.ColorGreen=            ; integer - Red,Green,Blue, default to [Side] -> ToolTipColor=
 Sidebar.HarvesterCounter.ColorYellow=255,255,0  ; integer - Red,Green,Blue
 Sidebar.HarvesterCounter.ColorRed=255,0,0       ; integer - Red,Green,Blue
 ```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -561,6 +561,7 @@ New:
 - [Customize default mirage disguises per vehicletypes](New-or-Enhanced-Logics.md#default-mirage-disguise-for-individual-vehicletypes) (by NetsuNegi)
 - [Allow customize jumpjet properties on warhead](Fixed-or-Improved-Logics.md#customizing-locomotor-warhead) (by NetsuNegi)
 - Customize effects range of power plant enhancer (by NetsuNegi)
+- Allow each side to customize the color when the proportion of working miners is higher than `HarvesterCounter.ConditionYellow` (by Noble_Fish)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -31,6 +31,7 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->IngameScore_WinTheme = pINI->ReadTheme(pSection, "IngameScore.WinTheme", this->IngameScore_WinTheme);
 	this->IngameScore_LoseTheme = pINI->ReadTheme(pSection, "IngameScore.LoseTheme", this->IngameScore_LoseTheme);
 	this->Sidebar_HarvesterCounter_Offset.Read(exINI, pSection, "Sidebar.HarvesterCounter.Offset");
+	this->Sidebar_HarvesterCounter_Green.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorGreen");
 	this->Sidebar_HarvesterCounter_Yellow.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorYellow");
 	this->Sidebar_HarvesterCounter_Red.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorRed");
 	this->Sidebar_WeedsCounter_Offset.Read(exINI, pSection, "Sidebar.WeedsCounter.Offset");
@@ -64,6 +65,7 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->ArrayIndex)
 		.Process(this->Sidebar_GDIPositions)
 		.Process(this->Sidebar_HarvesterCounter_Offset)
+		.Process(this->Sidebar_HarvesterCounter_Green)
 		.Process(this->Sidebar_HarvesterCounter_Yellow)
 		.Process(this->Sidebar_HarvesterCounter_Red)
 		.Process(this->Sidebar_WeedsCounter_Offset)

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -31,17 +31,17 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->IngameScore_WinTheme = pINI->ReadTheme(pSection, "IngameScore.WinTheme", this->IngameScore_WinTheme);
 	this->IngameScore_LoseTheme = pINI->ReadTheme(pSection, "IngameScore.LoseTheme", this->IngameScore_LoseTheme);
 	this->Sidebar_HarvesterCounter_Offset.Read(exINI, pSection, "Sidebar.HarvesterCounter.Offset");
-	this->Sidebar_HarvesterCounter_Green.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorGreen");
-	this->Sidebar_HarvesterCounter_Yellow.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorYellow");
-	this->Sidebar_HarvesterCounter_Red.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorRed");
+	this->Sidebar_HarvesterCounter_ColorGreen.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorGreen");
+	this->Sidebar_HarvesterCounter_ColorYellow.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorYellow");
+	this->Sidebar_HarvesterCounter_ColorRed.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorRed");
 	this->Sidebar_WeedsCounter_Offset.Read(exINI, pSection, "Sidebar.WeedsCounter.Offset");
 	this->Sidebar_WeedsCounter_Color.Read(exINI, pSection, "Sidebar.WeedsCounter.Color");
 	this->Sidebar_ProducingProgress_Offset.Read(exINI, pSection, "Sidebar.ProducingProgress.Offset");
 	this->Sidebar_PowerDelta_Offset.Read(exINI, pSection, "Sidebar.PowerDelta.Offset");
-	this->Sidebar_PowerDelta_Green.Read(exINI, pSection, "Sidebar.PowerDelta.ColorGreen");
-	this->Sidebar_PowerDelta_Yellow.Read(exINI, pSection, "Sidebar.PowerDelta.ColorYellow");
-	this->Sidebar_PowerDelta_Red.Read(exINI, pSection, "Sidebar.PowerDelta.ColorRed");
-	this->Sidebar_PowerDelta_Grey.Read(exINI, pSection, "Sidebar.PowerDelta.ColorGrey");
+	this->Sidebar_PowerDelta_ColorGreen.Read(exINI, pSection, "Sidebar.PowerDelta.ColorGreen");
+	this->Sidebar_PowerDelta_ColorYellow.Read(exINI, pSection, "Sidebar.PowerDelta.ColorYellow");
+	this->Sidebar_PowerDelta_ColorRed.Read(exINI, pSection, "Sidebar.PowerDelta.ColorRed");
+	this->Sidebar_PowerDelta_ColorGrey.Read(exINI, pSection, "Sidebar.PowerDelta.ColorGrey");
 	this->Sidebar_PowerDelta_Align.Read(exINI, pSection, "Sidebar.PowerDelta.Align");
 	this->ToolTip_Background_Color.Read(exINI, pSection, "ToolTip.Background.Color");
 	this->ToolTip_Background_Opacity.Read(exINI, pSection, "ToolTip.Background.Opacity");
@@ -65,17 +65,17 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->ArrayIndex)
 		.Process(this->Sidebar_GDIPositions)
 		.Process(this->Sidebar_HarvesterCounter_Offset)
-		.Process(this->Sidebar_HarvesterCounter_Green)
-		.Process(this->Sidebar_HarvesterCounter_Yellow)
-		.Process(this->Sidebar_HarvesterCounter_Red)
+		.Process(this->Sidebar_HarvesterCounter_ColorGreen)
+		.Process(this->Sidebar_HarvesterCounter_ColorYellow)
+		.Process(this->Sidebar_HarvesterCounter_ColorRed)
 		.Process(this->Sidebar_WeedsCounter_Offset)
 		.Process(this->Sidebar_WeedsCounter_Color)
 		.Process(this->Sidebar_ProducingProgress_Offset)
 		.Process(this->Sidebar_PowerDelta_Offset)
-		.Process(this->Sidebar_PowerDelta_Green)
-		.Process(this->Sidebar_PowerDelta_Yellow)
-		.Process(this->Sidebar_PowerDelta_Red)
-		.Process(this->Sidebar_PowerDelta_Grey)
+		.Process(this->Sidebar_PowerDelta_ColorGreen)
+		.Process(this->Sidebar_PowerDelta_ColorYellow)
+		.Process(this->Sidebar_PowerDelta_ColorRed)
+		.Process(this->Sidebar_PowerDelta_ColorGrey)
 		.Process(this->Sidebar_PowerDelta_Align)
 		.Process(this->ToolTip_Background_Color)
 		.Process(this->ToolTip_Background_Opacity)

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -20,17 +20,17 @@ public:
 		Valueable<int> IngameScore_WinTheme;
 		Valueable<int> IngameScore_LoseTheme;
 		Valueable<Point2D> Sidebar_HarvesterCounter_Offset;
-		Nullable<ColorStruct> Sidebar_HarvesterCounter_Green;
-		Valueable<ColorStruct> Sidebar_HarvesterCounter_Yellow;
-		Valueable<ColorStruct> Sidebar_HarvesterCounter_Red;
+		Nullable<ColorStruct> Sidebar_HarvesterCounter_ColorGreen;
+		Valueable<ColorStruct> Sidebar_HarvesterCounter_ColorYellow;
+		Valueable<ColorStruct> Sidebar_HarvesterCounter_ColorRed;
 		Valueable<Point2D> Sidebar_WeedsCounter_Offset;
 		Nullable<ColorStruct> Sidebar_WeedsCounter_Color;
 		Valueable<Point2D> Sidebar_ProducingProgress_Offset;
 		Valueable<Point2D> Sidebar_PowerDelta_Offset;
-		Valueable<ColorStruct> Sidebar_PowerDelta_Green;
-		Valueable<ColorStruct> Sidebar_PowerDelta_Yellow;
-		Valueable<ColorStruct> Sidebar_PowerDelta_Red;
-		Valueable<ColorStruct> Sidebar_PowerDelta_Grey;
+		Valueable<ColorStruct> Sidebar_PowerDelta_ColorGreen;
+		Valueable<ColorStruct> Sidebar_PowerDelta_ColorYellow;
+		Valueable<ColorStruct> Sidebar_PowerDelta_ColorRed;
+		Valueable<ColorStruct> Sidebar_PowerDelta_ColorGrey;
 		Valueable<TextAlign> Sidebar_PowerDelta_Align;
 		Nullable<ColorStruct> ToolTip_Background_Color;
 		Nullable<int> ToolTip_Background_Opacity;
@@ -49,17 +49,17 @@ public:
 			, IngameScore_WinTheme { -2 }
 			, IngameScore_LoseTheme { -2 }
 			, Sidebar_HarvesterCounter_Offset { { 0, 0 } }
-			, Sidebar_HarvesterCounter_Green { }
-			, Sidebar_HarvesterCounter_Yellow { { 255, 255, 0 } }
-			, Sidebar_HarvesterCounter_Red { { 255, 0, 0 } }
+			, Sidebar_HarvesterCounter_ColorGreen { }
+			, Sidebar_HarvesterCounter_ColorYellow { { 255, 255, 0 } }
+			, Sidebar_HarvesterCounter_ColorRed { { 255, 0, 0 } }
 			, Sidebar_WeedsCounter_Offset { { 0, 0 } }
 			, Sidebar_WeedsCounter_Color {}
 			, Sidebar_ProducingProgress_Offset { { 0, 0 } }
 			, Sidebar_PowerDelta_Offset { { 0, 0 } }
-			, Sidebar_PowerDelta_Green { { 0, 255, 0 } }
-			, Sidebar_PowerDelta_Yellow { { 255, 255, 0 } }
-			, Sidebar_PowerDelta_Red { { 255, 0, 0 } }
-			, Sidebar_PowerDelta_Grey { { 0x80,0x80,0x80 } }
+			, Sidebar_PowerDelta_ColorGreen { { 0, 255, 0 } }
+			, Sidebar_PowerDelta_ColorYellow { { 255, 255, 0 } }
+			, Sidebar_PowerDelta_ColorRed { { 255, 0, 0 } }
+			, Sidebar_PowerDelta_ColorGrey { { 0x80,0x80,0x80 } }
 			, Sidebar_PowerDelta_Align { TextAlign::Left }
 			, ToolTip_Background_Color { }
 			, ToolTip_Background_Opacity { }

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -20,6 +20,7 @@ public:
 		Valueable<int> IngameScore_WinTheme;
 		Valueable<int> IngameScore_LoseTheme;
 		Valueable<Point2D> Sidebar_HarvesterCounter_Offset;
+		Nullable<ColorStruct> Sidebar_HarvesterCounter_Green;
 		Valueable<ColorStruct> Sidebar_HarvesterCounter_Yellow;
 		Valueable<ColorStruct> Sidebar_HarvesterCounter_Red;
 		Valueable<Point2D> Sidebar_WeedsCounter_Offset;
@@ -48,6 +49,7 @@ public:
 			, IngameScore_WinTheme { -2 }
 			, IngameScore_LoseTheme { -2 }
 			, Sidebar_HarvesterCounter_Offset { { 0, 0 } }
+			, Sidebar_HarvesterCounter_Green { }
 			, Sidebar_HarvesterCounter_Yellow { { 255, 255, 0 } }
 			, Sidebar_HarvesterCounter_Red { { 255, 0, 0 } }
 			, Sidebar_WeedsCounter_Offset { { 0, 0 } }

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -92,7 +92,7 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 		const double nPercentage = nTotal == 0 ? 1.0 : (double)nActive / (double)nTotal;
 
 		const ColorStruct clrToolTip = nPercentage > Phobos::UI::HarvesterCounter_ConditionYellow
-			? Drawing::TooltipColor : nPercentage > Phobos::UI::HarvesterCounter_ConditionRed
+			? pSideExt->Sidebar_HarvesterCounter_Green.Get(Drawing::TooltipColor) : nPercentage > Phobos::UI::HarvesterCounter_ConditionRed
 			? pSideExt->Sidebar_HarvesterCounter_Yellow : pSideExt->Sidebar_HarvesterCounter_Red;
 
 		swprintf_s(counter, L"%ls%d/%d", Phobos::UI::HarvesterLabel, nActive, nTotal);

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -92,8 +92,8 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 		const double nPercentage = nTotal == 0 ? 1.0 : (double)nActive / (double)nTotal;
 
 		const ColorStruct clrToolTip = nPercentage > Phobos::UI::HarvesterCounter_ConditionYellow
-			? pSideExt->Sidebar_HarvesterCounter_Green.Get(Drawing::TooltipColor) : nPercentage > Phobos::UI::HarvesterCounter_ConditionRed
-			? pSideExt->Sidebar_HarvesterCounter_Yellow : pSideExt->Sidebar_HarvesterCounter_Red;
+			? pSideExt->Sidebar_HarvesterCounter_ColorGreen.Get(Drawing::TooltipColor) : nPercentage > Phobos::UI::HarvesterCounter_ConditionRed
+			? pSideExt->Sidebar_HarvesterCounter_ColorYellow : pSideExt->Sidebar_HarvesterCounter_ColorRed;
 
 		swprintf_s(counter, L"%ls%d/%d", Phobos::UI::HarvesterLabel, nActive, nTotal);
 
@@ -115,7 +115,7 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 
 		if (pPlayer->PowerBlackoutTimer.InProgress())
 		{
-			clrToolTip = pSideExt->Sidebar_PowerDelta_Grey;
+			clrToolTip = pSideExt->Sidebar_PowerDelta_ColorGrey;
 			swprintf_s(counter, L"%ls", Phobos::UI::PowerBlackoutLabel);
 		}
 		else
@@ -127,8 +127,8 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 				? Phobos::UI::PowerDelta_ConditionRed * 2.f : Phobos::UI::PowerDelta_ConditionYellow;
 
 			clrToolTip = percent < Phobos::UI::PowerDelta_ConditionYellow
-				? pSideExt->Sidebar_PowerDelta_Green : LESS_EQUAL(percent, Phobos::UI::PowerDelta_ConditionRed)
-				? pSideExt->Sidebar_PowerDelta_Yellow : pSideExt->Sidebar_PowerDelta_Red;
+				? pSideExt->Sidebar_PowerDelta_ColorGreen : LESS_EQUAL(percent, Phobos::UI::PowerDelta_ConditionRed)
+				? pSideExt->Sidebar_PowerDelta_ColorYellow : pSideExt->Sidebar_PowerDelta_ColorRed;
 
 			swprintf_s(counter, L"%ls%+d", Phobos::UI::PowerLabel, delta);
 		}


### PR DESCRIPTION
1. Allow defining the color of the "green" state of *[Harvester counter](https://phobos.readthedocs.io/en/latest/User-Interface.html#harvester-counter)* independently of `ToolTipColor`.
2. Align the variable names related to color definitions of the old *Harvester counter* and *[Power delta counter](https://phobos.readthedocs.io/en/latest/User-Interface.html#power-delta-counter)* that do not correspond to INI flags with the structure of INI flags.