### PR TITLE
New Feature: Support Convert to another type.

### DIFF
--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -163,6 +163,20 @@ int BuildingTypeExt::GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass*
 	return isUpgrade ? result : -1;
 }
 
+// Computes the top-left cell of the building that would be placed if the given
+// foot deployed into the given building type at its current location. Mirrors the
+// vanilla deploy logic, which offsets the top-left cell by (-1,-1) for any
+// foundation larger than 2x2.
+CellStruct BuildingTypeExt::GetBuildingTopLeftCellFromDeployCell(BuildingTypeClass* pBuilding, const CellStruct& cell)
+{
+	auto mapCoords = cell;
+
+	if (pBuilding->GetFoundationWidth() > 2 || pBuilding->GetFoundationHeight(false) > 2)
+		mapCoords += CellStruct { -1, -1 };
+
+	return mapCoords;
+}
+
 void BuildingTypeExt::Initialize()
 {
 	TechnoTypeExt::Initialize();

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -297,5 +297,6 @@ public:
 	static bool CanUpgrade(BuildingClass* pBuilding, BuildingTypeClass* pUpgradeType, HouseClass* pUpgradeOwner);
 	static int CountOwnedNowWithDeployOrUpgrade(BuildingTypeClass* pBuilding, HouseClass* pHouse);
 	static int GetUpgradesAmount(BuildingTypeClass* pBuilding, HouseClass* pHouse);
+	static CellStruct GetBuildingTopLeftCellFromDeployCell(BuildingTypeClass* pBuilding, const CellStruct &cell);
 };
 

--- a/src/Ext/Foot/Body.cpp
+++ b/src/Ext/Foot/Body.cpp
@@ -3,11 +3,14 @@
 #include <JumpjetLocomotionClass.h>
 
 #include <Ext/Anim/Body.h>
+#include <Ext/BuildingType/Body.h>
 #include <Ext/House/Body.h>
 #include <Ext/Scenario/Body.h>
 #include <Ext/Unit/Body.h>
 #include <Misc/FlyingStrings.h>
 #include <Utilities/AresFunctions.h>
+
+FootClass* FootExt::Deployer = nullptr;
 
 void FootExt::UpdateTiberiumEater()
 {
@@ -846,23 +849,36 @@ void FootExt::AmmoAutoConvertActions()
 		TechnoExt::ConvertToType(pThis, pTypeExt->Ammo_AutoConvertType);
 }
 
-void FootExt::HealthAutoConvertActions()
+// Checks if vehicle can deploy into a building at its current location. If unit has no DeploysInto set returns noDeploysIntoDefaultValue (def = false) instead.
+bool FootExt::CanDeployIntoBuilding(FootClass* pThis, bool noDeploysIntoDefaultValue)
 {
-	const auto pTypeExt = this->TypeExtData;
+	if (!pThis)
+		return false;
 
-	if (!pTypeExt->Convert_Health.isset())
-		return;
+	BuildingTypeClass* pDeployType = nullptr;
+	if (auto const pUnit = abstract_cast<UnitClass*>(pThis))
+		pDeployType = pUnit->Type->DeploysInto;
 
-	const double min = pTypeExt->Convert_Health_AbovePercent;
-	const double max = pTypeExt->Convert_Health_BelowPercent;
+	if (!pDeployType)
+	{
+		if (auto const pType = TechnoTypeExt::Fetch(pThis->GetTechnoType())->Convert_Deploy.Get())
+			pDeployType = abstract_cast<BuildingTypeClass*, true>(pType);
+	}
 
-	if (min < 0 && max < 0)
-		return;
+	if (!pDeployType)
+		return noDeploysIntoDefaultValue;
 
-	const auto pThis = this->OwnerObject();
+	const auto mapCoords = BuildingTypeExt::GetBuildingTopLeftCellFromDeployCell(
+		pDeployType,
+		CellClass::Coord2Cell(pThis->GetCoords()));
 
-	if (TechnoExt::IsHealthInThreshold(pThis, min, max))
-		TechnoExt::ConvertToType(pThis, pTypeExt->Convert_Health);
+	// The vanilla game used an inappropriate approach here, resulting in potential risk of desync.
+	// Now, through additional checks, we can directly exclude the unit who want to deploy.
+	FootExt::Deployer = pThis;
+	const bool canDeploy = pDeployType->CanCreateHere(mapCoords, pThis->Owner);
+	FootExt::Deployer = nullptr;
+
+	return canDeploy;
 }
 
 // =============================

--- a/src/Ext/Foot/Body.h
+++ b/src/Ext/Foot/Body.h
@@ -63,11 +63,13 @@ public:
 	void UpdateOnTunnelEnter();
 	void UpdateOnTunnelExit();
 	void UpdateTypeData(TechnoTypeClass* pCurrentType);
-	void HealthAutoConvertActions();
 	void AmmoAutoConvertActions();
 
 	virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 	virtual void SaveToStream(PhobosStreamWriter& Stm) override;
+
+	static FootClass* Deployer;
+	static bool CanDeployIntoBuilding(FootClass* pThis, bool noDeploysIntoDefaultValue = false);
 
 private:
 	template <typename T>

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -262,27 +262,26 @@ DEFINE_HOOK(0x7015C9, TechnoClass_Captured_UpdateTracking, 0x6)
 		pNewOwnerExt->OwnedCountedHarvesters.push_back(pThis);
 	}
 
-	if (const auto pMe = generic_cast<FootClass*, true>(pThis))
+	const bool I_am_human = pThis->Owner->IsControlledByHuman();
+
+	if (I_am_human != pNewOwner->IsControlledByHuman())
 	{
-		const bool I_am_human = pThis->Owner->IsControlledByHuman();
-
-		if (I_am_human != pNewOwner->IsControlledByHuman())
+		if (const auto pConvertTo = I_am_human
+			? pTypeExt->Convert_HumanToComputer.Get()
+			: pTypeExt->Convert_ComputerToHuman.Get())
 		{
-			if (const auto pConvertTo = I_am_human
-				? pTypeExt->Convert_HumanToComputer.Get()
-				: pTypeExt->Convert_ComputerToHuman.Get())
-			{
-				if (pConvertTo->WhatAmI() == pType->WhatAmI())
-					TechnoExt::ConvertToType(pMe, pConvertTo);
-			}
+			TechnoExt::ConvertToType(pThis, pConvertTo);
+		}
 
+		if (const auto pMe = generic_cast<FootClass*, true>(pThis))
+		{
 			if (!I_am_human)
 				TechnoExt::ChangeOwnerMissionFix(pMe);
 		}
-
-		pThis->Owner->RecheckTechTree = true;
-		pNewOwner->RecheckTechTree = true;
 	}
+
+	pThis->Owner->RecheckTechTree = true;
+	pNewOwner->RecheckTechTree = true;
 
 	for (const auto& pTrail : pExt->LaserTrails)
 	{

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -349,8 +349,8 @@ void SWTypeExt::ApplySWNext(SuperClass* pSW, const CellStruct& cell)
 
 void SWTypeExt::ApplyTypeConversion(SuperClass* pSW)
 {
-	for (const auto pTargetFoot : FootClass::Array)
-		TypeConvertGroup::Convert(pTargetFoot, this->Convert_Pairs, pSW->Owner);
+	for (const auto pTarget : TechnoClass::Array)
+		TypeConvertGroup::Convert(pTarget, this->Convert_Pairs, pSW->Owner);
 }
 
 void SWTypeExt::HandleEMPulseLaunch(SuperClass* pSW, const CellStruct& cell) const

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -372,8 +372,9 @@ static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 	auto const pToInfantry = abstract_cast<InfantryClass*>(pToTechno);
 	if (pFromBuilding)
 	{
-		if (pFromBuilding->CurrentMission == Mission::Selling)
+		if (pFromBuilding->CurrentMission == Mission::None)
 			return false;
+		pFromBuilding->ForceMission(Mission::None);
 
 		auto const buildingCell = CellClass::Coord2Cell(location);
 		auto const tmpCell = BuildingTypeExt::GetBuildingTopLeftCellFromDeployCell(pFromBuilding->Type, buildingCell);

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -406,7 +406,7 @@ static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 
 	if (pFromFoot && pFromFoot->IsDeploying)
 	{
-		if (pToInfantry->Type->Sequence->GetSequence(Sequence::Deployed))
+		if (pToInfantry->Type->Sequence->GetSequence(Sequence::Deployed).CountFrames)
 		{
 			pToInfantry->PlayAnim(Sequence::Deployed, true);
 		}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -351,7 +351,7 @@ bool TechnoExt::AllowedTargetByZone(TechnoClass* pThis, TechnoClass* pTarget, Ta
 static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 {
 	auto const pToObject = pToType->CreateObject(pFromTechno->Owner);
-	auto const pToTechno = abstract_cast<TechnoClass*>(pToObject);
+	auto const pToTechno = static_cast<TechnoClass*>(pToObject);
 	if (!pToTechno)
 	{
 		if (pToObject)
@@ -441,8 +441,9 @@ bool TechnoExt::ConvertToType(TechnoClass* pThisTechno, TechnoTypeClass* pToType
 		return false;
 	}
 
-	if (pType->WhatAmI() != pToType->WhatAmI()
-		|| (pType->WhatAmI() == pToType->WhatAmI() && pType->WhatAmI() == AbstractType::BuildingType))
+    const auto absType = pType->WhatAmI();
+    
+	if (absType != pToType->WhatAmI() || absType == AbstractType::BuildingType)
 		return XConvertToType(pThisTechno, pToType);
 
 	auto const pThis = abstract_cast<FootClass*>(pThisTechno);
@@ -589,8 +590,12 @@ void TechnoExt::TransferStatus(TechnoClass* pFrom, TechnoClass* pTo)
 	pTo->ArmorMultiplier = pFrom->ArmorMultiplier;
 	pTo->FirepowerMultiplier = pFrom->FirepowerMultiplier;
 	if (auto const pFromFoot = abstract_cast<FootClass*>(pFrom))
+	{
 		if (auto const pToFoot = abstract_cast<FootClass*>(pTo))
+		{
 			pToFoot->SpeedMultiplier = pFromFoot->SpeedMultiplier;
+		}
+	}
 }
 
 void TechnoExt::TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo)
@@ -599,13 +604,13 @@ void TechnoExt::TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClas
 		? pTechnoFrom->MindControlRingAnim->Type
 		: TechnoExt::Fetch(pTechnoFrom)->MindControlRingAnimType;
 
-	if (const auto Controller = pTechnoFrom->MindControlledBy)
+	if (const auto pController = pTechnoFrom->MindControlledBy)
 	{
-		if (const auto Manager = Controller->CaptureManager)
+		if (const auto pManager = pController->CaptureManager)
 		{
-			CaptureManagerExt::FreeUnit(Manager, pTechnoFrom, true);
+			CaptureManagerExt::FreeUnit(pManager, pTechnoFrom, true);
 
-			if (CaptureManagerExt::CaptureUnit(Manager, pTechnoTo, false, pAnimType, true))
+			if (CaptureManagerExt::CaptureUnit(pManager, pTechnoTo, false, pAnimType, true))
 			{
 				if (const auto pBld = abstract_cast<BuildingClass*, true>(pTechnoTo))
 				{
@@ -629,9 +634,9 @@ void TechnoExt::TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClas
 			}
 		}
 	}
-	else if (const auto MCHouse = pTechnoFrom->MindControlledByHouse)
+	else if (const auto phMC = pTechnoFrom->MindControlledByHouse)
 	{
-		pTechnoTo->MindControlledByHouse = MCHouse;
+		pTechnoTo->MindControlledByHouse = phMC;
 		pTechnoFrom->MindControlledByHouse = nullptr;
 	}
 	else if (pTechnoFrom->MindControlledByAUnit) // Perma MC

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -2,6 +2,7 @@
 #include <Ext/Anim/Body.h>
 #include <Ext/Building/Body.h>
 #include <Ext/BuildingType/Body.h>
+#include <Ext/CaptureManager/Body.h>
 #include <Ext/House/Body.h>
 #include <Ext/Infantry/Body.h>
 #include <Ext/Unit/Body.h>
@@ -347,18 +348,106 @@ bool TechnoExt::AllowedTargetByZone(TechnoClass* pThis, TechnoClass* pTarget, Ta
 	return true;
 }
 
-// Feature for common usage : TechnoType conversion -- Trsdy
-// BTW, who said it was merely a Type pointer replacement and he could make a better one than Ares?
-bool TechnoExt::ConvertToType(FootClass* pThis, TechnoTypeClass* pToType)
+static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 {
-	const auto pType = pThis->GetTechnoType();
-
-	// It really should be at the beginning.
-	if (pType == pToType || pType->WhatAmI() != pToType->WhatAmI())
+	auto const pToObject = pToType->CreateObject(pFromTechno->Owner);
+	auto const pToTechno = abstract_cast<TechnoClass*>(pToObject);
+	if (!pToTechno)
 	{
-		Debug::Log("Incompatible types between %s and %s\n", pThis->get_ID(), pToType->get_ID());
+		if (pToObject)
+			pToObject->UnInit();
 		return false;
 	}
+
+	auto const wasSelected = pFromTechno->IsSelected;
+
+	TechnoExt::TransferStatus(pFromTechno, pToTechno);
+
+	pToTechno->SetTarget(pFromTechno->Target);
+
+	auto location = pFromTechno->GetCoords();
+	auto const pFromBuilding = abstract_cast<BuildingClass*>(pFromTechno);
+	auto const pToBuilding = abstract_cast<BuildingClass*>(pToTechno);
+	if (pFromBuilding)
+	{
+		auto const buildingCell = CellClass::Coord2Cell(location);
+		auto const tmpCell = BuildingTypeExt::GetBuildingTopLeftCellFromDeployCell(pFromBuilding->Type, buildingCell);
+		location = CellClass::Cell2Coord(buildingCell + buildingCell - tmpCell, location.Z);
+	}
+	if (pToBuilding)
+	{
+		auto const deployCell = CellClass::Coord2Cell(location);
+		auto const buildingCell = BuildingTypeExt::GetBuildingTopLeftCellFromDeployCell(pToBuilding->Type, deployCell);
+		location = CellClass::Cell2Coord(buildingCell, location.Z);
+
+		auto const pBuildingExt = BuildingExt::Fetch(pToBuilding);
+		pBuildingExt->DeployedTechno = true;
+	}
+
+	if (auto const pFromFoot = abstract_cast<FootClass*>(pFromTechno))
+		pToTechno->SetDestination(pFromFoot->Destination, true);
+	pToTechno->QueueMission(pFromTechno->CurrentMission, false);
+
+	++Unsorted::ScenarioInit;
+	pToTechno->Unlimbo(location, pFromTechno->PrimaryFacing.Current().GetDir());
+	--Unsorted::ScenarioInit;
+
+	// Keep selection
+	if (wasSelected)
+		pToTechno->Select();
+
+	if (pFromBuilding && pFromBuilding->CanBeSold() && !pFromBuilding->IsStrange())
+	{
+		pFromBuilding->SetArchiveTarget(nullptr); // Reset to ensure it must to be sold
+		pFromBuilding->Sell(-1);
+	}
+	else
+	{
+		pFromTechno->Limbo();
+		pFromTechno->UnInit();
+	}
+
+	if (!pToBuilding)
+		return true;
+
+	if (pToBuilding->Type->Buildup)
+	{
+		pToBuilding->BeginMode(BStateType::Construction);
+		pToBuilding->QueueMission(Mission::Construction, false);
+	}
+	else
+	{
+		pToBuilding->BeginMode(BStateType::Idle);
+		pToBuilding->QueueMission(Mission::Guard, false);
+		pToBuilding->NextMission();
+	}
+	
+	pToBuilding->Place(false);
+	VoxClass::PlayAtPos(RulesClass::Instance->BuildingSlam, &location);
+
+	return true;
+}
+
+// Feature for common usage : TechnoType conversion -- Trsdy
+// BTW, who said it was merely a Type pointer replacement and he could make a better one than Ares?
+bool TechnoExt::ConvertToType(TechnoClass* pThisTechno, TechnoTypeClass* pToType)
+{
+	const auto pType = pThisTechno->GetTechnoType();
+
+	// It really should be at the beginning.
+	if (pType == pToType)
+	{
+		Debug::Log("Incompatible types between %s and %s\n", pThisTechno->get_ID(), pToType->get_ID());
+		return false;
+	}
+
+	if (pType->WhatAmI() != pToType->WhatAmI()
+		|| (pType->WhatAmI() == pToType->WhatAmI() && pType->WhatAmI() == AbstractType::BuildingType))
+		return XConvertToType(pThisTechno, pToType);
+
+	auto const pThis = abstract_cast<FootClass*>(pThisTechno);
+	if (!pThis)
+		return false;
 
 	if (AresFunctions::ConvertTypeTo)
 	{
@@ -468,6 +557,107 @@ bool TechnoExt::ConvertToType(FootClass* pThis, TechnoTypeClass* pToType)
 
 	FootExt::Fetch(pThis)->UpdateTypeData(pToType);
 	return true;
+}
+
+void TechnoExt::HealthAutoConvertActions()
+{
+	const auto pTypeExt = this->TypeExtData;
+
+	if (!pTypeExt->Convert_Health.isset())
+		return;
+
+	const double min = pTypeExt->Convert_Health_AbovePercent;
+	const double max = pTypeExt->Convert_Health_BelowPercent;
+
+	if (min < 0 && max < 0)
+		return;
+
+	const auto pThis = this->OwnerObject();
+
+	if (TechnoExt::IsHealthInThreshold(pThis, min, max))
+		TechnoExt::ConvertToType(pThis, pTypeExt->Convert_Health);
+}
+
+void TechnoExt::TransferStatus(TechnoClass* pFrom, TechnoClass* pTo)
+{
+	pTo->SetHealthPercentage(pFrom->GetHealthPercentage());
+	pTo->Veterancy = pFrom->Veterancy;
+	TransferMindControlOnDeploy(pFrom, pTo);
+	ShieldClass::SyncShieldToAnother(pFrom, pTo);
+	TechnoExt::SyncInvulnerability(pFrom, pTo);
+	AttachEffectClass::TransferAttachedEffects(pFrom, pTo);
+	pTo->ArmorMultiplier = pFrom->ArmorMultiplier;
+	pTo->FirepowerMultiplier = pFrom->FirepowerMultiplier;
+	if (auto const pFromFoot = abstract_cast<FootClass*>(pFrom))
+		if (auto const pToFoot = abstract_cast<FootClass*>(pTo))
+			pToFoot->SpeedMultiplier = pFromFoot->SpeedMultiplier;
+}
+
+void TechnoExt::TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo)
+{
+	const auto pAnimType = pTechnoFrom->MindControlRingAnim
+		? pTechnoFrom->MindControlRingAnim->Type
+		: TechnoExt::Fetch(pTechnoFrom)->MindControlRingAnimType;
+
+	if (const auto Controller = pTechnoFrom->MindControlledBy)
+	{
+		if (const auto Manager = Controller->CaptureManager)
+		{
+			CaptureManagerExt::FreeUnit(Manager, pTechnoFrom, true);
+
+			if (CaptureManagerExt::CaptureUnit(Manager, pTechnoTo, false, pAnimType, true))
+			{
+				if (const auto pBld = abstract_cast<BuildingClass*, true>(pTechnoTo))
+				{
+					// Capturing the building after unlimbo before buildup has finished or even started appears to throw certain things off,
+					// Hopefully this is enough to fix most of it like anims playing prematurely etc.
+					pBld->ActuallyPlacedOnMap = false;
+					pBld->DestroyNthAnim(BuildingAnimSlot::All);
+
+					pBld->BeginMode(BStateType::Construction);
+					pBld->QueueMission(Mission::Construction, false);
+				}
+			}
+			else
+			{
+				int nSound = pTechnoTo->GetTechnoType()->MindClearedSound;
+				if (nSound == -1)
+					nSound = RulesClass::Instance->MindClearedSound;
+
+				if (nSound != -1)
+					VocClass::PlayIndexAtPos(nSound, pTechnoTo->Location);
+			}
+		}
+	}
+	else if (const auto MCHouse = pTechnoFrom->MindControlledByHouse)
+	{
+		pTechnoTo->MindControlledByHouse = MCHouse;
+		pTechnoFrom->MindControlledByHouse = nullptr;
+	}
+	else if (pTechnoFrom->MindControlledByAUnit) // Perma MC
+	{
+		pTechnoTo->MindControlledByAUnit = true;
+
+		const auto pBuilding = abstract_cast<BuildingClass*, true>(pTechnoTo);
+		CoordStruct location = pTechnoTo->GetCoords();
+
+		location.Z += pBuilding
+			? pBuilding->Type->Height * Unsorted::LevelHeight
+			: pTechnoTo->GetTechnoType()->MindControlRingOffset;
+
+		const auto pAnim = pAnimType
+			? GameCreate<AnimClass>(pAnimType, location, 0, 1)
+			: nullptr;
+
+		if (pAnim)
+		{
+			if (pBuilding)
+				pAnim->ZAdjust = -1024;
+
+			pTechnoTo->MindControlRingAnim = pAnim;
+			pAnim->SetOwnerObject(pTechnoTo);
+		}
+	}
 }
 
 bool TechnoExt::IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource)
@@ -791,37 +981,37 @@ void TechnoExt::ClickedApproachObject(FootClass* pThis, ObjectClass* pObject)
 
 bool TechnoExt::CanBeRecruitedFix(FootClass* pThis, HouseClass* pHouse)
 {
-    if (pThis->Team != nullptr ||
-        !pThis->IsAlive ||
-        pThis->Health <= 0 ||
-        pThis->InLimbo ||
-        pThis->Owner != pHouse)
-    {
-        return false;
-    }
+	if (pThis->Team != nullptr ||
+		!pThis->IsAlive ||
+		pThis->Health <= 0 ||
+		pThis->InLimbo ||
+		pThis->Owner != pHouse)
+	{
+		return false;
+	}
 
-    if (!(pThis->RecruitableA && pThis->RecruitableB))
-    {
-        return false;
-    }
+	if (!(pThis->RecruitableA && pThis->RecruitableB))
+	{
+		return false;
+	}
 
-    const Mission mission = pThis->GetCurrentMission();
-    if (!MissionClass::IsRecruitableMission(mission))
-    {
-        return false;
-    }
+	const Mission mission = pThis->GetCurrentMission();
+	if (!MissionClass::IsRecruitableMission(mission))
+	{
+		return false;
+	}
 
-    if (pThis->ShouldEnterAbsorber ||
-        pThis->ShouldEnterOccupiable ||
-        pThis->ShouldGarrisonStructure ||
-        pThis->DrainTarget != nullptr ||
-        pThis->BunkerLinkedItem ||
-        pThis->LocomotorSource != nullptr)
-    {
-        return false;
-    }
+	if (pThis->ShouldEnterAbsorber ||
+		pThis->ShouldEnterOccupiable ||
+		pThis->ShouldGarrisonStructure ||
+		pThis->DrainTarget != nullptr ||
+		pThis->BunkerLinkedItem ||
+		pThis->LocomotorSource != nullptr)
+	{
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 bool TechnoExt::EjectRandomly(FootClass* pEjectee, const CoordStruct& coords, int distance, bool select)
@@ -938,7 +1128,7 @@ struct DummyExtHere
 	char _pad0[0x50];
 	CDTimerClass DisableWeaponsTimer;
 	char _pad1[0x40];
-	bool DriverKilled; 
+	bool DriverKilled;
 };
 
 struct DummyTypeExtHere

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -366,8 +366,10 @@ static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 	pToTechno->SetTarget(pFromTechno->Target);
 
 	auto location = pFromTechno->GetCoords();
+	auto const pFromFoot = abstract_cast<FootClass*>(pFromTechno);
 	auto const pFromBuilding = abstract_cast<BuildingClass*>(pFromTechno);
 	auto const pToBuilding = abstract_cast<BuildingClass*>(pToTechno);
+	auto const pToInfantry = abstract_cast<InfantryClass*>(pToTechno);
 	if (pFromBuilding)
 	{
 		auto const buildingCell = CellClass::Coord2Cell(location);
@@ -384,9 +386,35 @@ static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 		pBuildingExt->DeployedTechno = true;
 	}
 
-	if (auto const pFromFoot = abstract_cast<FootClass*>(pFromTechno))
+	if (pFromFoot)
 		pToTechno->SetDestination(pFromFoot->Destination, true);
 	pToTechno->QueueMission(pFromTechno->CurrentMission, false);
+
+	if (pFromBuilding && pFromBuilding->Occupants.Count > 0)
+	{
+		if (pToBuilding
+			&& pToBuilding->Type->CanBeOccupied
+			&& pToBuilding->Type->MaxNumberOccupants >= pFromBuilding->Occupants.Count)
+		{
+			pToBuilding->Occupants = pFromBuilding->Occupants;
+		}
+		else
+		{
+			pFromBuilding->Mission_Unload();
+		}
+	}
+
+	if (pFromFoot && pFromFoot->IsDeploying)
+	{
+		if (pToInfantry->Type->Sequence->GetSequence(Sequence::Deployed))
+		{
+			pToInfantry->PlayAnim(Sequence::Deployed, true);
+		}
+		else
+		{
+			pToInfantry->PlayAnim(Sequence::Ready, true);
+		}
+	}
 
 	++Unsorted::ScenarioInit;
 	pToTechno->Unlimbo(location, pFromTechno->PrimaryFacing.Current().GetDir());

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -372,6 +372,9 @@ static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 	auto const pToInfantry = abstract_cast<InfantryClass*>(pToTechno);
 	if (pFromBuilding)
 	{
+		if (pFromBuilding->CurrentMission == Mission::Selling)
+			return false;
+
 		auto const buildingCell = CellClass::Coord2Cell(location);
 		auto const tmpCell = BuildingTypeExt::GetBuildingTopLeftCellFromDeployCell(pFromBuilding->Type, buildingCell);
 		location = CellClass::Cell2Coord(buildingCell + buildingCell - tmpCell, location.Z);
@@ -424,16 +427,8 @@ static bool XConvertToType(TechnoClass* pFromTechno, TechnoTypeClass* pToType)
 	if (wasSelected)
 		pToTechno->Select();
 
-	if (pFromBuilding && pFromBuilding->CanBeSold() && !pFromBuilding->IsStrange())
-	{
-		pFromBuilding->SetArchiveTarget(nullptr); // Reset to ensure it must to be sold
-		pFromBuilding->Sell(-1);
-	}
-	else
-	{
-		pFromTechno->Limbo();
-		pFromTechno->UnInit();
-	}
+	pFromTechno->Limbo();
+	pFromTechno->UnInit();
 
 	if (!pToBuilding)
 		return true;

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -183,6 +183,7 @@ public:
 	void UpdateTintValues();
 	void UpdateLastTargetCrd();
 	int GetSight();
+	void HealthAutoConvertActions();
 
 	static bool CanReceiveEvent(TechnoClass* pThis, HouseClass* pHouse);
 
@@ -245,7 +246,9 @@ public:
 	static CoordStruct PassengerKickOutLocation(TechnoClass* pThis, FootClass* pPassenger, int maxAttempts);
 	static bool AllowedTargetByZone(TechnoClass* pThis, TechnoClass* pTarget, TargetZoneScanType zoneScanType, WeaponTypeClass* pWeapon = nullptr, bool useZone = false, int zone = -1);
 	static void UpdateAttachedAnimLayers(TechnoClass* pThis);
-	static bool ConvertToType(FootClass* pThis, TechnoTypeClass* toType);
+	static bool ConvertToType(TechnoClass* pThis, TechnoTypeClass* pToType);
+	static void TransferStatus(TechnoClass* pFrom, TechnoClass* pTo);
+	static void TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo);
 	static bool IsTypeImmune(TechnoClass* pThis, TechnoClass* pSource);
 	static int GetTintColor(TechnoClass* pThis, bool invulnerability, bool airstrike, bool berserk);
 	static int GetCustomTintColor(TechnoClass* pThis);

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -31,7 +31,9 @@ DEFINE_HOOK(0x6F9E50, TechnoClass_AI, 0x5)
 {
 	GET(TechnoClass*, pThis, ECX);
 
-	TechnoExt::Fetch(pThis)->OnEarlyUpdate();
+	auto const pExt = TechnoExt::Fetch(pThis);
+	pExt->OnEarlyUpdate();
+	pExt->HealthAutoConvertActions();
 
 	return 0;
 }
@@ -45,7 +47,6 @@ DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
 	pExt->UpdateWarpInDelay();
 	pExt->UpdateTiberiumEater();
 	pExt->AmmoAutoConvertActions();
-	pExt->HealthAutoConvertActions();
 
 	if (pExt->AttackMoveFollowerTempCount)
 		pExt->AttackMoveFollowerTempCount--;

--- a/src/Ext/Unit/Body.cpp
+++ b/src/Ext/Unit/Body.cpp
@@ -8,8 +8,6 @@
 
 UnitExt::ExtContainer UnitExt::ExtMap;
 
-UnitClass* UnitExt::Deployer = nullptr;
-
 UnitExt::~UnitExt()
 {
 	if (this->UndergroundTracked)
@@ -315,31 +313,6 @@ bool UnitExt::SimpleDeployerAllowedToDeploy(UnitClass* pThis, bool defaultValue,
 	}
 
 	return true;
-}
-
-// Checks if vehicle can deploy into a building at its current location. If unit has no DeploysInto set returns noDeploysIntoDefaultValue (def = false) instead.
-bool UnitExt::CanDeployIntoBuilding(UnitClass* pThis, bool noDeploysIntoDefaultValue)
-{
-	if (!pThis)
-		return false;
-
-	auto const pDeployType = pThis->Type->DeploysInto;
-
-	if (!pDeployType)
-		return noDeploysIntoDefaultValue;
-
-	auto mapCoords = CellClass::Coord2Cell(pThis->GetCoords());
-
-	if (pDeployType->GetFoundationWidth() > 2 || pDeployType->GetFoundationHeight(false) > 2)
-		mapCoords += CellStruct { -1, -1 };
-
-	// The vanilla game used an inappropriate approach here, resulting in potential risk of desync.
-	// Now, through additional checks, we can directly exclude the unit who want to deploy.
-	UnitExt::Deployer = pThis;
-	const bool canDeploy = pDeployType->CanCreateHere(mapCoords, pThis->Owner);
-	UnitExt::Deployer = nullptr;
-
-	return canDeploy;
 }
 
 UnitTypeClass* UnitExt::GetUnitTypeExtra(UnitClass* pUnit, UnitTypeExt* pData)

--- a/src/Ext/Unit/Body.h
+++ b/src/Ext/Unit/Body.h
@@ -50,13 +50,10 @@ public:
 	void UpdateRecoilData();
 	void RecordRecoilData();
 
-	static UnitClass* Deployer;
-
 	static bool CannotMove(UnitClass* pThis);
 	static bool HasAmmoToDeploy(UnitClass* pThis);
 	static void HandleOnDeployAmmoChange(UnitClass* pThis, int maxAmmoOverride = -1);
 	static bool SimpleDeployerAllowedToDeploy(UnitClass* pThis, bool defaultValue, bool alwaysCheckLandTypes);
-	static bool CanDeployIntoBuilding(UnitClass* pThis, bool noDeploysIntoDefaultValue = false);
 	static UnitTypeClass* GetUnitTypeExtra(UnitClass* pUnit, UnitTypeExt* pData);
 
 	UnitClass* OwnerObject() const

--- a/src/Ext/Unit/Hooks.DeployFire.cpp
+++ b/src/Ext/Unit/Hooks.DeployFire.cpp
@@ -28,6 +28,21 @@ DEFINE_HOOK(0x4C77E4, EventClass_Execute_DeployCommand, 0x6)
 		}
 	}
 
+	if (auto const pFoot = abstract_cast<FootClass*>(pThis))
+	{
+		const auto pExt = TechnoExt::Fetch(pThis);
+		auto const pConvertToType = pExt->TypeExtData->Convert_Deploy.Get();
+		if (pConvertToType
+			&& pConvertToType->WhatAmI() == AbstractType::BuildingType
+			&& !FootExt::CanDeployIntoBuilding(pFoot, false))
+		{
+			if (pThis->IsOwnedByCurrentPlayer)
+				VoxClass::PlayIndex(VoxClass::FindIndex(GameStrings::EVA_CannotDeployHere));
+
+			return DoNotExecute;
+		}
+	}
+
 	return 0;
 }
 

--- a/src/Ext/Unit/Hooks.DeploysInto.cpp
+++ b/src/Ext/Unit/Hooks.DeploysInto.cpp
@@ -3,7 +3,6 @@
 #include "Body.h"
 
 #include <Ext/TerrainType/Body.h>
-#include <Ext/CaptureManager/Body.h>
 #include <Ext/Building/Body.h>
 
 #pragma region AllowDeployControlledMCV
@@ -18,82 +17,12 @@ DEFINE_HOOK(0x700ED0, TechnoClass_AllowDeployControlledMCV, 0x6)// UnitClass::Ca
 
 #pragma endregion
 
-static inline void TransferMindControlOnDeploy(TechnoClass* pTechnoFrom, TechnoClass* pTechnoTo)
-{
-	const auto pAnimType = pTechnoFrom->MindControlRingAnim
-		? pTechnoFrom->MindControlRingAnim->Type
-		: TechnoExt::Fetch(pTechnoFrom)->MindControlRingAnimType;
-
-	if (const auto Controller = pTechnoFrom->MindControlledBy)
-	{
-		if (const auto Manager = Controller->CaptureManager)
-		{
-			CaptureManagerExt::FreeUnit(Manager, pTechnoFrom, true);
-
-			if (CaptureManagerExt::CaptureUnit(Manager, pTechnoTo, false, pAnimType, true))
-			{
-				if (const auto pBld = abstract_cast<BuildingClass*, true>(pTechnoTo))
-				{
-					// Capturing the building after unlimbo before buildup has finished or even started appears to throw certain things off,
-					// Hopefully this is enough to fix most of it like anims playing prematurely etc.
-					pBld->ActuallyPlacedOnMap = false;
-					pBld->DestroyNthAnim(BuildingAnimSlot::All);
-
-					pBld->BeginMode(BStateType::Construction);
-					pBld->QueueMission(Mission::Construction, false);
-				}
-			}
-			else
-			{
-				int nSound = pTechnoTo->GetTechnoType()->MindClearedSound;
-				if (nSound == -1)
-					nSound = RulesClass::Instance->MindClearedSound;
-
-				if (nSound != -1)
-					VocClass::PlayIndexAtPos(nSound, pTechnoTo->Location);
-			}
-		}
-	}
-	else if (const auto MCHouse = pTechnoFrom->MindControlledByHouse)
-	{
-		pTechnoTo->MindControlledByHouse = MCHouse;
-		pTechnoFrom->MindControlledByHouse = nullptr;
-	}
-	else if (pTechnoFrom->MindControlledByAUnit) // Perma MC
-	{
-		pTechnoTo->MindControlledByAUnit = true;
-
-		const auto pBuilding = abstract_cast<BuildingClass*, true>(pTechnoTo);
-		CoordStruct location = pTechnoTo->GetCoords();
-
-		location.Z += pBuilding
-			? pBuilding->Type->Height * Unsorted::LevelHeight
-			: pTechnoTo->GetTechnoType()->MindControlRingOffset;
-
-		const auto pAnim = pAnimType
-			? GameCreate<AnimClass>(pAnimType, location, 0, 1)
-			: nullptr;
-
-		if (pAnim)
-		{
-			if (pBuilding)
-				pAnim->ZAdjust = -1024;
-
-			pTechnoTo->MindControlRingAnim = pAnim;
-			pAnim->SetOwnerObject(pTechnoTo);
-		}
-	}
-}
-
 DEFINE_HOOK(0x739956, UnitClass_Deploy_Transfer, 0x6)
 {
 	GET(UnitClass*, pUnit, EBP);
 	GET(BuildingClass*, pStructure, EBX);
 
-	TransferMindControlOnDeploy(pUnit, pStructure);
-	ShieldClass::SyncShieldToAnother(pUnit, pStructure);
-	TechnoExt::SyncInvulnerability(pUnit, pStructure);
-	AttachEffectClass::TransferAttachedEffects(pUnit, pStructure);
+	TechnoExt::TransferStatus(pUnit, pStructure);
 
 	return 0;
 }
@@ -103,10 +32,7 @@ DEFINE_HOOK(0x44A03C, BuildingClass_Mi_Selling_Transfer, 0x6)
 	GET(BuildingClass*, pStructure, EBP);
 	GET(UnitClass*, pUnit, EBX);
 
-	TransferMindControlOnDeploy(pStructure, pUnit);
-	ShieldClass::SyncShieldToAnother(pStructure, pUnit);
-	TechnoExt::SyncInvulnerability(pStructure, pUnit);
-	AttachEffectClass::TransferAttachedEffects(pStructure, pUnit);
+	TechnoExt::TransferStatus(pStructure, pUnit);
 
 	// This line will break the bahavior of UnDeploysInto buildings. However, it might serve a purpose that no one knows yet
 	// Comment out the line instead of removing it for now, so we can turn to it if something related goes wrong in the future
@@ -127,6 +53,23 @@ DEFINE_HOOK(0x449E2E, BuildingClass_Mi_Selling_CreateUnit, 0x6)
 	}
 
 	return 0x449E34;
+}
+
+DEFINE_HOOK(0x7000DF, TechnoClass_WhatAction_Deploy, 0x5)
+{
+	GET(TechnoClass*, pThis, ESI);
+
+	if (auto pInfantry = abstract_cast<InfantryClass*, true>(pThis))
+	{
+		if (!FootExt::CanDeployIntoBuilding(pInfantry, true))
+		{
+			R->EAX(Action::NoDeploy);
+
+			return 0x7000E4;
+		}
+	}
+
+	return 0;
 }
 
 DEFINE_HOOK(0x7396AD, UnitClass_Deploy_CreateBuilding, 0x6)
@@ -151,7 +94,7 @@ DEFINE_HOOK(0x73FEC1, UnitClass_WhatAction_DeploysIntoDesyncFix, 0x6)
 	GET(UnitClass* const, pThis, ESI);
 	REF_STACK(Action, action, STACK_OFFSET(0x20, 0x8));
 
-	if (!UnitExt::CanDeployIntoBuilding(pThis))
+	if (!FootExt::CanDeployIntoBuilding(pThis))
 		action = Action::NoDeploy;
 
 	return SkipGameCode;
@@ -196,7 +139,7 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 	}
 	else if (pBuildingType->LaserFencePost || pBuildingType->Gate)
 	{
-		bool skipFlag = UnitExt::Deployer ? UnitExt::Deployer->CurrentMapCoords == pCell->MapCoords : false;
+		bool skipFlag = FootExt::Deployer ? FootExt::Deployer->CurrentMapCoords == pCell->MapCoords : false;
 		bool builtOnCanBeBuiltOn = false;
 
 		for (auto pObject = pCell->FirstObject; pObject; pObject = pObject->NextObject)
@@ -210,7 +153,7 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 			}
 			else if (pObject->AbstractFlags & AbstractFlags::Techno)
 			{
-				if (pObject == UnitExt::Deployer)
+				if (pObject == FootExt::Deployer)
 				{
 					skipFlag = true;
 				}
@@ -245,14 +188,14 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 	}
 	else
 	{
-		bool skipFlag = UnitExt::Deployer ? UnitExt::Deployer->CurrentMapCoords == pCell->MapCoords : false;
+		bool skipFlag = FootExt::Deployer ? FootExt::Deployer->CurrentMapCoords == pCell->MapCoords : false;
 		bool builtOnCanBeBuiltOn = false;
 
 		for (auto pObject = pCell->FirstObject; pObject; pObject = pObject->NextObject)
 		{
 			if (pObject->AbstractFlags & AbstractFlags::Techno)
 			{
-				if (pObject == UnitExt::Deployer)
+				if (pObject == FootExt::Deployer)
 					skipFlag = true;
 				else
 					return CanNotExistHere;
@@ -266,7 +209,7 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 			}
 		}
 
-		if (!builtOnCanBeBuiltOn && (pCell->OccupationFlags & (skipFlag ? 0x1F : 0x3F)))
+		if (!builtOnCanBeBuiltOn && (pCell->OccupationFlags & (skipFlag ? 0x02 : 0x3F)))
 			return CanNotExistHere;
 	}
 

--- a/src/Ext/WarheadType/Detonate.cpp
+++ b/src/Ext/WarheadType/Detonate.cpp
@@ -674,12 +674,7 @@ void WarheadTypeExt::InterceptBullets(TechnoClass* pOwner, BulletClass* pInterce
 
 void WarheadTypeExt::ApplyConvert(HouseClass* pHouse, TechnoClass* pTarget)
 {
-	const auto pTargetFoot = abstract_cast<FootClass*, true>(pTarget);
-
-	if (!pTargetFoot)
-		return;
-
-	TypeConvertGroup::Convert(pTargetFoot, this->Convert_Pairs, pHouse);
+	TypeConvertGroup::Convert(pTarget, this->Convert_Pairs, pHouse);
 }
 
 void WarheadTypeExt::ApplyLocomotorInfliction(TechnoClass* pTarget)

--- a/src/Interop/TechnoExt.cpp
+++ b/src/Interop/TechnoExt.cpp
@@ -5,7 +5,7 @@
 std::vector<CalculateExtraThreatCallback> TechnoExtInterop::CalculateExtraThreatCallbacks = {};
 std::vector<CalculateSightCallback> TechnoExtInterop::CalculateSightCallbacks = {};
 
-DEFINE_EXPORT(HRESULT, ConvertToType_Phobos, FootClass* pThis, TechnoTypeClass* toType)
+DEFINE_EXPORT(HRESULT, ConvertToType_Phobos, TechnoClass* pThis, TechnoTypeClass* toType)
 {
 	if (!pThis || !toType)
 		return E_POINTER;

--- a/src/Interop/TechnoExt.h
+++ b/src/Interop/TechnoExt.h
@@ -31,10 +31,10 @@ public:
 /// <summary>
 /// Converts a unit to a different type.
 /// </summary>
-/// <param name="pThis">Pointer to the FootClass instance to convert</param>
+/// <param name="pThis">Pointer to the TechnoClass instance to convert</param>
 /// <param name="toType">Pointer to the target TechnoTypeClass</param>
 /// <returns>S_OK if conversion was successful, E_INVALIDARG if types are incompatible, E_FAIL if conversion failed</returns>
-DEFINE_EXPORT(HRESULT, ConvertToType_Phobos, FootClass* pThis, TechnoTypeClass* toType);
+DEFINE_EXPORT(HRESULT, ConvertToType_Phobos, TechnoClass* pThis, TechnoTypeClass* toType);
 
 DEFINE_EXPORT(HRESULT, RegisterCalculateExtraThreatCallback, CalculateExtraThreatCallback callback);
 

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -63,10 +63,7 @@ static void __fastcall LetGo(TemporalClass* pTemporal)
 
 static bool __stdcall ConvertToType(TechnoClass* pThis, TechnoTypeClass* pToType)
 {
-	if (const auto pFoot = abstract_cast<FootClass*, true>(pThis))
-		return TechnoExt::ConvertToType(pFoot, pToType);
-
-	return false;
+	return TechnoExt::ConvertToType(pThis, pToType);
 }
 
 // Technically this replaces GetTechnoType() call.

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -780,7 +780,7 @@ DEFINE_HOOK(0x4D580B, FootClass_ApproachTarget_DeployToFire, 0x6)
 
 	GET(UnitClass*, pThis, EBX);
 
-	R->EAX(UnitExt::CanDeployIntoBuilding(pThis, true));
+	R->EAX(FootExt::CanDeployIntoBuilding(pThis, true));
 
 	return SkipGameCode;
 }
@@ -791,7 +791,7 @@ DEFINE_HOOK(0x741050, UnitClass_CanFire_DeployToFire, 0x6)
 
 	GET(UnitClass*, pThis, ESI);
 
-	if (pThis->Type->DeployToFire && pThis->CanDeployNow() && !UnitExt::CanDeployIntoBuilding(pThis, true))
+	if (pThis->Type->DeployToFire && pThis->CanDeployNow() && !FootExt::CanDeployIntoBuilding(pThis, true))
 		return MustDeploy;
 
 	return SkipGameCode;

--- a/src/New/Type/Affiliated/TypeConvertGroup.cpp
+++ b/src/New/Type/Affiliated/TypeConvertGroup.cpp
@@ -1,14 +1,14 @@
 #include <Ext/Techno/Body.h>
 #include "TypeConvertGroup.h"
 
-void TypeConvertGroup::Convert(FootClass* pTargetFoot, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner)
+void TypeConvertGroup::Convert(TechnoClass* pTarget, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner)
 {
 	for (const auto& [fromTypes, toType, affectedHouses] : convertPairs)
 	{
 		if (!toType.Get())
 			continue;
 
-		if (pOwner && !EnumFunctions::CanTargetHouse(affectedHouses, pOwner, pTargetFoot->Owner))
+		if (pOwner && !EnumFunctions::CanTargetHouse(affectedHouses, pOwner, pTarget->Owner))
 			continue;
 
 		if (fromTypes.size())
@@ -16,16 +16,16 @@ void TypeConvertGroup::Convert(FootClass* pTargetFoot, const std::vector<TypeCon
 			for (const auto& from : fromTypes)
 			{
 				// Check if the target matches upgrade-from TechnoType and it has something to upgrade to
-				if (from == pTargetFoot->GetTechnoType())
+				if (from == pTarget->GetTechnoType())
 				{
-					TechnoExt::ConvertToType(pTargetFoot, toType);
+					TechnoExt::ConvertToType(pTarget, toType);
 					goto end; // Breaking out of nested loops without extra checks one of the very few remaining valid usecases for goto, leave it be.
 				}
 			}
 		}
 		else
 		{
-			TechnoExt::ConvertToType(pTargetFoot, toType);
+			TechnoExt::ConvertToType(pTarget, toType);
 			break;
 		}
 	}

--- a/src/New/Type/Affiliated/TypeConvertGroup.h
+++ b/src/New/Type/Affiliated/TypeConvertGroup.h
@@ -14,7 +14,7 @@ public:
 
 	static void Parse(std::vector<TypeConvertGroup>& list, INI_EX& exINI, const char* section, AffectedHouse defaultAffectHouse);
 
-	static void Convert(FootClass* pTargetFoot, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner);
+	static void Convert(TechnoClass* pTargetFoot, const std::vector<TypeConvertGroup>& convertPairs, HouseClass* pOwner);
 
 private:
 	template <typename T>


### PR DESCRIPTION
## What kind of change is this?

- [x] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

This PR allows Phobos TechnoType conversion logic to convert between different TechnoType categories.

### Changes

- Generalized `TechnoExt::ConvertToType` to accept `TechnoClass` instead of only `FootClass`.
- Added support for conversions between infantry, vehicles, aircraft and buildings.
- Added support for conversions involving `BuildingType`, including building-to-building conversions.
- Same-category conversions between non-building TechnoTypes continue to use the existing in-place conversion logic.
- Cross-category conversions and conversions involving buildings create a new object, transfer applicable state, and remove the original object.
- Transferable state includes:
  - Health percentage
  - Veterancy
  - Mind control
  - Shield state
  - Invulnerability
  - Attached effects
  - Armor and firepower multipliers
  - Target
  - Destination
  - Current mission
  - Selection state
  - FootClass speed multiplier where applicable
- Added building placement and coordinate handling for converted buildings.
- Preserved building deployment and buildup initialization when the conversion result is a building.
- Reused the conversion logic for `Convert.Deploy`, `Convert.Undeploy`, `Ammo.AutoConvertType` and `Convert.Health`.
- Moved health-based automatic conversion into the common `TechnoClass` update path.
- Unified deployment placement checks for vehicles and infantry.
- `Convert.Deploy` conversions to buildings now validate building placement rules before execution.
- Cross-category conversions do not depend on Ares 3.0 and use Phobos' own conversion implementation.

### Notes

Because cross-category conversions create a new map object, some state or associations attached to the original object may not be preserved.