### PR TITLE
Auto-remove earliest beacon

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -817,6 +817,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix voxel projectile and animation lighting issues
   - Export interface for external call
   - Allow chat box in singleplayer
+  - Auto-remove earliest beacon
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -399,6 +399,17 @@ In `rulesmd.ini`:
 AllowDeployControlledMCV=false   ; boolean
 ```
 
+### Auto-remove earliest beacon
+
+- In vanilla, each player can place up to 3 beacons. When all 3 beacon slots are occupied, attempting to place a new beacon does nothing. Now you can make the game automatically remove the earliest-placed beacon to free up a slot for the new one.
+  - `[General] -> AutoRemoveEarliestBeacon` controls this behavior.
+
+In `rulesmd.ini`:
+```ini
+[General]
+AutoRemoveEarliestBeacon=no   ; boolean
+```
+
 ### Chrono sparkle animation customization & improvements
 
 - It is now possible to customize the frame delay between instances of `[General] -> ChronoSparkle1` animations created on objects being warped by setting `[General] -> ChronoSparkleDisplayDelay`.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -601,6 +601,7 @@ HideShakeEffects=false           ; boolean
 - [Allow chat box in singleplayer](User-Interface.md#allow-chat-box-in-singleplayer) (by TaranDahl)
 - [Firer-only message and EVA on superweapon activated](New-or-Enhanced-Logics.md#recipient-specific-message-and-eva-on-superweapon-activation) (by Flactine)
 - [Add a toggle for disabling `SecondaryFire` / `SecondaryProne` on water](Fixed-or-Improved-Logics.md#ensure-infantry-use-correct-firing-sequences-on-water) (by Noble_Fish)
+- [Auto-remove earliest beacon](Fixed-or-Improved-Logics.md#auto-remove-earliest-beacon) (by TaranDahl)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -2761,6 +2761,9 @@ msgstr "用于外部调用的导出接口"
 msgid "Allow chat box in singleplayer"
 msgstr "允许在单人模式使用聊天框"
 
+msgid "Auto-remove earliest beacon"
+msgstr "自动移除最早的信标"
+
 msgid "**solar-III (凤九歌)**"
 msgstr "**solar-III（凤九歌）**"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1935,6 +1935,19 @@ msgstr "在原版中你不能将一个被心灵控制的载具部署为 `Constru
 msgid "In `rulesmd.ini`:"
 msgstr "在 `rulesmd.ini`："
 
+msgid "Auto-remove earliest beacon"
+msgstr "自动移除最早的信标"
+
+msgid ""
+"In vanilla, each player can place up to 3 beacons. When all 3 beacon slots "
+"are occupied, attempting to place a new beacon does nothing. Now you can "
+"make the game automatically remove the earliest-placed beacon to free up a "
+"slot for the new one."
+msgstr "在原版中，每个玩家最多可以放置 3 个信标。当 3 个信标槽位都被占用时，尝试放置新信标将不起作用。现在你可以让游戏自动移除最早放置的信标，为新信标腾出槽位。"
+
+msgid "`[General] -> AutoRemoveEarliestBeacon` controls this behavior."
+msgstr "`[General] -> AutoRemoveEarliestBeacon` 控制此行为。"
+
 msgid "Chrono sparkle animation customization & improvements"
 msgstr "超时空闪光动画的自定义与改进"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2057,6 +2057,12 @@ msgid ""
 "singleplayer) (by TaranDahl)"
 msgstr "[允许在单人模式使用聊天框](User-Interface.md#allow-chat-box-in-singleplayer)（by TaranDahl）"
 
+"[Auto-remove earliest beacon](Fixed-or-Improved-Logics.md#auto-remove-"
+"earliest-beacon) (by TaranDahl)"
+msgstr ""
+"[自动移除最早的信标](Fixed-or-Improved-Logics.md#auto-remove-earliest-"
+"beacon)（by TaranDahl）"
+
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："
 

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -712,6 +712,7 @@ void HouseExt::ExtData::Serialize(T& Stm)
 		.Process(this->FreeRadar)
 		.Process(this->ForceRadar)
 		.Process(this->PlayerAutoRepair)
+		//.Process(this->BeaconsPlacedOrder) beacon is not saved, so this follows it.
 		;
 }
 

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -4,6 +4,8 @@
 #include <Utilities/Container.h>
 #include <Utilities/TemplateDef.h>
 
+#include <array>
+
 class HouseExt
 {
 public:
@@ -69,6 +71,8 @@ public:
 
 		bool PlayerAutoRepair;
 
+		std::array<int, 3> BeaconsPlacedOrder;
+
 		ExtData(HouseClass* OwnerObject) : Extension<HouseClass>(OwnerObject)
 			, PowerPlantEnhancers {}
 			, OwnedLimboDeliveredBuildings {}
@@ -103,6 +107,7 @@ public:
 			, FreeRadar(false)
 			, ForceRadar(false)
 			, PlayerAutoRepair(true)
+			, BeaconsPlacedOrder { 0, 0, 0 }
 		{ }
 
 		bool OwnsLimboDeliveredBuilding(BuildingClass* pBuilding) const;

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -6,7 +6,11 @@
 #include "Ext/Building/Body.h"
 #include <Ext/Event/Body.h>
 
+#include <BeaconManagerClass.h>
+
 #include <unordered_map>
+#include <algorithm>
+#include <utility>
 
 // Trigger power recalculation on gain/loss of any techno, not just buildings.
 DEFINE_HOOK_AGAIN(0x5025F0, HouseClass_RegisterGain, 0x5) // RegisterLoss
@@ -678,6 +682,89 @@ DEFINE_HOOK(0x45063F, BuildingClass_UpdateRepairSell_PlayerAutoRepair, 0x6)
 			pThis->SetRepairState(0);
 		return CanNotAutoRepair;
 	}
+}
+
+#pragma endregion
+
+#pragma region BeaconOrder
+
+DEFINE_HOOK(0x43131B, BeaconManagerClass_DeleteBeacon_RecordOrder, 0x5)
+{
+	if (!RulesExt::Global()->AutoRemoveEarliestBeacon)
+		return 0;
+
+	GET(int, beaconIdx, EBX);
+	GET(int, houseIdx, ECX);
+
+	const auto pHouse = HouseClass::Array.GetItem(houseIdx);
+	const auto pExt = HouseExt::ExtMap.Find(pHouse);
+
+	const int oldValue = std::exchange(pExt->BeaconsPlacedOrder[beaconIdx], 0);
+
+	if (oldValue != 0)
+	{
+		for (int i = 0; i < 3; ++i)
+		{
+			if (i != beaconIdx && pExt->BeaconsPlacedOrder[i] > oldValue)
+				--pExt->BeaconsPlacedOrder[i];
+		}
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x430E5D, BeaconManagerClass_PlaceBeacon_RecordOrder, 0x5)
+DEFINE_HOOK(0x430C64, BeaconManagerClass_PlaceBeacon_RecordOrder, 0x5)
+{
+	if (!RulesExt::Global()->AutoRemoveEarliestBeacon)
+		return 0;
+
+	GET(int, beaconIdx, EAX);
+	GET(int, houseIdx, EBX);
+
+	const auto pHouse = HouseClass::Array.GetItem(houseIdx);
+	const auto pExt = HouseExt::ExtMap.Find(pHouse);
+
+	const int maxVal = std::max({ pExt->BeaconsPlacedOrder[0], pExt->BeaconsPlacedOrder[1], pExt->BeaconsPlacedOrder[2] });
+	pExt->BeaconsPlacedOrder[beaconIdx] = maxVal + 1;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x4AC9B2, MouseClass_ToggleBeaconMode_AllUsed, 0x6)
+{
+	enum { RET = 0x4AC9B8 };
+
+	GET(bool, canPlace, EAX);
+
+	if (canPlace)
+		return RET;
+
+	if (!RulesExt::Global()->AutoRemoveEarliestBeacon)
+	{
+		R->BL(0);
+		return RET;
+	}
+
+	const auto pHouse = HouseClass::CurrentPlayer;
+	const auto pExt = HouseExt::ExtMap.Find(pHouse);
+
+	for (int i = 0; i < 3; ++i)
+	{
+		if (pExt->BeaconsPlacedOrder[i] == 1)
+		{
+			auto pManager = &BeaconManagerClass::Instance;
+			auto pBeacon = pManager->Beacons[pHouse->ArrayIndex][i];
+			// Select and delete beacon.
+			// If you don't select the beacon, the game will not send the IPX packet.
+			MapClass::UnselectAll();
+			pBeacon->Bitfield |= 2;
+			pManager->DeleteBeacon(-1, -1);
+			break;
+		}
+	}
+
+	return RET;
 }
 
 #pragma endregion

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -448,6 +448,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AllowChatBoxInSinglePlayer.Read(exINI, GameStrings::General, "AllowChatBoxInSinglePlayer");
 
 	this->SecondaryFireSequenceLandOnly.Read(exINI, GameStrings::General, "SecondaryFireSequenceLandOnly");
+	this->AutoRemoveEarliestBeacon.Read(exINI, GameStrings::General, "AutoRemoveEarliestBeacon");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -796,6 +797,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->BunkerStateUpdateDelay)
 		.Process(this->AllowChatBoxInSinglePlayer)
 		.Process(this->SecondaryFireSequenceLandOnly)
+		.Process(this->AutoRemoveEarliestBeacon)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -379,6 +379,8 @@ public:
 		Valueable<bool> AllowChatBoxInSinglePlayer;
 
 		Valueable<bool> SecondaryFireSequenceLandOnly;
+		
+		Valueable<bool> AutoRemoveEarliestBeacon;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -698,6 +700,8 @@ public:
 			, AllowChatBoxInSinglePlayer { false }
 
 			, SecondaryFireSequenceLandOnly { true }
+
+			, AutoRemoveEarliestBeacon { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
### Auto-remove earliest beacon

- In vanilla, each player can place up to 3 beacons. When all 3 beacon slots are occupied, attempting to place a new beacon does nothing. Now you can make the game automatically remove the earliest-placed beacon to free up a slot for the new one.
  - `[General] -> AutoRemoveEarliestBeacon` controls this behavior.

In `rulesmd.ini`:
```ini
[General]
AutoRemoveEarliestBeacon=no   ; boolean
```