### PR TITLE
Fix tint color RGB mode conversion

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -654,6 +654,7 @@ Vanilla fixes:
 - `ElectricAssault` weapons can now auto acquire allies' overpowerable defenses (by Ollerus)
 - Fixed the issue that the time for units in the area guard mission to reacquire targets after eliminating the target is significantly longer than that in other missions (by TaranDahl)
 - Purely visual animations and particles excluded from sync checks (by Starkku)
+- Fixed the issue where tint color RGB mode conversion was incorrect (by Shatyuka)
 
 Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -288,10 +288,10 @@ int GeneralUtils::GetColorFromColorAdd(int colorIndex)
 		colorValue |= (red << 6 | green) << 5 | blue;
 		break;
 	case RGBMode::RGB556:
-		colorValue |= (red << 5 | green) << 6 | blue;
+		colorValue |= (red << 5 | green >> 1) << 6 | blue;
 		break;
 	default:
-		colorValue |= (red << 5 | green) << 5 | blue;
+		colorValue |= (red << 5 | green >> 1) << 5 | blue;
 		break;
 	}
 

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -282,13 +282,18 @@ int GeneralUtils::GetColorFromColorAdd(int colorIndex)
 	const int green = color.G;
 	const int blue = color.B;
 
-	if (Drawing::ColorMode == RGBMode::RGB565)
+	switch (Drawing::ColorMode)
+	{
+	case RGBMode::RGB565:
 		colorValue |= blue | (32 * (green | (red << 6)));
-
-	if (Drawing::ColorMode != RGBMode::RGB655)
+		break;
+	case RGBMode::RGB556:
 		colorValue |= blue | (((32 * red) | (green >> 1)) << 6);
-
-	colorValue |= blue | (32 * ((32 * red) | (green >> 1)));
+		break;
+	default:
+		colorValue |= blue | (32 * ((32 * red) | (green >> 1)));
+		break;
+	}
 
 	return colorValue;
 }

--- a/src/Utilities/GeneralUtils.cpp
+++ b/src/Utilities/GeneralUtils.cpp
@@ -285,13 +285,13 @@ int GeneralUtils::GetColorFromColorAdd(int colorIndex)
 	switch (Drawing::ColorMode)
 	{
 	case RGBMode::RGB565:
-		colorValue |= blue | (32 * (green | (red << 6)));
+		colorValue |= (red << 6 | green) << 5 | blue;
 		break;
 	case RGBMode::RGB556:
-		colorValue |= blue | (((32 * red) | (green >> 1)) << 6);
+		colorValue |= (red << 5 | green) << 6 | blue;
 		break;
 	default:
-		colorValue |= blue | (32 * ((32 * red) | (green >> 1)));
+		colorValue |= (red << 5 | green) << 5 | blue;
 		break;
 	}
 


### PR DESCRIPTION
The game's code looks weird because the switch case forgot to add break.

Has very little impact on the vanilla game:
| TintColor | RGB565 Before | RGB565 After | RGB24 Before | RGB24 After |
| - | - | - | - | - |
| IronCurtain | 0x0000 | 0x0000 | `#000000` | `#000000` |
| ForceShield | 0x0018 | 0x0018 | `#0000C6` | `#0000C6` |
| Berserk | 0xE000 | 0xC000 | `#E70000` | `#C60000` |

Vanilla Berserk tint in game:
 Before | After 
---|---
<img width="320" alt="before" src="https://github.com/user-attachments/assets/05755945-2018-4fdc-8c92-ea70101189ca" /> | <img width="320" alt="after" src="https://github.com/user-attachments/assets/f70d114b-f544-4f9c-b1c6-004b07faf63b" />

---

Update: Custom tint color for better comparison, R=21, G=21, B=0

| RGB565 Before | RGB565 After | RGB24 Before | RGB24 After |
| - | - | - | - |
| 0xFFE0 | 0xAAA0 | `#FFFF00` | `#AD5500` |

Custom tint in game:
 Before | After 
---|---
<img width="320" alt="before" src="https://github.com/user-attachments/assets/08349c6e-83b7-4d82-81ed-e265c943512b" /> | <img width="320" alt="after" src="https://github.com/user-attachments/assets/06fcc4f5-777c-4367-9a94-a2a2d11ea392" />
