### PR TITLE
Allow infantry to perform type conversion when deploying and undeploying

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -377,6 +377,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - `EVA.Tag` already supports being set for specific countries, and `EVAIndex` is no longer reset after load game.
 - `DisableWeapons.Duration` now makes `Gattling=yes` rate tick down and stops the sounds from playing, no longer interferes with target acquisition and works together with Phobos' `OpenTopped.CheckTransportDisableWeapons`.
 - Allowed Ares' `SW.AuxBuildings` and `SW.NegBuildings` to count building upgrades.
+- Allowed infantry to use `Convert.Deploy` without requiring `IsSimpleDeployer=true`.
 
 ## Newly added global settings
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -701,6 +701,21 @@ SpyEffect.InfiltratorSuperWeapon=  ; SuperWeaponType
 
 ## Infantry
 
+### Allow infantry to perform type conversion when deploying and undeploying
+
+- Now infantry can perform type conversion when executing the `Deploy` and `Undeploy` sequences.
+
+In `rulesmd.ini`:
+```ini
+[SOMEINFANTRY]             ; InfantryType
+Convert.Deploy=            ; InfantryType
+Convert.Undeploy=          ; InfantryType
+```
+
+```{note}
+For the sake of logical clarity, this feature does not allow the converted unit to trigger another conversion before the current sequence ends. If continuous conversion is needed, please use `Convert.Land/Water`.
+```
+
 ### Customizable FLH when infantry is prone or deployed
 
 - Now infantry can override `PrimaryFireFLH` and `SecondaryFireFLH` if is prone (crawling) or deployed. Also works in conjunction with [burst-index specific firing offsets](#firing-offsets-for-specific-burst-shots).

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -579,6 +579,7 @@ HideShakeEffects=false           ; boolean
 - [Allow customizing guard mission retry delay for buildings with weapons](Fixed-or-Improved-Logics.md#armed-building-guard-retry-delay) (by Starkku)
 - [Allow `Temporal` warhead to apply ratio and bonus](Fixed-or-Improved-Logics.md#allow-temporal-warhead-to-apply-ratio-and-bonus) (by NetsuNegi)
 - Allow enabling a looser movement state check for the `DiscardOn=move` condition of AE to support more usage scenarios (by Noble_Fish)
+- [Allow infantry to perform type conversion when deploying and undeploying](New-or-Enhanced-Logics.md#allow-infantry-to-perform-type-conversion-when-deploying-and-undeploying) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)
@@ -737,6 +738,7 @@ HideShakeEffects=false           ; boolean
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus & NetsuNegi)
 - [Aux technos and TechLevel requirement of superweapon](New-or-Enhanced-Logics.md#aux-technos-and-techlevel-requirement-of-superweapon) (by NetsuNegi & Ollerus)
 - [Export interface for external call](index.md#interoperability) (by TaranDahl)
+- Allowed infantry to use `Convert.Deploy` without requiring `IsSimpleDeployer=true` (by Noble_Fish)
 
 ```
 

--- a/src/Ext/Infantry/Hooks.cpp
+++ b/src/Ext/Infantry/Hooks.cpp
@@ -1,5 +1,6 @@
 #include <Ext/BuildingType/Body.h>
 #include <Ext/TechnoType/Body.h>
+#include <Ext/Techno/Body.h>
 
 #include <InputManagerClass.h>
 
@@ -9,6 +10,15 @@ DEFINE_HOOK(0x51B2BD, InfantryClass_UpdateTarget_IsControlledByHuman, 0x6)
 	GET(AbstractClass*, pTarget, EDI);
 
 	return (!pTarget || pThis->Owner->IsControlledByHuman()) ? 0x51B33F : 0;
+}
+
+
+DEFINE_HOOK(0x520AE9, InfantryClass_DoingAI_DeployConvert, 0x6)
+{
+	GET(InfantryClass*, pThis, ESI);
+	auto const pExt = TechnoExt::ExtMap.Find(pThis);
+	pExt->DeployConvertAction();
+	return 0;
 }
 
 #pragma region WhatActionObjectFix

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -217,6 +217,40 @@ void TechnoExt::ExtData::AmmoAutoConvertActions()
 	}
 }
 
+void TechnoExt::ExtData::DeployConvertAction()
+{
+	auto const pTypeExt = this->TypeExtData;
+	if (!pTypeExt->Convert_Deploy && !pTypeExt->Convert_Undeploy)
+		return;
+
+	auto const pThis = this->OwnerObject();
+	if (pThis->WhatAmI() != AbstractType::Infantry)
+		return;
+
+	auto const pInf = static_cast<InfantryClass*>(pThis);
+	const auto curSeq = pInf->SequenceAnim;
+
+	if (curSeq != Sequence::Deploy && curSeq != Sequence::Undeploy)
+	{
+		this->HasDeployConvertedInCurrentSequence = false;
+		return;
+	}
+
+	if (this->HasDeployConvertedInCurrentSequence)
+		return;
+
+	if (curSeq == Sequence::Deploy && pTypeExt->Convert_Deploy)
+	{
+		this->HasDeployConvertedInCurrentSequence = true;
+		TechnoExt::ConvertToType(pInf, pTypeExt->Convert_Deploy);
+	}
+	else if (curSeq == Sequence::Undeploy && pTypeExt->Convert_Undeploy)
+	{
+		this->HasDeployConvertedInCurrentSequence = true;
+		TechnoExt::ConvertToType(pInf, pTypeExt->Convert_Undeploy);
+	}
+}
+
 // Subterranean harvester factory exit state machine.
 void TechnoExt::ExtData::UpdateSubterraneanHarvester()
 {

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -219,16 +219,17 @@ void TechnoExt::ExtData::AmmoAutoConvertActions()
 
 void TechnoExt::ExtData::DeployConvertAction()
 {
-	auto const pTypeExt = this->TypeExtData;
+	const auto pTypeExt = this->TypeExtData;
+
 	if (!pTypeExt->Convert_Deploy && !pTypeExt->Convert_Undeploy)
 		return;
 
-	auto const pThis = this->OwnerObject();
-	if (pThis->WhatAmI() != AbstractType::Infantry)
+	const auto pThis = abstract_cast<InfantryClass*, true>(this->OwnerObject());
+
+	if (!pThis)
 		return;
 
-	auto const pInf = static_cast<InfantryClass*>(pThis);
-	const auto curSeq = pInf->SequenceAnim;
+	const auto curSeq = pThis->SequenceAnim;
 
 	if (curSeq != Sequence::Deploy && curSeq != Sequence::Undeploy)
 	{
@@ -242,12 +243,12 @@ void TechnoExt::ExtData::DeployConvertAction()
 	if (curSeq == Sequence::Deploy && pTypeExt->Convert_Deploy)
 	{
 		this->HasDeployConvertedInCurrentSequence = true;
-		TechnoExt::ConvertToType(pInf, pTypeExt->Convert_Deploy);
+		TechnoExt::ConvertToType(pThis, pTypeExt->Convert_Deploy);
 	}
 	else if (curSeq == Sequence::Undeploy && pTypeExt->Convert_Undeploy)
 	{
 		this->HasDeployConvertedInCurrentSequence = true;
-		TechnoExt::ConvertToType(pInf, pTypeExt->Convert_Undeploy);
+		TechnoExt::ConvertToType(pThis, pTypeExt->Convert_Undeploy);
 	}
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1341,6 +1341,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->HoverShutdown)
 		.Process(this->LastTargetCrd)
 		.Process(this->LastTargetCrdClearTimer)
+		.Process(this->HasDeployConvertedInCurrentSequence)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -106,6 +106,8 @@ public:
 		CoordStruct LastTargetCrd;
 		CDTimerClass LastTargetCrdClearTimer;
 
+		bool HasDeployConvertedInCurrentSequence;
+
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
 			, Shield {}
@@ -177,6 +179,8 @@ public:
 			, HoverShutdown { false }
 			, LastTargetCrd { CoordStruct::Empty }
 			, LastTargetCrdClearTimer {}
+
+			, HasDeployConvertedInCurrentSequence { false }
 		{ }
 
 		void OnEarlyUpdate();
@@ -218,7 +222,7 @@ public:
 
 		void AmmoAutoConvertActions();
 		void DeployConvertAction();
-		bool HasDeployConvertedInCurrentSequence = false;
+
 		void UpdateLastTargetCrd();
 		int GetSight();
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -217,6 +217,8 @@ public:
 		void UpdateTintValues();
 
 		void AmmoAutoConvertActions();
+		void DeployConvertAction();
+		bool HasDeployConvertedInCurrentSequence = false;
 		void UpdateLastTargetCrd();
 		int GetSight();
 

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -61,6 +61,7 @@ DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
 	pExt->UpdateWarpInDelay();
 	pExt->UpdateTiberiumEater();
 	pExt->AmmoAutoConvertActions();
+	pExt->DeployConvertAction();
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -49,7 +49,6 @@ DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
 	pExt->UpdateWarpInDelay();
 	pExt->UpdateTiberiumEater();
 	pExt->AmmoAutoConvertActions();
-	pExt->DeployConvertAction();
 
 	return 0;
 }

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1010,6 +1010,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->CurleyShuffle.Read(exINI, pSection, "CurleyShuffle");
 
 	this->Convert_Deploy.Read(exINI, pSection, "Convert.Deploy");
+	this->Convert_Undeploy.Read(exINI, pSection, "Convert.Undeploy");
 	this->Convert_HumanToComputer.Read(exINI, pSection, "Convert.HumanToComputer");
 	this->Convert_ComputerToHuman.Read(exINI, pSection, "Convert.ComputerToHuman");
 	this->Convert_ResetMindControl.Read(exINI, pSection, "Convert.ResetMindControl");
@@ -1736,6 +1737,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->TiberiumEaterType)
 
 		.Process(this->Convert_Deploy)
+		.Process(this->Convert_Undeploy)
 		.Process(this->Convert_HumanToComputer)
 		.Process(this->Convert_ComputerToHuman)
 		.Process(this->Convert_ResetMindControl)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -289,6 +289,7 @@ public:
 		Nullable<bool> CurleyShuffle;
 
 		Valueable<TechnoTypeClass*> Convert_Deploy; // Ares
+		Valueable<TechnoTypeClass*> Convert_Undeploy;
 		Valueable<TechnoTypeClass*> Convert_HumanToComputer;
 		Valueable<TechnoTypeClass*> Convert_ComputerToHuman;
 		Valueable<bool> Convert_ResetMindControl;
@@ -771,6 +772,7 @@ public:
 			, CurleyShuffle {}
 
 			, Convert_Deploy { }
+			, Convert_Undeploy { }
 			, Convert_HumanToComputer { }
 			, Convert_ComputerToHuman { }
 			, Convert_ResetMindControl { false }


### PR DESCRIPTION
Now infantry can perform type conversion when executing the `Deploy` and `Undeploy` sequences.

<img width="257" height="134" alt="Convert (Un)deploy" src="https://github.com/user-attachments/assets/933ac552-003f-4a97-83fd-3ff3b9758a50" />

*E1↔GGI, YURI↔YURIPR, E2→BORIS*

In `rulesmd.ini`:
```ini
[SOMEINFANTRY]             ; InfantryType
Convert.Deploy=            ; InfantryType
Convert.Undeploy=          ; InfantryType
```

> [!Note]
> For the sake of logical clarity, this feature does not allow the converted unit to trigger another conversion before the current sequence ends. If continuous conversion is needed, please use `Convert.Land/Water`.