### PR TITLE
Dehardcode of parasites unlimboing after killing naval targets

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -794,7 +794,7 @@ This page lists all the individual contributions to the project by their author.
 - **E1 Elite** - TileSet 255 and above bridge repair fix
 - **AutoGavy** - interceptor logic, Warhead critical hit logic
 - **Chasheen (Chasheenburg)** - CN docs help for Build#24
-- **Noble Fish** - some minor improvements and fixes, established Community Chinese docs, took over and completely rewrite the Official Chinese docs during Build#46
+- **Noble Fish** - some minor improvements and fixes, established Community Chinese docs, took over and completely rewrite the Official Chinese docs during Build#46, Dehardcode of parasites unlimboing after killing naval targets
 - **tomsons26** - all-around help, assistance and guidance in reverse-engineering, YR binary mappings
 - **CCHyper** - all-around help, current project logo, assistance and guidance in reverse-engineering, YR binary mappings, custom locomotors example implementation
 - **AlexB** - Original FlyingStrings implementation

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1745,19 +1745,18 @@ How to generate `DebrisTypes` in the game:
 
 ### Dehardcode of parasites unlimboing after killing naval targets
 
-In vanilla, parasites with `Naval=no` perform a series of additional checks on the current cell after killing a target, including various determinations such as whether there is a bridge when the cell's LandType is `Water`, `Beach`, or `Rock`, which prevents them from normally unlimbo directly on open water. Now, you can customize whether to perform these additional checks.
+- In vanilla, parasites with `Naval=false` perform a series of additional checks on the current cell after killing a target, including a series of determinations such as whether there is a bridge when the cell's LandType is `Water`, `Beach`, or `Rock`, which prevents them from normally unlimbo in open water; while parasites with `Naval=true` skip these checks. Now, you can customize the behavior of parasites after killing a target in water:
+  - If not set, the original behavior is performed by default.
+  - If set to `true`, they can unlimbo normally even if `Naval=false`.
+  - If set to `false`, they cannot unlimbo normally even if `Naval=true`.
 
 In `rulesmd.ini`:
 ```ini
 [General]
-Parasite.SkipNavalCheck=true  ; boolean
+Parasite.AllowWaterExit=  ; boolean
 
-[SOMETECHNO]                  ; TechnoType
-Parasite.SkipNavalCheck=      ; boolean, defaults to [General] -> Parasite.SkipNavalCheck
-```
-
-```{note}
-This does not change the check for whether a BuildingType exists on the cell, which is also required even if it has `Naval=true`.
+[SOMETECHNO]              ; TechnoType
+Parasite.AllowWaterExit=  ; boolean, defaults to [General] -> Parasite.AllowWaterExit
 ```
 
 ### DropPod

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1759,6 +1759,10 @@ Parasite.AllowWaterExit=  ; boolean
 Parasite.AllowWaterExit=  ; boolean, defaults to [General] -> Parasite.AllowWaterExit
 ```
 
+```{note}
+Setting `Parasite.AllowWaterExit` to `true` does not skip the original check of whether a BuildingType exists on the cell.
+```
+
 ### DropPod
 
 - DropPod properties can now be customized on a per-TechnoType (non-building) basis.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1743,6 +1743,23 @@ How to generate `DebrisTypes` in the game:
 4. When the number of debris generated after a single traversal is not enough to exceed the total number, it will end if `DebrisTypes.Limit` is enabled, otherwise the traversal will restart like vanilla game do.
 ```
 
+### Dehardcode of parasites unlimboing after killing naval targets
+
+In vanilla, parasites with `Naval=no` perform a series of additional checks on the current cell after killing a target, including various determinations such as whether there is a bridge when the cell's LandType is `Water`, `Beach`, or `Rock`, which prevents them from normally unlimbo directly on open water. Now, you can customize whether to perform these additional checks.
+
+In `rulesmd.ini`:
+```ini
+[General]
+Parasite.WaterExit.RequireNaval=true  ; boolean
+
+[SOMETECHNO]                          ; TechnoType
+Parasite.WaterExit.RequireNaval=      ; boolean, defaults to [General] -> Parasite.WaterExit.RequireNaval
+```
+
+```{note}
+This does not change the check for whether a BuildingType exists on the cell, which is also required even if it has `Naval=true`.
+```
+
 ### DropPod
 
 - DropPod properties can now be customized on a per-TechnoType (non-building) basis.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1750,10 +1750,10 @@ In vanilla, parasites with `Naval=no` perform a series of additional checks on
 In `rulesmd.ini`:
 ```ini
 [General]
-Parasite.WaterExit.RequireNaval=true  ; boolean
+Parasite.SkipNavalCheck=true  ; boolean
 
-[SOMETECHNO]                          ; TechnoType
-Parasite.WaterExit.RequireNaval=      ; boolean, defaults to [General] -> Parasite.WaterExit.RequireNaval
+[SOMETECHNO]                  ; TechnoType
+Parasite.SkipNavalCheck=      ; boolean, defaults to [General] -> Parasite.SkipNavalCheck
 ```
 
 ```{note}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -585,6 +585,7 @@ HideShakeEffects=false           ; boolean
 - [Building turret idle/firing/low power animations](Fixed-or-Improved-Logics.md#building-turret-animations) (by Starkku)
 - [Add action `512 Set Follower for Associated Unit...`](AI-Scripting-and-Mapping.md#set-follower-for-associated-unit) (by Noble_Fish)
 - [Dynamic team delays](AI-Scripting-and-Mapping.md#dynamic-team-delays) (by Ollerus)
+- [Dehardcode of parasites unlimboing after killing naval targets](Fixed-or-Improved-Logics.md#dehardcode-of-parasites-unlimboing-after-killing-naval-targets) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -335,7 +335,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AttackMove_StopWhenTargetAcquired.Read(exINI, GameStrings::General, "AttackMove.StopWhenTargetAcquired");
 
 	this->Parasite_GrappleAnim.Read(exINI, GameStrings::AudioVisual, "Parasite.GrappleAnim");
-	this->Parasite_ExitAnywhere.Read(exINI, GameStrings::General, "Parasite.ExitAnywhere");
+	this->Parasite_SkipNavalCheck.Read(exINI, GameStrings::General, "Parasite.SkipNavalCheck");
 
 	this->AINormalTargetingDelay.Read(exINI, GameStrings::General, "AINormalTargetingDelay");
 	this->PlayerNormalTargetingDelay.Read(exINI, GameStrings::General, "PlayerNormalTargetingDelay");
@@ -720,7 +720,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttackMove_IgnoreWeaponCheck)
 		.Process(this->AttackMove_StopWhenTargetAcquired)
 		.Process(this->Parasite_GrappleAnim)
-		.Process(this->Parasite_ExitAnywhere)
+		.Process(this->Parasite_SkipNavalCheck)
 		.Process(this->InfantryAutoDeploy)
 		.Process(this->AdjacentWallDamage)
 		.Process(this->WarheadAnimZAdjust)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -335,7 +335,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AttackMove_StopWhenTargetAcquired.Read(exINI, GameStrings::General, "AttackMove.StopWhenTargetAcquired");
 
 	this->Parasite_GrappleAnim.Read(exINI, GameStrings::AudioVisual, "Parasite.GrappleAnim");
-	this->Parasite_SkipNavalCheck.Read(exINI, GameStrings::General, "Parasite.SkipNavalCheck");
+	this->Parasite_AllowWaterExit.Read(exINI, GameStrings::General, "Parasite.AllowWaterExit");
 
 	this->AINormalTargetingDelay.Read(exINI, GameStrings::General, "AINormalTargetingDelay");
 	this->PlayerNormalTargetingDelay.Read(exINI, GameStrings::General, "PlayerNormalTargetingDelay");
@@ -720,7 +720,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttackMove_IgnoreWeaponCheck)
 		.Process(this->AttackMove_StopWhenTargetAcquired)
 		.Process(this->Parasite_GrappleAnim)
-		.Process(this->Parasite_SkipNavalCheck)
+		.Process(this->Parasite_AllowWaterExit)
 		.Process(this->InfantryAutoDeploy)
 		.Process(this->AdjacentWallDamage)
 		.Process(this->WarheadAnimZAdjust)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -335,6 +335,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AttackMove_StopWhenTargetAcquired.Read(exINI, GameStrings::General, "AttackMove.StopWhenTargetAcquired");
 
 	this->Parasite_GrappleAnim.Read(exINI, GameStrings::AudioVisual, "Parasite.GrappleAnim");
+	this->Parasite_WaterExit_RequireNaval.Read(exINI, GameStrings::General, "Parasite.WaterExit.RequireNaval");
 
 	this->AINormalTargetingDelay.Read(exINI, GameStrings::General, "AINormalTargetingDelay");
 	this->PlayerNormalTargetingDelay.Read(exINI, GameStrings::General, "PlayerNormalTargetingDelay");
@@ -719,6 +720,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttackMove_IgnoreWeaponCheck)
 		.Process(this->AttackMove_StopWhenTargetAcquired)
 		.Process(this->Parasite_GrappleAnim)
+		.Process(this->Parasite_WaterExit_RequireNaval)
 		.Process(this->InfantryAutoDeploy)
 		.Process(this->AdjacentWallDamage)
 		.Process(this->WarheadAnimZAdjust)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -335,7 +335,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AttackMove_StopWhenTargetAcquired.Read(exINI, GameStrings::General, "AttackMove.StopWhenTargetAcquired");
 
 	this->Parasite_GrappleAnim.Read(exINI, GameStrings::AudioVisual, "Parasite.GrappleAnim");
-	this->Parasite_WaterExit_RequireNaval.Read(exINI, GameStrings::General, "Parasite.WaterExit.RequireNaval");
+	this->Parasite_ExitAnywhere.Read(exINI, GameStrings::General, "Parasite.ExitAnywhere");
 
 	this->AINormalTargetingDelay.Read(exINI, GameStrings::General, "AINormalTargetingDelay");
 	this->PlayerNormalTargetingDelay.Read(exINI, GameStrings::General, "PlayerNormalTargetingDelay");
@@ -720,7 +720,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttackMove_IgnoreWeaponCheck)
 		.Process(this->AttackMove_StopWhenTargetAcquired)
 		.Process(this->Parasite_GrappleAnim)
-		.Process(this->Parasite_WaterExit_RequireNaval)
+		.Process(this->Parasite_ExitAnywhere)
 		.Process(this->InfantryAutoDeploy)
 		.Process(this->AdjacentWallDamage)
 		.Process(this->WarheadAnimZAdjust)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -287,7 +287,7 @@ public:
 		Nullable<bool> AttackMove_StopWhenTargetAcquired;
 
 		NullableIdx<AnimTypeClass> Parasite_GrappleAnim;
-		Valueable<bool> Parasite_SkipNavalCheck;
+		Nullable<bool> Parasite_AllowWaterExit;
 
 		// cache tint color
 		int TintColorIronCurtain;
@@ -600,7 +600,7 @@ public:
 			, AttackMove_StopWhenTargetAcquired { }
 
 			, Parasite_GrappleAnim {}
-			, Parasite_SkipNavalCheck { true }
+			, Parasite_AllowWaterExit {}
 			, InfantryAutoDeploy { false }
 			, AdjacentWallDamage { 200 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -287,7 +287,7 @@ public:
 		Nullable<bool> AttackMove_StopWhenTargetAcquired;
 
 		NullableIdx<AnimTypeClass> Parasite_GrappleAnim;
-		Valueable<bool> Parasite_ExitAnywhere;
+		Valueable<bool> Parasite_SkipNavalCheck;
 
 		// cache tint color
 		int TintColorIronCurtain;
@@ -600,7 +600,7 @@ public:
 			, AttackMove_StopWhenTargetAcquired { }
 
 			, Parasite_GrappleAnim {}
-			, Parasite_ExitAnywhere { true }
+			, Parasite_SkipNavalCheck { true }
 			, InfantryAutoDeploy { false }
 			, AdjacentWallDamage { 200 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -287,7 +287,7 @@ public:
 		Nullable<bool> AttackMove_StopWhenTargetAcquired;
 
 		NullableIdx<AnimTypeClass> Parasite_GrappleAnim;
-		Valueable<bool> Parasite_WaterExit_RequireNaval;
+		Valueable<bool> Parasite_ExitAnywhere;
 
 		// cache tint color
 		int TintColorIronCurtain;
@@ -600,7 +600,7 @@ public:
 			, AttackMove_StopWhenTargetAcquired { }
 
 			, Parasite_GrappleAnim {}
-			, Parasite_WaterExit_RequireNaval { true }
+			, Parasite_ExitAnywhere { true }
 			, InfantryAutoDeploy { false }
 			, AdjacentWallDamage { 200 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -287,6 +287,7 @@ public:
 		Nullable<bool> AttackMove_StopWhenTargetAcquired;
 
 		NullableIdx<AnimTypeClass> Parasite_GrappleAnim;
+		Valueable<bool> Parasite_WaterExit_RequireNaval;
 
 		// cache tint color
 		int TintColorIronCurtain;
@@ -599,6 +600,7 @@ public:
 			, AttackMove_StopWhenTargetAcquired { }
 
 			, Parasite_GrappleAnim {}
+			, Parasite_WaterExit_RequireNaval { true }
 			, InfantryAutoDeploy { false }
 			, AdjacentWallDamage { 200 }
 

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -842,6 +842,21 @@ DEFINE_HOOK(0x6298CC, ParasiteClass_AI_GrippleAnim, 0x5)
 	return SkipGameCode;
 }
 
+DEFINE_HOOK(0x62AB71, ParasiteClass_CanExistOnVictimCell_WaterExit, 0x6)
+{
+	GET(ParasiteClass*, pParasite, ESI);
+	auto const pOwner = pParasite->Owner;
+	if (pOwner)
+	{
+		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->GetTechnoType());
+		if (!pTypeExt->Parasite_WaterExit_RequireNaval.Get(RulesExt::Global()->Parasite_WaterExit_RequireNaval))
+		{
+			return 0x62AC0F;
+		}
+	}
+	return 0;
+}
+
 #pragma region RadarDrawing
 
 DEFINE_HOOK(0x655DDD, RadarClass_ProcessPoint_RadarInvisible, 0x6)

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -842,16 +842,30 @@ DEFINE_HOOK(0x6298CC, ParasiteClass_AI_GrippleAnim, 0x5)
 	return SkipGameCode;
 }
 
-DEFINE_HOOK(0x62AB71, ParasiteClass_CanExistOnVictimCell_WaterExit, 0x6)
+DEFINE_HOOK(0x62AB6F, ParasiteClass_CanExistOnVictimCell_AllowWaterExit, 0x8)
 {
 	GET(ParasiteClass*, pParasite, ESI);
 	auto const pOwner = pParasite->Owner;
 	if (pOwner)
 	{
 		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->GetTechnoType());
-		if (!pTypeExt->Parasite_SkipNavalCheck.Get(RulesExt::Global()->Parasite_SkipNavalCheck))
+		const auto& globalVal = RulesExt::Global()->Parasite_AllowWaterExit;
+
+		if (pTypeExt->Parasite_AllowWaterExit.isset())
 		{
-			return 0x62AC0F;
+			return pTypeExt->Parasite_AllowWaterExit.Get() ? 0x62AC0F : 0x62AB4B;
+		}
+		else if (globalVal.isset())
+		{
+			return globalVal.Get() ? 0x62AC0F : 0x62AB4B;
+		}
+		else
+		{
+			auto const pType = pOwner->GetTechnoType();
+			if (pType->Naval)
+				return 0x62AC0F;
+			else
+				return 0;
 		}
 	}
 	return 0;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -844,17 +844,19 @@ DEFINE_HOOK(0x6298CC, ParasiteClass_AI_GrippleAnim, 0x5)
 
 DEFINE_HOOK(0x62AB69, ParasiteClass_CanExistOnVictimCell_AllowWaterExit, 0x6)
 {
+	enum { SkipChecks = 0x62AC0F, ForceFail = 0x62AB4B, ContinueVanilla = 0x62AB77 };
+
 	GET(TechnoTypeClass*, pType, EAX);
 
 	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
 	const auto& globalVal = RulesExt::Global()->Parasite_AllowWaterExit;
 
 	if (pTypeExt->Parasite_AllowWaterExit.isset())
-		return pTypeExt->Parasite_AllowWaterExit.Get() ? 0x62AC0F : 0x62AB4B;
+		return pTypeExt->Parasite_AllowWaterExit.Get() ? SkipChecks : ForceFail;
 	else if (globalVal.isset())
-		return globalVal.Get() ? 0x62AC0F : 0x62AB4B;
+		return globalVal.Get() ? SkipChecks : ForceFail;
 	else
-		return pType->Naval ? 0x62AC0F : 0x62AB77;
+		return pType->Naval ? SkipChecks : ContinueVanilla;
 }
 
 #pragma region RadarDrawing

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -849,7 +849,7 @@ DEFINE_HOOK(0x62AB71, ParasiteClass_CanExistOnVictimCell_WaterExit, 0x6)
 	if (pOwner)
 	{
 		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->GetTechnoType());
-		if (!pTypeExt->Parasite_WaterExit_RequireNaval.Get(RulesExt::Global()->Parasite_WaterExit_RequireNaval))
+		if (!pTypeExt->Parasite_ExitAnywhere.Get(RulesExt::Global()->Parasite_ExitAnywhere))
 		{
 			return 0x62AC0F;
 		}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -842,33 +842,19 @@ DEFINE_HOOK(0x6298CC, ParasiteClass_AI_GrippleAnim, 0x5)
 	return SkipGameCode;
 }
 
-DEFINE_HOOK(0x62AB6F, ParasiteClass_CanExistOnVictimCell_AllowWaterExit, 0x8)
+DEFINE_HOOK(0x62AB69, ParasiteClass_CanExistOnVictimCell_AllowWaterExit, 0x6)
 {
-	GET(ParasiteClass*, pParasite, ESI);
-	auto const pOwner = pParasite->Owner;
-	if (pOwner)
-	{
-		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->GetTechnoType());
-		const auto& globalVal = RulesExt::Global()->Parasite_AllowWaterExit;
+	GET(TechnoTypeClass*, pType, EAX);
 
-		if (pTypeExt->Parasite_AllowWaterExit.isset())
-		{
-			return pTypeExt->Parasite_AllowWaterExit.Get() ? 0x62AC0F : 0x62AB4B;
-		}
-		else if (globalVal.isset())
-		{
-			return globalVal.Get() ? 0x62AC0F : 0x62AB4B;
-		}
-		else
-		{
-			auto const pType = pOwner->GetTechnoType();
-			if (pType->Naval)
-				return 0x62AC0F;
-			else
-				return 0;
-		}
-	}
-	return 0;
+	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+	const auto& globalVal = RulesExt::Global()->Parasite_AllowWaterExit;
+
+	if (pTypeExt->Parasite_AllowWaterExit.isset())
+		return pTypeExt->Parasite_AllowWaterExit.Get() ? 0x62AC0F : 0x62AB4B;
+	else if (globalVal.isset())
+		return globalVal.Get() ? 0x62AC0F : 0x62AB4B;
+	else
+		return pType->Naval ? 0x62AC0F : 0x62AB77;
 }
 
 #pragma region RadarDrawing

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -849,7 +849,7 @@ DEFINE_HOOK(0x62AB71, ParasiteClass_CanExistOnVictimCell_WaterExit, 0x6)
 	if (pOwner)
 	{
 		auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pOwner->GetTechnoType());
-		if (!pTypeExt->Parasite_ExitAnywhere.Get(RulesExt::Global()->Parasite_ExitAnywhere))
+		if (!pTypeExt->Parasite_SkipNavalCheck.Get(RulesExt::Global()->Parasite_SkipNavalCheck))
 		{
 			return 0x62AC0F;
 		}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1197,7 +1197,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->HarvesterLoadRate.Read(exINI, pSection, "HarvesterLoadRate");
 	this->HarvesterDumpRate.Read(exINI, pSection, "HarvesterDumpRate");
 
-	this->Parasite_WaterExit_RequireNaval.Read(exINI, pSection, "Parasite.WaterExit.RequireNaval");
+	this->Parasite_ExitAnywhere.Read(exINI, pSection, "Parasite.ExitAnywhere");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1940,7 +1940,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->HarvesterLoadRate)
 		.Process(this->HarvesterDumpRate)
 
-		.Process(this->Parasite_WaterExit_RequireNaval)
+		.Process(this->Parasite_ExitAnywhere)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1197,6 +1197,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->HarvesterLoadRate.Read(exINI, pSection, "HarvesterLoadRate");
 	this->HarvesterDumpRate.Read(exINI, pSection, "HarvesterDumpRate");
 
+	this->Parasite_WaterExit_RequireNaval.Read(exINI, pSection, "Parasite.WaterExit.RequireNaval");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1937,6 +1939,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 
 		.Process(this->HarvesterLoadRate)
 		.Process(this->HarvesterDumpRate)
+
+		.Process(this->Parasite_WaterExit_RequireNaval)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1197,7 +1197,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->HarvesterLoadRate.Read(exINI, pSection, "HarvesterLoadRate");
 	this->HarvesterDumpRate.Read(exINI, pSection, "HarvesterDumpRate");
 
-	this->Parasite_SkipNavalCheck.Read(exINI, pSection, "Parasite.SkipNavalCheck");
+	this->Parasite_AllowWaterExit.Read(exINI, pSection, "Parasite.AllowWaterExit");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1940,7 +1940,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->HarvesterLoadRate)
 		.Process(this->HarvesterDumpRate)
 
-		.Process(this->Parasite_SkipNavalCheck)
+		.Process(this->Parasite_AllowWaterExit)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1197,7 +1197,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->HarvesterLoadRate.Read(exINI, pSection, "HarvesterLoadRate");
 	this->HarvesterDumpRate.Read(exINI, pSection, "HarvesterDumpRate");
 
-	this->Parasite_ExitAnywhere.Read(exINI, pSection, "Parasite.ExitAnywhere");
+	this->Parasite_SkipNavalCheck.Read(exINI, pSection, "Parasite.SkipNavalCheck");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1940,7 +1940,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->HarvesterLoadRate)
 		.Process(this->HarvesterDumpRate)
 
-		.Process(this->Parasite_ExitAnywhere)
+		.Process(this->Parasite_SkipNavalCheck)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -510,7 +510,7 @@ public:
 		Nullable<int> HarvesterLoadRate;
 		Nullable<double> HarvesterDumpRate;
 
-		Nullable<bool> Parasite_SkipNavalCheck;
+		Nullable<bool> Parasite_AllowWaterExit;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -975,7 +975,7 @@ public:
 			, HarvesterLoadRate {}
 			, HarvesterDumpRate {}
 				
-			, Parasite_SkipNavalCheck {}
+			, Parasite_AllowWaterExit {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -510,6 +510,8 @@ public:
 		Nullable<int> HarvesterLoadRate;
 		Nullable<double> HarvesterDumpRate;
 
+		Nullable<bool> Parasite_WaterExit_RequireNaval;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, HealthBar_HidePips { false }
@@ -972,6 +974,8 @@ public:
 
 			, HarvesterLoadRate {}
 			, HarvesterDumpRate {}
+				
+			, Parasite_WaterExit_RequireNaval {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -510,7 +510,7 @@ public:
 		Nullable<int> HarvesterLoadRate;
 		Nullable<double> HarvesterDumpRate;
 
-		Nullable<bool> Parasite_ExitAnywhere;
+		Nullable<bool> Parasite_SkipNavalCheck;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -975,7 +975,7 @@ public:
 			, HarvesterLoadRate {}
 			, HarvesterDumpRate {}
 				
-			, Parasite_ExitAnywhere {}
+			, Parasite_SkipNavalCheck {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -510,7 +510,7 @@ public:
 		Nullable<int> HarvesterLoadRate;
 		Nullable<double> HarvesterDumpRate;
 
-		Nullable<bool> Parasite_WaterExit_RequireNaval;
+		Nullable<bool> Parasite_ExitAnywhere;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -975,7 +975,7 @@ public:
 			, HarvesterLoadRate {}
 			, HarvesterDumpRate {}
 				
-			, Parasite_WaterExit_RequireNaval {}
+			, Parasite_ExitAnywhere {}
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION

- In vanilla, parasites with `Naval=false` perform a series of additional checks on the current cell after killing a target, including a series of determinations such as whether there is a bridge when the cell's LandType is `Water`, `Beach`, or `Rock`, which prevents them from normally unlimbo in open water; while parasites with `Naval=true` skip these checks. Now, you can customize the behavior of parasites after killing a target in water:
  - If not set, the original behavior is performed by default.
  - If set to `true`, they can unlimbo normally even if `Naval=false`.
  - If set to `false`, they cannot unlimbo normally even if `Naval=true`.

In `rulesmd.ini`:
```ini
[General]
Parasite.AllowWaterExit=  ; boolean

[SOMETECHNO]              ; TechnoType
Parasite.AllowWaterExit=  ; boolean, defaults to [General] -> Parasite.AllowWaterExit
```

> [!Note]
> Setting `Parasite.AllowWaterExit` to `true` does not skip the original check of whether a BuildingType exists on the cell.

<img width="348" height="167" alt="Parasite_AllowWaterExit" src="https://github.com/user-attachments/assets/5131fb78-ef9e-4cc4-87f1-ddab1111e3d7" />

*`[DRON] -> Parasite.AllowWaterExit=true` & `[SQD] -> Parasite.AllowWaterExit=false`*