### PR TITLE
Add a toggle for disabling `SecondaryFire` / `SecondaryProne` on water

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -691,6 +691,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow infantry to use `Convert.Deploy` without requiring `IsSimpleDeployer=true`
   - Allow infantry to perform type conversion when deploying and undeploying
   - Custom cruise missiles
+  - Add a toggle for disabling `SecondaryFire` / `SecondaryProne` on water
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -159,7 +159,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Projectiles created from `AirburstWeapon` now remember the WeaponType and can apply radiation etc.
 - Fixed damaged aircraft not repairing on `UnitReload=true` docks unless they land on the dock first.
 - Certain global tileset indices (`ShorePieces`, `WaterSet`, `CliffSet`, `WaterCliffs`, `WaterBridge`, `BridgeSet` and `WoodBridgeSet`) can now be toggled to be parsed for lunar theater by setting `[General] -> ApplyLunarFixes` to true in `lunarmd.ini`. Do note that enabling this without fixing f.ex `WoodBridgeTileSet` pointing to a tileset with `TilesInSet=0` will cause issues in-game.
-- Fixed infantry `SecondaryFire` / `SecondaryProne` sequences being displayed in water instead of `WetAttack`.
 - Fixed objects with ally target and `AttackFriendlies=true` having their target reset every frame, particularly AI-owned buildings.
 - `<Player @ X>` can now be used as owner for pre-placed objects on skirmish and multiplayer maps.
 - Follower vehicle index for preplaced vehicles in maps is now explicitly constrained to `[Units]` list in map files and is no longer thrown off by vehicles that could not be created or created vehicles having other vehicles as initial passengers.
@@ -1332,6 +1331,23 @@ InfantryAutoDeploy=false      ; boolean
 
 [SOMEINFANTRY]                ; InfantryType
 InfantryAutoDeploy=           ; boolean, default to [General] -> InfantryAutoDeploy
+```
+
+### Ensure infantry use correct firing sequences on water
+
+- In Yuri's Revenge, the two new sequences `SecondaryFire` / `SecondaryProne` are used to control the sequences used when firing secondary weapons, but they not only affect land infantry, even water infantry are also affected by them.
+- Now, the default behavior has been changed so that water infantry use the water attack sequence `WetAttack` for their secondary weapons. You can restore the vanilla behavior with the following flag.
+
+In `rulesmd.ini`:
+```ini
+[General]
+SecondaryFireSequenceLandOnly=true  ; boolean
+```
+
+In `artmd.ini`:
+```ini
+[SOMEINFANTRY]                      ; InfantryType image
+SecondaryFireSequenceLandOnly=      ; boolean, defaults to [General] -> SecondaryFireSequenceLandOnly
 ```
 
 ### Prone speed customization

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -599,6 +599,7 @@ HideShakeEffects=false           ; boolean
 - [Tank Bunker foundation and state update delay improvements](Fixed-or-Improved-Logics.md#tank-bunker-improvements) (by Starkku)
 - [Custom cruise missiles](New-or-Enhanced-Logics.md#custom-cruise-missiles) (by Noble_Fish)
 - [Allow chat box in singleplayer](User-Interface.md#allow-chat-box-in-singleplayer) (by TaranDahl)
+- [Add a toggle for disabling `SecondaryFire` / `SecondaryProne` on water](Fixed-or-Improved-Logics.md#ensure-infantry-use-correct-firing-sequences-on-water) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -447,6 +447,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->AllowChatBoxInSinglePlayer.Read(exINI, GameStrings::General, "AllowChatBoxInSinglePlayer");
 
+	this->SecondaryFireSequenceLandOnly.Read(exINI, GameStrings::General, "SecondaryFireSequenceLandOnly");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -793,6 +795,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->BerzerkMission)
 		.Process(this->BunkerStateUpdateDelay)
 		.Process(this->AllowChatBoxInSinglePlayer)
+		.Process(this->SecondaryFireSequenceLandOnly)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -378,6 +378,8 @@ public:
 
 		Valueable<bool> AllowChatBoxInSinglePlayer;
 
+		Valueable<bool> SecondaryFireSequenceLandOnly;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -694,6 +696,8 @@ public:
 			, BunkerStateUpdateDelay { 15 }
 				
 			, AllowChatBoxInSinglePlayer { false }
+
+			, SecondaryFireSequenceLandOnly { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -837,12 +837,13 @@ DEFINE_HOOK(0x51D7E0, InfantryClass_DoAction_Water, 0x5)
 
 	R->EBP(0); // Restore overridden instructions.
 
-	if (TechnoTypeExt::ExtMap.Find(pThis->Type)->OnlyUseLandSequences)
+	const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->Type);
+	if (pTypeExt->OnlyUseLandSequences)
 		return SkipWaterSequences;
 
 	if (sequence == Sequence::Walk || sequence == Sequence::Crawl) // Restore overridden instructions.
 		return UseSwim;
-	else if (sequence == Sequence::SecondaryFire || sequence == Sequence::SecondaryProne)
+	else if ((sequence == Sequence::SecondaryFire || sequence == Sequence::SecondaryProne) && pTypeExt->SecondaryFireSequenceLandOnly.Get(RulesExt::Global()->SecondaryFireSequenceLandOnly))
 		return UseWetAttack;
 
 	return Continue;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1370,6 +1370,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->ParseBurstFLHs(exArtINI, pArtSection, this->CrouchedWeaponBurstFLHs, this->EliteCrouchedWeaponBurstFLHs, "Prone");
 
 	this->OnlyUseLandSequences.Read(exArtINI, pArtSection, "OnlyUseLandSequences");
+	this->SecondaryFireSequenceLandOnly.Read(exArtINI, pArtSection, "SecondaryFireSequenceLandOnly");
 
 	this->PronePrimaryFireFLH.Read(exArtINI, pArtSection, "PronePrimaryFireFLH");
 	this->ProneSecondaryFireFLH.Read(exArtINI, pArtSection, "ProneSecondaryFireFLH");
@@ -1678,6 +1679,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Passengers_SyncOwner_RevertOnExit)
 
 		.Process(this->OnlyUseLandSequences)
+		.Process(this->SecondaryFireSequenceLandOnly)
 
 		.Process(this->PronePrimaryFireFLH)
 		.Process(this->ProneSecondaryFireFLH)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -396,6 +396,7 @@ public:
 
 		std::vector<LaserTrailDataEntry> LaserTrailData;
 		Valueable<bool> OnlyUseLandSequences;
+		Nullable<bool> SecondaryFireSequenceLandOnly;
 		Nullable<CoordStruct> PronePrimaryFireFLH;
 		Nullable<CoordStruct> ProneSecondaryFireFLH;
 		Nullable<CoordStruct> DeployedPrimaryFireFLH;
@@ -708,6 +709,7 @@ public:
 			, Passengers_SyncOwner_RevertOnExit { true }
 
 			, OnlyUseLandSequences { false }
+			, SecondaryFireSequenceLandOnly {}
 
 			, PronePrimaryFireFLH {}
 			, ProneSecondaryFireFLH {}


### PR DESCRIPTION
From 344b12107c30f16744d25e1cf1dda8f8c284d9c4

> Fixed infantry `SecondaryFire` / `SecondaryProne` sequences being displayed in water instead of `WetAttack`.

Since user feedback has been seen on Discord, QQ, and forums, a toggle is added for this, enabled by default for the fix, but freely allowed to be disabled.

In `rulesmd.ini`:
```ini
[General]
SecondaryFireSequenceLandOnly=true  ; boolean
```

In `artmd.ini`:
```ini
[SOMEINFANTRY]                      ; InfantryType image
SecondaryFireSequenceLandOnly=      ; boolean, defaults to [General] -> SecondaryFireSequenceLandOnly
```
