### PR TITLE
`ZAdjust` for Projectiles

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -696,6 +696,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize the step limit of the credits indicator
   - Disable the credits indicator smooth transition
   - Add `selling`, `undeploying` and `harvesting` conditions to `DiscardOn`
+  - `ZAdjust` for Projectiles
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1557,6 +1557,20 @@ Shrapnel.IgnoreHitBuildings=                ; boolean
 Shrapnel.ObeyWarheadTriggerConditions=      ; boolean, defaults to [CombatDamage] -> Shrapnel.ObeyWarheadTriggerConditions
 ```
 
+### `ZAdjust` for Projectiles
+
+- In vanilla, the Z‑depth of projectiles is automatically calculated, but this calculation is not foolproof. For example, when launching a missile straight up from a building, the projectile will be blocked by the building. Now you can manually set a correction value, similar to animations.
+
+In `artmd.ini`:
+```ini
+[SOMEPROJECTILE]  ; Projectile Image
+ZAdjust=0         ; integer
+```
+
+```{note}
+Unlike those using Shape, projectiles that use Voxel resource files as images will use another complex per-pixel dynamic mapping calculation. Likewise, they cannot be simply adjusted via this INI flag—this feature only works on projectiles that use Shape assets as images.
+```
+
 ## Technos
 
 ### Airstrike flare visual customizations

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -607,6 +607,7 @@ HideShakeEffects=false           ; boolean
 - [Customize the step limit of the credits indicator](User-Interface.md#customize-the-step-limit-of-the-credits-indicator) (by Noble_Fish)
 - [Disable the credits indicator smooth transition](User-Interface.md#disable-the-credits-indicator-smooth-transition) (by Noble_Fish)
 - Add `selling`, `undeploying` and `harvesting` conditions to `DiscardOn` (by Noble_Fish)
+- [`ZAdjust` for Projectiles](Fixed-or-Improved-Logics.md#zadjust-for-projectiles) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -605,3 +605,15 @@ DEFINE_HOOK(0x467AB2, BulletClass_AI_Parabomb, 0x7)
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x4683F2, BulletClass_Draw_ZAdjust, 0x5)
+{
+	GET(BulletClass*, pThis, ESI);
+	GET(int, height, ECX);
+
+	auto const pTypeExt = BulletTypeExt::ExtMap.Find(pThis->Type);
+
+	R->EAX(TacticalClass::AdjustForZ(height) - pTypeExt->ZAdjust);
+
+	return 0x4683F7;
+}

--- a/src/Ext/BulletType/Body.cpp
+++ b/src/Ext/BulletType/Body.cpp
@@ -93,6 +93,8 @@ void BulletTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->LaserTrail_Types.Read(exArtINI, pSection, "LaserTrail.Types");
 
+	this->ZAdjust.Read(exArtINI, pSection, "ZAdjust");
+
 	this->TrajectoryValidation();
 }
 
@@ -186,6 +188,7 @@ void BulletTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->Parachuted_MaxFallRate)
 		.Process(this->BombParachute)
 		.Process(this->AU)
+		.Process(this->ZAdjust)
 
 		.Process(this->TrajectoryType) // just keep this shit at last
 		;

--- a/src/Ext/BulletType/Body.h
+++ b/src/Ext/BulletType/Body.h
@@ -80,6 +80,8 @@ public:
 
 		Valueable<bool> AU;
 
+		Valueable<int> ZAdjust;
+
 		// Ares 0.7
 		Nullable<Leptons> BallisticScatter_Min;
 		Nullable<Leptons> BallisticScatter_Max;
@@ -138,6 +140,7 @@ public:
 			, Parachuted_MaxFallRate {}
 			, BombParachute {}
 			, AU { false }
+			, ZAdjust { 0 }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- In vanilla, the Z‑depth of projectiles is automatically calculated, but this calculation is not foolproof. For example, when launching a missile straight up from a building, the projectile will be blocked by the building. Now you can manually set a correction value, similar to animations.

In `artmd.ini`:
```ini
[SOMEPROJECTILE]  ; Projectile Image
ZAdjust=0         ; integer
```

> [!Note]
> Unlike those using Shape, projectiles that use Voxel resource files as images will use another complex per-pixel dynamic mapping calculation. Likewise, they cannot be simply adjusted via this INI flag—this feature only works on projectiles that use Shape assets as images.

---
<img width="243" height="199" alt="Default" src="https://github.com/user-attachments/assets/e2ccdaee-50bb-4c28-9643-4586ab909570" />

<img width="243" height="199" alt="ZAdjust-200" src="https://github.com/user-attachments/assets/f2a8727f-e43e-4191-8ef3-69ff4c703914" />

*Default (DevBuild#48) / `ZAdjust=-200` (This PR)*