### PR TITLE
[Vanilla Enhancement] Customize `Temporal=yes` Warhead

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -536,6 +536,7 @@ This page lists all the individual contributions to the project by their author.
   - Aux technos and TechLevel requirement of superweapon
   - Allow `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades
   - Fix the bug where passengers, when their transport unit is removed, would cause incorrect `LimboTracker` counts due to either having their destructor called directly (bypassing `UnInit`) or nested `UnInit` calls resetting the deletion flag too early, thereby breaking auto-death and superweapon auxiliary techno checks
+  - Customize if warhead with `Temporal=yes` will use versus or not
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -536,7 +536,7 @@ This page lists all the individual contributions to the project by their author.
   - Aux technos and TechLevel requirement of superweapon
   - Allow `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades
   - Fix the bug where passengers, when their transport unit is removed, would cause incorrect `LimboTracker` counts due to either having their destructor called directly (bypassing `UnInit`) or nested `UnInit` calls resetting the deletion flag too early, thereby breaking auto-death and superweapon auxiliary techno checks
-  - Customize if warhead with `Temporal=yes` will use versus or not
+  - Customize if warhead with `Temporal=yes` will use versus and buff or not
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -536,7 +536,7 @@ This page lists all the individual contributions to the project by their author.
   - Aux technos and TechLevel requirement of superweapon
   - Allow `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades
   - Fix the bug where passengers, when their transport unit is removed, would cause incorrect `LimboTracker` counts due to either having their destructor called directly (bypassing `UnInit`) or nested `UnInit` calls resetting the deletion flag too early, thereby breaking auto-death and superweapon auxiliary techno checks
-  - Customize if warhead with `Temporal=yes` will use versus and buff or not
+  - Allow `Temporal` warhead to apply ratio and bonus
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2663,6 +2663,19 @@ In `rulesmd.ini`:
 ShakeIsLocal=false  ; boolean
 ```
 
+### Customize if warhead with `Temporal=yes` will use versus or not
+
+- You can now specify whether `Temporal=yes` warhead should use versus or not.
+
+In `rulesmd.ini`:
+```ini
+[CombatDamage]
+Temporal.ConsiderVersus=false  ; boolean
+
+[SOMEWARHEAD]       ; WarheadType
+Temporal.ConsiderVersus=       ; boolean
+```
+
 ## Weapons
 
 ### AmbientDamage customizations

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2434,6 +2434,23 @@ Trailer.SpawnDelay=2  ; integer, game frames
 
 ## Warheads
 
+### Allow `Temporal` warhead to apply ratio and bonus
+
+- In vanilla, for a warhead with `Temporal=yes` , it fixedly uses `10 * target's maximum hit points / Damage` to obtain the time required for eradication. Now, this can support more detailed calculations.
+  - `Temporal.ApplyVersus` can be used to define whether this logic considers warhead ratios such as `Versus` and `ProneDamage`.
+  - `Temporal.ApplyMultiplier` can be used to define whether this logic considers firepower modifiers and armor modifiers such as `BunkerDamageMultiplier` and `OpenToppedDamageMultiplier`.
+
+In `rulesmd.ini`:
+```ini
+[CombatDamage]
+Temporal.ApplyVersus=false      ; boolean
+Temporal.ApplyMultiplier=false  ; boolean
+
+[SOMEWARHEAD]                   ; WarheadType
+Temporal.ApplyVersus=           ; boolean, default to [CombatDamage] -> Temporal.ApplyVersus
+Temporal.ApplyMultiplier=       ; boolean, default to [CombatDamage] -> Temporal.ApplyMultiplier
+```
+
 ### Allowing damage dealt to firer
 
 - You can now allow warhead to deal damage (and apply damage-adjacent effects such as `KillDriver` and `DisableWeapons/Sonar/Flash.Duration` *(Ares features)*) on the object that is considered as the firer of the Warhead even if it does not have `DamageSelf=true`.
@@ -2661,21 +2678,6 @@ In `rulesmd.ini`:
 ```ini
 [SOMEWARHEAD]       ; WarheadType
 ShakeIsLocal=false  ; boolean
-```
-
-### Customize `Temporal=yes` Warhead
-
-- You can now specify whether `Temporal=yes` warhead should use versus and buff or not.
-
-In `rulesmd.ini`:
-```ini
-[CombatDamage]
-Temporal.ApplyVersus=false      ; boolean
-Temporal.ApplyMultiplier=false  ; boolean
-
-[SOMEWARHEAD]                   ; WarheadType
-Temporal.ApplyVersus=           ; boolean
-Temporal.ApplyMultiplier=       ; boolean
 ```
 
 ## Weapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2663,17 +2663,19 @@ In `rulesmd.ini`:
 ShakeIsLocal=false  ; boolean
 ```
 
-### Customize if warhead with `Temporal=yes` will use versus or not
+### Customize `Temporal=yes` Warhead
 
-- You can now specify whether `Temporal=yes` warhead should use versus or not.
+- You can now specify whether `Temporal=yes` warhead should use versus and buff or not.
 
 In `rulesmd.ini`:
 ```ini
 [CombatDamage]
-Temporal.ConsiderVersus=false  ; boolean
+Temporal.ApplyVersus=false      ; boolean
+Temporal.ApplyMultiplier=false  ; boolean
 
-[SOMEWARHEAD]       ; WarheadType
-Temporal.ConsiderVersus=       ; boolean
+[SOMEWARHEAD]                   ; WarheadType
+Temporal.ApplyVersus=           ; boolean
+Temporal.ApplyMultiplier=       ; boolean
 ```
 
 ## Weapons

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -576,7 +576,7 @@ HideShakeEffects=false           ; boolean
 - Allow disabling the processing of the Z-depth of EBolt drawn by BuildingType being clamped to non-positive numbers (by Noble_Fish)
 - Add the `Bolt.ZAdjust` setting item to the LaserTrailType with `DrawType=ebolt` (by Noble_Fish)
 - Allow *Harvester counter* to display only the total number or the number currently working (by Noble_Fish)
-- Customize if warhead with `Temporal=yes` will use versus or not (by NetsuNegi)
+- Customize if warhead with `Temporal=yes` will use versus and buff or not (by NetsuNegi)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -576,7 +576,7 @@ HideShakeEffects=false           ; boolean
 - Allow disabling the processing of the Z-depth of EBolt drawn by BuildingType being clamped to non-positive numbers (by Noble_Fish)
 - Add the `Bolt.ZAdjust` setting item to the LaserTrailType with `DrawType=ebolt` (by Noble_Fish)
 - Allow *Harvester counter* to display only the total number or the number currently working (by Noble_Fish)
-- Customize if warhead with `Temporal=yes` will use versus and buff or not (by NetsuNegi)
+- [Allow `Temporal` warhead to apply ratio and bonus](Fixed-or-Improved-Logics.md#allow-temporal-warhead-to-apply-ratio-and-bonus) (by NetsuNegi)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -576,6 +576,7 @@ HideShakeEffects=false           ; boolean
 - Allow disabling the processing of the Z-depth of EBolt drawn by BuildingType being clamped to non-positive numbers (by Noble_Fish)
 - Add the `Bolt.ZAdjust` setting item to the LaserTrailType with `DrawType=ebolt` (by Noble_Fish)
 - Allow *Harvester counter* to display only the total number or the number currently working (by Noble_Fish)
+- Customize if warhead with `Temporal=yes` will use versus or not (by NetsuNegi)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1776,8 +1776,8 @@ msgstr ""
 msgid "Fix the bug where passengers, when their transport unit is removed, would cause incorrect `LimboTracker` counts due to either having their destructor called directly (bypassing `UnInit`) or nested `UnInit` calls resetting the deletion flag too early, thereby breaking auto-death and superweapon auxiliary techno checks"
 msgstr "修复了乘客在其所在的运输工具被移除时，因被直接调用析构函数（绕过 `UnInit` ）或 `UnInit` 嵌套调用导致删除标志过早重置，从而使 `LimboTracker` 计数错误，进而影响自动死亡及超武辅助单位判定的 Bug"
 
-msgid "Customize if warhead with `Temporal=yes` will use versus and buff or not"
-msgstr "自定义 `Temporal=yes` 的弹头是否使用弹头修正与增益"
+msgid "Allow `Temporal` warhead to apply ratio and bonus"
+msgstr "允许 `Temporal` 弹头应用比率和加成"
 
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1776,6 +1776,9 @@ msgstr ""
 msgid "Fix the bug where passengers, when their transport unit is removed, would cause incorrect `LimboTracker` counts due to either having their destructor called directly (bypassing `UnInit`) or nested `UnInit` calls resetting the deletion flag too early, thereby breaking auto-death and superweapon auxiliary techno checks"
 msgstr "修复了乘客在其所在的运输工具被移除时，因被直接调用析构函数（绕过 `UnInit` ）或 `UnInit` 嵌套调用导致删除标志过早重置，从而使 `LimboTracker` 计数错误，进而影响自动死亡及超武辅助单位判定的 Bug"
 
+msgid "Customize if warhead with `Temporal=yes` will use versus or not"
+msgstr "自定义 `Temporal=yes` 的弹头是否使用弹头修正"
+
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1776,8 +1776,8 @@ msgstr ""
 msgid "Fix the bug where passengers, when their transport unit is removed, would cause incorrect `LimboTracker` counts due to either having their destructor called directly (bypassing `UnInit`) or nested `UnInit` calls resetting the deletion flag too early, thereby breaking auto-death and superweapon auxiliary techno checks"
 msgstr "修复了乘客在其所在的运输工具被移除时，因被直接调用析构函数（绕过 `UnInit` ）或 `UnInit` 嵌套调用导致删除标志过早重置，从而使 `LimboTracker` 计数错误，进而影响自动死亡及超武辅助单位判定的 Bug"
 
-msgid "Customize if warhead with `Temporal=yes` will use versus or not"
-msgstr "自定义 `Temporal=yes` 的弹头是否使用弹头修正"
+msgid "Customize if warhead with `Temporal=yes` will use versus and buff or not"
+msgstr "自定义 `Temporal=yes` 的弹头是否使用弹头修正与增益"
 
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -5475,6 +5475,14 @@ msgid ""
 "view."
 msgstr "现在你可以指定这个弹头是否只能在可视的当前屏幕可见区域内爆炸时才能抖动（`ShakeX/Ylo/hi`）屏幕"
 
+msgid ""
+"Customize if warhead with `Temporal=yes` will use versus or not"
+msgstr "自定义 `Temporal=yes` 的弹头是否使用弹头修正"
+
+msgid ""
+"You can now specify whether `Temporal=yes` warhead should use versus or not."
+msgstr "现在你可以指定 `Temporal=yes` 的弹头是否应当使用修正比率。"
+
 msgid "Weapons"
 msgstr "武器"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -5476,12 +5476,12 @@ msgid ""
 msgstr "现在你可以指定这个弹头是否只能在可视的当前屏幕可见区域内爆炸时才能抖动（`ShakeX/Ylo/hi`）屏幕"
 
 msgid ""
-"Customize if warhead with `Temporal=yes` will use versus or not"
-msgstr "自定义 `Temporal=yes` 的弹头是否使用弹头修正"
+"Customize `Temporal=yes` Warhead"
+msgstr "自定义 `Temporal=yes` 弹头"
 
 msgid ""
-"You can now specify whether `Temporal=yes` warhead should use versus or not."
-msgstr "现在你可以指定 `Temporal=yes` 的弹头是否应当使用修正比率。"
+"You can now specify whether `Temporal=yes` warhead should use versus and buff or not."
+msgstr "现在你可以指定 `Temporal=yes` 的弹头是否应当使用修正和增益。"
 
 msgid "Weapons"
 msgstr "武器"

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -5179,6 +5179,29 @@ msgstr "现在你可以自定义 Voxel 碎片的尾烟动画生成间隔。"
 msgid "Warheads"
 msgstr "弹头"
 
+msgid "Allow `Temporal` warhead to apply ratio and bonus"
+msgstr "允许 `Temporal` 弹头应用比率和加成"
+
+msgid ""
+"In vanilla, for a warhead with `Temporal=yes` , it fixedly uses `10 * "
+"target's maximum hit points / Damage` to obtain the time required for "
+"eradication. Now, this can support more detailed calculations."
+msgstr ""
+"在原版中，`Temporal=yes` 的弹头固定使用 `10 * 目标最大生命值/Damage` 来获得一个抹除所需的时间。现在，这可以支持更细致的计算。"
+
+msgid ""
+"`Temporal.ApplyVersus` can be used to define whether this logic considers"
+" warhead ratios such as `Versus` and `ProneDamage`."
+msgstr ""
+"`Temporal.ApplyVersus` 可用于定义该逻辑是否考虑弹头比率如 `Versus` 和 `ProneDamage`。"
+
+msgid ""
+"`Temporal.ApplyMultiplier` can be used to define whether this logic "
+"considers firepower modifiers and armor modifiers such as "
+"`BunkerDamageMultiplier` and `OpenToppedDamageMultiplier`."
+msgstr ""
+"`Temporal.ApplyMultiplier` 可用于定义该逻辑是否考虑火力倍率和护甲倍率如 `BunkerDamageMultiplier` 和 `OpenToppedDamageMultiplier`。"
+
 msgid "Allowing damage dealt to firer"
 msgstr "允许杀伤开火者"
 
@@ -5474,14 +5497,6 @@ msgid ""
 "(`ShakeX/Ylo/hi`) if it is detonated while visible on current screen "
 "view."
 msgstr "现在你可以指定这个弹头是否只能在可视的当前屏幕可见区域内爆炸时才能抖动（`ShakeX/Ylo/hi`）屏幕"
-
-msgid ""
-"Customize `Temporal=yes` Warhead"
-msgstr "自定义 `Temporal=yes` 弹头"
-
-msgid ""
-"You can now specify whether `Temporal=yes` warhead should use versus and buff or not."
-msgstr "现在你可以指定 `Temporal=yes` 的弹头是否应当使用修正和增益。"
 
 msgid "Weapons"
 msgstr "武器"

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -1923,9 +1923,9 @@ msgstr ""
 "为拥有 `DrawType=ebolt` 的激光尾迹类型添加 `Bolt.ZAdjust` 设置项（by Noble_Fish）"
 
 msgid ""
-"Customize if warhead with `Temporal=yes` will use versus or not (by NetsuNegi)"
+"Customize if warhead with `Temporal=yes` will use versus and buff or not (by NetsuNegi)"
 msgstr ""
-"自定义 `Temporal=yes` 的弹头是否使用弹头修正（by NetsuNegi）"
+"自定义 `Temporal=yes` 的弹头是否使用弹头修正与增益（by NetsuNegi）"
 
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -1923,9 +1923,11 @@ msgstr ""
 "为拥有 `DrawType=ebolt` 的激光尾迹类型添加 `Bolt.ZAdjust` 设置项（by Noble_Fish）"
 
 msgid ""
-"Customize if warhead with `Temporal=yes` will use versus and buff or not (by NetsuNegi)"
+"[Allow `Temporal` warhead to apply ratio and bonus](Fixed-or-Improved-"
+"Logics.md#allow-temporal-warhead-to-apply-ratio-and-bonus) (by NetsuNegi)"
 msgstr ""
-"自定义 `Temporal=yes` 的弹头是否使用弹头修正与增益（by NetsuNegi）"
+"[允许 `Temporal` 弹头应用比率和加成](Fixed-or-Improved-"
+"Logics.md#allow-temporal-warhead-to-apply-ratio-and-bonus)（by NetsuNegi）"
 
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -1922,6 +1922,11 @@ msgid ""
 msgstr ""
 "为拥有 `DrawType=ebolt` 的激光尾迹类型添加 `Bolt.ZAdjust` 设置项（by Noble_Fish）"
 
+msgid ""
+"Customize if warhead with `Temporal=yes` will use versus or not (by NetsuNegi)"
+msgstr ""
+"自定义 `Temporal=yes` 的弹头是否使用弹头修正（by NetsuNegi）"
+
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -409,6 +409,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->Shrapnel_IgnoreHitBuildings.Read(exINI, GameStrings::CombatDamage, "Shrapnel.IgnoreHitBuildings");
 
+	this->Temporal_ConsiderVersus.Read(exINI, GameStrings::CombatDamage, "Temporal.ConsiderVersus");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -737,6 +739,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->FiringAnim_Update)
 		.Process(this->ExtendedPlayerRepair)
 		.Process(this->Shrapnel_IgnoreHitBuildings)
+		.Process(this->Temporal_ConsiderVersus)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -409,7 +409,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->Shrapnel_IgnoreHitBuildings.Read(exINI, GameStrings::CombatDamage, "Shrapnel.IgnoreHitBuildings");
 
-	this->Temporal_ConsiderVersus.Read(exINI, GameStrings::CombatDamage, "Temporal.ConsiderVersus");
+	this->Temporal_ApplyVersus.Read(exINI, GameStrings::CombatDamage, "Temporal.ApplyVersus");
+	this->Temporal_ApplyMultiplier.Read(exINI, GameStrings::CombatDamage, "Temporal.ApplyMultiplier");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -739,7 +740,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->FiringAnim_Update)
 		.Process(this->ExtendedPlayerRepair)
 		.Process(this->Shrapnel_IgnoreHitBuildings)
-		.Process(this->Temporal_ConsiderVersus)
+		.Process(this->Temporal_ApplyVersus)
+		.Process(this->Temporal_ApplyMultiplier)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -352,7 +352,8 @@ public:
 
 		Valueable<bool> Shrapnel_IgnoreHitBuildings;
 
-		Valueable<bool> Temporal_ConsiderVersus;
+		Valueable<bool> Temporal_ApplyVersus;
+		Valueable<bool> Temporal_ApplyMultiplier;
     
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -645,7 +646,8 @@ public:
 			, FiringAnim_Update { false }
 			, ExtendedPlayerRepair { false }
 			, Shrapnel_IgnoreHitBuildings { false }
-			, Temporal_ConsiderVersus { false }
+			, Temporal_ApplyVersus { false }
+			, Temporal_ApplyMultiplier { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -351,6 +351,8 @@ public:
 		Valueable<bool> ShipLocomotorMakesWake;
 
 		Valueable<bool> Shrapnel_IgnoreHitBuildings;
+
+		Valueable<bool> Temporal_ConsiderVersus;
     
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -643,6 +645,7 @@ public:
 			, FiringAnim_Update { false }
 			, ExtendedPlayerRepair { false }
 			, Shrapnel_IgnoreHitBuildings { false }
+			, Temporal_ConsiderVersus { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
 
 #include <Ext/Anim/Body.h>
+#include <Ext/BuildingType/Body.h>
 #include <Ext/House/Body.h>
 #include <Ext/Scenario/Body.h>
 #include <Ext/WeaponType/Body.h>
@@ -200,8 +201,31 @@ double TechnoExt::GetCurrentSpeedMultiplier(FootClass* pThis)
 
 double TechnoExt::GetCurrentFirepowerMultiplier(TechnoClass* pThis)
 {
-	return pThis->FirepowerMultiplier * pThis->Owner->FirepowerMultiplier * TechnoExt::ExtMap.Find(pThis)->AE.FirepowerMultiplier *
+	double mult = pThis->FirepowerMultiplier * pThis->Owner->FirepowerMultiplier * TechnoExt::ExtMap.Find(pThis)->AE.FirepowerMultiplier *
 		(pThis->HasAbility(Ability::Firepower) ? RulesClass::Instance->VeteranCombat : 1.0);
+
+	if (const auto pBuilding = abstract_cast<BuildingClass*, true>(pThis))
+	{
+		const auto pBuildingType = pBuilding->Type;
+
+		if (pBuildingType->CanBeOccupied && pBuildingType->CanOccupyFire && pBuildingType->MaxNumberOccupants)
+		{
+			const auto pBuildingTypeExt = BuildingTypeExt::ExtMap.Find(pBuildingType);
+			mult *= pBuildingTypeExt->BuildingOccupyDamageMult.Get(RulesClass::Instance->OccupyDamageMultiplier);
+		}
+	}
+	else if (const auto pBunker = abstract_cast<BuildingClass*>(pThis->BunkerLinkedItem))
+	{
+		const auto pBunkerTypeExt = BuildingTypeExt::ExtMap.Find(pBunker->Type);
+		mult *= pBunkerTypeExt->BuildingBunkerDamageMult.Get(RulesClass::Instance->BunkerDamageMultiplier);
+	}
+	else if (pThis->InOpenToppedTransport && pThis->Transporter)
+	{
+		const auto pTransporterTypeExt = TechnoExt::ExtMap.Find(pThis->Transporter)->TypeExtData;
+		mult *= pTransporterTypeExt->OpenTopped_DamageMultiplier.Get(RulesClass::Instance->OpenToppedDamageMultiplier);
+	}
+
+	return mult;
 }
 
 double TechnoExt::GetCurrentArmorMultiplier(TechnoClass* pThis, TechnoTypeClass* pType, WarheadTypeClass* pWarhead)

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -194,15 +194,13 @@ double TechnoExt::GetCurrentSpeedMultiplier(FootClass* pThis)
 	else
 		houseMultiplier = pThis->Owner->Type->SpeedUnitsMult;
 
-	auto const pExt = TechnoExt::ExtMap.Find(pThis);
-
-	return pThis->SpeedMultiplier * houseMultiplier * pExt->AE.SpeedMultiplier *
+	return pThis->SpeedMultiplier * houseMultiplier * TechnoExt::ExtMap.Find(pThis)->AE.SpeedMultiplier *
 		(pThis->HasAbility(Ability::Faster) ? RulesClass::Instance->VeteranSpeed : 1.0);
 }
 
 double TechnoExt::GetCurrentFirepowerMultiplier(TechnoClass* pThis)
 {
-	return pThis->FirepowerMultiplier * TechnoExt::ExtMap.Find(pThis)->AE.FirepowerMultiplier *
+	return pThis->FirepowerMultiplier * pThis->Owner->FirepowerMultiplier * TechnoExt::ExtMap.Find(pThis)->AE.FirepowerMultiplier *
 		(pThis->HasAbility(Ability::Firepower) ? RulesClass::Instance->VeteranCombat : 1.0);
 }
 

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2080,12 +2080,25 @@ int WrapPerStep::TemporalClassFake::_GetWarpPerStep(int helperCount)
 		const auto pWeapon = pOwner->GetWeapon(weaponIdx)->WeaponType;
 		int warpPerStep = pWeapon->Damage;
 
-		if (const auto pTarget = pTemporal->Target)
+		if (const auto pWarhead = pWeapon->Warhead)
 		{
-			const auto pWarhead = pWeapon->Warhead;
+			const auto pWHExt = WarheadTypeExt::ExtMap.Find(pWarhead);
+			const bool applyMultiplier = pWHExt->Temporal_ApplyMultiplier.Get(RulesExt::Global()->Temporal_ApplyMultiplier);
+			double multiplier = 1.0;
 
-			if (pWarhead && WarheadTypeExt::ExtMap.Find(pWarhead)->Temporal_ConsiderVersus.Get(RulesExt::Global()->Temporal_ConsiderVersus))
-				warpPerStep = MapClass::GetTotalDamage(warpPerStep, pWarhead, pTarget->GetType()->Armor, 0);
+			if (applyMultiplier)
+				multiplier = TechnoExt::GetCurrentFirepowerMultiplier(pOwner);
+
+			if (const auto pTarget = pTemporal->Target)
+			{
+				if (applyMultiplier)
+					multiplier /= TechnoExt::GetCurrentArmorMultiplier(pTarget, pTarget->GetTechnoType(), pWarhead);
+
+				if (pWHExt->Temporal_ApplyVersus.Get(RulesExt::Global()->Temporal_ApplyVersus))
+					warpPerStep = MapClass::GetTotalDamage(warpPerStep, pWarhead, pTarget->GetType()->Armor, 0);
+			}
+
+			warpPerStep = static_cast<int>(warpPerStep * multiplier);
 		}
 
 		pTemporal->WarpPerStep = warpPerStep;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -79,20 +79,24 @@ DEFINE_HOOK(0x736480, UnitClass_AI, 0x6)
 }
 
 // Ares-hook jmp to this offset
-DEFINE_HOOK(0x71A88D, TemporalClass_AI, 0x0)
+DEFINE_HOOK(0x71A88D, TemporalClass_AI, 0x8)
 {
 	GET(TemporalClass*, pThis, ESI);
 
-	if (auto const pTarget = pThis->Target)
+	if (const auto pTarget = pThis->Target)
 	{
 		pTarget->IsMouseHovering = false;
+		const int initialWarpRemaining = pTarget->GetType()->Strength * 10;
+
+		if (pThis->WarpRemaining > initialWarpRemaining)
+			pThis->WarpRemaining = initialWarpRemaining;
 
 		const auto pExt = TechnoExt::ExtMap.Find(pTarget);
 		pExt->UpdateTemporal();
 	}
 
 	// Recovering vanilla instructions that were broken by a hook call
-	return R->EAX<int>() <= 0 ? 0x71A895 : 0x71AB08;
+	return pThis->WarpRemaining <= 0 ? 0x71A895 : 0x71AB08;
 }
 
 DEFINE_HOOK_AGAIN(0x51B389, FootClass_TunnelAI_Enter, 0x6) // InfantryClass_TunnelAI

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2108,7 +2108,14 @@ int WrapPerStep::TemporalClassFake::_GetWarpPerStep(int helperCount)
 					multiplier /= TechnoExt::GetCurrentArmorMultiplier(pTarget, pTarget->GetTechnoType(), pWarhead);
 
 				if (pWHExt->Temporal_ApplyVersus.Get(RulesExt::Global()->Temporal_ApplyVersus))
+				{
+					const auto pTargetInfantry = abstract_cast<InfantryClass*, true>(pTarget);
+
+					if (pTargetInfantry && pTargetInfantry->Crawling && warpPerStep > 0)
+						warpPerStep = std::max(static_cast<int>(warpPerStep * pWarhead->ProneDamage), 1);
+
 					warpPerStep = MapClass::GetTotalDamage(warpPerStep, pWarhead, pTarget->GetType()->Armor, 0);
+				}
 			}
 
 			warpPerStep = static_cast<int>(warpPerStep * multiplier);

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2090,22 +2090,7 @@ int WrapPerStep::TemporalClassFake::_GetWarpPerStep(int helperCount)
 			const bool applyMultiplier = pWHExt->Temporal_ApplyMultiplier.Get(RulesExt::Global()->Temporal_ApplyMultiplier);
 
 			if (applyMultiplier)
-			{
-				double firepowerMultiplier = TechnoExt::GetCurrentFirepowerMultiplier(pOwner);
-
-				if (const auto pBunker = abstract_cast<BuildingClass*>(pOwner->BunkerLinkedItem))
-				{
-					const auto pBunkerTypeExt = BuildingTypeExt::ExtMap.Find(pBunker->Type);
-					firepowerMultiplier *= pBunkerTypeExt->BuildingBunkerDamageMult.Get(RulesClass::Instance->BunkerDamageMultiplier);
-				}
-				else if (pOwner->InOpenToppedTransport && pOwner->Transporter)
-				{
-					const auto pTransporterTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->Transporter->GetTechnoType());
-					firepowerMultiplier *= pTransporterTypeExt->OpenTopped_DamageMultiplier.Get(RulesClass::Instance->OpenToppedDamageMultiplier);
-				}
-
-				warpPerStep = static_cast<int>(warpPerStep * firepowerMultiplier);
-			}
+				warpPerStep = static_cast<int>(warpPerStep * TechnoExt::GetCurrentFirepowerMultiplier(pOwner));
 
 			const auto pTarget = pTemporal->Target;
 

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2087,7 +2087,20 @@ int WrapPerStep::TemporalClassFake::_GetWarpPerStep(int helperCount)
 			double multiplier = 1.0;
 
 			if (applyMultiplier)
+			{
 				multiplier = TechnoExt::GetCurrentFirepowerMultiplier(pOwner);
+
+				if (const auto pBunker = abstract_cast<BuildingClass*>(pOwner->BunkerLinkedItem))
+				{
+					const auto pBunkerTypeExt = BuildingTypeExt::ExtMap.Find(pBunker->Type);
+					multiplier *= pBunkerTypeExt->BuildingBunkerDamageMult.Get(RulesClass::Instance->BunkerDamageMultiplier);
+				}
+				else if (pOwner->InOpenToppedTransport && pOwner->Transporter)
+				{
+					const auto pTransporterTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->Transporter->GetTechnoType());
+					multiplier *= pTransporterTypeExt->OpenTopped_DamageMultiplier.Get(RulesClass::Instance->OpenToppedDamageMultiplier);
+				}
+			}
 
 			if (const auto pTarget = pTemporal->Target)
 			{

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2084,41 +2084,49 @@ int WrapPerStep::TemporalClassFake::_GetWarpPerStep(int helperCount)
 		{
 			const auto pWHExt = WarheadTypeExt::ExtMap.Find(pWarhead);
 			const bool applyMultiplier = pWHExt->Temporal_ApplyMultiplier.Get(RulesExt::Global()->Temporal_ApplyMultiplier);
-			double multiplier = 1.0;
 
 			if (applyMultiplier)
 			{
-				multiplier = TechnoExt::GetCurrentFirepowerMultiplier(pOwner);
+				double firepowerMultiplier = TechnoExt::GetCurrentFirepowerMultiplier(pOwner);
 
 				if (const auto pBunker = abstract_cast<BuildingClass*>(pOwner->BunkerLinkedItem))
 				{
 					const auto pBunkerTypeExt = BuildingTypeExt::ExtMap.Find(pBunker->Type);
-					multiplier *= pBunkerTypeExt->BuildingBunkerDamageMult.Get(RulesClass::Instance->BunkerDamageMultiplier);
+					firepowerMultiplier *= pBunkerTypeExt->BuildingBunkerDamageMult.Get(RulesClass::Instance->BunkerDamageMultiplier);
 				}
 				else if (pOwner->InOpenToppedTransport && pOwner->Transporter)
 				{
 					const auto pTransporterTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->Transporter->GetTechnoType());
-					multiplier *= pTransporterTypeExt->OpenTopped_DamageMultiplier.Get(RulesClass::Instance->OpenToppedDamageMultiplier);
+					firepowerMultiplier *= pTransporterTypeExt->OpenTopped_DamageMultiplier.Get(RulesClass::Instance->OpenToppedDamageMultiplier);
 				}
+
+				warpPerStep = static_cast<int>(warpPerStep * firepowerMultiplier);
 			}
 
-			if (const auto pTarget = pTemporal->Target)
+			const auto pTarget = pTemporal->Target;
+
+			if (pTarget && warpPerStep > 0)
 			{
+				double multiplier = 1.0;
+
 				if (applyMultiplier)
 					multiplier /= TechnoExt::GetCurrentArmorMultiplier(pTarget, pTarget->GetTechnoType(), pWarhead);
 
 				if (pWHExt->Temporal_ApplyVersus.Get(RulesExt::Global()->Temporal_ApplyVersus))
 				{
-					const auto pTargetInfantry = abstract_cast<InfantryClass*, true>(pTarget);
-
-					if (pTargetInfantry && pTargetInfantry->Crawling && warpPerStep > 0)
-						warpPerStep = std::max(static_cast<int>(warpPerStep * pWarhead->ProneDamage), 1);
+					if (const auto pTargetInfantry = abstract_cast<InfantryClass*, true>(pTarget))
+					{
+						if (pTargetInfantry->IsDeployed())
+							multiplier *= pWHExt->Damage_Deployed;
+						else if (pTargetInfantry->Crawling)
+							multiplier *= pWarhead->ProneDamage;
+					}
 
 					warpPerStep = MapClass::GetTotalDamage(warpPerStep, pWarhead, pTarget->GetType()->Armor, 0);
 				}
-			}
 
-			warpPerStep = static_cast<int>(warpPerStep * multiplier);
+				warpPerStep = static_cast<int>(warpPerStep * multiplier);
+			}
 		}
 
 		pTemporal->WarpPerStep = warpPerStep;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2041,3 +2041,60 @@ DEFINE_HOOK(0x70AFEF, TechnoClass_UpdateSight_DynamicSight2, 0x6)
 }
 
 #pragma endregion
+
+namespace WrapPerStep
+{
+	class TemporalClassFake final : public TemporalClass
+	{
+		int _GetWarpPerStep(int helperCount);
+	};
+
+	struct DummyExtHere
+	{
+		char _[0xA];
+		BYTE WeaponIndex_Warp;
+	};
+}
+
+int WrapPerStep::TemporalClassFake::_GetWarpPerStep(int helperCount)
+{
+	const auto pThis = static_cast<TemporalClass*>(this);
+	auto pTemporal = pThis;
+	int sum = 0;
+
+	do
+	{
+		if (helperCount > 50)
+			break;
+
+		++helperCount;
+
+		const auto pOwner = pTemporal->Owner;
+		int weaponIdx = 0;
+
+		if (AresHelper::CanUseAres)
+			weaponIdx = reinterpret_cast<WrapPerStep::DummyExtHere*>(*(uintptr_t*)((char*)pOwner + 0x154))->WeaponIndex_Warp;
+		else
+			weaponIdx = pOwner->SelectWeapon(nullptr);
+		
+		const auto pWeapon = pOwner->GetWeapon(weaponIdx)->WeaponType;
+		int warpPerStep = pWeapon->Damage;
+
+		if (const auto pTarget = pTemporal->Target)
+		{
+			const auto pWarhead = pWeapon->Warhead;
+
+			if (pWarhead && WarheadTypeExt::ExtMap.Find(pWarhead)->Temporal_ConsiderVersus.Get(RulesExt::Global()->Temporal_ConsiderVersus))
+				warpPerStep = MapClass::GetTotalDamage(warpPerStep, pWarhead, pTarget->GetType()->Armor, 0);
+		}
+
+		pTemporal->WarpPerStep = warpPerStep;
+		sum += warpPerStep;
+
+		pTemporal = pTemporal->PrevTemporal;
+	}
+	while (pTemporal);
+
+	return sum;
+}
+DEFINE_FUNCTION_JUMP(LJMP, 0x71AB10, WrapPerStep::TemporalClassFake::_GetWarpPerStep)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -448,6 +448,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->EffectsRequireVerses.Read(exINI, pSection, "EffectsRequireVerses");
 	this->Malicious.Read(exINI, pSection, "Malicious");
 	this->Flash_Duration.Read(exINI, pSection, "Flash.Duration");
+	this->Damage_Deployed.Read(exINI, pSection, "Damage.Deployed");
 
 	// List all Warheads here that respect CellSpread
 	// Used in WarheadTypeExt::ExtData::Detonate
@@ -752,6 +753,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->EffectsRequireVerses)
 		.Process(this->Malicious)
 		.Process(this->Flash_Duration)
+		.Process(this->Damage_Deployed)
 
 		.Process(this->WasDetonatedOnAllMapObjects)
 		.Process(this->RemainingAnimCreationInterval)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -163,7 +163,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->PenetratesForceShield.Read(exINI, pSection, "PenetratesForceShield");
 	this->Rocker_AmplitudeMultiplier.Read(exINI, pSection, "Rocker.AmplitudeMultiplier");
 	this->Rocker_AmplitudeOverride.Read(exINI, pSection, "Rocker.AmplitudeOverride");
-	this->Temporal_ConsiderVersus.Read(exINI, pSection, "Temporal.ConsiderVersus");
+	this->Temporal_ApplyVersus.Read(exINI, pSection, "Temporal.ApplyVersus");
+	this->Temporal_ApplyMultiplier.Read(exINI, pSection, "Temporal.ApplyMultiplier");
 
 	// Crits
 	this->Crit_Chance.Read(exINI, pSection, "Crit.Chance");
@@ -548,7 +549,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PenetratesForceShield)
 		.Process(this->Rocker_AmplitudeMultiplier)
 		.Process(this->Rocker_AmplitudeOverride)
-		.Process(this->Temporal_ConsiderVersus)
+		.Process(this->Temporal_ApplyVersus)
+		.Process(this->Temporal_ApplyMultiplier)
 
 		.Process(this->Crit_Chance)
 		.Process(this->Crit_ApplyChancePerTarget)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -163,6 +163,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->PenetratesForceShield.Read(exINI, pSection, "PenetratesForceShield");
 	this->Rocker_AmplitudeMultiplier.Read(exINI, pSection, "Rocker.AmplitudeMultiplier");
 	this->Rocker_AmplitudeOverride.Read(exINI, pSection, "Rocker.AmplitudeOverride");
+	this->Temporal_ConsiderVersus.Read(exINI, pSection, "Temporal.ConsiderVersus");
 
 	// Crits
 	this->Crit_Chance.Read(exINI, pSection, "Crit.Chance");
@@ -547,6 +548,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->PenetratesForceShield)
 		.Process(this->Rocker_AmplitudeMultiplier)
 		.Process(this->Rocker_AmplitudeOverride)
+		.Process(this->Temporal_ConsiderVersus)
 
 		.Process(this->Crit_Chance)
 		.Process(this->Crit_ApplyChancePerTarget)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -50,7 +50,8 @@ public:
 		Nullable<bool> PenetratesForceShield;
 		Valueable<double> Rocker_AmplitudeMultiplier;
 		Nullable<int> Rocker_AmplitudeOverride;
-		Nullable<bool> Temporal_ConsiderVersus;
+		Nullable<bool> Temporal_ApplyVersus;
+		Nullable<bool> Temporal_ApplyMultiplier;
 
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
@@ -308,7 +309,8 @@ public:
 			, PenetratesForceShield {}
 			, Rocker_AmplitudeMultiplier { 1.0 }
 			, Rocker_AmplitudeOverride {}
-			, Temporal_ConsiderVersus {}
+			, Temporal_ApplyVersus {}
+			, Temporal_ApplyMultiplier {}
 
 			, Crit_Chance { 0.0 }
 			, Crit_ApplyChancePerTarget { false }

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -256,6 +256,7 @@ public:
 		Valueable<bool> EffectsRequireVerses;
 		Valueable<bool> Malicious;
 		Nullable<int> Flash_Duration;
+		Valueable<double> Damage_Deployed { 1.0 };
 
 		double Crit_RandomBuffer;
 		double Crit_CurrentChance;

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -50,6 +50,7 @@ public:
 		Nullable<bool> PenetratesForceShield;
 		Valueable<double> Rocker_AmplitudeMultiplier;
 		Nullable<int> Rocker_AmplitudeOverride;
+		Nullable<bool> Temporal_ConsiderVersus;
 
 		Valueable<double> Crit_Chance;
 		Valueable<bool> Crit_ApplyChancePerTarget;
@@ -306,7 +307,8 @@ public:
 			, PenetratesIronCurtain { false }
 			, PenetratesForceShield {}
 			, Rocker_AmplitudeMultiplier { 1.0 }
-			, Rocker_AmplitudeOverride { }
+			, Rocker_AmplitudeOverride {}
+			, Temporal_ConsiderVersus {}
 
 			, Crit_Chance { 0.0 }
 			, Crit_ApplyChancePerTarget { false }


### PR DESCRIPTION
- You can now specify whether `Temporal=yes` warhead should use versus and buff or not.

In `rulesmd.ini`:
```ini
[CombatDamage]
Temporal.ApplyVersus=false      ; boolean
Temporal.ApplyMultiplier=false  ; boolean

[SOMEWARHEAD]                   ; WarheadType
Temporal.ApplyVersus=           ; boolean
Temporal.ApplyMultiplier=       ; boolean
```