### PR TITLE
Fix flying strings drawing through Fog of War

### DIFF
--- a/src/Misc/FlyingStrings.cpp
+++ b/src/Misc/FlyingStrings.cpp
@@ -8,7 +8,7 @@
 
 std::vector<FlyingStrings::Item> FlyingStrings::Data;
 
-bool FlyingStrings::DrawAllowed(CoordStruct& nCoords)
+bool FlyingStrings::DrawAllowed(const CoordStruct& nCoords)
 {
 	if (auto const pCell = MapClass::Instance.TryGetCellAt(nCoords))
 		return !(pCell->IsFogged() || pCell->IsShrouded());
@@ -30,7 +30,7 @@ void FlyingStrings::Add(const wchar_t* text, const CoordStruct& coords, ColorStr
 void FlyingStrings::AddMoneyString(int amount, ObjectClass* pSource, HouseClass* pOwner,
 	AffectedHouse displayToHouses, const CoordStruct& coords, Point2D pixelOffset)
 {
-	if (amount == 0 || MapClass::Instance.IsLocationShrouded(coords))
+	if (amount == 0 || !FlyingStrings::DrawAllowed(coords))
 		return;
 
 	if (displayToHouses != AffectedHouse::All && !EnumFunctions::CanTargetHouse(displayToHouses, pOwner, HouseClass::CurrentPlayer))
@@ -64,17 +64,20 @@ void FlyingStrings::UpdateAll()
 
 		point += dataItem.PixelOffset;
 
-		RectangleStruct bound = DSurface::Temp->GetRect();
-		bound.Height -= 32;
+		if (FlyingStrings::DrawAllowed(dataItem.Location))
+		{
+			RectangleStruct bound = DSurface::Temp->GetRect();
+			bound.Height -= 32;
 
-		if (Unsorted::CurrentFrame > dataItem.CreationFrame + Duration - 70)
-		{
-			point.Y -= (Unsorted::CurrentFrame - dataItem.CreationFrame);
-			DSurface::Temp->DrawText(dataItem.Text, &bound, &point, dataItem.Color, 0, TextPrintType::NoShadow);
-		}
-		else
-		{
-			DSurface::Temp->DrawText(dataItem.Text, &bound, &point, dataItem.Color, 0, TextPrintType::NoShadow);
+			if (Unsorted::CurrentFrame > dataItem.CreationFrame + Duration - 70)
+			{
+				point.Y -= (Unsorted::CurrentFrame - dataItem.CreationFrame);
+				DSurface::Temp->DrawText(dataItem.Text, &bound, &point, dataItem.Color, 0, TextPrintType::NoShadow);
+			}
+			else
+			{
+				DSurface::Temp->DrawText(dataItem.Text, &bound, &point, dataItem.Color, 0, TextPrintType::NoShadow);
+			}
 		}
 
 		if (Unsorted::CurrentFrame > dataItem.CreationFrame + Duration || Unsorted::CurrentFrame < dataItem.CreationFrame)

--- a/src/Misc/FlyingStrings.h
+++ b/src/Misc/FlyingStrings.h
@@ -26,7 +26,7 @@ private:
 	static const int Duration = 75;
 	static std::vector<Item> Data;
 
-	static bool DrawAllowed(CoordStruct& nCoords);
+	static bool DrawAllowed(const CoordStruct& nCoords);
 
 public:
 	static void Add(const wchar_t* text, const CoordStruct& coords, ColorStruct color, Point2D pixelOffset = Point2D::Empty);


### PR DESCRIPTION
Fixes a narrow part of #28.

This keeps Phobos flying text and money display strings from drawing while their map location is covered by fog or shroud. The existing helper already checks both conditions, but the draw loop did not use it, and money strings only checked shroud when they were created.

What changed:
- money strings are no longer queued when their location is fogged or shrouded
- existing flying strings are skipped while their location is fogged or shrouded
- string expiry still runs normally even while a string is hidden
- the existing public `AddMoneyString` interface is unchanged

Verification:
- `git diff --check` passed
- checked all `AddMoneyString` call sites; the signature is unchanged
- ran a focused static check confirming `UpdateAll` gates `DrawText` with `DrawAllowed` and keeps expiry cleanup

I could not run the full Phobos build in this workspace because it is macOS and the project requires Visual Studio/MSBuild with the Windows SDK. `clang++ -fsyntax-only` stops at the missing `windows.h`, and `cmd.exe /c scripts\\build_debug.bat` is not available here.

This is intentionally not a full Fog of War rewrite; it only addresses the flying text / money display leakage path.
