### PR TITLE
Fix infantry with Engineer=yes ignores cell occupier in AreaGuard, Parol and Guard mission

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -749,6 +749,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow replacing vanilla repairing with togglable auto repairing
   - Fix an issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions
   - Framework for dynamic sight
+  - Fix infantry with Engineer=yes ignores cell occupier in AreaGuard, Parol and Guard mission
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -324,6 +324,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Enabled playing ingame movie in non-campaign modes (i.e. trigger action `100 Play Sidebar Movie...` and `117 Play Sidebar Movie and pause...`).
 - `ElectricAssault` weapons can now auto acquire allies' overpowerable defenses.
 - Fixed the issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions.
+- Fixed infantry with Engineer=yes ignores cell occupier in AreaGuard, Parol and Guard mission.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -652,6 +652,7 @@ Vanilla fixes:
 - Enabled playing ingame movie in non-campaign modes (i.e. trigger action `100 Play Sidebar Movie...` and `117 Play Sidebar Movie and pause...`) (by TaranDahl)
 - `ElectricAssault` weapons can now auto acquire allies' overpowerable defenses (by Ollerus)
 - Fixed the issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions (by TaranDahl)
+- Fixed infantry with Engineer=yes ignores cell occupier in AreaGuard, Parol and Guard mission.
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3513,3 +3513,6 @@ DEFINE_HOOK(0x707A2E, TechnoClass_PointerExpired_TargetExpired, 0x5)
 	}
 	return 0;
 }
+
+// Fix infantry with Engineer=yes ignores cell occupier in AreaGuard, Parol and Guard mission.
+DEFINE_JUMP(LJMP, 0x51C335, 0x51C41C);


### PR DESCRIPTION
To be tested: If I recall correctly, the AI Engineer will automatically repair damaged surrounding buildings when in guard or area guard mission. It is necessary to confirm that this fix does not break this behavior.