### PR TITLE
Allow weapon range modifiers to apply on ProjectileRange

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -302,6 +302,7 @@ This page lists all the individual contributions to the project by their author.
   - Animation theater/tile palette toggle
   - Animatable template
   - Tank Bunker improvements
+  - `ProjectileRange` weapon range modifiers interaction fix
 - **Morton (MortonPL)**:
   - `XDrawOffset` for animations
   - Shield passthrough & absorption

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -379,6 +379,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allowed adding custom cruise missiles, so that Ares' `Missile.RaiseRate` is no longer meaningless.
 - Fix the issue of Ares' EMP not suspending the production of AI factories.
 - Removed the restriction that prohibits InfantryTypes from using the InitialPayload logic.
+- `ProjectileRange` now has weapon range modifiers applied to it if greater than 0 and unless `ProjectileRange.ApplyModifiers` is set to false on the WeaponType
 
 ## Newly added global settings
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -30,6 +30,7 @@ This serves as a changelog for when you just need to drop the new version in wit
 
 ### Version TBD (develop branch nightly builds)
 
+- `ProjectileRange` (Ares feature) now has weapon range modifiers applied to it if greater than 0 and unless `ProjectileRange.ApplyModifiers` is set to false on the WeaponType.
 - `Splits.TargetCellRange` < 0 now applies special behaviour where the projectile does not consider nearby cells as additional targets if there are not enough techno targets to match `Cluster` count at all.
 - Combat light customizations introduced a bug that removed vanilla behaviour of ignoring detail level / framerate checks for colored combat light. This bug has been fixed but the previous behaviour can be restored by setting `CombatLightDetailLevel.CheckColored` on Warhead or globally under `[AudioVisual]`.
 - `[TechnoType] -> WarpAway=` has now been changed to set the animation when units are erased to maintain semantic consistency with `[General] -> WarpAway=`. The animation that was originally controlled by `[TechnoType] -> WarpAway=`, which played instead of `[General] -> WarpOut=` when a Techno is chronowarped by chronosphere, now needs to be specified using `[TechnoType] -> Chronoshift.WarpOut=`, which defaults to the value of `[TechnoType] -> WarpOut=`.
@@ -794,6 +795,7 @@ HideShakeEffects=false           ; boolean
 - Fixed a bug where passengers created by the InitialPayload logic or TeamType with `Full=true` would fail to execute the auto death logic (by Noble_Fish)
 - Fixed the issue of Ares' EMP not suspending the production of AI factories (by CrimRecya)
 - Removed the restriction that prohibits InfantryTypes from using the InitialPayload logic (by Noble_Fish)
+- `ProjectileRange` now has weapon range modifiers applied to it if greater than 0 and unless `ProjectileRange.ApplyModifiers` is set to false on the WeaponType (by Starkku)
 ```
 
 ### 0.4.0.3

--- a/src/Ext/Bullet/Body.cpp
+++ b/src/Ext/Bullet/Body.cpp
@@ -516,6 +516,7 @@ void BulletExt::Serialize(T& Stm)
 		.Process(this->IsInstantDetonation)
 		.Process(this->FirepowerMult)
 		.Process(this->IsSplitFromAirburst)
+		.Process(this->DistanceTraveled)
 
 		.Process(this->Trajectory) // Keep this shit at last
 		;

--- a/src/Ext/Bullet/Body.h
+++ b/src/Ext/Bullet/Body.h
@@ -43,6 +43,7 @@ public:
 	bool IsInstantDetonation;
 	double FirepowerMult;
 	bool IsSplitFromAirburst;
+	int DistanceTraveled;
 
 	TrajectoryPointer Trajectory;
 
@@ -61,6 +62,7 @@ public:
 		, IsInstantDetonation { false }
 		, FirepowerMult { 1.0 }
 		, IsSplitFromAirburst { false }
+		, DistanceTraveled { 0 }
 	{ }
 
 	virtual ~BulletExt() = default;

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -632,3 +632,30 @@ DEFINE_HOOK(0x4683F2, BulletClass_Draw_ZAdjust, 0x5)
 
 	return 0x4683F7;
 }
+
+// Replaces Ares' handling of Ranged=true projectiles.
+DEFINE_HOOK(0x467BA4, BulletClass_AI_Ranged, 0x6)
+{
+	GET(BulletClass*, pThis, EBP);
+	REF_STACK(CoordStruct, coordNew, STACK_OFFSET(0x1A8, -0x184));
+	REF_STACK(bool, shouldExplode, STACK_OFFSET(0x1A8, -0x190));
+
+	if (pThis->Type->Ranged)
+	{
+		auto const pExt = BulletExt::Fetch(pThis);
+		pExt->DistanceTraveled += Game::F2I(coordNew.DistanceFrom(pThis->GetCoords()));
+		int maxRange = pThis->Range;
+
+		if (maxRange > 0 && pThis->WeaponType && pThis->Owner
+			&& WeaponTypeExt::Fetch(pThis->WeaponType)->ProjectileRange_ApplyModifiers)
+		{
+			maxRange = WeaponTypeExt::GetRangeWithModifiers(pThis->WeaponType, pThis->Owner, maxRange);
+		}
+
+		shouldExplode |= pExt->DistanceTraveled >= maxRange;
+	}
+
+	pThis->SetLocation(coordNew);
+
+	return 0;
+}

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -634,11 +634,11 @@ DEFINE_HOOK(0x4683F2, BulletClass_Draw_ZAdjust, 0x5)
 }
 
 // Replaces Ares' handling of Ranged=true projectiles.
-DEFINE_HOOK(0x467BA4, BulletClass_AI_Ranged, 0x6)
+DEFINE_HOOK(0x467B8E, BulletClass_AI_Ranged, 0x6)
 {
 	GET(BulletClass*, pThis, EBP);
-	REF_STACK(CoordStruct, coordNew, STACK_OFFSET(0x1A8, -0x184));
-	REF_STACK(bool, shouldExplode, STACK_OFFSET(0x1A8, -0x190));
+	REF_STACK(CoordStruct, coordNew, STACK_OFFSET(0x1AC, -0x184));
+	REF_STACK(bool, shouldExplode, STACK_OFFSET(0x1AC, -0x190));
 
 	if (pThis->Type->Ranged)
 	{
@@ -656,6 +656,5 @@ DEFINE_HOOK(0x467BA4, BulletClass_AI_Ranged, 0x6)
 	}
 
 	pThis->SetLocation(coordNew);
-
 	return 0;
 }

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -81,6 +81,7 @@ void WeaponTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->DiskLaser_Radius.Read(exINI, pSection, "DiskLaser.Radius");
 	this->ProjectileRange.Read(exINI, pSection, "ProjectileRange");
+	this->ProjectileRange_ApplyModifiers.Read(exINI, pSection, "ProjectileRange.ApplyModifiers");
 
 	for (int idx = 0; idx < 3; ++idx)
 	{
@@ -220,6 +221,7 @@ void WeaponTypeExt::Serialize(T& Stm)
 	Stm
 		.Process(this->DiskLaser_Radius)
 		.Process(this->ProjectileRange)
+		.Process(this->ProjectileRange_ApplyModifiers)
 		.Process(this->Bolt_Color)
 		.Process(this->Bolt_Disable)
 		.Process(this->Bolt_ParticleSystem)
@@ -410,7 +412,7 @@ int WeaponTypeExt::GetRangeWithModifiers(WeaponTypeClass* pThis, TechnoClass* pF
 		if (type->WeaponRange_DisallowWeapons.size() > 0 && type->WeaponRange_DisallowWeapons.Contains(pThis))
 			continue;
 
-		range = static_cast<int>(range * Math::max(type->WeaponRange_Multiplier, 0.0));
+		range = GeneralUtils::SafeMultiply(range, Math::max(type->WeaponRange_Multiplier, 0.0));
 		extraRange += type->WeaponRange_ExtraRange;
 	}
 

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -27,6 +27,7 @@ public:
 
 	Valueable<double> DiskLaser_Radius;
 	Valueable<Leptons> ProjectileRange;
+		Valueable<bool> ProjectileRange_ApplyModifiers;
 	Valueable<RadTypeClass*> RadType;
 	Nullable<ColorStruct> Bolt_Color[3];
 	Valueable<bool> Bolt_Disable[3];
@@ -120,6 +121,7 @@ public:
 	WeaponTypeExt(WeaponTypeClass* OwnerObject) : AbstractTypeExt(OwnerObject)
 		, DiskLaser_Radius { DiskLaserClass::Radius }
 		, ProjectileRange { Leptons(100000) }
+			, ProjectileRange_ApplyModifiers { true }
 		, RadType {}
 		, Bolt_Color {}
 		, Bolt_Disable { Valueable<bool>(false) }

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -276,6 +276,9 @@ void Apply_Ares3_0_Patches()
 	// Fix building direction of Ares's UnitDelivery
 	Patch::Apply_VTABLE(AresHelper::AresBaseAddress + 0xA8D94, &UnitDeliveryStateMachine_Update_Wrapper);
 
+	// Skip Ares' ProjectileRange handling - our replacement hooked at 0x467BA4 (BulletClass_AI_Ranged).
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x1ACA3, AresHelper::AresBaseAddress + 0x1AD20);
+
 	// Replace Ares paradrop plane send function call with our wrapper.
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x745B8, &SendPDPlane);
 
@@ -383,6 +386,9 @@ void Apply_Ares3_0p1_Patches()
 
 	// Fix building direction of Ares's UnitDelivery
 	Patch::Apply_VTABLE(AresHelper::AresBaseAddress + 0xA9F28, &UnitDeliveryStateMachine_Update_Wrapper);
+
+	// Skip Ares' ProjectileRange handling - our replacement hooked at 0x467BA4 (BulletClass_AI_Ranged).
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x1B393, AresHelper::AresBaseAddress + 0x1B410);
 
 	// Replace Ares paradrop plane send function call with our wrapper.
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x75668, &SendPDPlane);


### PR DESCRIPTION
`ProjectileRange` now has weapon range modifiers applied to it if greater than 0 and unless `ProjectileRange.ApplyModifiers` is set to false on the WeaponType.

----------------------

Summary of changes:
- Patches Ares code to skip `Ranged=true` projectile checks and updating projectile position to new coordinates.
- Add new hook at `0x467BA4` (Ares hook return address) with updated projectile range check as well as the skipped position update.
- New mechanism treats `BulletClass::Range` as immutable initial max range (as opposed to distance that the projectile can still travel that is deducted from every frame) to preserve ability to check effective range with dynamic modifiers, distance traveled so far is stored in new field `BulletExt::DistanceTraveled`.

----------------------

Fixes the main underlying reason for #2227's existence, whether or not it has any reason to remain after addressing this I do not know.
