### PR TITLE
Fix the target point position error in visual effect drawing introduced by #1553.

### DIFF
--- a/src/Ext/Bullet/Body.cpp
+++ b/src/Ext/Bullet/Body.cpp
@@ -207,7 +207,7 @@ inline void BulletExt::SimulatedFiringLaser(BulletClass* pBullet, HouseClass* pH
 	if (pWeapon->IsHouseColor || pWeaponExt->Laser_IsSingleColor)
 	{
 		const auto black = ColorStruct { 0, 0, 0 };
-		const auto pLaser = GameCreate<LaserDrawClass>(pBullet->SourceCoords, (pBullet->Type->Inviso ? pBullet->Location : pBullet->TargetCoords),
+		const auto pLaser = GameCreate<LaserDrawClass>(pBullet->SourceCoords, ((pBullet->Type->Inviso && pBullet->Type->FlakScatter) ? pBullet->Location : abstract_cast<ObjectClass*>(pBullet->Target)->GetTargetCoords()),
 			((pWeapon->IsHouseColor && pHouse) ? pHouse->LaserColor : pWeapon->LaserInnerColor), black, black, pWeapon->LaserDuration);
 
 		pLaser->IsHouseColor = true;
@@ -216,7 +216,7 @@ inline void BulletExt::SimulatedFiringLaser(BulletClass* pBullet, HouseClass* pH
 	}
 	else
 	{
-		const auto pLaser = GameCreate<LaserDrawClass>(pBullet->SourceCoords, (pBullet->Type->Inviso ? pBullet->Location : pBullet->TargetCoords),
+		const auto pLaser = GameCreate<LaserDrawClass>(pBullet->SourceCoords, ((pBullet->Type->Inviso && pBullet->Type->FlakScatter) ? pBullet->Location : abstract_cast<ObjectClass*>(pBullet->Target)->GetTargetCoords()),
 			pWeapon->LaserInnerColor, pWeapon->LaserOuterColor, pWeapon->LaserOuterSpread, pWeapon->LaserDuration);
 
 		pLaser->IsHouseColor = false;
@@ -237,7 +237,7 @@ inline void BulletExt::SimulatedFiringElectricBolt(BulletClass* pBullet)
 	const auto pBolt = EBoltExt::CreateEBolt(pWeapon);
 	pBolt->AlternateColor = pWeapon->IsAlternateColor;
 
-	const auto targetCoords = pBullet->Type->Inviso ? pBullet->Location : pBullet->TargetCoords;
+	const auto targetCoords = (pBullet->Type->Inviso && pBullet->Type->FlakScatter) ? pBullet->Location : abstract_cast<ObjectClass*>(pBullet->Target)->GetTargetCoords();
 	const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
 	int zAdjust = pWeaponExt->EBoltZAdjust.Get(RulesExt::Global()->EBoltZAdjust);
 
@@ -268,7 +268,7 @@ inline void BulletExt::SimulatedFiringRadBeam(BulletClass* pBullet, HouseClass* 
 	const auto pRadBeam = RadBeam::Allocate(isTemporal ? RadBeamType::Temporal : RadBeamType::RadBeam);
 
 	pRadBeam->SetCoordsSource(pBullet->SourceCoords);
-	pRadBeam->SetCoordsTarget((pBullet->Type->Inviso ? pBullet->Location : pBullet->TargetCoords));
+	pRadBeam->SetCoordsTarget((pBullet->Type->Inviso && pBullet->Type->FlakScatter) ? pBullet->Location : abstract_cast<ObjectClass*>(pBullet->Target)->GetTargetCoords());
 
 	const auto pWeaponExt = WeaponTypeExt::ExtMap.Find(pWeapon);
 
@@ -285,7 +285,7 @@ inline void BulletExt::SimulatedFiringParticleSystem(BulletClass* pBullet, House
 	if (const auto pPSType = pBullet->WeaponType->AttachedParticleSystem)
 	{
 		GameCreate<ParticleSystemClass>(pPSType, pBullet->SourceCoords, pBullet->Target, pBullet->Owner,
-			(pBullet->Type->Inviso ? pBullet->Location : pBullet->TargetCoords), pHouse);
+			((pBullet->Type->Inviso && pBullet->Type->FlakScatter) ? pBullet->Location : abstract_cast<ObjectClass*>(pBullet->Target)->GetTargetCoords()), pHouse);
 	}
 }
 

--- a/src/Ext/Techno/Hooks.WeaponEffects.cpp
+++ b/src/Ext/Techno/Hooks.WeaponEffects.cpp
@@ -231,11 +231,11 @@ DEFINE_HOOK(0x6FD38D, TechnoClass_DrawSth_DrawToInvisoFlakScatterLocation, 0x7) 
 		{
 			const auto& pRulesExt = RulesExt::Global();
 			const auto radius = ScenarioClass::Instance->Random.RandomRanged(pRulesExt->VisualScatter_Min.Get(), pRulesExt->VisualScatter_Max.Get());
-			*pTargetCoords = MapClass::GetRandomCoordsNear((pBullet->Type->Inviso ? pBullet->Location : pBullet->TargetCoords), radius, false);
+			*pTargetCoords = MapClass::GetRandomCoordsNear(((pBullet->Type->Inviso && pBullet->Type->FlakScatter) ? pBullet->Location : abstract_cast<ObjectClass*>(pBullet->Target)->GetTargetCoords()), radius, false);
 		}
 		else
 		{
-			*pTargetCoords = (pBullet->Type->Inviso ? pBullet->Location : pBullet->TargetCoords);
+			*pTargetCoords = ((pBullet->Type->Inviso && pBullet->Type->FlakScatter) ? pBullet->Location : abstract_cast<ObjectClass*>(pBullet->Target)->GetTargetCoords());
 		}
 	}
 	else if (const auto pObstacleCell = FireAtTemp::pObstacleCell)


### PR DESCRIPTION
Fix the bug caused by #1553 where the visual effect rendering ignores `[BuildingType] -> TargetCoordOffset=`. Also strictly constrain the condition to the scenario of `Inviso` && `FlakScatter` rather than `Inviso` alone.  
This change was added between DevBuild#46 and DevBuild#47, later than Release v0.4, so no documentation changes are required.

In the previous commit (96c6550b9f8534a209910da14e76509bbeab36df) before merging #1553:
<img width="270" height="377" alt="image" src="https://github.com/user-attachments/assets/2138628a-87f5-4b8e-b18f-c1860d7ce8d1" />

Latest development branch nightly:
<img width="271" height="361" alt="image" src="https://github.com/user-attachments/assets/2762fbc1-09c5-47f0-ada1-4d13839731a6" />

This PR:
<img width="280" height="393" alt="image" src="https://github.com/user-attachments/assets/cedf0bca-e75e-477c-b9ca-f2d71c1bc4ca" />
