### PR TITLE
Customize whether technos with `Locomotor=Fly` wobble

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -680,6 +680,7 @@ This page lists all the individual contributions to the project by their author.
   - Dehardcode of parasites unlimboing after killing naval targets
   - Allow warhead to only affect invoker
   - Allow customizing whether the creation of shrapnel weapon is controlled by the new target check on the warhead of the parent weapon
+  - Customize whether technos with `Locomotor=Fly` wobble
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1739,7 +1739,7 @@ FallingDownDamage.AllowEMP=true     ; boolean
 ### Customize whether technos with `Locomotor=Fly` wobble
 
 - In vanilla, if technos use `Locomotor=Fly` and do not have `IsDropship=true`, they will have a hardcoded wobble effect. However, using `IsDropship=true` also introduces a series of hardcoded behaviors associated with it. Now, you can customize whether to disable this behavior, and it can also be used to enable this behavior for technos with `IsDropship=true`.
-  - If not defined, the original behavior is used by default.
+  - If the flag on technos is not defined, default to using the global value; if the global flag is not defined, use the original rule, which determines whether to disable wobble behavior based on whether the technos have `IsDropship=true`.
 
 In `rulesmd.ini`:
 ```ini

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1736,6 +1736,20 @@ FallingDownDamage.Water=            ; integer / percentage
 FallingDownDamage.AllowEMP=true     ; boolean
 ```
 
+### Customize whether technos with `Locomotor=Fly` wobble
+
+- In vanilla, if technos use `Locomotor=Fly` and do not have `IsDropship=true`, they will have a hardcoded wobble effect. However, using `IsDropship=true` also introduces a series of hardcoded behaviors associated with it. Now, you can customize whether to disable this behavior, and it can also be used to enable this behavior for technos with `IsDropship=true`.
+  - If not defined, the original behavior is used by default.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+FlyNoWobbles=  ; boolean
+
+[SOMETECHNO]   ; TechnoType with Locomotor=Fly
+FlyNoWobbles=  ; boolean, defaults to [AudioVisual] -> FlyNoWobbles
+```
+
 ### Damaged speed customization
 
 - In vanilla, units using drive/ship loco will has hardcoded speed multiplier when damaged. Now you can customize it.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -589,6 +589,7 @@ HideShakeEffects=false           ; boolean
 - [Dehardcode of parasites unlimboing after killing naval targets](Fixed-or-Improved-Logics.md#dehardcode-of-parasites-unlimboing-after-killing-naval-targets) (by Noble_Fish)
 - [Allow warhead to only affect invoker](New-or-Enhanced-Logics.md#allow-warhead-to-only-affect-invoker) (by Noble_Fish)
 - Allow customizing whether the creation of shrapnel weapon is controlled by the new target check on the warhead of the parent weapon (by Noble_Fish)
+- [Customize whether technos with `Locomotor=Fly` wobble](Fixed-or-Improved-Logics.md#customize-whether-technos-with-locomotor-fly-wobble) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -426,6 +426,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->RemoveMindControl_Silent.Read(exINI, GameStrings::AudioVisual, "RemoveMindControl.Silent");
 	this->MindControl_Permanent_ReplaceSilent.Read(exINI, GameStrings::AudioVisual, "MindControl.Permanent.ReplaceSilent");
 
+	this->FlyNoWobbles.Read(exINI, GameStrings::AudioVisual, "FlyNoWobbles");
+
 	this->TeamDelays_DynamicType.Read(exINI, GameStrings::General, "TeamDelays.DynamicType");
 
 	char tempBuffer[40];
@@ -772,6 +774,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->DiscardOn_MoveBasedOnDestination)
 		.Process(this->RemoveMindControl_Silent)
 		.Process(this->MindControl_Permanent_ReplaceSilent)
+		.Process(this->FlyNoWobbles)
 		.Process(this->TeamDelays_DynamicType)
 		.Process(this->TeamDelays_Count)
 		;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -363,6 +363,7 @@ public:
 		Valueable<bool> DiscardOn_MoveBasedOnDestination;
 		Valueable<bool> RemoveMindControl_Silent;
 		Valueable<bool> MindControl_Permanent_ReplaceSilent;
+		Nullable<bool> FlyNoWobbles;
 
 		Valueable<DynamicTeamDelayType> TeamDelays_DynamicType;
 		Valueable<Vector3D<int>> TeamDelays_Count[8];
@@ -668,6 +669,8 @@ public:
 			, DiscardOn_MoveBasedOnDestination { false }
 			, RemoveMindControl_Silent { false }
 			, MindControl_Permanent_ReplaceSilent { false }
+
+			, FlyNoWobbles {}
 
 			, TeamDelays_DynamicType { DynamicTeamDelayType::StartingPoint }
 			, TeamDelays_Count {}

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2065,29 +2065,15 @@ DEFINE_HOOK(0x70AFEF, TechnoClass_UpdateSight_DynamicSight2, 0x6)
 
 #pragma endregion
 
-DEFINE_HOOK(0x4CF8B1, FlyNoWobbles, 0x6)
+DEFINE_HOOK(0x4CF8B1, FlyLocomotionClass_Draw_Point_NoWobbles, 0x6)
 {
-	enum { Continue = 0x4CF8B7 };
-	GET(TechnoTypeClass*, pType, EAX);
+    enum { Continue = 0x4CF8B7 };
+    GET(TechnoTypeClass*, pType, EAX);
 
 	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-	const auto& globalVal = RulesExt::Global()->FlyNoWobbles;
+    R->CL(pTypeExt->FlyNoWobbles.Get(RulesExt::Global()->FlyNoWobbles.Get(pType->IsDropship)));
 
-	if (pTypeExt->FlyNoWobbles.isset())
-	{
-		R->CL(pTypeExt->FlyNoWobbles.Get() ? 1 : 0);
-		return Continue;
-	}
-	else if (globalVal.isset())
-	{
-		R->CL(globalVal.Get() ? 1 : 0);
-		return Continue;
-	}
-	else
-	{
-		R->CL(pType->IsDropship);
-		return Continue;
-	}
+	return Continue;
 }
 
 namespace WarpPerStep

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2065,6 +2065,31 @@ DEFINE_HOOK(0x70AFEF, TechnoClass_UpdateSight_DynamicSight2, 0x6)
 
 #pragma endregion
 
+DEFINE_HOOK(0x4CF8B1, FlyNoWobbles, 0x6)
+{
+	enum { Continue = 0x4CF8B7 };
+	GET(TechnoTypeClass*, pType, EAX);
+
+	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+	const auto& globalVal = RulesExt::Global()->FlyNoWobbles;
+
+	if (pTypeExt->FlyNoWobbles.isset())
+	{
+		R->CL(pTypeExt->FlyNoWobbles.Get() ? 1 : 0);
+		return Continue;
+	}
+	else if (globalVal.isset())
+	{
+		R->CL(globalVal.Get() ? 1 : 0);
+		return Continue;
+	}
+	else
+	{
+		R->CL(pType->IsDropship);
+		return Continue;
+	}
+}
+
 namespace WarpPerStep
 {
 	class TemporalClassFake final : public TemporalClass

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1199,6 +1199,8 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Parasite_AllowWaterExit.Read(exINI, pSection, "Parasite.AllowWaterExit");
 
+	this->FlyNoWobbles.Read(exINI, pSection, "FlyNoWobbles");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1941,6 +1943,8 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->HarvesterDumpRate)
 
 		.Process(this->Parasite_AllowWaterExit)
+
+		.Process(this->FlyNoWobbles)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -512,6 +512,8 @@ public:
 
 		Nullable<bool> Parasite_AllowWaterExit;
 
+		Nullable<bool> FlyNoWobbles;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, HealthBar_HidePips { false }
@@ -976,6 +978,8 @@ public:
 			, HarvesterDumpRate {}
 				
 			, Parasite_AllowWaterExit {}
+
+			, FlyNoWobbles {}
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- In vanilla, if technos use `Locomotor=Fly` and do not have `IsDropship=true`, they will have a hardcoded wobble effect. However, using `IsDropship=true` also introduces a series of hardcoded behaviors associated with it. Now, you can customize whether to disable this behavior, and it can also be used to enable this behavior for technos with `IsDropship=true`.
  - If not defined, the original behavior is used by default.

In `rulesmd.ini`:
```ini
[AudioVisual]
FlyNoWobbles=  ; boolean

[SOMETECHNO]   ; TechnoType with Locomotor=Fly
FlyNoWobbles=  ; boolean, defaults to [AudioVisual] -> FlyNoWobbles
```

---

<img width="246" height="114" alt="Wobble" src="https://github.com/user-attachments/assets/2d2c7199-e068-490a-b313-05e9268e974f" />

*FlyLocomotorVehicle*

<img width="246" height="114" alt="NoWobble" src="https://github.com/user-attachments/assets/fea4a305-abc9-4f9c-ab75-d94b50a19937" />

*FlyLocomotorVehicle with `FlyNoWobbles=true`*
