### PR TITLE
Fix HouseClass_ShouldDisableCameo_GreyCameo hook address.

### DIFF
--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -350,7 +350,7 @@ static inline bool CheckShouldDisableDefensesCameo(HouseClass* pHouse, TechnoTyp
 	return false;
 }
 
-DEFINE_HOOK(0x50B669, HouseClass_ShouldDisableCameo_GreyCameo, 0x5)
+DEFINE_HOOK(0x50B370, HouseClass_ShouldDisableCameo_GreyCameo, 0x5)
 {
 	GET(HouseClass*, pThis, ECX);
 	GET_STACK(TechnoTypeClass*, pType, 0x4);


### PR DESCRIPTION
Hook address of `HouseClass_ShouldDisableCameo_GreyCameo` should be at `0x50B370` instead of `0x50B669`. Ares has the same hook, loading Phobos with Ares is fine, but without Ares would crash because of this.