### PR TITLE
Introduce weight selection rules for ExtraWarheads

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -3138,6 +3138,9 @@ ExtraRange.Prefiring.IncludeBurst=              ; boolean, default to [General] 
   - `ExtraWarheads.DetonationChances` can be used to customize the chance of each extra Warhead detonation occuring. Value from position matching the position from `ExtraWarheads` is used if found, or last listed value if not found. If list is empty, every extra Warhead detonation is guaranteed to occur.
   - `ExtraWarheads.FullDetonation` can be used to customize whether or not each individual Warhead is detonated fully (as part of a dummy weapon) or simply deals area damage and applies Phobos' Warhead effects. Value from position matching the position from `ExtraWarheads` is used if found, or last listed value if not found. If list is empty, defaults to true.
   - Note that the listed Warheads must be listed in `[Warheads]` for them to work.
+- These warheads can be made random with these optional tags. The game will randomly choose only a single warhead from the list for each roll chance provided.
+  - `ExtraWarheads.RollChances` lists chances of each "dice roll" happening. Valid values range from 0% (never happens) to 100% (always happens). Defaults to a single sure roll.
+  - `ExtraWarheads.RandomWeightsN` lists the weights for each "dice roll" that increase the probability of picking a specific warhead. Valid values are 0 (don't pick) and above (the higher value, the bigger the likelyhood). `RandomWeights` are a valid alias for `RandomWeights0`. If a roll attempt doesn't have weights specified, the last weights will be used.
 
 In `rulesmd.ini`:
 ```ini
@@ -3146,6 +3149,8 @@ ExtraWarheads=                    ; List of WarheadTypes
 ExtraWarheads.DamageOverrides=    ; List of integers
 ExtraWarheads.DetonationChances=  ; List of floating-point values (percentage or absolute)
 ExtraWarheads.FullDetonation=     ; List of booleans
+ExtraWarheads.RollChances=        ; List of percentages
+ExtraWarheads.RandomWeightsN=     ; List of integers
 ```
 
 ### Feedback weapon

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -579,6 +579,7 @@ HideShakeEffects=false           ; boolean
 - [Allow customizing guard mission retry delay for buildings with weapons](Fixed-or-Improved-Logics.md#armed-building-guard-retry-delay) (by Starkku)
 - [Allow `Temporal` warhead to apply ratio and bonus](Fixed-or-Improved-Logics.md#allow-temporal-warhead-to-apply-ratio-and-bonus) (by NetsuNegi)
 - Allow enabling a looser movement state check for the `DiscardOn=move` condition of AE to support more usage scenarios (by Noble_Fish)
+- Introduce weight selection rules for ExtraWarheads (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Bullet/Hooks.DetonateLogics.cpp
+++ b/src/Ext/Bullet/Hooks.DetonateLogics.cpp
@@ -379,50 +379,92 @@ DEFINE_HOOK(0x469AA4, BulletClass_Logics_Extras, 0x5)
 		auto const& extraWarheads = pWeaponExt->ExtraWarheads;
 		auto const& damageOverrides = pWeaponExt->ExtraWarheads_DamageOverrides;
 		auto const& detonationChances = pWeaponExt->ExtraWarheads_DetonationChances;
+		auto const& rollChances = pWeaponExt->ExtraWarheads_RollChances;
 		auto const& fullDetonation = pWeaponExt->ExtraWarheads_FullDetonation;
 		const int defaultDamage = pWeapon->Damage;
 		auto& random = ScenarioClass::Instance->Random;
 
-		for (size_t i = 0; i < extraWarheads.size(); i++)
+		auto const pTarget = abstract_cast<TechnoClass*>(pThis->Target);
+
+		auto detonateWarhead = [&](int index)
+			{
+				if (index < 0 || index >= static_cast<int>(extraWarheads.size()))
+					return;
+
+				auto const pWH = extraWarheads[index];
+				auto const pWHExt = WarheadTypeExt::ExtMap.Find(pWH);
+
+				if (pTarget && (!pWHExt->IsHealthInThreshold(pTarget) || !pWHExt->IsVeterancyInThreshold(pTarget)))
+					return;
+
+				int damage = defaultDamage;
+				size_t size = damageOverrides.size();
+				if (size > static_cast<size_t>(index))
+					damage = damageOverrides[index];
+				else if (size > 0)
+					damage = damageOverrides[size - 1];
+
+				size = fullDetonation.size();
+				bool isFull = true;
+				if (size > static_cast<size_t>(index))
+					isFull = fullDetonation[index];
+				else if (size > 0)
+					isFull = fullDetonation[size - 1];
+
+				if (isFull)
+					WarheadTypeExt::DetonateAt(pWH, *coords, pTechno, damage, pOwner, pThis->Target);
+				else
+					pWHExt->DamageAreaWithTarget(*coords, damage, pTechno, pWH, true, pOwner, pTarget);
+			};
+
+		if (pWeaponExt->ExtraWarheads_WeightsData.size() > 0)
 		{
-			auto const pWH = extraWarheads[i];
-			auto const pWHExt = WarheadTypeExt::ExtMap.Find(pWH);
-			auto const pTarget = abstract_cast<TechnoClass*>(pThis->Target);
+			size_t rollCount = rollChances.size();
+			if (rollCount == 0)
+				rollCount = 1;
 
-			if (pTarget && !pWHExt->IsHealthInThreshold(pTarget) && !pWHExt->IsVeterancyInThreshold(pTarget))
-				continue;
+			for (size_t i = 0; i < rollCount; i++)
+			{
+				double dice = random.RandomDouble();
+				if (rollChances.size() > 0 && dice > rollChances[i])
+					continue;
 
-			int damage = defaultDamage;
-			size_t size = damageOverrides.size();
+				const size_t weightIndex = std::min(i, pWeaponExt->ExtraWarheads_WeightsData.size() - 1);
+				const auto& weights = pWeaponExt->ExtraWarheads_WeightsData[weightIndex];
 
-			if (size > i)
-				damage = damageOverrides[i];
-			else if (size > 0)
-				damage = damageOverrides[size - 1];
+				int selectedIndex = GeneralUtils::ChooseOneWeighted(dice, &weights);
 
-			size = detonationChances.size();
-			bool detonate = true;
+				bool detonate = true;
+				size_t chanceSize = detonationChances.size();
+				if (chanceSize > 0)
+				{
+					double chanceDice = random.RandomDouble();
+					if (chanceSize > static_cast<size_t>(selectedIndex))
+						detonate = detonationChances[selectedIndex] >= chanceDice;
+					else
+						detonate = detonationChances[chanceSize - 1] >= chanceDice;
+				}
 
-			if (size > i)
-				detonate = detonationChances[i] >= random.RandomDouble();
-			else if (size > 0)
-				detonate = detonationChances[size - 1] >= random.RandomDouble();
+				if (detonate)
+					detonateWarhead(selectedIndex);
+			}
+		}
+		else
+		{
+			for (size_t i = 0; i < extraWarheads.size(); i++)
+			{
+				size_t size = detonationChances.size();
+				bool detonate = true;
+				if (size > i)
+					detonate = detonationChances[i] >= random.RandomDouble();
+				else if (size > 0)
+					detonate = detonationChances[size - 1] >= random.RandomDouble();
 
-			size = fullDetonation.size();
-			bool isFull = true;
+				if (!detonate)
+					continue;
 
-			if (size > i)
-				isFull = fullDetonation[i];
-			else if (size > 0)
-				isFull = fullDetonation[size - 1];
-
-			if (!detonate)
-				continue;
-
-			if (isFull)
-				WarheadTypeExt::DetonateAt(pWH, *coords, pTechno, damage, pOwner, pThis->Target);
-			else
-				pWHExt->DamageAreaWithTarget(*coords, damage, pTechno, pWH, true, pOwner, pTarget);
+				detonateWarhead(static_cast<int>(i));
+			}
 		}
 	}
 

--- a/src/Ext/WeaponType/Body.cpp
+++ b/src/Ext/WeaponType/Body.cpp
@@ -129,6 +129,30 @@ void WeaponTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ExtraWarheads.Read(exINI, pSection, "ExtraWarheads");
 	this->ExtraWarheads_DamageOverrides.Read(exINI, pSection, "ExtraWarheads.DamageOverrides");
 	this->ExtraWarheads_DetonationChances.Read(exINI, pSection, "ExtraWarheads.DetonationChances");
+	this->ExtraWarheads_RollChances.Read(exINI, pSection, "ExtraWarheads.RollChances");
+
+	// ExtraWarheads.RandomWeights
+	for (size_t i = 0; ; ++i)
+	{
+		ValueableVector<int> weights3;
+		_snprintf_s(tempBuffer, sizeof(tempBuffer), "ExtraWarheads.RandomWeights%d", i);
+		weights3.Read(exINI, pSection, tempBuffer);
+
+		if (!weights3.size())
+			break;
+
+		this->ExtraWarheads_WeightsData.emplace_back(std::move(weights3));
+	}
+	ValueableVector<int> weights3;
+	weights3.Read(exINI, pSection, "ExtraWarheads.RandomWeights");
+	if (weights3.size())
+	{
+		if (this->ExtraWarheads_WeightsData.size())
+			this->ExtraWarheads_WeightsData[0] = std::move(weights3);
+		else
+			this->ExtraWarheads_WeightsData.emplace_back(std::move(weights3));
+	}
+
 	this->ExtraWarheads_FullDetonation.Read(exINI, pSection, "ExtraWarheads.FullDetonation");
 	this->AmbientDamage_Warhead.Read<true>(exINI, pSection, "AmbientDamage.Warhead");
 	this->AmbientDamage_IgnoreTarget.Read(exINI, pSection, "AmbientDamage.IgnoreTarget");
@@ -228,6 +252,8 @@ void WeaponTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ExtraWarheads)
 		.Process(this->ExtraWarheads_DamageOverrides)
 		.Process(this->ExtraWarheads_DetonationChances)
+		.Process(this->ExtraWarheads_RollChances)
+		.Process(this->ExtraWarheads_WeightsData)
 		.Process(this->ExtraWarheads_FullDetonation)
 		.Process(this->AmbientDamage_Warhead)
 		.Process(this->AmbientDamage_IgnoreTarget)

--- a/src/Ext/WeaponType/Body.h
+++ b/src/Ext/WeaponType/Body.h
@@ -57,6 +57,8 @@ public:
 		ValueableVector<WarheadTypeClass*> ExtraWarheads;
 		ValueableVector<int> ExtraWarheads_DamageOverrides;
 		ValueableVector<double> ExtraWarheads_DetonationChances;
+		ValueableVector<float> ExtraWarheads_RollChances;
+		std::vector<ValueableVector<int>> ExtraWarheads_WeightsData;
 		ValueableVector<bool> ExtraWarheads_FullDetonation;
 		Nullable<WarheadTypeClass*> AmbientDamage_Warhead;
 		Valueable<bool> AmbientDamage_IgnoreTarget;
@@ -146,6 +148,8 @@ public:
 			, ExtraWarheads {}
 			, ExtraWarheads_DamageOverrides {}
 			, ExtraWarheads_DetonationChances {}
+			, ExtraWarheads_RollChances {}
+			, ExtraWarheads_WeightsData {}
 			, ExtraWarheads_FullDetonation {}
 			, AmbientDamage_Warhead {}
 			, AmbientDamage_IgnoreTarget { false }


### PR DESCRIPTION
This will first perform a random selection before using `ExtraWarheads.DetonationChances` , and the selected warheads will then each use `ExtraWarheads.DetonationChances` to decide whether to detonate or not.