### PR TITLE
Fix the Unsellable judgment error introduced by fc1219

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -717,7 +717,7 @@ Fixes / interactions with other extensions:
 ```{dropdown} Click to show
 
 Vanilla fixes:
-- Vehicles overlapping `Wall=true` OverlayTypes no longer display sell cursor and cannot be sold (by CnCRAZER & Starkku)
+- Vehicles overlapping `Wall=true` OverlayTypes no longer display sell cursor and cannot be sold (by CnCRAZER, Starkku, Noble_Fish)
 - Fixed a desync due to an inconsistent shroud state caused by `GapGenerator` and `SpySat` interaction (by Starkku)
 
 Phobos fixes:

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2516,8 +2516,8 @@ msgstr "0.4.0.3"
 
 msgid ""
 "Vehicles overlapping `Wall=true` OverlayTypes no longer display sell "
-"cursor and cannot be sold (by CnCRAZER & Starkku)"
-msgstr "图像与 `Wall=true` 的覆盖物重叠的载具上不再会显示出售光标也不再能被出售（by RAZER & Starkku）"
+"cursor and cannot be sold (by CnCRAZER, Starkku, Noble_Fish)"
+msgstr "图像与 `Wall=true` 的覆盖物重叠的载具上不再会显示出售光标也不再能被出售（by RAZER、Starkku、Noble_Fish）"
 
 msgid ""
 "Fixed a desync due to an inconsistent shroud state caused by "

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3078,7 +3078,7 @@ static bool inline CanBeSold(TechnoClass* pTechno, AbstractType rtti)
 	{
 		auto const pTypeExt = TechnoExt::ExtMap.Find(pTechno)->TypeExtData;
 
-		if (!pTypeExt->Unsellable.Get(RulesExt::Global()->UnitsUnsellable))
+		if (pTypeExt->Unsellable.Get(RulesExt::Global()->UnitsUnsellable))
 			return false;
 
 		auto const pCell = MapClass::Instance.GetCellAt(pTechno->GetCenterCoords());


### PR DESCRIPTION
Fix the bug introduced by commit fc12197d73a9e73247e2cf9ff032923af7b133d4 where the `Unsellable` [value incorrectly corresponded](https://github.com/Phobos-developers/Phobos/commit/fc12197d73a9e73247e2cf9ff032923af7b133d4#diff-5e24fcccc37dd8fb07ae7b1fb3a409dfd21b68c5a0aa8782f79a4007d2afda62R2965-R2974) to whether it could be sold.