### PR TITLE
Fix the conditions for the leader guard mission

### DIFF
--- a/src/Ext/Script/Body.cpp
+++ b/src/Ext/Script/Body.cpp
@@ -497,7 +497,7 @@ void ScriptExt::Mission_Gather_NearTheLeader(TeamClass* pTeam, int countdown)
 					const auto mission = pUnit->GetCurrentMission();
 
 					// Is near of the leader, then protect the area
-					if (mission != Mission::Area_Guard || mission != Mission::Attack)
+					if (mission != Mission::Area_Guard && mission != Mission::Attack)
 						pUnit->QueueMission(Mission::Area_Guard, true);
 
 					nTogether++;


### PR DESCRIPTION
The current condition is always true; it's a typo.