### PR TITLE
Fix the bug that `MissileSpawn=true` causes the spawnee launcher to crash immediately when attacking

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -699,6 +699,7 @@ This page lists all the individual contributions to the project by their author.
   - Disable the credits indicator smooth transition
   - Add `selling`, `undeploying` and `harvesting` conditions to `DiscardOn`
   - `ZAdjust` for Projectiles
+  - Fix the bug that `MissileSpawn=true` causes the spawnee launcher to crash immediately when attacking
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1441,7 +1441,7 @@ AutoTargetAI.NoThreatBuildings=true     ; boolean
 
 - If `Spawner.LimitRange` is set, the spawned units will abort their pursuit if the enemy is out of the range of the largest weapon `Range` of a `Spawner=true` weapon of the spawner.
   - `Spawner.ExtraLimitRange` adds extra pursuit range on top of the weapon range.
-- `Spawner.DelayFrames` can be used to set the minimum number of game frames in between each spawn ejecting from the spawner. By default this is 9 frames for missiles and 20 for everything else.
+- `Spawner.DelayFrames` can be used to set the minimum number of game frames in between each spawn ejecting from the spawner. By default this is 10 frames for launchers with `MissileSpawn=true` and 20 for everything else.
 - If `Spawner.AttackImmediately` is set to true, spawned aircraft will assume attack mission immediately after being spawned instead of waiting for the remaining aircraft to spawn first.
 - `Spawner.UseTurretFacing`, if set, makes spawned aircraft face the same way as turret does upon being created if the spawner has a turret.
 - `Spawner.RecycleRange` defines the range (in cell) that the spawned is considered close enough to the spawner to be recycled.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -735,6 +735,7 @@ HideShakeEffects=false           ; boolean
 - Fixed a bug where stationary vehicles would also block movement caused by external factors (by Noble_Fish)
 - Fixed `src/Interop/Version.cpp` not being compiled into the project (by Chang_zhi)
 - Fixed the issue that `NoQueueUpToEnter` will clear passenger's planning tokens when entered transport (by NetsuNegi)
+- Fixed the bug that `MissileSpawn=true` causes the spawnee launcher to crash immediately when attacking (by Noble_Fish)
 
 #### Fixes / interactions with other extensions:
 - Taking over Ares' AlphaImage respawn logic to reduce lags from it (by NetsuNegi)

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -3518,8 +3518,9 @@ msgstr "`Spawner.ExtraLimitRange` 是追击范围相对于武器射程进行调�
 msgid ""
 "`Spawner.DelayFrames` can be used to set the minimum number of game "
 "frames in between each spawn ejecting from the spawner. By default this "
-"is 9 frames for missiles and 20 for everything else."
-msgstr "`Spawner.DelayFrames` 可用于设置每次从子机发射器中生成单位的最小游戏帧数。对于导弹默认是 9 帧，其他默认是 20 帧。"
+"is 10 frames for launchers with `MissileSpawn=true` and 20 for everything"
+" else."
+msgstr "`Spawner.DelayFrames` 可用于设置每次从子机发射器中生成单位的最小游戏帧数。对于 `MissileSpawn=true` 的发射车默认是 10 帧，其他默认是 20 帧。"
 
 msgid ""
 "If `Spawner.AttackImmediately` is set to true, spawned aircraft will "

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -95,20 +95,24 @@ DEFINE_HOOK(0x6B72FE, SpawnerManagerClass_AI_MissileCheck, 0x9)
 		? NoSpawn : SpawnMissile;
 }
 
-DEFINE_HOOK_AGAIN(0x6B73BE, SpawnManagerClass_AI_SpawnTimer, 0x6)
-DEFINE_HOOK(0x6B73AD, SpawnManagerClass_AI_SpawnTimer, 0x5)
+DEFINE_HOOK_AGAIN(0x6B73A8, SpawnManagerClass_AI_SpawnTimer, 0x5)
+DEFINE_HOOK(0x6B73B9, SpawnManagerClass_AI_SpawnTimer, 0x5)
 {
-	GET(SpawnManagerClass* const, pThis, ESI);
+	GET(SpawnManagerClass*, pThis, ESI);
 
+	int delay = pThis->Owner->GetTechnoType()->MissileSpawn ? 9 : 20;
 	if (auto const pOwner = pThis->Owner)
 	{
-		auto const pTypeExt = TechnoExt::ExtMap.Find(pOwner)->TypeExtData;
-
-		if (pTypeExt->Spawner_DelayFrames.isset())
-			R->ECX(pTypeExt->Spawner_DelayFrames.Get());
+		auto const pExt = TechnoExt::ExtMap.Find(pOwner);
+		if (pExt && pExt->TypeExtData)
+		{
+			auto const pTypeExt = pExt->TypeExtData;
+			if (pTypeExt->Spawner_DelayFrames.isset())
+				delay = pTypeExt->Spawner_DelayFrames.Get();
+		}
 	}
-
-	return 0;
+	pThis->SpawnTimer.Start(delay);
+	return 0x6B73C4;
 }
 
 DEFINE_HOOK_AGAIN(0x6B769F, SpawnManagerClass_AI_InitDestination, 0x7)

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -109,9 +109,12 @@ DEFINE_HOOK(0x6B73B9, SpawnManagerClass_AI_SpawnTimer, 0x5)
 			pThis->SpawnTimer.Start(pTypeExt->Spawner_DelayFrames.Get());
 			return 0x6B73C4;
 		}
+
+		R->ECX(pOwner->GetTechnoType()->MissileSpawn ? 9 : 20);
+		return 0;
 	}
 
-	R->ECX(pThis->Owner->GetTechnoType()->MissileSpawn ? 9 : 20);
+	R->ECX(20);
 	return 0;
 }
 

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -98,21 +98,21 @@ DEFINE_HOOK(0x6B72FE, SpawnerManagerClass_AI_MissileCheck, 0x9)
 DEFINE_HOOK_AGAIN(0x6B73A8, SpawnManagerClass_AI_SpawnTimer, 0x5)
 DEFINE_HOOK(0x6B73B9, SpawnManagerClass_AI_SpawnTimer, 0x5)
 {
-	GET(SpawnManagerClass*, pThis, ESI);
+	GET(SpawnManagerClass* const, pThis, ESI);
 
-	int delay = pThis->Owner->GetTechnoType()->MissileSpawn ? 9 : 20;
 	if (auto const pOwner = pThis->Owner)
 	{
-		auto const pExt = TechnoExt::ExtMap.Find(pOwner);
-		if (pExt && pExt->TypeExtData)
+		auto const pTypeExt = TechnoExt::ExtMap.Find(pOwner)->TypeExtData;
+
+		if (pTypeExt->Spawner_DelayFrames.isset())
 		{
-			auto const pTypeExt = pExt->TypeExtData;
-			if (pTypeExt->Spawner_DelayFrames.isset())
-				delay = pTypeExt->Spawner_DelayFrames.Get();
+			pThis->SpawnTimer.Start(pTypeExt->Spawner_DelayFrames.Get());
+			return 0x6B73C4;
 		}
 	}
-	pThis->SpawnTimer.Start(delay);
-	return 0x6B73C4;
+
+	R->ECX(pThis->Owner->GetTechnoType()->MissileSpawn ? 9 : 20);
+	return 0;
 }
 
 DEFINE_HOOK_AGAIN(0x6B769F, SpawnManagerClass_AI_InitDestination, 0x7)

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -100,6 +100,7 @@ DEFINE_HOOK(0x6B73B9, SpawnManagerClass_AI_SpawnTimer, 0x5)
 {
 	GET(SpawnManagerClass* const, pThis, ESI);
 
+	int delay = 20;
 	if (auto const pOwner = pThis->Owner)
 	{
 		auto const pTypeExt = TechnoExt::ExtMap.Find(pOwner)->TypeExtData;
@@ -109,12 +110,11 @@ DEFINE_HOOK(0x6B73B9, SpawnManagerClass_AI_SpawnTimer, 0x5)
 			pThis->SpawnTimer.Start(pTypeExt->Spawner_DelayFrames.Get());
 			return 0x6B73C4;
 		}
-
-		R->ECX(pOwner->GetTechnoType()->MissileSpawn ? 9 : 20);
-		return 0;
+		if (pOwner->GetTechnoType()->MissileSpawn)
+			delay = 9;
 	}
 
-	R->ECX(20);
+	R->ECX(delay);
 	return 0;
 }
 

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -100,7 +100,6 @@ DEFINE_HOOK(0x6B73B9, SpawnManagerClass_AI_SpawnTimer, 0x5)
 {
 	GET(SpawnManagerClass* const, pThis, ESI);
 
-	int delay = 20;
 	if (auto const pOwner = pThis->Owner)
 	{
 		auto const pTypeExt = TechnoExt::ExtMap.Find(pOwner)->TypeExtData;
@@ -110,11 +109,8 @@ DEFINE_HOOK(0x6B73B9, SpawnManagerClass_AI_SpawnTimer, 0x5)
 			pThis->SpawnTimer.Start(pTypeExt->Spawner_DelayFrames.Get());
 			return 0x6B73C4;
 		}
-		if (pOwner->GetTechnoType()->MissileSpawn)
-			delay = 9;
 	}
 
-	R->ECX(delay);
 	return 0;
 }
 


### PR DESCRIPTION
This bug was introduced by the two hooks that modified `SpawnTimer` in #622.

```ini
[CARRIER_MS]:[CARRIER]
MissileSpawn=true
[CARRIER_SDF]:[CARRIER]
Spawner.DelayFrames=10000
[CARRIER_SDF_MS]:[CARRIER_MS]
Spawner.DelayFrames=10000

[Units]
3=Americans House,CARRIER,256,34,35,64,Guard,None,0,-1,0,-1,0,0
4=Americans House,CARRIER_MS,256,34,34,64,Guard,None,0,-1,0,-1,0,0
5=Americans House,CARRIER_SDF,256,34,33,64,Guard,None,0,-1,0,-1,0,0
6=Americans House,CARRIER_SDF_MS,256,34,32,64,Guard,None,0,-1,0,-1,0,0
```

<img width="279" height="214" alt="pic-0" src="https://github.com/user-attachments/assets/fb32c46e-e07c-41ae-8a5b-555ec17bdbef" />
<img width="279" height="214" alt="pic-1" src="https://github.com/user-attachments/assets/3bc52eaa-6118-46e9-9444-c6930546b2c4" />

*This PR - normal operation / Nightly Build(c4490e841a06be3663436b516510ba970a3a3ff8) - Fatal Error: Hey guys!*