### PR TITLE
[Minor] Refactor MSBuild project structure

### DIFF
--- a/Phobos.props
+++ b/Phobos.props
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="DevBuild|Win32">
+      <Configuration>DevBuild</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  <PropertyGroup>
+    <GenerateManifest>false</GenerateManifest>
+    <IncludePath>$(ExpandedIncludePath);$(MSBuildThisFileDirectory)src\;$(YRppDir);$(VC_IncludePath)</IncludePath>
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\IntDir\</IntDir>
+    <CoreLibraryDependencies></CoreLibraryDependencies>
+    <PhobosExtraLibs>dbghelp.lib;onecore.lib</PhobosExtraLibs>
+  </PropertyGroup>
+  <!-- Global -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <SDLCheck />
+      <ConformanceMode>true</ConformanceMode>
+      <PreprocessorDefinitions>SYR_VER=2;HAS_EXCEPTIONS=0;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;%(PreprocessorDefinitions);%(AdditionalDefinitions);PHOBOS_DLL="$(ProjectName).dll"</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>false</ExceptionHandling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>8Bytes</StructMemberAlignment>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AssemblerListingLocation>$(IntDir)\%(Directory)</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)\%(Directory)</ObjectFileName>
+      <CallingConvention>StdCall</CallingConvention>
+      <DisableSpecificWarnings>4100;4201;4530;4731;4740;4458;4819;5103;5105</DisableSpecificWarnings>
+      <EnableModules>true</EnableModules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <OpenMPSupport>true</OpenMPSupport>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>$(PhobosExtraLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+      <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
+      <ProfileGuidedDatabase>$(IntDir)$(TargetName).pgd</ProfileGuidedDatabase>
+      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+    </Link>
+  </ItemDefinitionGroup>
+  <!-- Release -->
+  <ItemDefinitionGroup Condition="$(Configuration.Contains('Release'))">
+    <ClCompile>
+      <PreprocessorDefinitions>IS_RELEASE_VER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>MaxSpeed</Optimization>
+      <OmitFramePointers>true</OmitFramePointers>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>IS_RELEASE_VER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <!-- DevBuild -->
+  <ItemDefinitionGroup Condition="$(Configuration.Contains('DevBuild'))">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <OmitFramePointers>true</OmitFramePointers>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <!-- Debug -->
+  <ItemDefinitionGroup Condition="$(Configuration.Contains('Debug'))">
+    <ClCompile>
+      <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <OmitFramePointers>false</OmitFramePointers>
+      <DisableSpecificWarnings>4100;4201;4530;4731;4740;4458;4819;5103;5105;26495</DisableSpecificWarnings>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <!-- GitCommit -->
+  <ItemDefinitionGroup Condition="'$(GitCommit)' != ''">
+    <ClCompile>
+      <AdditionalOptions>/DGIT_COMMIT="$(GitCommit)" %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalOptions>/DGIT_COMMIT="$(GitCommit)" %(AdditionalOptions)</AdditionalOptions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <!-- GitBranch -->
+  <ItemDefinitionGroup Condition="'$(GitBranch)' != ''">
+    <ClCompile>
+      <AdditionalOptions>/DGIT_BRANCH="$(GitBranch)" %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalOptions>/DGIT_BRANCH="$(GitBranch)" %(AdditionalOptions)</AdditionalOptions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Phobos.props
+++ b/Phobos.props
@@ -74,7 +74,11 @@
       <PreprocessorDefinitions>IS_RELEASE_VER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization>MaxSpeed</Optimization>
       <OmitFramePointers>true</OmitFramePointers>
+      <!-- <WholeProgramOptimization>true</WholeProgramOptimization> -->
     </ClCompile>
+    <Link>
+      <!-- <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration> -->
+    </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>IS_RELEASE_VER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
@@ -84,7 +88,11 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <OmitFramePointers>true</OmitFramePointers>
+      <!-- <WholeProgramOptimization>true</WholeProgramOptimization> -->
     </ClCompile>
+    <Link>
+      <!-- <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration> -->
+    </Link>
   </ItemDefinitionGroup>
   <!-- Debug -->
   <ItemDefinitionGroup Condition="$(Configuration.Contains('Debug'))">

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -3,329 +3,389 @@
   <PropertyGroup>
     <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="DevBuild|Win32">
-      <Configuration>DevBuild</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>Phobos</ProjectName>
+    <RootNamespace>Phobos</RootNamespace>
+    <ProjectGuid>{3FAF7126-F38C-4D1E-9973-C21A37870F60}</ProjectGuid>
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ShowAllFiles>true</ShowAllFiles>
+    <ThisDir>$(MSBuildThisFileDirectory)</ThisDir>
+    <YRppDir>$(ThisDir)YRpp</YRppDir>
+  </PropertyGroup>
+  <!-- Import props -->
+  <Import Project="$(ThisDir)\Phobos.props" />
+  <Import Project="$(YRppDir)\YRpp.props" />
+  <!-- Resource files -->
   <ItemGroup>
-    <ClCompile Include="src\Commands\DeselectObject5.cpp" />
-    <ClCompile Include="src\Commands\DeselectObject.cpp" />
-    <ClCompile Include="src\Ext\Cell\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Event\Body.cpp" />
-    <ClCompile Include="src\Ext\HouseType\Body.cpp" />
-    <ClCompile Include="src\Ext\HouseType\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Infantry\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Infantry\Hooks.Firing.cpp" />
-    <ClCompile Include="src\Ext\TechnoType\Hooks.MultiWeapon.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.Targeting.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.DrawIt.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.Firing.cpp" />
-    <ClCompile Include="src\Ext\EBolt\Body.cpp" />
-    <ClCompile Include="src\Ext\EBolt\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.SimpleDeployer.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.Unload.cpp" />
-    <ClCompile Include="src\New\Entity\Ares\RadarJammerClass.cpp" />
-    <ClCompile Include="src\New\Type\Affiliated\CreateUnitTypeClass.cpp" />
+    <ResourceCompile Include="src\version.rc" />
+  </ItemGroup>
+  <!-- Compiled files -->
+  <ItemGroup>
+    <!-- src/ -->
+    <ClCompile Include="src\Phobos.COM.cpp" />
+    <ClCompile Include="src\Phobos.cpp" />
+    <ClCompile Include="src\Phobos.CRT.cpp" />
+    <ClCompile Include="src\Phobos.Ext.cpp" />
+    <ClCompile Include="src\Phobos.INI.cpp" />
+    <ClCompile Include="src\Phobos.Save.cpp" />
+    <!-- src\Blowfish -->
     <ClCompile Include="src\Blowfish\blowfish.cpp" />
     <ClCompile Include="src\Blowfish\Hooks.Blowfish.cpp" />
-    <ClCompile Include="src\Ext\Cell\Body.cpp" />
-    <ClCompile Include="src\Ext\House\Hooks.ForceEnemy.cpp" />
-    <ClCompile Include="src\Commands\ToggleSWSidebar.cpp" />
-    <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWColumnClass.cpp" />
-    <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWSidebarClass.cpp" />
-    <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWButtonClass.cpp" />
-    <ClCompile Include="src\Ext\Sidebar\SWSidebar\ToggleSWButtonClass.cpp" />
-    <ClCompile Include="src\Ext\TechnoType\Hooks.MatrixOp.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.Airstrike.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.Sinking.cpp" />
-    <ClCompile Include="src\Misc\Hooks.AlphaImage.cpp" />
-    <ClCompile Include="src\New\Entity\AttachEffectClass.cpp" />
-    <ClCompile Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\AttachEffectTypeClass.cpp" />
-    <ClCompile Include="src\Misc\MessageColumn.cpp" />
-    <ClCompile Include="src\Commands\ToggleMessageList.cpp" />
+    <!-- src\Commands -->
     <ClCompile Include="src\Commands\Commands.cpp" />
     <ClCompile Include="src\Commands\DamageDisplay.cpp" />
+    <ClCompile Include="src\Commands\DeselectObject.cpp" />
+    <ClCompile Include="src\Commands\DeselectObject5.cpp" />
     <ClCompile Include="src\Commands\FrameByFrame.cpp" />
     <ClCompile Include="src\Commands\FrameStep.cpp" />
     <ClCompile Include="src\Commands\NextIdleHarvester.cpp" />
     <ClCompile Include="src\Commands\ObjectInfo.cpp" />
     <ClCompile Include="src\Commands\QuickSave.cpp" />
+    <ClCompile Include="src\Commands\SaveVariablesToFile.cpp" />
     <ClCompile Include="src\Commands\ToggleDesignatorRange.cpp" />
     <ClCompile Include="src\Commands\ToggleDigitalDisplay.cpp" />
-    <ClCompile Include="src\Commands\SaveVariablesToFile.cpp" />
-    <ClCompile Include="src\Ext\Anim\Body.cpp" />
-    <ClCompile Include="src\Ext\Anim\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Anim\Hooks.AnimCreateUnit.cpp" />
-    <ClCompile Include="src\Ext\Bullet\Hooks.DetonateLogics.cpp" />
-    <ClCompile Include="src\Ext\Bullet\Trajectories\BombardTrajectory.cpp" />
-    <ClCompile Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.cpp" />
-    <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
-    <ClCompile Include="src\Ext\Bullet\Trajectories\ParabolaTrajectory.cpp" />
-    <ClCompile Include="src\Ext\CaptureManager\Hooks.cpp" />
-    <ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
-    <ClCompile Include="src\Ext\OverlayType\Body.cpp" />
-    <ClCompile Include="src\Ext\OverlayType\Hooks.cpp" />
-    <ClCompile Include="src\Ext\ParticleType\Body.cpp" />
-    <ClCompile Include="src\Ext\ParticleType\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Scenario\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Scenario\Hooks.Variables.cpp" />
-    <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
-    <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Surface\Body.cpp" />
-    <ClCompile Include="src\Ext\SWType\FireSuperWeapon.cpp" />
-    <ClCompile Include="src\Ext\SWType\NewSWType\NewSWType.cpp" />
-    <ClCompile Include="src\Ext\SWType\SWHelpers.cpp" />
-    <ClCompile Include="src\Ext\SWType\Hooks.cpp" />
-    <ClCompile Include="src\Ext\TAction\Body.cpp" />
-    <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Team\Body.cpp" />
-    <ClCompile Include="src\Ext\Team\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.Pips.cpp" />
-    <ClCompile Include="src\Ext\Techno\Body.Visuals.cpp" />
-    <ClCompile Include="src\Ext\TEvent\Hooks.cpp" />
-    <ClCompile Include="src\Ext\TEvent\Body.cpp" />
-    <ClCompile Include="src\Ext\Trigger\Hooks.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.Crushing.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.Harvester.cpp" />
-    <ClCompile Include="src\Locomotion\TestLocomotionClass.cpp" />
-    <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
-    <ClCompile Include="src\Misc\Hooks.Ares.cpp" />
-    <ClCompile Include="src\Misc\Hooks.Crates.cpp" />
-    <ClCompile Include="src\Misc\Hooks.LightEffects.cpp" />
-    <ClCompile Include="src\Misc\Hooks.VeinholeMonster.cpp" />
-    <ClCompile Include="src\Misc\PhobosToolTip.cpp" />
-    <ClCompile Include="src\Misc\TextInput.cpp" />
-    <ClCompile Include="src\New\Entity\BannerClass.cpp" />
-    <ClCompile Include="src\New\Entity\ShieldClass.cpp" />
-    <ClCompile Include="src\Misc\RetryDialog.cpp" />
-    <ClCompile Include="src\New\Type\BannerTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\Affiliated\DroppodTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\DigitalDisplayTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\InsigniaTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\RadTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\SelectBoxTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\ShieldTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\LaserTrailTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\Affiliated\InterceptorTypeClass.cpp" />
-    <ClCompile Include="src\New\Type\Affiliated\PassengerDeletionTypeClass.cpp" />
-    <ClCompile Include="src\New\Entity\LaserTrailClass.cpp" />
+    <ClCompile Include="src\Commands\ToggleMessageList.cpp" />
+    <ClCompile Include="src\Commands\ToggleSWSidebar.cpp" />
+    <!-- src\Ext -->
+    <!-- src\Ext\Aircraft -->
     <ClCompile Include="src\Ext\Aircraft\Body.cpp" />
     <ClCompile Include="src\Ext\Aircraft\Hooks.cpp" />
+    <!-- src\Ext\Anim -->
+    <ClCompile Include="src\Ext\Anim\Body.cpp" />
+    <ClCompile Include="src\Ext\Anim\Hooks.AnimCreateUnit.cpp" />
+    <ClCompile Include="src\Ext\Anim\Hooks.cpp" />
+    <!-- src\Ext\AnimType -->
     <ClCompile Include="src\Ext\AnimType\Body.cpp" />
+    <!-- src\Ext\Building -->
     <ClCompile Include="src\Ext\Building\Body.cpp" />
     <ClCompile Include="src\Ext\Building\Hooks.cpp" />
     <ClCompile Include="src\Ext\Building\Hooks.Grinding.cpp" />
-    <ClCompile Include="src\Ext\Building\Hooks.Refinery.cpp" />
     <ClCompile Include="src\Ext\Building\Hooks.Production.cpp" />
+    <ClCompile Include="src\Ext\Building\Hooks.Refinery.cpp" />
     <ClCompile Include="src\Ext\Building\Hooks.Selling.cpp" />
-    <ClCompile Include="src\Ext\BulletType\Body.cpp" />
+    <!-- src\Ext\BuildingType -->
+    <ClCompile Include="src\Ext\BuildingType\Body.cpp" />
+    <ClCompile Include="src\Ext\BuildingType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\BuildingType\Hooks.Placing.cpp" />
+    <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
+    <!-- src\Ext\Bullet -->
     <ClCompile Include="src\Ext\Bullet\Body.cpp" />
     <ClCompile Include="src\Ext\Bullet\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Hooks.DetonateLogics.cpp" />
     <ClCompile Include="src\Ext\Bullet\Hooks.Obstacles.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Trajectories\BombardTrajectory.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Trajectories\ParabolaTrajectory.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.cpp" />
+    <ClCompile Include="src\Ext\Bullet\Trajectories\StraightTrajectory.cpp" />
+    <!-- src\Ext\BulletType -->
+    <ClCompile Include="src\Ext\BulletType\Body.cpp" />
+    <!-- src\Ext\CaptureManager -->
+    <ClCompile Include="src\Ext\CaptureManager\Body.cpp" />
+    <ClCompile Include="src\Ext\CaptureManager\Hooks.cpp" />
+    <!-- src\Ext\Cell -->
+    <ClCompile Include="src\Ext\Cell\Body.cpp" />
+    <ClCompile Include="src\Ext\Cell\Hooks.cpp" />
+    <!-- src\Ext\EBolt -->
+    <ClCompile Include="src\Ext\EBolt\Body.cpp" />
+    <ClCompile Include="src\Ext\EBolt\Hooks.cpp" />
+    <!-- src\Ext\Event -->
+    <ClCompile Include="src\Ext\Event\Body.cpp" />
+    <!-- src\Ext\House -->
     <ClCompile Include="src\Ext\House\Body.cpp" />
-    <ClCompile Include="src\Ext\House\Hooks.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.AINavalProduction.cpp" />
+    <ClCompile Include="src\Ext\House\Hooks.cpp" />
+    <ClCompile Include="src\Ext\House\Hooks.ForceEnemy.cpp" />
     <ClCompile Include="src\Ext\House\Hooks.UnitFromFactory.cpp" />
+    <ClCompile Include="src\Ext\HouseType\Body.cpp" />
+    <ClCompile Include="src\Ext\HouseType\Hooks.cpp" />
+    <!-- src\Ext\Infantry -->
+    <ClCompile Include="src\Ext\Infantry\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Infantry\Hooks.Firing.cpp" />
+    <!-- src\Ext\OverlayType -->
+    <ClCompile Include="src\Ext\OverlayType\Body.cpp" />
+    <ClCompile Include="src\Ext\OverlayType\Hooks.cpp" />
+    <!-- src\Ext\ParticleSystemType -->
     <ClCompile Include="src\Ext\ParticleSystemType\Body.cpp" />
+    <!-- src\Ext\ParticleType -->
+    <ClCompile Include="src\Ext\ParticleType\Body.cpp" />
+    <ClCompile Include="src\Ext\ParticleType\Hooks.cpp" />
+    <!-- src\Ext\RadSite -->
     <ClCompile Include="src\Ext\RadSite\Body.cpp" />
     <ClCompile Include="src\Ext\RadSite\Hooks.cpp" />
+    <!-- src\Ext\Rules -->
+    <ClCompile Include="src\Ext\Rules\Body.cpp" />
+    <ClCompile Include="src\Ext\Rules\Hooks.Image.cpp" />
+    <!-- src\Ext\Scenario -->
     <ClCompile Include="src\Ext\Scenario\Body.cpp" />
+    <ClCompile Include="src\Ext\Scenario\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Scenario\Hooks.Variables.cpp" />
     <ClCompile Include="src\Ext\Scenario\Hooks.Waypoints.cpp" />
+    <!-- src\Ext\Script -->
     <ClCompile Include="src\Ext\Script\Body.cpp" />
     <ClCompile Include="src\Ext\Script\Hooks.cpp" />
     <ClCompile Include="src\Ext\Script\Mission.Attack.cpp" />
     <ClCompile Include="src\Ext\Script\Mission.Move.cpp" />
-    <ClCompile Include="src\Ext\Rules\Body.cpp" />
-    <ClCompile Include="src\Ext\Rules\Hooks.Image.cpp" />
-    <ClCompile Include="src\Ext\SWType\Body.cpp" />
+    <!-- src\Ext\Side -->
     <ClCompile Include="src\Ext\Side\Body.cpp" />
     <ClCompile Include="src\Ext\Side\Hooks.cpp" />
     <ClCompile Include="src\Ext\Side\Hooks.SidebarGDIPositions.cpp" />
-    <ClCompile Include="src\Ext\TechnoType\Body.cpp" />
-    <ClCompile Include="src\Ext\TechnoType\Hooks.Teleport.cpp" />
-    <ClCompile Include="src\Ext\TechnoType\Hooks.cpp" />
+    <!-- src\Ext\Sidebar -->
+    <ClCompile Include="src\Ext\Sidebar\Body.cpp" />
+    <ClCompile Include="src\Ext\Sidebar\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWButtonClass.cpp" />
+    <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWColumnClass.cpp" />
+    <ClCompile Include="src\Ext\Sidebar\SWSidebar\SWSidebarClass.cpp" />
+    <ClCompile Include="src\Ext\Sidebar\SWSidebar\ToggleSWButtonClass.cpp" />
+    <!-- src\Ext\Surface -->
+    <ClCompile Include="src\Ext\Surface\Body.cpp" />
+    <!-- src\Ext\SWType -->
+    <ClCompile Include="src\Ext\SWType\Body.cpp" />
+    <ClCompile Include="src\Ext\SWType\FireSuperWeapon.cpp" />
+    <ClCompile Include="src\Ext\SWType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\SWType\NewSWType\NewSWType.cpp" />
+    <ClCompile Include="src\Ext\SWType\SWHelpers.cpp" />
+    <!-- src\Ext\TAction -->
+    <ClCompile Include="src\Ext\TAction\Body.cpp" />
+    <ClCompile Include="src\Ext\TAction\Hooks.cpp" />
+    <!-- src\Ext\Team -->
+    <ClCompile Include="src\Ext\Team\Body.cpp" />
+    <ClCompile Include="src\Ext\Team\Hooks.cpp" />
+    <!-- src\Ext\Techno -->
     <ClCompile Include="src\Ext\Techno\Body.cpp" />
     <ClCompile Include="src\Ext\Techno\Body.Internal.cpp" />
     <ClCompile Include="src\Ext\Techno\Body.Update.cpp" />
-    <ClCompile Include="src\Ext\Techno\WeaponHelpers.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.cpp" />
+    <ClCompile Include="src\Ext\Techno\Body.Visuals.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Airstrike.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Cloak.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.Misc.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Firing.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Misc.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Pips.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.ReceiveDamage.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.TargetEvaluation.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Targeting.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.Tint.cpp" />
     <ClCompile Include="src\Ext\Techno\Hooks.Transport.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.WeaponEffects.cpp" />
+    <ClCompile Include="src\Ext\Techno\Hooks.WeaponRange.cpp" />
+    <ClCompile Include="src\Ext\Techno\WeaponHelpers.cpp" />
+    <ClCompile Include="src\Ext\TechnoType\Body.cpp" />
+    <ClCompile Include="src\Ext\TechnoType\Hooks.cpp" />
+    <ClCompile Include="src\Ext\TechnoType\Hooks.MatrixOp.cpp" />
+    <ClCompile Include="src\Ext\TechnoType\Hooks.MultiWeapon.cpp" />
+    <ClCompile Include="src\Ext\TechnoType\Hooks.Teleport.cpp" />
+    <!-- src\Ext\TerrainType -->
     <ClCompile Include="src\Ext\TerrainType\Body.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Hooks.cpp" />
     <ClCompile Include="src\Ext\TerrainType\Hooks.Passable.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.DeployFire.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.DisallowMoving.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.DeploysInto.cpp" />
-    <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
-    <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.WeaponEffects.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.Tint.cpp" />
-    <ClCompile Include="src\Ext\Techno\Hooks.WeaponRange.cpp" />
+    <!-- src\Ext\TEvent -->
+    <ClCompile Include="src\Ext\TEvent\Body.cpp" />
+    <ClCompile Include="src\Ext\TEvent\Hooks.cpp" />
+    <!-- src\Ext\Tiberium -->
     <ClCompile Include="src\Ext\Tiberium\Body.cpp" />
     <ClCompile Include="src\Ext\Tiberium\Hooks.cpp" />
-    <ClCompile Include="src\Ext\VoxelAnimType\Body.cpp" />
+    <!-- src\Ext\Trigger -->
+    <ClCompile Include="src\Ext\Trigger\Hooks.cpp" />
+    <!-- src\Ext\Unit -->
+    <ClCompile Include="src\Ext\Unit\Hooks.Crushing.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.DeployFire.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.DeploysInto.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.DisallowMoving.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.DrawIt.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.Firing.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.Harvester.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.Jumpjet.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.SimpleDeployer.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.Sinking.cpp" />
+    <ClCompile Include="src\Ext\Unit\Hooks.Unload.cpp" />
+    <!-- src\Ext\VoxelAnim -->
     <ClCompile Include="src\Ext\VoxelAnim\Body.cpp" />
     <ClCompile Include="src\Ext\VoxelAnim\Hooks.cpp" />
+    <!-- src\Ext\VoxelAnimType -->
+    <ClCompile Include="src\Ext\VoxelAnimType\Body.cpp" />
+    <!-- src\Ext\WarheadType -->
+    <ClCompile Include="src\Ext\WarheadType\Body.cpp" />
+    <ClCompile Include="src\Ext\WarheadType\Detonate.cpp" />
+    <ClCompile Include="src\Ext\WarheadType\Hooks.cpp" />
+    <!-- src\Ext\WeaponType -->
     <ClCompile Include="src\Ext\WeaponType\Body.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Hooks.cpp" />
     <ClCompile Include="src\Ext\WeaponType\Hooks.DiskLaserRadius.cpp" />
+    <!-- src\Locomotion -->
+    <ClCompile Include="src\Locomotion\TestLocomotionClass.cpp" />
+    <!-- src\Misc -->
     <ClCompile Include="src\Misc\BlittersFix.cpp" />
-    <ClCompile Include="src\Misc\Selection.cpp" />
-    <ClCompile Include="src\Utilities\Anchor.cpp" />
-    <ClCompile Include="src\Utilities\Debug.cpp" />
-    <ClCompile Include="src\Ext\BuildingType\Body.cpp" />
-    <ClCompile Include="src\Ext\BuildingType\Hooks.cpp" />
-    <ClCompile Include="src\Ext\BuildingType\Hooks.Placing.cpp" />
-    <ClCompile Include="src\Ext\WarheadType\Body.cpp" />
-    <ClCompile Include="src\Ext\WarheadType\Hooks.cpp" />
     <ClCompile Include="src\Misc\FlyingStrings.cpp" />
+    <ClCompile Include="src\Misc\Hooks.AlphaImage.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Ares.cpp" />
     <ClCompile Include="src\Misc\Hooks.BugFixes.cpp" />
-    <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
-    <ClCompile Include="src\Misc\Hooks.UI.cpp" />
-    <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
-    <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Crates.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Gamespeed.cpp" />
     <ClCompile Include="src\Misc\Hooks.INIInheritance.cpp" />
+    <ClCompile Include="src\Misc\Hooks.LaserDraw.cpp" />
+    <ClCompile Include="src\Misc\Hooks.LightEffects.cpp" />
     <ClCompile Include="src\Misc\Hooks.Overlay.cpp" />
+    <ClCompile Include="src\Misc\Hooks.PCX.cpp" />
+    <ClCompile Include="src\Misc\Hooks.Timers.cpp" />
+    <ClCompile Include="src\Misc\Hooks.UI.cpp" />
+    <ClCompile Include="src\Misc\Hooks.VeinholeMonster.cpp" />
+    <ClCompile Include="src\Misc\MessageColumn.cpp" />
+    <ClCompile Include="src\Misc\PhobosToolTip.cpp" />
+    <ClCompile Include="src\Misc\RetryDialog.cpp" />
+    <ClCompile Include="src\Misc\Selection.cpp" />
+    <ClCompile Include="src\Misc\SyncLogging.cpp" />
+    <ClCompile Include="src\Misc\TextInput.cpp" />
+    <!-- src\New -->
+    <!-- src\New\Entity -->
+    <ClCompile Include="src\New\Entity\Ares\RadarJammerClass.cpp" />
+    <ClCompile Include="src\New\Entity\AttachEffectClass.cpp" />
+    <ClCompile Include="src\New\Entity\BannerClass.cpp" />
+    <ClCompile Include="src\New\Entity\LaserTrailClass.cpp" />
+    <ClCompile Include="src\New\Entity\ShieldClass.cpp" />
+    <!-- src\New\Type -->
+    <ClCompile Include="src\New\Type\AttachEffectTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\BannerTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\DigitalDisplayTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\InsigniaTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\LaserTrailTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\RadTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\SelectBoxTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\ShieldTypeClass.cpp" />
+    <!-- src\New\Type\Affiliated -->
+    <ClCompile Include="src\New\Type\Affiliated\CreateUnitTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\Affiliated\DroppodTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\Affiliated\InterceptorTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\Affiliated\PassengerDeletionTypeClass.cpp" />
+    <ClCompile Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.cpp" />
     <ClCompile Include="src\New\Type\Affiliated\TypeConvertGroup.cpp" />
-    <ClCompile Include="src\Ext\BuildingType\Hooks.Upgrade.cpp" />
-    <ClCompile Include="src\Phobos.COM.cpp" />
-    <ClCompile Include="src\Phobos.CRT.cpp" />
-    <ClCompile Include="src\Phobos.Ext.cpp" />
-    <ClCompile Include="src\Phobos.INI.cpp" />
-    <ClCompile Include="src\Phobos.Save.cpp" />
-    <ClCompile Include="src\Phobos.cpp" />
-    <ClCompile Include="src\Utilities\ShapeTextPrinter.cpp" />
-    <ClCompile Include="src\Utilities\SpawnerHelper.cpp" />
-    <ClCompile Include="src\Utilities\Stream.cpp" />
+    <!-- src\Utilities -->
+    <ClCompile Include="src\Utilities\Anchor.cpp" />
+    <ClCompile Include="src\Utilities\AresAddressInit.cpp" />
+    <ClCompile Include="src\Utilities\AresHelper.cpp" />
     <ClCompile Include="src\Utilities\Constructs.cpp" />
+    <ClCompile Include="src\Utilities\Debug.cpp" />
     <ClCompile Include="src\Utilities\EnumFunctions.cpp" />
     <ClCompile Include="src\Utilities\GeneralUtils.cpp" />
     <ClCompile Include="src\Utilities\Patch.cpp" />
-    <ClCompile Include="src\Utilities\AresHelper.cpp" />
-    <ClCompile Include="src\Utilities\AresAddressInit.cpp" />
-    <ClCompile Include="src\Misc\SyncLogging.cpp" />
-    <ClCompile Include="YRpp\StaticInits.cpp" />
+    <ClCompile Include="src\Utilities\ShapeTextPrinter.cpp" />
+    <ClCompile Include="src\Utilities\SpawnerHelper.cpp" />
+    <ClCompile Include="src\Utilities\Stream.cpp" />
   </ItemGroup>
+  <!-- Header files -->
   <ItemGroup>
-    <ClInclude Include="src\Commands\DeselectObject5.h" />
-    <ClInclude Include="src\Commands\DeselectObject.h" />
-    <ClInclude Include="src\Ext\EBolt\Body.h" />
-    <ClInclude Include="src\Ext\Event\Body.h" />
-    <ClInclude Include="src\Ext\HouseType\Body.h" />
-    <ClInclude Include="src\New\Entity\Ares\RadarJammerClass.h" />
-    <ClInclude Include="src\New\Type\Affiliated\CreateUnitTypeClass.h" />
+    <!-- lib\ -->
+    <ClInclude Include="lib\nameof\nameof.h" />
+    <!-- src/ -->
+    <ClInclude Include="src\Phobos.COM.h" />
+    <ClInclude Include="src\Phobos.CRT.h" />
+    <ClInclude Include="src\Phobos.h" />
+    <ClInclude Include="src\Phobos.version.h" />
+    <!-- src\Blowfish\ -->
     <ClInclude Include="src\Blowfish\blowfish.h" />
-    <ClInclude Include="src\Ext\Cell\Body.h" />
+    <!-- src\Commands\ -->
+    <ClInclude Include="src\Commands\Commands.h" />
+    <ClInclude Include="src\Commands\DamageDisplay.h" />
+    <ClInclude Include="src\Commands\DeselectObject.h" />
+    <ClInclude Include="src\Commands\DeselectObject5.h" />
     <ClInclude Include="src\Commands\FireTacticalSW.h" />
-    <ClInclude Include="src\Commands\ToggleSWSidebar.h" />
-    <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWColumnClass.h" />
-    <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWSidebarClass.h" />
-    <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWButtonClass.h" />
-    <ClInclude Include="src\Ext\Sidebar\SWSidebar\ToggleSWButtonClass.h" />
-    <ClInclude Include="src\New\Entity\AttachEffectClass.h" />
-    <ClInclude Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.h" />
-    <ClInclude Include="src\New\Type\AttachEffectTypeClass.h" />
-    <ClInclude Include="src\Misc\MessageColumn.h" />
-    <ClInclude Include="src\Commands\ToggleMessageList.h" />
     <ClInclude Include="src\Commands\FrameByFrame.h" />
     <ClInclude Include="src\Commands\FrameStep.h" />
     <ClInclude Include="src\Commands\NextIdleHarvester.h" />
     <ClInclude Include="src\Commands\NextTeam.h" />
     <ClInclude Include="src\Commands\ObjectInfo.h" />
-    <ClInclude Include="src\Commands\Commands.h" />
-    <ClInclude Include="src\Commands\DamageDisplay.h" />
     <ClInclude Include="src\Commands\QuickSave.h" />
+    <ClInclude Include="src\Commands\SaveVariablesToFile.h" />
     <ClInclude Include="src\Commands\ToggleDesignatorRange.h" />
     <ClInclude Include="src\Commands\ToggleDigitalDisplay.h" />
-    <ClInclude Include="src\Commands\SaveVariablesToFile.h" />
+    <ClInclude Include="src\Commands\ToggleMessageList.h" />
+    <ClInclude Include="src\Commands\ToggleSWSidebar.h" />
+    <!-- src\Ext -->
+    <ClInclude Include="src\Ext\Aircraft\Body.h" />
+    <ClInclude Include="src\Ext\Anim\Body.h" />
+    <ClInclude Include="src\Ext\AnimType\Body.h" />
+    <ClInclude Include="src\Ext\Building\Body.h" />
+    <ClInclude Include="src\Ext\BuildingType\Body.h" />
+    <ClInclude Include="src\Ext\Bullet\Body.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\BombardTrajectory.h" />
+    <ClInclude Include="src\Ext\Bullet\Trajectories\ParabolaTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\PhobosTrajectory.h" />
     <ClInclude Include="src\Ext\Bullet\Trajectories\StraightTrajectory.h" />
-    <ClInclude Include="src\Ext\Bullet\Trajectories\ParabolaTrajectory.h" />
+    <ClInclude Include="src\Ext\BulletType\Body.h" />
+    <ClInclude Include="src\Ext\CaptureManager\Body.h" />
+    <ClInclude Include="src\Ext\Cell\Body.h" />
+    <ClInclude Include="src\Ext\EBolt\Body.h" />
+    <ClInclude Include="src\Ext\Event\Body.h" />
+    <ClInclude Include="src\Ext\House\Body.h" />
+    <ClInclude Include="src\Ext\HouseType\Body.h" />
     <ClInclude Include="src\Ext\OverlayType\Body.h" />
+    <ClInclude Include="src\Ext\ParticleSystemType\Body.h" />
     <ClInclude Include="src\Ext\ParticleType\Body.h" />
+    <ClInclude Include="src\Ext\RadSite\Body.h" />
+    <ClInclude Include="src\Ext\Rules\Body.h" />
+    <ClInclude Include="src\Ext\Scenario\Body.h" />
+    <ClInclude Include="src\Ext\Script\Body.h" />
+    <ClInclude Include="src\Ext\Side\Body.h" />
     <ClInclude Include="src\Ext\Sidebar\Body.h" />
-    <ClInclude Include="src\Ext\Anim\Body.h" />
+    <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWButtonClass.h" />
+    <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWColumnClass.h" />
+    <ClInclude Include="src\Ext\Sidebar\SWSidebar\SWSidebarClass.h" />
+    <ClInclude Include="src\Ext\Sidebar\SWSidebar\ToggleSWButtonClass.h" />
     <ClInclude Include="src\Ext\Surface\Body.h" />
+    <ClInclude Include="src\Ext\SWType\Body.h" />
     <ClInclude Include="src\Ext\SWType\NewSWType\NewSWType.h" />
     <ClInclude Include="src\Ext\TAction\Body.h" />
     <ClInclude Include="src\Ext\Team\Body.h" />
+    <ClInclude Include="src\Ext\Techno\Body.h" />
+    <ClInclude Include="src\Ext\TechnoType\Body.h" />
+    <ClInclude Include="src\Ext\TerrainType\Body.h" />
     <ClInclude Include="src\Ext\TEvent\Body.h" />
+    <ClInclude Include="src\Ext\Tiberium\Body.h" />
+    <ClInclude Include="src\Ext\VoxelAnim\Body.h" />
+    <ClInclude Include="src\Ext\VoxelAnimType\Body.h" />
+    <ClInclude Include="src\Ext\WarheadType\Body.h" />
+    <ClInclude Include="src\Ext\WeaponType\Body.h" />
+    <!-- src\Locomotion -->
     <ClInclude Include="src\Locomotion\TestLocomotionClass.h" />
+    <!-- src\Misc -->
     <ClInclude Include="src\Misc\BlittersFix.h" />
-    <ClInclude Include="src\Ext\CaptureManager\Body.h" />
     <ClInclude Include="src\Misc\FlyingStrings.h" />
+    <ClInclude Include="src\Misc\MessageColumn.h" />
     <ClInclude Include="src\Misc\PhobosToolTip.h" />
     <ClInclude Include="src\Misc\SyncLogging.h" />
+    <!-- src\New -->
+    <!-- src\New\Entity -->
+    <ClInclude Include="src\New\Entity\Ares\RadarJammerClass.h" />
+    <ClInclude Include="src\New\Entity\AttachEffectClass.h" />
     <ClInclude Include="src\New\Entity\BannerClass.h" />
+    <ClInclude Include="src\New\Entity\LaserTrailClass.h" />
+    <ClInclude Include="src\New\Entity\ShieldClass.h" />
+    <!-- src\New\Type -->
+    <ClInclude Include="src\New\Type\AttachEffectTypeClass.h" />
     <ClInclude Include="src\New\Type\BannerTypeClass.h" />
-    <ClInclude Include="src\New\Type\Affiliated\TypeConvertGroup.h" />
-    <ClInclude Include="src\New\Type\Affiliated\DroppodTypeClass.h" />
     <ClInclude Include="src\New\Type\DigitalDisplayTypeClass.h" />
     <ClInclude Include="src\New\Type\EVATypeClass.h" />
     <ClInclude Include="src\New\Type\InsigniaTypeClass.h" />
+    <ClInclude Include="src\New\Type\LaserTrailTypeClass.h" />
     <ClInclude Include="src\New\Type\RadTypeClass.h" />
     <ClInclude Include="src\New\Type\SelectBoxTypeClass.h" />
     <ClInclude Include="src\New\Type\ShieldTypeClass.h" />
-    <ClInclude Include="src\New\Type\LaserTrailTypeClass.h" />
+    <!-- src\New\Type\Affiliated -->
+    <ClInclude Include="src\New\Type\Affiliated\CreateUnitTypeClass.h" />
+    <ClInclude Include="src\New\Type\Affiliated\DroppodTypeClass.h" />
     <ClInclude Include="src\New\Type\Affiliated\InterceptorTypeClass.h" />
     <ClInclude Include="src\New\Type\Affiliated\PassengerDeletionTypeClass.h" />
-    <ClInclude Include="src\New\Entity\LaserTrailClass.h" />
-    <ClInclude Include="src\New\Entity\ShieldClass.h" />
+    <ClInclude Include="src\New\Type\Affiliated\TiberiumEaterTypeClass.h" />
+    <ClInclude Include="src\New\Type\Affiliated\TypeConvertGroup.h" />
+    <!-- src\Utilities -->
     <ClInclude Include="src\Utilities\Anchor.h" />
-    <ClInclude Include="src\Utilities\Enumerable.h" />
-    <ClInclude Include="src\Ext\Aircraft\Body.h" />
-    <ClInclude Include="src\Ext\AnimType\Body.h" />
-    <ClInclude Include="src\Ext\Building\Body.h" />
-    <ClInclude Include="src\Ext\BulletType\Body.h" />
-    <ClInclude Include="src\Ext\Bullet\Body.h" />
-    <ClInclude Include="src\Ext\House\Body.h" />
-    <ClInclude Include="src\Ext\ParticleSystemType\Body.h" />
-    <ClInclude Include="src\Ext\RadSite\Body.h" />
-    <ClInclude Include="src\Ext\Scenario\Body.h" />
-    <ClInclude Include="src\Ext\Script\Body.h" />
-    <ClInclude Include="src\Ext\Rules\Body.h" />
-    <ClInclude Include="src\Ext\SWType\Body.h" />
-    <ClInclude Include="src\Ext\Side\Body.h" />
-    <ClInclude Include="src\Ext\TechnoType\Body.h" />
-    <ClInclude Include="src\Ext\Techno\Body.h" />
-    <ClInclude Include="src\Ext\TerrainType\Body.h" />
-    <ClInclude Include="src\Ext\Tiberium\Body.h" />
-    <ClInclude Include="src\Ext\VoxelAnimType\Body.h" />
-    <ClInclude Include="src\Ext\VoxelAnim\Body.h" />
-    <ClInclude Include="src\Ext\WeaponType\Body.h" />
-    <ClInclude Include="src\Utilities\Savegame.h" />
-    <ClInclude Include="src\Utilities\SavegameDef.h" />
-    <ClInclude Include="src\Utilities\ShapeTextPrinter.h" />
-    <ClInclude Include="src\Utilities\SpawnerHelper.h" />
-    <ClInclude Include="src\Utilities\Stream.h" />
-    <ClInclude Include="src\Utilities\Swizzle.h" />
-    <ClInclude Include="src\Phobos.COM.h" />
-    <ClInclude Include="src\Phobos.CRT.h" />
-    <ClInclude Include="src\Phobos.version.h" />
+    <ClInclude Include="src\Utilities\AresFunctions.h" />
+    <ClInclude Include="src\Utilities\AresHelper.h" />
     <ClInclude Include="src\Utilities\Constructs.h" />
     <ClInclude Include="src\Utilities\Container.h" />
     <ClInclude Include="src\Utilities\Debug.h" />
-    <ClInclude Include="src\Ext\BuildingType\Body.h" />
-    <ClInclude Include="src\Ext\WarheadType\Body.h" />
-    <ClInclude Include="src\Phobos.h" />
     <ClInclude Include="src\Utilities\Enum.h" />
+    <ClInclude Include="src\Utilities\Enumerable.h" />
     <ClInclude Include="src\Utilities\EnumFunctions.h" />
     <ClInclude Include="src\Utilities\GeneralUtils.h" />
     <ClInclude Include="src\Utilities\Helpers.Alex.h" />
@@ -334,228 +394,13 @@
     <ClInclude Include="src\Utilities\Macro.h" />
     <ClInclude Include="src\Utilities\Parser.h" />
     <ClInclude Include="src\Utilities\Patch.h" />
+    <ClInclude Include="src\Utilities\Savegame.h" />
+    <ClInclude Include="src\Utilities\SavegameDef.h" />
+    <ClInclude Include="src\Utilities\ShapeTextPrinter.h" />
+    <ClInclude Include="src\Utilities\SpawnerHelper.h" />
+    <ClInclude Include="src\Utilities\Stream.h" />
+    <ClInclude Include="src\Utilities\Swizzle.h" />
     <ClInclude Include="src\Utilities\Template.h" />
     <ClInclude Include="src\Utilities\TemplateDef.h" />
-    <ClInclude Include="src\Utilities\AresHelper.h" />
-    <ClInclude Include="src\Utilities\AresFunctions.h" />
-    <ClInclude Include="lib\nameof\nameof.h" />
-    <ClInclude Include="YRpp\GameTextManager.h" />
   </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="src\version.rc" />
-  </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{3FAF7126-F38C-4D1E-9973-C21A37870F60}</ProjectGuid>
-    <RootNamespace>Phobos</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ProjectName>Phobos</ProjectName>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <XPDeprecationWarning>false</XPDeprecationWarning>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <XPDeprecationWarning>false</XPDeprecationWarning>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <XPDeprecationWarning>false</XPDeprecationWarning>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <GenerateManifest>false</GenerateManifest>
-    <IncludePath>$(SolutionDir)src\;$(SolutionDir)src\ExtraHeaders;$(SolutionDir)yrpp;$(SolutionDir)lib;$(VC_IncludePath)</IncludePath>
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\IntDir\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'">
-    <GenerateManifest>false</GenerateManifest>
-    <IncludePath>$(SolutionDir)src\;$(SolutionDir)src\ExtraHeaders;$(SolutionDir)yrpp;$(SolutionDir)lib;$(VC_IncludePath)</IncludePath>
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\IntDir\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <GenerateManifest>false</GenerateManifest>
-    <IncludePath>$(SolutionDir)src\;$(SolutionDir)src\ExtraHeaders;$(SolutionDir)yrpp;$(SolutionDir)lib;$(VC_IncludePath)</IncludePath>
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\IntDir\</IntDir>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level4</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <SDLCheck />
-      <ConformanceMode>true</ConformanceMode>
-      <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <OmitFramePointers>true</OmitFramePointers>
-      <PreprocessorDefinitions>IS_RELEASE_VER;SYR_VER=2;HAS_EXCEPTIONS=0;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;%(PreprocessorDefinitions);%(AdditionalDefinitions);PHOBOS_DLL="$(ProjectName).dll"</PreprocessorDefinitions>
-      <StringPooling>true</StringPooling>
-      <ExceptionHandling>false</ExceptionHandling>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <StructMemberAlignment>8Bytes</StructMemberAlignment>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
-      <ControlFlowGuard>false</ControlFlowGuard>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <RuntimeTypeInfo>false</RuntimeTypeInfo>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <AssemblerListingLocation>$(IntDir)\%(RelativeDir)</AssemblerListingLocation>
-      <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
-      <CallingConvention>StdCall</CallingConvention>
-      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>4100;4201;4530;4731;4740;4458;4819;5103;5105</DisableSpecificWarnings>
-      <EnableModules>true</EnableModules>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <OpenMPSupport>true</OpenMPSupport>
-    </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-      <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
-      <ProfileGuidedDatabase>$(IntDir)$(TargetName).pgd</ProfileGuidedDatabase>
-      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
-    </Link>
-    <PostBuildEvent>
-      <Command />
-    </PostBuildEvent>
-    <ResourceCompile>
-      <PreprocessorDefinitions>IS_RELEASE_VER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DevBuild|Win32'">
-    <ClCompile>
-      <WarningLevel>Level4</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <SDLCheck />
-      <ConformanceMode>true</ConformanceMode>
-      <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <OmitFramePointers>true</OmitFramePointers>
-      <PreprocessorDefinitions>SYR_VER=2;HAS_EXCEPTIONS=0;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;%(PreprocessorDefinitions);%(AdditionalDefinitions);PHOBOS_DLL="$(ProjectName).dll"</PreprocessorDefinitions>
-      <StringPooling>true</StringPooling>
-      <ExceptionHandling>false</ExceptionHandling>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <StructMemberAlignment>8Bytes</StructMemberAlignment>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
-      <ControlFlowGuard>false</ControlFlowGuard>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <RuntimeTypeInfo>false</RuntimeTypeInfo>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <AssemblerListingLocation>$(IntDir)\%(RelativeDir)</AssemblerListingLocation>
-      <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
-      <CallingConvention>StdCall</CallingConvention>
-      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>4100;4201;4530;4731;4740;4458;4819;5103;5105</DisableSpecificWarnings>
-      <EnableModules>true</EnableModules>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <OpenMPSupport>true</OpenMPSupport>
-    </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-      <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
-      <ProfileGuidedDatabase>$(IntDir)$(TargetName).pgd</ProfileGuidedDatabase>
-      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
-    </Link>
-    <PostBuildEvent>
-      <Command />
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <WarningLevel>Level4</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <SDLCheck>
-      </SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
-      <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <OmitFramePointers>false</OmitFramePointers>
-      <PreprocessorDefinitions>DEBUG;SYR_VER=2;HAS_EXCEPTIONS=0;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;NTDDI_VERSION=0x06010000;%(PreprocessorDefinitions);%(AdditionalDefinitions);PHOBOS_DLL="$(ProjectName).dll"</PreprocessorDefinitions>
-      <StringPooling>true</StringPooling>
-      <ExceptionHandling>false</ExceptionHandling>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <StructMemberAlignment>8Bytes</StructMemberAlignment>
-      <BufferSecurityCheck>false</BufferSecurityCheck>
-      <ControlFlowGuard>false</ControlFlowGuard>
-      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <RuntimeTypeInfo>false</RuntimeTypeInfo>
-      <LanguageStandard>stdcpp20</LanguageStandard>
-      <AssemblerListingLocation>$(IntDir)\%(RelativeDir)</AssemblerListingLocation>
-      <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
-      <CallingConvention>StdCall</CallingConvention>
-      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>4100;4201;4530;4731;4740;4458;4819;5103;5105;26495</DisableSpecificWarnings>
-      <EnableModules>true</EnableModules>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <OpenMPSupport>true</OpenMPSupport>
-    </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-      <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
-      <ProfileGuidedDatabase>$(IntDir)$(TargetName).pgd</ProfileGuidedDatabase>
-      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
-    </Link>
-    <PostBuildEvent>
-      <Command>
-      </Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(GitCommit)' != ''">
-    <ClCompile>
-      <AdditionalOptions>/DGIT_COMMIT="$(GitCommit)" %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
-    <ResourceCompile>
-      <AdditionalOptions>/DGIT_COMMIT="$(GitCommit)" %(AdditionalOptions)</AdditionalOptions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(GitBranch)' != ''">
-    <ClCompile>
-      <AdditionalOptions>/DGIT_BRANCH="$(GitBranch)" %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
-    <ResourceCompile>
-      <AdditionalOptions>/DGIT_BRANCH="$(GitBranch)" %(AdditionalOptions)</AdditionalOptions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/src/Utilities/Macro.h
+++ b/src/Utilities/Macro.h
@@ -100,7 +100,11 @@ typedef _VTABLE _OFFSET;
 	{                                                             \
 		__declspec(allocate(PATCH_SECTION_NAME))                  \
 		Patch patch = {offset, size, (byte*)data};                \
-	}
+	}                                                             \
+	_YR_DEFINE_INCLUDE_ANCHOR(                                    \
+		_YR_PP_CAT(YrKeepPatch_, offset),                         \
+		&STATIC_PATCH##offset::patch                              \
+	)
 
 #define DEFINE_PATCH_TYPED(type, offset, ...)                     \
 	namespace STATIC_PATCH##offset                                \
@@ -121,7 +125,7 @@ typedef _VTABLE _OFFSET;
 
 #define DEFINE_NAKED_HOOK(hook, funcname)                         \
 	void funcname();                                              \
-	DEFINE_FUNCTION_JUMP(LJMP, hook, funcname)                 \
+	DEFINE_FUNCTION_JUMP(LJMP, hook, funcname)                    \
 	void NAKED funcname()
 
 #pragma endregion Static Patch


### PR DESCRIPTION
Refactors the MSBuild project layout and prepares the build configuration for safer optimized builds.

Changes:

- Split Phobos build settings into Phobos.props.
- Import project-wide props from Phobos.vcxproj.
- Cleaned up duplicated and redundant MSBuild settings.
- Prepared linker retention settings for WPO/LTCG compatibility.

Note:
> The macro changes are a workaround needed to prevent the linker from removing records from custom sections such as `.patch`, `.syexe00`, and `.syhks00`.
>
> Without these anchors, the linker may treat those symbols as unused and discard them when WPO/LTCG is enabled.
