### PR TITLE
Allow *Harvester counter* to display only the total number or the number currently working

### DIFF
--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -653,6 +653,8 @@ MissingCameo=XXICON.SHP  ; filename - including the .shp/.pcx extension
     - Can be set to true on buildings with `ProduceCashAmount` to count them as active 'harvesters' while generating credits.
   - The counter is displayed with the format of `Label(Active Harvesters)/(Total Harvesters)`. The label is `⛏ U+26CF` by default.
   - You can adjust counter position by `Sidebar.HarvesterCounter.Offset`, negative means left/up, positive means right/down.
+  - You can use `Sidebar.HarvesterCounter.HideMaxValue` to allow the counter to display only the number of active harvesters. If this value is `false`, you can use `Sidebar.HarvesterCounter.OnlyMaxValue` to allow the counter to display only the number of total harvesters.
+    - This does not disable the color change of the counter text; to adapt accordingly, you need to configure the counter color yourself for the side that uses this feature.
   - By setting `HarvesterCounter.ConditionYellow` and `HarvesterCounter.ConditionRed`, the game will warn player by changing the color of counter whenever the active percentage of harvesters less than or equals to them, like HP changing with `ConditionYellow` and `ConditionRed`.
   - The feature can be toggled on/off by user if enabled in mod via `ShowHarvesterCounter` setting in `RA2MD.INI`.
 
@@ -672,6 +674,8 @@ Harvester.Counted=                              ; boolean
 
 [SOMESIDE]                                      ; Side
 Sidebar.HarvesterCounter.Offset=0,0             ; X,Y, pixels relative to default
+Sidebar.HarvesterCounter.HideMaxValue=false     ; boolean
+Sidebar.HarvesterCounter.OnlyMaxValue=false     ; boolean
 Sidebar.HarvesterCounter.ColorGreen=            ; integer - Red,Green,Blue, default to [Side] -> ToolTipColor=
 Sidebar.HarvesterCounter.ColorYellow=255,255,0  ; integer - Red,Green,Blue
 Sidebar.HarvesterCounter.ColorRed=255,0,0       ; integer - Red,Green,Blue

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -575,6 +575,7 @@ HideShakeEffects=false           ; boolean
 - [Electric bolt Z-adjust](Fixed-or-Improved-Logics.md#electric-bolt-z-adjust) (by Noble_Fish)
 - Allow disabling the processing of the Z-depth of EBolt drawn by BuildingType being clamped to non-positive numbers (by Noble_Fish)
 - Add the `Bolt.ZAdjust` setting item to the LaserTrailType with `DrawType=ebolt` (by Noble_Fish)
+- Allow *Harvester counter* to display only the total number or the number currently working (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Side/Body.cpp
+++ b/src/Ext/Side/Body.cpp
@@ -31,6 +31,8 @@ void SideExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->IngameScore_WinTheme = pINI->ReadTheme(pSection, "IngameScore.WinTheme", this->IngameScore_WinTheme);
 	this->IngameScore_LoseTheme = pINI->ReadTheme(pSection, "IngameScore.LoseTheme", this->IngameScore_LoseTheme);
 	this->Sidebar_HarvesterCounter_Offset.Read(exINI, pSection, "Sidebar.HarvesterCounter.Offset");
+	this->Sidebar_HarvesterCounter_HideMaxValue.Read(exINI, pSection, "Sidebar.HarvesterCounter.HideMaxValue");
+	this->Sidebar_HarvesterCounter_OnlyMaxValue.Read(exINI, pSection, "Sidebar.HarvesterCounter.OnlyMaxValue");
 	this->Sidebar_HarvesterCounter_ColorGreen.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorGreen");
 	this->Sidebar_HarvesterCounter_ColorYellow.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorYellow");
 	this->Sidebar_HarvesterCounter_ColorRed.Read(exINI, pSection, "Sidebar.HarvesterCounter.ColorRed");
@@ -65,6 +67,8 @@ void SideExt::ExtData::Serialize(T& Stm)
 		.Process(this->ArrayIndex)
 		.Process(this->Sidebar_GDIPositions)
 		.Process(this->Sidebar_HarvesterCounter_Offset)
+		.Process(this->Sidebar_HarvesterCounter_HideMaxValue)
+		.Process(this->Sidebar_HarvesterCounter_OnlyMaxValue)
 		.Process(this->Sidebar_HarvesterCounter_ColorGreen)
 		.Process(this->Sidebar_HarvesterCounter_ColorYellow)
 		.Process(this->Sidebar_HarvesterCounter_ColorRed)

--- a/src/Ext/Side/Body.h
+++ b/src/Ext/Side/Body.h
@@ -20,6 +20,8 @@ public:
 		Valueable<int> IngameScore_WinTheme;
 		Valueable<int> IngameScore_LoseTheme;
 		Valueable<Point2D> Sidebar_HarvesterCounter_Offset;
+		Valueable<bool> Sidebar_HarvesterCounter_HideMaxValue;
+		Valueable<bool> Sidebar_HarvesterCounter_OnlyMaxValue;
 		Nullable<ColorStruct> Sidebar_HarvesterCounter_ColorGreen;
 		Valueable<ColorStruct> Sidebar_HarvesterCounter_ColorYellow;
 		Valueable<ColorStruct> Sidebar_HarvesterCounter_ColorRed;
@@ -49,6 +51,8 @@ public:
 			, IngameScore_WinTheme { -2 }
 			, IngameScore_LoseTheme { -2 }
 			, Sidebar_HarvesterCounter_Offset { { 0, 0 } }
+			, Sidebar_HarvesterCounter_HideMaxValue { false }
+			, Sidebar_HarvesterCounter_OnlyMaxValue { false }
 			, Sidebar_HarvesterCounter_ColorGreen { }
 			, Sidebar_HarvesterCounter_ColorYellow { { 255, 255, 0 } }
 			, Sidebar_HarvesterCounter_ColorRed { { 255, 0, 0 } }

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -95,7 +95,12 @@ DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 			? pSideExt->Sidebar_HarvesterCounter_ColorGreen.Get(Drawing::TooltipColor) : nPercentage > Phobos::UI::HarvesterCounter_ConditionRed
 			? pSideExt->Sidebar_HarvesterCounter_ColorYellow : pSideExt->Sidebar_HarvesterCounter_ColorRed;
 
-		swprintf_s(counter, L"%ls%d/%d", Phobos::UI::HarvesterLabel, nActive, nTotal);
+		if (pSideExt->Sidebar_HarvesterCounter_HideMaxValue)
+			swprintf_s(counter, L"%ls%d", Phobos::UI::HarvesterLabel, nActive);
+		else if (pSideExt->Sidebar_HarvesterCounter_OnlyMaxValue)
+			swprintf_s(counter, L"%ls%d", Phobos::UI::HarvesterLabel, nTotal);
+		else
+			swprintf_s(counter, L"%ls%d/%d", Phobos::UI::HarvesterLabel, nActive, nTotal);
 
 		Point2D vPos = {
 			DSurface::Sidebar->GetWidth() / 2 + 50 + pSideExt->Sidebar_HarvesterCounter_Offset.Get().X,


### PR DESCRIPTION
- You can use `Sidebar.HarvesterCounter.HideMaxValue` to allow the counter to display only the number of active harvesters. If this value is `false`, you can use `Sidebar.HarvesterCounter.OnlyMaxValue` to allow the counter to display only the number of total harvesters.
  - This does not disable the color change of the counter text; to adapt accordingly, you need to configure the counter color yourself for the side that uses this feature.

In `rulesmd.ini`:
```ini
[SOMESIDE]                                      ; Side
Sidebar.HarvesterCounter.HideMaxValue=false     ; boolean
Sidebar.HarvesterCounter.OnlyMaxValue=false     ; boolean
```

<img width="79" height="99" alt="HideMaxValue" src="https://github.com/user-attachments/assets/3ae064d9-fad0-4a59-8125-89f19c5839be" />

*HideMaxValue*

<img width="84" height="87" alt="OnlyMaxValue" src="https://github.com/user-attachments/assets/c152e186-487e-4e73-98ab-d2b00b43fc5f" />

*OnlyMaxValue*