### PR TITLE
Allow beacon placement hotkey in single player

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -818,6 +818,7 @@ This page lists all the individual contributions to the project by their author.
   - Export interface for external call
   - Allow chat box in singleplayer
   - Auto-remove earliest beacon
+  - Allow beacon placement hotkey in single player
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -57,6 +57,8 @@
     <ClCompile Include="src\Ext\Anim\Hooks.cpp" />
     <!-- src\Ext\AnimType -->
     <ClCompile Include="src\Ext\AnimType\Body.cpp" />
+    <!-- src\Ext\Beacon -->
+    <ClCompile Include="src\Ext\Beacon\Hooks.cpp" />
     <!-- src\Ext\Building -->
     <ClCompile Include="src\Ext\Building\Body.cpp" />
     <ClCompile Include="src\Ext\Building\Hooks.cpp" />

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -389,6 +389,16 @@ It was originally planned to list global features that are exclusively related t
 
 -->
 
+### Allow beacon placement hotkey in single player
+
+- In vanilla, the beacon placement hotkey is restricted to multiplayer games only. Now you can allow using the beacon placement hotkey in single player and skirmish modes by setting `AllowBeaconHotKeyInSinglePlayer` to true.
+
+In `rulesmd.ini`:
+```ini
+[General]
+AllowBeaconHotKeyInSinglePlayer=false  ; boolean
+```
+
 ### Allow deploy controlled MCV
 
 In vanilla, you cannot deploy a controlled vehicle to `ConstructionYard=true` building. Now you can customize it.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -601,6 +601,7 @@ HideShakeEffects=false           ; boolean
 - [Allow chat box in singleplayer](User-Interface.md#allow-chat-box-in-singleplayer) (by TaranDahl)
 - [Firer-only message and EVA on superweapon activated](New-or-Enhanced-Logics.md#recipient-specific-message-and-eva-on-superweapon-activation) (by Flactine)
 - [Add a toggle for disabling `SecondaryFire` / `SecondaryProne` on water](Fixed-or-Improved-Logics.md#ensure-infantry-use-correct-firing-sequences-on-water) (by Noble_Fish)
+- [Allow beacon placement hotkey in single player](Fixed-or-Improved-Logics.md#allow-beacon-placement-hotkey-in-single-player) (by TaranDahl)
 - [Auto-remove earliest beacon](Fixed-or-Improved-Logics.md#auto-remove-earliest-beacon) (by TaranDahl)
 
 #### Vanilla fixes:

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -2764,6 +2764,9 @@ msgstr "允许在单人模式使用聊天框"
 msgid "Auto-remove earliest beacon"
 msgstr "自动移除最早的信标"
 
+msgid "Allow beacon placement hotkey in single player"
+msgstr "允许在单人模式下使用信标放置快捷键"
+
 msgid "**solar-III (凤九歌)**"
 msgstr "**solar-III（凤九歌）**"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1924,6 +1924,17 @@ msgid ""
 "needing to be defined on any specific object."
 msgstr "这个类别下列出了所有全局生效而无需在任何特定对象上定义的功能。"
 
+msgid "Allow beacon placement hotkey in single player"
+msgstr "允许在单人模式下使用信标放置快捷键"
+
+msgid ""
+"In vanilla, the beacon placement hotkey is restricted to multiplayer games "
+"only. Now you can allow using the beacon placement hotkey in single player "
+"and skirmish modes by setting `AllowBeaconHotKeyInSinglePlayer` to true."
+msgstr ""
+"在原版中，信标放置快捷键仅限于多人游戏使用。现在你可以通过将 "
+"`AllowBeaconHotKeyInSinglePlayer` 设置为 true 来允许在单人模式和遭遇战中使用信标放置快捷键。"
+
 msgid "Allow deploy controlled MCV"
 msgstr "允许部署被心控的 MCV"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2063,6 +2063,13 @@ msgstr ""
 "[自动移除最早的信标](Fixed-or-Improved-Logics.md#auto-remove-earliest-"
 "beacon)（by TaranDahl）"
 
+msgid ""
+"[Allow beacon placement hotkey in single player](Fixed-or-Improved-"
+"Logics.md#allow-beacon-placement-hotkey-in-single-player) (by TaranDahl)"
+msgstr ""
+"[允许在单人模式下使用信标放置快捷键](Fixed-or-Improved-Logics.md#allow-beacon-placement-"
+"hotkey-in-single-player)（by TaranDahl）"
+
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："
 

--- a/src/Ext/Beacon/Hooks.cpp
+++ b/src/Ext/Beacon/Hooks.cpp
@@ -1,0 +1,11 @@
+#include <Ext/Rules/Body.h>
+
+DEFINE_HOOK(0x5370A0, BeaconPlacementCommandClass_ExecuteSub_Start, 0x5)
+{
+	if (RulesExt::Global()->AllowBeaconHotKeyInSinglePlayer)
+		return 0x5370AE;
+
+	return 0;
+}
+
+DEFINE_JUMP(LJMP, 0x430CD4, 0x430CEA);

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -449,6 +449,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->SecondaryFireSequenceLandOnly.Read(exINI, GameStrings::General, "SecondaryFireSequenceLandOnly");
 	this->AutoRemoveEarliestBeacon.Read(exINI, GameStrings::General, "AutoRemoveEarliestBeacon");
+	this->AllowBeaconHotKeyInSinglePlayer.Read(exINI, GameStrings::General, "AllowBeaconHotKeyInSinglePlayer");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -798,6 +799,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AllowChatBoxInSinglePlayer)
 		.Process(this->SecondaryFireSequenceLandOnly)
 		.Process(this->AutoRemoveEarliestBeacon)
+		.Process(this->AllowBeaconHotKeyInSinglePlayer)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -379,8 +379,8 @@ public:
 		Valueable<bool> AllowChatBoxInSinglePlayer;
 
 		Valueable<bool> SecondaryFireSequenceLandOnly;
-		
 		Valueable<bool> AutoRemoveEarliestBeacon;
+		Valueable<bool> AllowBeaconHotKeyInSinglePlayer;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -702,6 +702,8 @@ public:
 			, SecondaryFireSequenceLandOnly { true }
 
 			, AutoRemoveEarliestBeacon { false }
+
+			, AllowBeaconHotKeyInSinglePlayer { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Allow beacon placement hotkey in single player

- In vanilla, the beacon placement hotkey is restricted to multiplayer games only. Now you can allow using the beacon placement hotkey in single player and skirmish modes by setting `AllowBeaconHotKeyInSinglePlayer` to true.

In `rulesmd.ini`:
```ini
[General]
AllowBeaconHotKeyInSinglePlayer=false  ; boolean
```