### PR TITLE
Customize the initial facing of buildings

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -699,6 +699,7 @@ This page lists all the individual contributions to the project by their author.
   - Disable the credits indicator smooth transition
   - Add `selling`, `undeploying` and `harvesting` conditions to `DiscardOn`
   - `ZAdjust` for Projectiles
+  - Customize the initial facing of buildings
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1249,10 +1249,12 @@ Ares' [Battery Super Weapon](https://ares-developers.github.io/Ares-docs/new/sup
 In `rulesmd.ini`:
 ```ini
 [General]
-BuildingStartFacing=0  ; integer
+BuildingStartFacing=0             ; integer
+BuildingStartFacing.Random=false  ; boolean
 
-[SOMEBUILDING]         ; BuildingType
-StartFacing=           ; integer, defaults to [General] -> BuildingStartFacing
+[SOMEBUILDING]                    ; BuildingType
+StartFacing=                      ; integer, defaults to [General] -> BuildingStartFacing
+StartFacing.Random=               ; boolean, defaults to [General] -> BuildingStartFacing.Random
 ```
 
 ```{note}

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1242,6 +1242,23 @@ Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons can never
 Ares' [Battery Super Weapon](https://ares-developers.github.io/Ares-docs/new/superweapons/types/battery.html) won't be affected by this.
 ```
 
+### Customize the initial facing of buildings
+
+- In vanilla, buildings always face due north (0). Now you can customize it.
+
+In `rulesmd.ini`:
+```ini
+[General]
+BuildingStartFacing=0  ; integer
+
+[SOMEBUILDING]         ; BuildingType
+StartFacing=           ; integer, defaults to [General] -> BuildingStartFacing
+```
+
+```{note}
+Unlike the identically named INI flag in Tiberian Sun, this flag uses a 256-point circle rather than an 8-point circle.
+```
+
 ### Disable `DamageSound`
 
 - Now you can disable `DamageSound` of a building.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -612,6 +612,7 @@ HideShakeEffects=false           ; boolean
 - [Adjust recruitable status on team member discharge](AI-Scripting-and-Mapping.md#adjust-recruitable-status-on-team-member-discharge) (by TaranDahl)
 - Customize whether or not passenger can fire out when the transport is moving (by Ollerus)
 - [RA1-Style Multi-Turret and Multi-Barrel](New-or-Enhanced-Logics.md#ra1-style-multi-turret-and-multi-barrel) (by TaranDahl & CrimRecya)
+- [Customize the initial facing of buildings](Fixed-or-Improved-Logics.md#customize-the-initial-facing-of-buildings) (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Building/Body.cpp
+++ b/src/Ext/Building/Body.cpp
@@ -563,10 +563,11 @@ void BuildingExt::ExtData::Serialize(T& Stm)
 		.Process(this->CurrentLaserWeaponIndex)
 		.Process(this->PoweredUpToLevel)
 		.Process(this->CurrentEMPulseSW)
+		//.Process(this->IsFiringNow) It is set and reset within a same function.
 		.Process(this->TurretAnimIdleFrame)
 		.Process(this->TurretAnimFiringFrame)
 		.Process(this->TurretAnimRateTick)
-		//.Process(this->IsFiringNow) It is set and reset within a same function.
+		.Process(this->ConstructionStartFacing) 
 		;
 }
 

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -30,6 +30,7 @@ public:
 		int TurretAnimIdleFrame;
 		int TurretAnimFiringFrame;
 		int TurretAnimRateTick;
+		int ConstructionStartFacing;
 
 		ExtData(BuildingClass* OwnerObject) : Extension<BuildingClass>(OwnerObject)
 			, TypeExtData { nullptr }
@@ -48,6 +49,7 @@ public:
 			, TurretAnimIdleFrame { 0 }
 			, TurretAnimFiringFrame { -1 }
 			, TurretAnimRateTick { 0 }
+			, ConstructionStartFacing { -1 }
 		{ }
 
 		void DisplayIncomeString();

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1301,9 +1301,20 @@ DEFINE_HOOK(0x44C976, BuildingClass_Mission_Repair_TankBunker, 0x5)
 
 #pragma endregion
 
+#pragma region BuildingStartFacing
+
 static int GetBuildingStartFacing(BuildingClass* pThis)
 {
 	auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+
+	if (pTypeExt->StartFacing_Random.Get(RulesExt::Global()->StartFacing_Random))
+	{
+		auto pExt = BuildingExt::ExtMap.Find(pThis);
+		if (pExt->ConstructionStartFacing < 0)
+			pExt->ConstructionStartFacing = ScenarioClass::Instance->Random.RandomRanged(0, 255);
+		return pExt->ConstructionStartFacing;
+	}
+
 	return pTypeExt->StartFacing.Get(RulesExt::Global()->StartFacing);
 }
 
@@ -1330,3 +1341,5 @@ DEFINE_HOOK(0x449DE9, BuildingClass_Mission_Selling_StartFacing_Set, 0x6)
 	R->CH(static_cast<BYTE>(facing));
 	return 0x449DEF;
 }
+
+#pragma endregion

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1342,7 +1342,7 @@ DEFINE_HOOK(0x449DE9, BuildingClass_Mission_Selling_StartFacing_Set, 0x6)
 	return 0x449DEF;
 }
 
-DEFINE_HOOK(0x6F6D9E, TechnoClass_Unimbo_BuildingStartFacing, 0x7)
+DEFINE_HOOK(0x6F6D9E, TechnoClass_Unlimbo_BuildingStartFacing, 0x7)
 {
 	GET(TechnoClass*, pThis, ESI);
 

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1301,14 +1301,32 @@ DEFINE_HOOK(0x44C976, BuildingClass_Mission_Repair_TankBunker, 0x5)
 
 #pragma endregion
 
-DEFINE_HOOK(0x449AFE, BuildingClass_MissionConstruction_StartFacing, 0x6)
+static int GetBuildingStartFacing(BuildingClass* pThis)
+{
+	auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pThis->Type);
+	return pTypeExt->StartFacing.Get(RulesExt::Global()->StartFacing);
+}
+
+DEFINE_HOOK(0x449AFE, BuildingClass_Mission_Construction_StartFacing, 0x6)
 {
 	GET(BuildingClass*, pThis, ESI);
-	auto const pType = pThis->Type;
-	auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pType);
-
-	int facing = pTypeExt->StartFacing.Get(RulesExt::Global()->StartFacing);
-
+	int facing = GetBuildingStartFacing(pThis);
 	R->CH(static_cast<BYTE>(facing));
 	return 0x449B04;
+}
+
+DEFINE_HOOK(0x449DAA, BuildingClass_Mission_Selling_StartFacing_Compare, 0x6)
+{
+	GET(BuildingClass*, pThis, EBP);
+	int facing = GetBuildingStartFacing(pThis);
+	R->EBX(facing);
+	return 0x449DB0;
+}
+
+DEFINE_HOOK(0x449DE9, BuildingClass_Mission_Selling_StartFacing_Set, 0x6)
+{
+	GET(BuildingClass*, pThis, EBP);
+	int facing = GetBuildingStartFacing(pThis);
+	R->CH(static_cast<BYTE>(facing));
+	return 0x449DEF;
 }

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1300,3 +1300,15 @@ DEFINE_HOOK(0x44C976, BuildingClass_Mission_Repair_TankBunker, 0x5)
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x449AFE, BuildingClass_MissionConstruction_StartFacing, 0x6)
+{
+	GET(BuildingClass*, pThis, ESI);
+	auto const pType = pThis->Type;
+	auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pType);
+
+	int facing = pTypeExt->StartFacing.Get(RulesExt::Global()->StartFacing);
+
+	R->CH(static_cast<BYTE>(facing));
+	return 0x449B04;
+}

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1342,4 +1342,20 @@ DEFINE_HOOK(0x449DE9, BuildingClass_Mission_Selling_StartFacing_Set, 0x6)
 	return 0x449DEF;
 }
 
+DEFINE_HOOK(0x6F6D9E, TechnoClass_Unimbo_BuildingStartFacing, 0x7)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	if (abstract_cast<FootClass*>(pThis))
+		return 0;
+
+	const auto pBuilding = static_cast<BuildingClass*>(pThis);
+
+	if (BuildingExt::ExtMap.Find(pBuilding)->IsCreatedFromMapFile)
+		return 0;
+
+	R->AH(static_cast<BYTE>(GetBuildingStartFacing(pBuilding)));
+	return 0;
+}
+
 #pragma endregion

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -242,6 +242,8 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->TurretAnim_IdleRate.Read(exINI, pSection, "TurretAnim.IdleRate");
 	this->TurretAnim_FiringRate.Read(exINI, pSection, "TurretAnim.FiringRate");
 
+	this->StartFacing.Read(exINI, pSection, "StartFacing");
+
 	if (pThis->PowersUpBuilding[0] == NULL && this->PowersUp_Buildings.size() > 0)
 	{
 		strcpy_s(pThis->PowersUpBuilding, this->PowersUp_Buildings[0]->ID);
@@ -418,6 +420,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->TurretAnim_LowPowerFiringFrames)
 		.Process(this->TurretAnim_IdleRate)
 		.Process(this->TurretAnim_FiringFrames)
+		.Process(this->StartFacing)
 
 		// Ares 0.2
 		.Process(this->CloningFacility)

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -243,6 +243,7 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->TurretAnim_FiringRate.Read(exINI, pSection, "TurretAnim.FiringRate");
 
 	this->StartFacing.Read(exINI, pSection, "StartFacing");
+	this->StartFacing_Random.Read(exINI, pSection, "StartFacing.Random");
 
 	if (pThis->PowersUpBuilding[0] == NULL && this->PowersUp_Buildings.size() > 0)
 	{
@@ -421,6 +422,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->TurretAnim_IdleRate)
 		.Process(this->TurretAnim_FiringFrames)
 		.Process(this->StartFacing)
+		.Process(this->StartFacing_Random)
 
 		// Ares 0.2
 		.Process(this->CloningFacility)

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -115,6 +115,8 @@ public:
 		Valueable<int> TurretAnim_IdleRate;
 		Valueable<int> TurretAnim_FiringRate;
 
+		Nullable<int> StartFacing;
+
 		// Ares 0.2
 		Valueable<bool> CloningFacility;
 
@@ -203,6 +205,7 @@ public:
 			, TurretAnim_LowPowerFiringFrames { 0 }
 			, TurretAnim_IdleRate { 1 }
 			, TurretAnim_FiringRate { 1 }
+			, StartFacing {}
 
 			// Ares 0.2
 			, CloningFacility { false }

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -116,6 +116,7 @@ public:
 		Valueable<int> TurretAnim_FiringRate;
 
 		Nullable<int> StartFacing;
+		Nullable<bool> StartFacing_Random;
 
 		// Ares 0.2
 		Valueable<bool> CloningFacility;
@@ -206,6 +207,7 @@ public:
 			, TurretAnim_IdleRate { 1 }
 			, TurretAnim_FiringRate { 1 }
 			, StartFacing {}
+			, StartFacing_Random {}
 
 			// Ares 0.2
 			, CloningFacility { false }

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -458,6 +458,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AutoRemoveEarliestBeacon.Read(exINI, GameStrings::General, "AutoRemoveEarliestBeacon");
 	this->AllowBeaconHotKeyInSinglePlayer.Read(exINI, GameStrings::General, "AllowBeaconHotKeyInSinglePlayer");
 	this->StartFacing.Read(exINI, GameStrings::General, "BuildingStartFacing");
+	this->StartFacing_Random.Read(exINI, GameStrings::General, "BuildingStartFacing.Random");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -816,6 +817,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AutoRemoveEarliestBeacon)
 		.Process(this->AllowBeaconHotKeyInSinglePlayer)
 		.Process(this->StartFacing)
+		.Process(this->StartFacing_Random)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -456,6 +456,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->SecondaryFireSequenceLandOnly.Read(exINI, GameStrings::General, "SecondaryFireSequenceLandOnly");
 	this->AutoRemoveEarliestBeacon.Read(exINI, GameStrings::General, "AutoRemoveEarliestBeacon");
 	this->AllowBeaconHotKeyInSinglePlayer.Read(exINI, GameStrings::General, "AllowBeaconHotKeyInSinglePlayer");
+	this->StartFacing.Read(exINI, GameStrings::General, "BuildingStartFacing");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -812,6 +813,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->SecondaryFireSequenceLandOnly)
 		.Process(this->AutoRemoveEarliestBeacon)
 		.Process(this->AllowBeaconHotKeyInSinglePlayer)
+		.Process(this->StartFacing)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -390,6 +390,7 @@ public:
 		Valueable<bool> AllowBeaconHotKeyInSinglePlayer;
 
 		Valueable<int> StartFacing;
+		Valueable<bool> StartFacing_Random;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -722,6 +723,7 @@ public:
 			, AllowBeaconHotKeyInSinglePlayer { false }
 
 			, StartFacing { 0 }
+			, StartFacing_Random { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -388,6 +388,8 @@ public:
 		Valueable<bool> AutoRemoveEarliestBeacon;
 		Valueable<bool> AllowBeaconHotKeyInSinglePlayer;
 
+		Valueable<int> StartFacing;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -716,6 +718,8 @@ public:
 			, AutoRemoveEarliestBeacon { false }
 
 			, AllowBeaconHotKeyInSinglePlayer { false }
+
+			, StartFacing { 0 }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
- In vanilla, buildings always face due north (0). Now you can customize it.

In `rulesmd.ini`:
```ini
[General]
BuildingStartFacing=0             ; integer
BuildingStartFacing.Random=false  ; boolean

[SOMEBUILDING]                    ; BuildingType
StartFacing=                      ; integer, defaults to [General] -> BuildingStartFacing
StartFacing.Random=               ; boolean, defaults to [General] -> BuildingStartFacing.Random
```

> [!Note]
> Unlike the identically named INI flag in Tiberian Sun, this flag uses a 256-point circle rather than an 8-point circle.