### PR TITLE
Customize the step limit of the credits indicator and disable the credits indicator smooth transition

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -691,6 +691,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow infantry to use `Convert.Deploy` without requiring `IsSimpleDeployer=true`
   - Allow infantry to perform type conversion when deploying and undeploying
   - Custom cruise missiles
+  - Customize the step limit of the credits indicator
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -692,6 +692,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow infantry to perform type conversion when deploying and undeploying
   - Custom cruise missiles
   - Customize the step limit of the credits indicator
+  - Disable the credits indicator smooth transition
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -83,6 +83,10 @@ In `uimd.ini`:
 CreditsIndicator.MaxStep=143  ; integer
 ```
 
+```{note}
+The game first takes the absolute value of the difference between the actual credits and the current value, then divides it by 8, and then clamps this value to the limit set here. If you wish to disable this smoothing effect, set [`CreditsIndicator.Smooth=false`](User-Interface.md#disable-the-credits-indicator-smooth-transition).
+```
+
 ### Digital display
 
 ![image](_static/images/digital_display_shapes.png)
@@ -205,6 +209,20 @@ The arrangement of static images on the plane is entirely up to you to draw free
 
 Of course, this is just the implementation method. To balance freedom with efficiency - that is, how to efficiently draw the patterns you need - you still need to independently explore a workflow that suits you.
 ````
+
+### Disable the credits indicator smooth transition
+
+- In vanilla, the Credits Indicator has a smooth transition effect when the displayed credit value approaches the actual credit value. Now you can disable this effect, allowing the change step to always follow the value of [`CreditsIndicator.MaxStep`](User-Interface.md#customize-the-step-limit-of-the-credits-indicator).
+
+In `uimd.ini`:
+```ini
+[Sidebar]
+CreditsIndicator.Smooth=true  ; boolean
+```
+
+```{hint}
+For example, if you want to make the credits update immediately without a transition process by setting `CreditsIndicator.MaxStep=0`, then you should also set `CreditsIndicator.Smooth=false`; otherwise, the displayed credit value will still change in the form of an exponential approximation function.
+```
 
 ### Flashing Technos on selecting
 

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -75,7 +75,7 @@ HealthBar.Permanent.PipScale=false   ; boolean
 ### Customize the step limit of the credits indicator
 
 - In vanilla, the Credits Indicator in the sidebar increases by at most 143 points per frame, and now you can customize this limit.
-  - If set to a value less than or equal to 0, it will continue to execute the vanilla behavior (limited to 143).
+  - If set to a value less than or equal to 0, the upper limit will be removed.
 
 In `uimd.ini`:
 ```ini

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -72,6 +72,17 @@ HealthBar.Permanent=false            ; boolean
 HealthBar.Permanent.PipScale=false   ; boolean
 ```
 
+### Customize the step limit of the credits indicator
+
+- In vanilla, the Credits Indicator in the sidebar increases by at most 143 points per frame, and now you can customize this limit.
+  - If set to a value less than or equal to 0, it will continue to execute the vanilla behavior (limited to 143).
+
+In `uimd.ini`:
+```ini
+[Sidebar]
+CreditsIndicator.MaxStep=143  ; integer
+```
+
 ### Digital display
 
 ![image](_static/images/digital_display_shapes.png)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -600,6 +600,7 @@ HideShakeEffects=false           ; boolean
 - [Custom cruise missiles](New-or-Enhanced-Logics.md#custom-cruise-missiles) (by Noble_Fish)
 - [Allow chat box in singleplayer](User-Interface.md#allow-chat-box-in-singleplayer) (by TaranDahl)
 - [Customize the step limit of the credits indicator](User-Interface.md#customize-the-step-limit-of-the-credits-indicator) (by Noble_Fish)
+- [Disable the credits indicator smooth transition](User-Interface.md#disable-the-credits-indicator-smooth-transition) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -599,6 +599,7 @@ HideShakeEffects=false           ; boolean
 - [Tank Bunker foundation and state update delay improvements](Fixed-or-Improved-Logics.md#tank-bunker-improvements) (by Starkku)
 - [Custom cruise missiles](New-or-Enhanced-Logics.md#custom-cruise-missiles) (by Noble_Fish)
 - [Allow chat box in singleplayer](User-Interface.md#allow-chat-box-in-singleplayer) (by TaranDahl)
+- [Customize the step limit of the credits indicator](User-Interface.md#customize-the-step-limit-of-the-credits-indicator) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -77,16 +77,18 @@ DEFINE_HOOK(0x641EE0, PreviewClass_ReadPreview, 0x6)
 
 DEFINE_HOOK(0x4A2729, CreditClass_AI_CreditsStepClamp, 0x5)
 {
+	enum { Continue = 0x4A2735 };
+
     int maxStep = Phobos::UI::CreditsIndicator_MaxStep;
     if (maxStep < 1)
-        return 0;
+        return Continue;
 
     int current = R->EAX();
     if (current > maxStep)
         current = maxStep;
     R->EAX(current);
 
-    return 0x4A2735;
+    return Continue;
 }
 
 DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -75,6 +75,20 @@ DEFINE_HOOK(0x641EE0, PreviewClass_ReadPreview, 0x6)
 	return 0x64203D;
 }
 
+DEFINE_HOOK(0x4A2729, CreditClass_AI_CreditsStepClamp, 0x5)
+{
+    int maxStep = Phobos::UI::CreditsIndicator_MaxStep;
+    if (maxStep < 1)
+        return 0;
+
+    int current = R->EAX();
+    if (current > maxStep)
+        current = maxStep;
+    R->EAX(current);
+
+    return 0x4A2735;
+}
+
 DEFINE_HOOK(0x4A25E0, CreditsClass_GraphicLogic_HarvesterCounter, 0x7)
 {
 	auto const pPlayer = HouseClass::CurrentPlayer;

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -75,18 +75,25 @@ DEFINE_HOOK(0x641EE0, PreviewClass_ReadPreview, 0x6)
 	return 0x64203D;
 }
 
+DEFINE_HOOK(0x4A26E8, CreditClass_AI_SmoothDisable, 0x6)
+{
+	if (!Phobos::UI::CreditsIndicator_Smooth)
+		return 0x4A26F0;
+	else
+		return 0;
+}
+
 DEFINE_HOOK(0x4A2729, CreditClass_AI_CreditsStepClamp, 0x5)
 {
 	enum { Continue = 0x4A2735 };
 
     int maxStep = Phobos::UI::CreditsIndicator_MaxStep;
-    if (maxStep < 1)
+    if (maxStep <= 0)
         return Continue;
 
-    int current = R->EAX();
-    if (current > maxStep)
-        current = maxStep;
-    R->EAX(current);
+    GET(int, current, EAX);
+
+    R->EAX(Math::min(current, maxStep));
 
     return Continue;
 }

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -41,6 +41,7 @@ int Phobos::UI::SuperWeaponSidebar_CameoHeight = 48;
 int Phobos::UI::SuperWeaponSidebar_Max = 0;
 int Phobos::UI::SuperWeaponSidebar_MaxColumns = INT32_MAX;
 int Phobos::UI::CreditsIndicator_MaxStep = 143;
+bool Phobos::UI::CreditsIndicator_Smooth = true;
 bool Phobos::UI::WeedsCounter_Show = false;
 bool Phobos::UI::AnchoredToolTips = false;
 
@@ -235,6 +236,9 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 
 		Phobos::UI::CreditsIndicator_MaxStep =
 			ini_uimd.ReadInteger(SIDEBAR_SECTION, "CreditsIndicator.MaxStep", Phobos::UI::CreditsIndicator_MaxStep);
+
+		Phobos::UI::CreditsIndicator_Smooth =
+			ini_uimd.ReadBool(SIDEBAR_SECTION, "CreditsIndicator.Smooth", Phobos::UI::CreditsIndicator_Smooth);
 	}
 
 	// UISettings

--- a/src/Phobos.INI.cpp
+++ b/src/Phobos.INI.cpp
@@ -40,6 +40,7 @@ int Phobos::UI::SuperWeaponSidebar_LeftOffset = 0;
 int Phobos::UI::SuperWeaponSidebar_CameoHeight = 48;
 int Phobos::UI::SuperWeaponSidebar_Max = 0;
 int Phobos::UI::SuperWeaponSidebar_MaxColumns = INT32_MAX;
+int Phobos::UI::CreditsIndicator_MaxStep = 143;
 bool Phobos::UI::WeedsCounter_Show = false;
 bool Phobos::UI::AnchoredToolTips = false;
 
@@ -231,6 +232,9 @@ DEFINE_HOOK(0x5FACDF, OptionsClass_LoadSettings_LoadPhobosSettings, 0x5)
 
 		Phobos::UI::SuperWeaponSidebar_MaxColumns =
 			ini_uimd.ReadInteger(SIDEBAR_SECTION, "SuperWeaponSidebar.MaxColumns", Phobos::UI::SuperWeaponSidebar_MaxColumns);
+
+		Phobos::UI::CreditsIndicator_MaxStep =
+			ini_uimd.ReadInteger(SIDEBAR_SECTION, "CreditsIndicator.MaxStep", Phobos::UI::CreditsIndicator_MaxStep);
 	}
 
 	// UISettings

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -62,6 +62,7 @@ public:
 		static int SuperWeaponSidebar_CameoHeight;
 		static int SuperWeaponSidebar_Max;
 		static int SuperWeaponSidebar_MaxColumns;
+		static int CreditsIndicator_MaxStep;
 		static bool WeedsCounter_Show;
 		static bool AnchoredToolTips;
 

--- a/src/Phobos.h
+++ b/src/Phobos.h
@@ -63,6 +63,7 @@ public:
 		static int SuperWeaponSidebar_Max;
 		static int SuperWeaponSidebar_MaxColumns;
 		static int CreditsIndicator_MaxStep;
+		static bool CreditsIndicator_Smooth;
 		static bool WeedsCounter_Show;
 		static bool AnchoredToolTips;
 


### PR DESCRIPTION
- In vanilla, the Credits Indicator in the sidebar increases by at most 143 points per frame, and now you can customize this limit.
  - If set to a value less than or equal to 0, the upper limit will be removed.

In `uimd.ini`:
```ini
[Sidebar]
CreditsIndicator.MaxStep=143  ; integer
```

- In vanilla, the Credits Indicator has a smooth transition effect when the displayed credit value approaches the actual credit value. Now you can disable this effect, allowing the change step to always follow the value of [`CreditsIndicator.MaxStep`](User-Interface.md#customize-the-step-limit-of-the-credits-indicator).

In `uimd.ini`:
```ini
[Sidebar]
CreditsIndicator.Smooth=true  ; boolean
```

> [!Tip]
> For example, if you want to make the credits update immediately without a transition process by setting `CreditsIndicator.MaxStep=0`, then you should also set `CreditsIndicator.Smooth=false`; otherwise, the displayed credit value will still change in the form of an exponential approximation function.

