### PR TITLE
Remove the redundant judgment in *Skip turret rotation under EMP*

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -677,6 +677,7 @@ Phobos fixes:
 - Fixed an issue where shadow matrix scaling was incorrectly applied to `TurretOffset` causing turret shadow misplacement (by Noble_Fish)
 - Fixed an issue that customizable warhead animation scatter cannot override 32 leptons scatter of `Inviso=yes` projectile (by NetsuNegi)
 - Fixed units with Fly, Jumpjet or Rocket locomotors destroyed while crashing off-map never being fully cleaned up, permanently blocking production slots and counting towards unit limits (by RAZER)
+- Fixed a bug where a unit's turrets would also get locked when the unit became deactivated for reasons other than being under EMP (by Noble_Fish)
 
 Fixes / interactions with other extensions:
 <!--  - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus)  -->

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -127,7 +127,7 @@ DEFINE_HOOK(0x736990, UnitClass_UpdateRotation_TurretFacing_EMP, 0x6)
 	GET(UnitClass* const, pThis, ECX);
 	enum { SkipAll = 0x736C0E };
 
-	if (pThis->Deactivated || pThis->IsUnderEMP())
+	if (pThis->IsUnderEMP())
 		return SkipAll;
 
 	return 0;


### PR DESCRIPTION
Commit 5243923 prevented turret rotation of units under EMP and additionally handled situations where a unit is in the Deactivated state, which causes other situations like Ares' [Operator logic](http://ares-developers.github.io/Ares-docs/new/operator.html) to also be forced to lock turret rotation.

Original:
<img width="246" height="116" alt="original" src="https://github.com/user-attachments/assets/449ea49a-e569-47be-b991-85d55985baed" />

Commit 5243923:
<img width="246" height="116" alt="locked" src="https://github.com/user-attachments/assets/dc21c77e-8e57-4356-b941-2caf247e6ca0" />
