### PR TITLE
Fix shield condition check in `IsRedSP` function

### DIFF
--- a/src/New/Entity/ShieldClass.h
+++ b/src/New/Entity/ShieldClass.h
@@ -95,7 +95,7 @@ public:
 	bool IsRedSP() const
 	{
 		auto const pType = this->Type;
-		return this->HP <= pType->GetConditionYellow() * pType->Strength.Get();
+		return this->HP <= pType->GetConditionRed() * pType->Strength.Get();
 	}
 
 	static void PointerGotInvalid(void* ptr, bool removed);


### PR DESCRIPTION
This function is not being used. Fix it to prevent issues if anyone calls it in the future.