### PR TITLE
Fix mirage tanks veterancy insignia display to non allied players

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -860,3 +860,4 @@ This page lists all the individual contributions to the project by their author.
   - Multiplayer gamespeed fix for RealTimeTimers
   - Revert Ares patch to allow OpenTopped transport customization
   - Fix for units with Fly, Jumpjet or Rocket locomotors crashing off-map not being cleaned up
+  - Fix for mirage tanks (and other vehicles disguised as terrain) incorrectly displaying veterancy insignia to enemy players when not clearly visible

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -728,6 +728,7 @@ HideShakeEffects=false           ; boolean
 - Fixed a bug where stationary vehicles would also block movement caused by external factors (by Noble_Fish)
 - Fixed AttachEffect with `RecreationDelay` of 0 checking `Delay` as well instead of immediately refreshing duration when possible (by Starkku)
 - Fixed building interceptors being able to pick targets during construction and selling (by Starkku)
+- Fixed mirage tanks (and other vehicles disguised as terrain) incorrectly displaying veterancy insignia to enemy players when not clearly visible (by RAZER)
 
 #### Fixes / interactions with other extensions:
 - Taking over Ares' AlphaImage respawn logic to reduce lags from it (by NetsuNegi)

--- a/src/Ext/Techno/Body.Visuals.cpp
+++ b/src/Ext/Techno/Body.Visuals.cpp
@@ -132,21 +132,22 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 	auto pOwner = pThis->Owner;
 	const bool isObserver = HouseClass::IsCurrentPlayerObserver();
 
-	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer)
-		&& !isObserver && !pOwner->IsAlliedWith(HouseClass::CurrentPlayer)
-		&& pThis->Disguise->WhatAmI() == AbstractType::TerrainType)
-	{
-		return;
-	}
-
-	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer) && !(isObserver
-		|| EnumFunctions::CanTargetHouse(RulesExt::Global()->DisguiseBlinkingVisibility, HouseClass::CurrentPlayer, pOwner)))
+	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer) && !isObserver)
 	{
 		if (auto const pType = TechnoTypeExt::GetTechnoType(pThis->Disguise))
 		{
-			pTechnoType = pType;
-			pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pType);
-			pOwner = pThis->DisguisedAsHouse;
+			// Disguised as a techno: borrow its insignia, unless blinking visibility reveals the real unit.
+			if (!EnumFunctions::CanTargetHouse(RulesExt::Global()->DisguiseBlinkingVisibility, HouseClass::CurrentPlayer, pOwner))
+			{
+				pTechnoType = pType;
+				pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+				pOwner = pThis->DisguisedAsHouse;
+			}
+		}
+		else if (pThis->Disguise->WhatAmI() == AbstractType::TerrainType && !pOwner->IsAlliedWith(HouseClass::CurrentPlayer))
+		{
+			// Disguised as terrain (e.g. mirage tank as a tree): terrain has no insignia.
+			return;
 		}
 	}
 

--- a/src/Ext/Techno/Body.Visuals.cpp
+++ b/src/Ext/Techno/Body.Visuals.cpp
@@ -132,6 +132,13 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 	auto pOwner = pThis->Owner;
 	const bool isObserver = HouseClass::IsCurrentPlayerObserver();
 
+	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer)
+		&& !isObserver && !pOwner->IsAlliedWith(HouseClass::CurrentPlayer)
+		&& pThis->Disguise->WhatAmI() == AbstractType::TerrainType)
+	{
+		return;
+	}
+
 	if (pThis->IsDisguised() && !pThis->IsClearlyVisibleTo(HouseClass::CurrentPlayer) && !(isObserver
 		|| EnumFunctions::CanTargetHouse(RulesExt::Global()->DisguiseBlinkingVisibility, HouseClass::CurrentPlayer, pOwner)))
 	{
@@ -140,10 +147,6 @@ void TechnoExt::DrawInsignia(TechnoClass* pThis, Point2D* pLocation, RectangleSt
 			pTechnoType = pType;
 			pTechnoTypeExt = TechnoTypeExt::ExtMap.Find(pType);
 			pOwner = pThis->DisguisedAsHouse;
-		}
-		else if (pThis->Disguise->WhatAmI() == AbstractType::TerrainType && (!isObserver && !pOwner->IsAlliedWith(HouseClass::CurrentPlayer)))
-		{
-			return;
 		}
 	}
 
@@ -873,3 +876,4 @@ void TechnoExt::ShowPromoteAnim(TechnoClass* pThis)
 	else if (!eliteAnims.empty())
 		AnimExt::CreateRandomAnim(eliteAnims, pThis->GetCenterCoords(), pThis, pThis->Owner, true, true);
 }
+


### PR DESCRIPTION
Please see https://github.com/CnCNet/cncnet-yr-client-package/issues/777 for reference.
Also please keep in mind on next release to include this for the YR repo(if merged).

This pull request addresses a visual bug affecting mirage tanks and other disguised vehicles. Specifically, it ensures that vehicles disguised as terrain (such as trees) do not incorrectly display veterancy insignia to enemy players when they are not clearly visible. This improves the game's visual consistency and prevents revealing information to opponents that should remain hidden.

Bug fix for disguised vehicles:

* Updated `TechnoExt::DrawInsignia` in `Body.Visuals.cpp` to prevent vehicles disguised as terrain from displaying veterancy insignia to enemy players unless they are clearly visible or blinking visibility rules apply. This ensures that mirage tanks and similar units remain properly hidden.
* Added a note to `docs/Whats-New.md` describing the fix for mirage tanks and other disguised vehicles showing insignia when not clearly visible.
* Updated `CREDITS.md` to credit the contributor responsible for the fix.