### PR TITLE
Customize `HarvesterDumpRate`

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2158,6 +2158,16 @@ HarvesterDumpAmount=0.0               ; floating point value
 HarvesterDumpAmount=                  ; floating point value
 ```
 
+### Customize `HarvesterDumpRate`
+
+- Now `HarvesterDumpRate` can be customized on each unit.
+
+In `rulesmd.ini`:
+```ini
+[SOMEVEHICLE]                         ; VehicleType
+HarvesterDumpRate=                    ; floating point value, default to [General] -> HarvesterDumpRate
+```
+
 ### Customize `HarvesterLoadRate`
 
 - Now `HarvesterLoadRate` can be customized on each unit.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -576,6 +576,7 @@ New:
 - Customize `HarvesterLoadRate` (by Noble_Fish)
 - [Toggle to prevent `ShrapnelWeapon` from targeting buildings multiple times](Fixed-or-Improved-Logics.md#shrapnel-enhancements) (by Starkku)
 - [Laser drawing Z-adjust customization](Fixed-or-Improved-Logics.md#laser-z-adjust) (by Starkku)
+- Customize `HarvesterDumpRate` (by Noble_Fish)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1195,6 +1195,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		|| ExtraThreatCoefficient_DistanceToLastTarget.Get(RulesExt::Global()->ExtraThreatCoefficient_DistanceToLastTarget) != 0;
 
 	this->HarvesterLoadRate.Read(exINI, pSection, "HarvesterLoadRate");
+	this->HarvesterDumpRate.Read(exINI, pSection, "HarvesterDumpRate");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1935,6 +1936,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ExtraThreatCoefficient_DistanceToLastTarget)
 
 		.Process(this->HarvesterLoadRate)
+		.Process(this->HarvesterDumpRate)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -508,6 +508,7 @@ public:
 		SHPStruct* TurretShape;
 
 		Nullable<int> HarvesterLoadRate;
+		Nullable<double> HarvesterDumpRate;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -970,6 +971,7 @@ public:
 			, ExtraThreatCoefficient_DistanceToLastTarget {}
 
 			, HarvesterLoadRate {}
+			, HarvesterDumpRate {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -68,24 +68,6 @@ DEFINE_HOOK(0x74613C, UnitClass_INoticeSink_CheckJumpjetHarvester, 0x6)
 
 #pragma endregion
 
-DEFINE_HOOK(0x73E411, UnitClass_Mission_Unload_DumpAmount, 0x7)
-{
-	enum { SkipGameCode = 0x73E41D };
-
-	GET(UnitClass*, pThis, ESI);
-	GET(const int, tiberiumIdx, EBP);
-	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
-	const float totalAmount = pThis->Tiberium.GetAmount(tiberiumIdx);
-	float dumpAmount = pTypeExt->HarvesterDumpAmount.Get(RulesExt::Global()->HarvesterDumpAmount);
-
-	if (dumpAmount <= 0.0f || totalAmount < dumpAmount)
-		dumpAmount = totalAmount;
-
-	__asm fld dumpAmount;
-
-	return SkipGameCode;
-}
-
 DEFINE_HOOK(0x4D6D34, FootClass_MissionAreaGuard_Miner, 0x5)
 {
 	enum { GoGuardArea = 0x4D6D69 };
@@ -114,16 +96,6 @@ DEFINE_HOOK(0x73D5D5, UnitClass_Harvesting_HarvesterLoadRate, 6)
 	return R->Origin() == 0x73D508 ? 0x73D50E : 0x73D5DB;
 }
 
-DEFINE_HOOK(0x73E951, UnitClass_Harvest_HarvesterLoadRate, 6)
-{
-	GET(UnitClass* const, pThis, EBP);
-	auto const pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
-
-	R->EAX(pTypeExt->HarvesterLoadRate.Get(RulesClass::Instance->HarvesterLoadRate));
-
-	return 0x73E957;
-}
-
 DEFINE_HOOK(0x73E361, UnitClass_Harvesting_HarvesterDumpRate, 6)
 {
 	GET(UnitClass* const, pThis, ESI);
@@ -134,6 +106,34 @@ DEFINE_HOOK(0x73E361, UnitClass_Harvesting_HarvesterDumpRate, 6)
 	__asm { fld dumpRate }
 
 	return 0x73E367;
+}
+
+DEFINE_HOOK(0x73E411, UnitClass_Mission_Unload_DumpAmount, 0x7)
+{
+	enum { SkipGameCode = 0x73E41D };
+
+	GET(UnitClass*, pThis, ESI);
+	GET(const int, tiberiumIdx, EBP);
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
+	const float totalAmount = pThis->Tiberium.GetAmount(tiberiumIdx);
+	float dumpAmount = pTypeExt->HarvesterDumpAmount.Get(RulesExt::Global()->HarvesterDumpAmount);
+
+	if (dumpAmount <= 0.0f || totalAmount < dumpAmount)
+		dumpAmount = totalAmount;
+
+	__asm fld dumpAmount;
+
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x73E951, UnitClass_Harvest_HarvesterLoadRate, 6)
+{
+	GET(UnitClass* const, pThis, EBP);
+	auto const pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
+
+	R->EAX(pTypeExt->HarvesterLoadRate.Get(RulesClass::Instance->HarvesterLoadRate));
+
+	return 0x73E957;
 }
 
 #pragma region HarvesterScanAfterUnload

--- a/src/Ext/Unit/Hooks.Harvester.cpp
+++ b/src/Ext/Unit/Hooks.Harvester.cpp
@@ -124,6 +124,18 @@ DEFINE_HOOK(0x73E951, UnitClass_Harvest_HarvesterLoadRate, 6)
 	return 0x73E957;
 }
 
+DEFINE_HOOK(0x73E361, UnitClass_Harvesting_HarvesterDumpRate, 6)
+{
+	GET(UnitClass* const, pThis, ESI);
+	auto const pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
+
+	double dumpRate = pTypeExt->HarvesterDumpRate.Get(RulesClass::Instance->HarvesterDumpRate);
+
+	__asm { fld dumpRate }
+
+	return 0x73E367;
+}
+
 #pragma region HarvesterScanAfterUnload
 
 DEFINE_HOOK(0x73E730, UnitClass_MissionHarvest_HarvesterScanAfterUnload, 0x5)


### PR DESCRIPTION
- Now `HarvesterDumpRate` can be customized on each unit.

In `rulesmd.ini`:
```ini
[SOMEVEHICLE]                         ; VehicleType
HarvesterDumpRate=                    ; floating point value, default to [General] -> HarvesterDumpRate
```