### PR TITLE
Allow `RemoveMindControl` and `MindControl.Permanent` warheads to mute `MindClearedSound`

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2452,7 +2452,7 @@ MergeBuildingDamage=         ; boolean
 *Mind control break warhead being utilized in [RA2: Reboot](https://www.moddb.com/mods/reboot)*
 
 - Warheads can now break mind control (doesn't apply to perma-MC-ed objects).
-- `RemoveMindControl.Silent` can be used to mute the `MindClearedSound` sound effect.
+- Both `RemoveMindControl` and `MindControl.Permanent` will remove the target's original conventional mind control effect and play the `MindClearedSound` sound effect. This can now be configured via `RemoveMindControl.Silent`, which defaults to `[AudioVisual] -> RemoveMindControl.Silent` for removing conventional mind control, and defaults to `[AudioVisual] -> MindControl.Permanent.ReplaceSilent` for cases where permanent mind control replaces conventional mind control.
 
 ```{hint}
 You can simply use this flag to reduce some noise, or play another sound effect at the same time when muting the original sound effect...
@@ -2461,11 +2461,12 @@ You can simply use this flag to reduce some noise, or play another sound effect 
 In `rulesmd.ini`:
 ```ini
 [AudioVisual]
-RemoveMindControl.Silent=false  ; boolean
+RemoveMindControl.Silent=false             ; boolean
+MindControl.Permanent.ReplaceSilent=false  ; boolean
 
-[SOMEWARHEAD]                   ; WarheadType
-RemoveMindControl=false         ; boolean
-RemoveMindControl.Silent=       ; boolean, default to [AudioVisual] -> RemoveMindControl.Silent
+[SOMEWARHEAD]                              ; WarheadType
+RemoveMindControl=false                    ; boolean
+RemoveMindControl.Silent=                  ; boolean, normal removal defaults to [AudioVisual] -> RemoveMindControl.Silent, permanent replacement defaults to [AudioVisual] -> MindControl.Permanent.ReplaceSilent
 ```
 
 ### CellSpread enhancement

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2452,11 +2452,20 @@ MergeBuildingDamage=         ; boolean
 *Mind control break warhead being utilized in [RA2: Reboot](https://www.moddb.com/mods/reboot)*
 
 - Warheads can now break mind control (doesn't apply to perma-MC-ed objects).
+- `RemoveMindControl.Silent` can be used to mute the `MindClearedSound` sound effect.
+
+```{hint}
+You can simply use this flag to reduce some noise, or play another sound effect at the same time when muting the original sound effect...
+```
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWARHEAD]            ; WarheadType
-RemoveMindControl=false  ; boolean
+[AudioVisual]
+RemoveMindControl.Silent=false  ; boolean
+
+[SOMEWARHEAD]                   ; WarheadType
+RemoveMindControl=false         ; boolean
+RemoveMindControl.Silent=       ; boolean, default to [AudioVisual] -> RemoveMindControl.Silent
 ```
 
 ### CellSpread enhancement

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -738,6 +738,7 @@ HideShakeEffects=false           ; boolean
 - Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building upgrades (by Ollerus & NetsuNegi)
 - [Aux technos and TechLevel requirement of superweapon](New-or-Enhanced-Logics.md#aux-technos-and-techlevel-requirement-of-superweapon) (by NetsuNegi & Ollerus)
 - [Export interface for external call](index.md#interoperability) (by TaranDahl)
+- Allowed `MindControl.Permanent` warhead to mute `MindClearedSound` (by NetsuNegi & Noble_Fish)
 
 ```
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -579,6 +579,7 @@ HideShakeEffects=false           ; boolean
 - [Allow customizing guard mission retry delay for buildings with weapons](Fixed-or-Improved-Logics.md#armed-building-guard-retry-delay) (by Starkku)
 - [Allow `Temporal` warhead to apply ratio and bonus](Fixed-or-Improved-Logics.md#allow-temporal-warhead-to-apply-ratio-and-bonus) (by NetsuNegi)
 - Allow enabling a looser movement state check for the `DiscardOn=move` condition of AE to support more usage scenarios (by Noble_Fish)
+- Allow `RemoveMindControl` warhead to mute `MindClearedSound` (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -415,6 +415,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->DiscardOn_MoveBasedOnDestination.Read(exINI, GameStrings::General, "DiscardOn.MoveBasedOnDestination");
 
+	this->RemoveMindControl_Silent.Read(exINI, GameStrings::AudioVisual, "RemoveMindControl.Silent");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -747,6 +749,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Temporal_ApplyVersus)
 		.Process(this->Temporal_ApplyMultiplier)
 		.Process(this->DiscardOn_MoveBasedOnDestination)
+		.Process(this->RemoveMindControl_Silent)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -416,6 +416,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->DiscardOn_MoveBasedOnDestination.Read(exINI, GameStrings::General, "DiscardOn.MoveBasedOnDestination");
 
 	this->RemoveMindControl_Silent.Read(exINI, GameStrings::AudioVisual, "RemoveMindControl.Silent");
+	this->MindControl_Permanent_ReplaceSilent.Read(exINI, GameStrings::AudioVisual, "MindControl.Permanent.ReplaceSilent");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -750,6 +751,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Temporal_ApplyMultiplier)
 		.Process(this->DiscardOn_MoveBasedOnDestination)
 		.Process(this->RemoveMindControl_Silent)
+		.Process(this->MindControl_Permanent_ReplaceSilent)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -358,6 +358,7 @@ public:
 		Valueable<bool> Temporal_ApplyMultiplier;
 
 		Valueable<bool> DiscardOn_MoveBasedOnDestination;
+		Valueable<bool> RemoveMindControl_Silent;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -654,6 +655,7 @@ public:
 			, Temporal_ApplyVersus { false }
 			, Temporal_ApplyMultiplier { false }
 			, DiscardOn_MoveBasedOnDestination { false }
+			, RemoveMindControl_Silent { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -359,6 +359,7 @@ public:
 
 		Valueable<bool> DiscardOn_MoveBasedOnDestination;
 		Valueable<bool> RemoveMindControl_Silent;
+		Valueable<bool> MindControl_Permanent_ReplaceSilent;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -656,6 +657,7 @@ public:
 			, Temporal_ApplyMultiplier { false }
 			, DiscardOn_MoveBasedOnDestination { false }
 			, RemoveMindControl_Silent { false }
+			, MindControl_Permanent_ReplaceSilent { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -153,6 +153,7 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->Conventional_IgnoreUnits.Read(exINI, pSection, "Conventional.IgnoreUnits");
 	this->RemoveDisguise.Read(exINI, pSection, "RemoveDisguise");
 	this->RemoveMindControl.Read(exINI, pSection, "RemoveMindControl");
+	this->RemoveMindControl_Silent.Read(exINI, pSection, "RemoveMindControl.Silent");
 	this->RemoveParasite.Read(exINI, pSection, "RemoveParasite");
 	this->RemoveParasite_Allow.Read(exINI, pSection, "RemoveParasite.Allow");
 	this->RemoveParasite_Disallow.Read(exINI, pSection, "RemoveParasite.Disallow");
@@ -540,6 +541,7 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Conventional_IgnoreUnits)
 		.Process(this->RemoveDisguise)
 		.Process(this->RemoveMindControl)
+		.Process(this->RemoveMindControl_Silent)
 		.Process(this->RemoveParasite)
 		.Process(this->RemoveParasite_Allow)
 		.Process(this->RemoveParasite_Disallow)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -40,6 +40,7 @@ public:
 		Valueable<bool> Conventional_IgnoreUnits;
 		Valueable<bool> RemoveDisguise;
 		Valueable<bool> RemoveMindControl;
+		Nullable<bool> RemoveMindControl_Silent;
 		Nullable<bool> RemoveParasite;
 		ValueableVector<TechnoTypeClass*> RemoveParasite_Allow;
 		ValueableVector<TechnoTypeClass*> RemoveParasite_Disallow;
@@ -300,6 +301,7 @@ public:
 			, Conventional_IgnoreUnits { false }
 			, RemoveDisguise { false }
 			, RemoveMindControl { false }
+			, RemoveMindControl_Silent {}
 			, RemoveParasite {}
 			, RemoveParasite_Allow {}
 			, RemoveParasite_Disallow {}

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -5,6 +5,7 @@
 #include <Misc/FlyingStrings.h>
 #include <Utilities/Helpers.Alex.h>
 #include <Utilities/AresFunctions.h>
+#include <Ext/CaptureManager/Body.h>
 
 #pragma region CreateGap Calls
 
@@ -459,7 +460,7 @@ HouseClass* WarheadTypeExt::ExtData::ApplyRemoveMindControl(HouseClass* pHouse, 
 {
 	if (const auto pController = pTarget->MindControlledBy)
 	{
-		pController->CaptureManager->FreeUnit(pTarget);
+		CaptureManagerExt::FreeUnit(pController->CaptureManager, pTarget, this->RemoveMindControl_Silent.Get(RulesExt::Global()->RemoveMindControl_Silent));
 		return pTarget->Owner;
 	}
 

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -6,6 +6,7 @@
 #include <Ext/Sidebar/Body.h>
 #include <Ext/EBolt/Body.h>
 #include <Ext/SWType/Body.h>
+#include <Ext/CaptureManager/Body.h>
 
 #include <New/Entity/Ares/RadarJammerClass.h>
 
@@ -76,13 +77,22 @@ static bool __fastcall SW_IsAvailable(SuperWeaponTypeClass** pExt_Ares, void*, H
 
 namespace PermaMCTemp
 {
+	WarheadTypeClass* Warhead = nullptr;
 	bool Selected = false;
+}
+
+static bool __fastcall ApplyPermaMC_Wrapper(WarheadTypeClass** pExt_Ares, void*, HouseClass* pSourceHouse, AbstractClass* pTarget)
+{
+	PermaMCTemp::Warhead = *pExt_Ares;
+	const bool result = AresFunctions::ApplyPermaMC(pExt_Ares, pSourceHouse, pTarget);
+	PermaMCTemp::Warhead = nullptr;
+	return result;
 }
 
 static bool __fastcall PermaMC_FreeUnit_SetContext(CaptureManagerClass* pManager, void*, TechnoClass* pTechno)
 {
 	PermaMCTemp::Selected = pTechno->IsSelected;
-	return pManager->FreeUnit(pTechno);
+	return CaptureManagerExt::FreeUnit(pManager, pTechno, WarheadTypeExt::ExtMap.Find(PermaMCTemp::Warhead)->RemoveMindControl_Silent.Get(RulesExt::Global()->MindControl_Permanent_ReplaceSilent));
 }
 
 static bool __fastcall PermaMC_SetOwningHouse_Select(TechnoClass* pTechno, void*, HouseClass* pHouse, bool announce)
@@ -194,6 +204,10 @@ void Apply_Ares3_0_Patches()
 	// Remove Ares check for houses for Psychedelic=yes Warheads.
 	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4AAAA, { 0x31, 0xC0, 0x90, 0x90, 0x90, 0x90 });
 
+	// Get warhead of MindControl.Permanent
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x5385A, &ApplyPermaMC_Wrapper);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x717C3, &ApplyPermaMC_Wrapper);
+
 	// Handle select of PsyDom
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x36107, &PermaMC_FreeUnit_SetContext);
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x36115, &PermaMC_SetOwningHouse_Select);
@@ -279,6 +293,10 @@ void Apply_Ares3_0p1_Patches()
 
 	// Remove Ares check for houses for Psychedelic=yes Warheads.
 	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x4B70A, { 0x31, 0xC0, 0x90, 0x90, 0x90, 0x90 });
+
+	// Get warhead of MindControl.Permanent
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x5450A, &ApplyPermaMC_Wrapper);
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x727E3, &ApplyPermaMC_Wrapper);
 
 	// Handle select of PsyDom
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x36BA7, &PermaMC_FreeUnit_SetContext);

--- a/src/Utilities/AresAddressInit.cpp
+++ b/src/Utilities/AresAddressInit.cpp
@@ -10,6 +10,7 @@ decltype(AresFunctions::SpawnSurvivors) AresFunctions::SpawnSurvivors = nullptr;
 decltype(AresFunctions::ReverseEngineer) AresFunctions::ReverseEngineer = nullptr;
 decltype(AresFunctions::IsTargetConstraintsEligible) AresFunctions::IsTargetConstraintsEligible = nullptr;
 decltype(AresFunctions::UnitDeliveryStateMachine_Update) AresFunctions::UnitDeliveryStateMachine_Update = nullptr;
+decltype(AresFunctions::ApplyPermaMC) AresFunctions::ApplyPermaMC = nullptr;
 decltype(AresFunctions::DetailsCurrentlyEnabled) AresFunctions::DetailsCurrentlyEnabled = nullptr;
 std::function<AresSWTypeExtData* (SuperWeaponTypeClass*)> AresFunctions::SWTypeExtMap_Find;
 PhobosMap<ObjectClass*, AlphaShapeClass*>* AresFunctions::AlphaExtMap = nullptr;
@@ -47,6 +48,8 @@ void AresFunctions::InitAres3_0()
 	NOTE_ARES_FUN(IsTargetConstraintsEligible, 0x032110);
 
 	NOTE_ARES_FUN(UnitDeliveryStateMachine_Update, 0x075DE0);
+
+	NOTE_ARES_FUN(ApplyPermaMC, 0x052CD0);
 
 	NOTE_ARES_FUN(DetailsCurrentlyEnabled, 0x02A6C0);
 
@@ -90,6 +93,8 @@ void AresFunctions::InitAres3_0p1()
 	NOTE_ARES_FUN(IsTargetConstraintsEligible, 0x032AF0);
 
 	NOTE_ARES_FUN(UnitDeliveryStateMachine_Update, 0x076E90);
+
+	NOTE_ARES_FUN(ApplyPermaMC, 0x053980);
 
 	NOTE_ARES_FUN(DetailsCurrentlyEnabled, 0x02B1C0);
 

--- a/src/Utilities/AresFunctions.h
+++ b/src/Utilities/AresFunctions.h
@@ -39,6 +39,9 @@ public:
 
 	static void(__thiscall* UnitDeliveryStateMachine_Update)(void*);
 
+	// WarheadTypeExt::ExtData
+	static bool(__thiscall* ApplyPermaMC)(void*, HouseClass* pSourceHouse, AbstractClass* pTarget);
+
 	static bool (*DetailsCurrentlyEnabled)();
 
 	static std::function<AresSWTypeExtData* (SuperWeaponTypeClass*)> SWTypeExtMap_Find;


### PR DESCRIPTION
Both `RemoveMindControl` and `MindControl.Permanent` will remove the target's original conventional mind control effect and play the `MindClearedSound` sound effect. This can now be configured via `RemoveMindControl.Silent`, which defaults to `[AudioVisual] -> RemoveMindControl.Silent` for removing conventional mind control, and defaults to `[AudioVisual] -> MindControl.Permanent.ReplaceSilent` for cases where permanent mind control replaces conventional mind control.

https://github.com/user-attachments/assets/836b6cec-4da1-4d3f-9491-df2cb60b7fc3

https://github.com/user-attachments/assets/55f852ce-38d6-42f5-b5e7-0367e88874c0

> [!Tip]
> You can simply use this flag to reduce some noise, or play another sound effect at the same time when muting the original sound effect...