### PR TITLE
Enhanced Berzerk behavior

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -799,6 +799,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow disable an over-optimization in targeting
   - Extra threat
   - Fix the incorrect mission switching in infantry EnterIdleMode
+  - Customizable Berzerk mission
   - Fix the issue that `BombSight` not being updated correctly in techno conversion
   - Fix BalloonHover incorrectly considering ground factors when pathfinding
   - Technos with Walk locomotor spawn wake like ship

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1739,6 +1739,18 @@ DisguiseBlinkingVisibility=owner  ; List of Affected House Enumeration (none|own
 UseDisguiseMovementSpeed=false    ; boolean
 ```
 
+### Enhanced Berzerk behavior
+
+- In vanilla, when a unit enters Berzerk state, the game assigns it a `Hunt` mission, which may cause the unit to choose a very distant target and simply move toward it without firing during the Berzerk duration.
+- Now you can customize which mission the unit uses when entering Berzerk state.
+  - Additionally, this enhancement adds the necessary stop handling (clearing destination), fixing jumpjet vehicles behaving incorrectly when getting Berzerk'd while moving.
+
+In `rulesmd.ini`:
+```ini
+[CombatDamage]
+BerzerkMission=Hunt               ; MissionType
+```
+
 ### Exclusion from base center calculations
 
 - It is possible to exclude TechnoType from base center calculations (used for number of things such as certain AI scripts and AI superweapon targeting modes etc). Normally only buildings are factored in, but the initial base center does count house's starting technos which this does affect.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -595,6 +595,7 @@ HideShakeEffects=false           ; boolean
 - [Customize the landing animation of technos that have `Locomotor=Fly`](Fixed-or-Improved-Logics.md#customize-the-landing-animation-of-technos-that-have-locomotor-fly) (by Noble_Fish)
 - [Allow infantry to perform type conversion when deploying and undeploying](New-or-Enhanced-Logics.md#allow-infantry-to-perform-type-conversion-when-deploying-and-undeploying) (by Noble_Fish)
 - Add `ClampToScreen` tag for `BannerType` (defaults to `true`) to control whether banner position is clamped to the visible area (by Chang_zhi)
+- [Customizable Berzerk mission](New-or-Enhanced-Logics.md#enhanced-berzerk-behavior) (by TaranDahl)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -4042,6 +4042,23 @@ msgstr ""
 "`UseDisguiseMovementSpeed` "
 "如果设置则在可行的情况下伪装单位将调整其移动速度以匹配伪装目标的速度。注意即使伪装被识破只要未被解除此设置就依旧生效。"
 
+msgid "Enhanced Berzerk behavior"
+msgstr "增强的混乱行为"
+
+msgid ""
+"In vanilla, when a unit enters Berzerk state, the game assigns it a "
+"`Hunt` mission, which may cause the unit to choose a very distant target "
+"and simply move toward it without firing during the Berzerk duration. Now "
+"you can customize which mission the unit uses when entering Berzerk state. "
+"Additionally, this enhancement adds the necessary stop handling (clearing "
+"destination), fixing jumpjet vehicles behaving incorrectly when getting "
+"Berzerk'd while moving."
+msgstr ""
+"在原版中，当单位进入混乱状态时，游戏会为其分配一个 `Hunt` 任务，这可能导致单位选择"
+"一个非常遥远的目标，然后在混乱期间只是向目标移动而不会开火。现在你可以自定义混乱"
+"状态下使用的任务类型。此外，此增强还补充了必要的停止处理（清除目的地），"
+"修复了Jumpjet载具在移动中被混乱时工作异常的问题。"
+
 msgid "Exclusion from base center calculations"
 msgstr "不参与基地中心计算"
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -441,6 +441,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 		this->TeamDelays_Count[i].Read(exINI, GameStrings::General, tempBuffer);
 	}
 
+	this->BerzerkMission.Read(exINI, GameStrings::CombatDamage, "BerzerkMission");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -784,6 +786,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->DefaultLandingAnim_Carryall)
 		.Process(this->TeamDelays_DynamicType)
 		.Process(this->TeamDelays_Count)
+		.Process(this->BerzerkMission)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <RulesClass.h>
 #include <Utilities/Container.h>
@@ -371,6 +371,8 @@ public:
 
 		Valueable<DynamicTeamDelayType> TeamDelays_DynamicType;
 		Valueable<Vector3D<int>> TeamDelays_Count[8];
+    
+		Valueable<Mission> BerzerkMission;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -682,6 +684,7 @@ public:
 
 			, TeamDelays_DynamicType { DynamicTeamDelayType::StartingPoint }
 			, TeamDelays_Count {}
+			, BerzerkMission { Mission::Hunt }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -471,6 +471,22 @@ DEFINE_HOOK(0x701D2E, TechnoClass_ReceiveDamage_AllowBerzerkOnAllies, 0x6)
 	return 0;
 }
 
+#pragma region BerzerkBehavior
+
+DEFINE_HOOK(0x701DAE, TechnoClass_ReceiveDamage_Berzerk, 0x6)
+{
+	enum { SkipQueueMission = 0x701DBA };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	pThis->SetDestination(0, false);
+	pThis->QueueMission(RulesExt::Global()->BerzerkMission, false);
+
+	return SkipQueueMission;
+}
+
+#pragma endregion
+
 DEFINE_HOOK(0x702823, TechnoClass_ReceiveDamage_SkipDamagedParticle, 0x7)
 {
 	enum { SkipParticle = 0x702A25, RemoveParticle = 0x70283C, SpawnParticle = 0x702857 };

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2210,3 +2210,4 @@ int WarpPerStep::TemporalClassFake::_GetWarpPerStep(int helperCount)
 	return sum;
 }
 DEFINE_FUNCTION_JUMP(LJMP, 0x71AB10, WarpPerStep::TemporalClassFake::_GetWarpPerStep)
+


### PR DESCRIPTION
### Enhanced Berzerk behavior

- In vanilla, when a unit enters Berzerk state, the game assigns it a `Hunt` mission, which may cause the unit to choose a very distant target and simply move toward it without firing during the Berzerk duration.
- Now you can customize which mission the unit uses when entering Berzerk state.
  - Additionally, this enhancement adds the necessary stop handling (clearing destination), fixing jumpjet vehicles behaving incorrectly when getting Berzerk'd while moving.

In `rulesmd.ini`:
```ini
[CombatDamage]
BerzerkMission=Hunt               ; MissionType
```