### PR TITLE
Customize `HarvesterLoadRate`

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2150,6 +2150,16 @@ HarvesterDumpAmount=0.0               ; floating point value
 HarvesterDumpAmount=                  ; floating point value
 ```
 
+### Customize `HarvesterLoadRate`
+
+- Now `HarvesterLoadRate` can be customized on each unit.
+
+In `rulesmd.ini`:
+```ini
+[SOMEVEHICLE]                         ; VehicleType
+HarvesterLoadRate=                    ; integer, default to [General] -> HarvesterLoadRate
+```
+
 ### Customize type selection for IFV
 
 In vanilla game, when using type selection command on IFVs, all of them will be selected regardless of their current modes, which is allowed to customize now.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -573,6 +573,7 @@ New:
 - [Allow replacing vanilla repairing with togglable auto repairing](User-Interface.md#allow-replacing-vanilla-repairing-with-togglable-auto-repairing) (by TaranDahl)
 - Use `OpenTopped.AllowFiringIfAttackedByLocomotor` to control whether the passengers of a non-building transport unit can fire when the unit is being attacked by a weapon whose warhead has `IsLocomotor=true` (by Noble_Fish)
 - Framework for dynamic sight (by TaranDahl)
+- Customize `HarvesterLoadRate` (by Noble_Fish)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1194,6 +1194,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		|| ExtraThreatCoefficient_Facing.Get(RulesExt::Global()->ExtraThreatCoefficient_Facing) != 0
 		|| ExtraThreatCoefficient_DistanceToLastTarget.Get(RulesExt::Global()->ExtraThreatCoefficient_DistanceToLastTarget) != 0;
 
+	this->HarvesterLoadRate.Read(exINI, pSection, "HarvesterLoadRate");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1931,6 +1933,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ExtraThreatCoefficient_InRangeDistance)
 		.Process(this->ExtraThreatCoefficient_Facing)
 		.Process(this->ExtraThreatCoefficient_DistanceToLastTarget)
+
+		.Process(this->HarvesterLoadRate)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -507,6 +507,8 @@ public:
 
 		SHPStruct* TurretShape;
 
+		Nullable<int> HarvesterLoadRate;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, HealthBar_HidePips { false }
@@ -966,6 +968,8 @@ public:
 			, ExtraThreatCoefficient_InRangeDistance {}
 			, ExtraThreatCoefficient_Facing {}
 			, ExtraThreatCoefficient_DistanceToLastTarget {}
+
+			, HarvesterLoadRate {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -1,4 +1,4 @@
-﻿#include <Ext/Techno/Body.h>
+#include <Ext/Techno/Body.h>
 
 #pragma region EnterRefineryFix
 
@@ -101,6 +101,27 @@ DEFINE_HOOK(0x4D6D34, FootClass_MissionAreaGuard_Miner, 0x5)
 	}
 
 	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x73D508, UnitClass_Harvesting_HarvesterLoadRate, 6)
+DEFINE_HOOK(0x73D5D5, UnitClass_Harvesting_HarvesterLoadRate, 6)
+{
+	GET(UnitClass* const, pThis, ESI);
+	auto const pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
+
+	R->EAX(pTypeExt->HarvesterLoadRate.Get(RulesClass::Instance->HarvesterLoadRate));
+
+	return R->Origin() == 0x73D508 ? 0x73D50E : 0x73D5DB;
+}
+
+DEFINE_HOOK(0x73E951, UnitClass_Harvest_HarvesterLoadRate, 6)
+{
+	GET(UnitClass* const, pThis, EBP);
+	auto const pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
+
+	R->EAX(pTypeExt->HarvesterLoadRate.Get(RulesClass::Instance->HarvesterLoadRate));
+
+	return 0x73E957;
 }
 
 #pragma region HarvesterScanAfterUnload


### PR DESCRIPTION
- Now `HarvesterLoadRate` can be customized on each unit.

In `rulesmd.ini`:
```ini
[SOMEVEHICLE]                         ; VehicleType
HarvesterLoadRate=                    ; integer, default to [General] -> HarvesterLoadRate
```