### PR TITLE
Global default value for `LeptonMindControlOffset` and `MindControlRingOffset`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -705,6 +705,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize the distance for `NoQueueUpToEnter` transport units to board passengers
   - Fix the bug that `MissileSpawn=true` causes the spawnee launcher to crash immediately when attacking
   - Customize the initial facing of buildings
+  - Global default value for `LeptonMindControlOffset` and `MindControlRingOffset`
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -287,7 +287,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue where mining vehicles could not move after leaving a tank bunker.
 - `ProductionAnim` is now available for `Factory=InfantryType` as well as non-`ConstructionYard=true` `Factory=BuildingType` buildings. `IdleAnim` will cease to play for its duration normally as well.
 - Fixed the bug where selected technos would lose their selection if their regular mind control was replaced with permanent mind control or with the control from the Psychic Dominator superweapon.
-- Allow the default value of `DefaultToGuardArea` to be defined by `[General] -> DefaultToGuardArea`.
 - Fixed the bug that cause technos teleport to cell 0,0 by ChronoSphere superweapon.
 - Fixed the bug that techno in attack move will move to target if it cannot attack it.
 - Fixed the bug in AI scripts 56 and 57 that forced the launch of superweapons with index numbers 3 and 4.
@@ -503,6 +502,24 @@ In `rulesmd.ini`:
 ```ini
 [CombatDamage]
 AdjacentWallDamage=200  ; integer
+```
+
+### Customize the global default values of some vanilla flags
+
+- The following flags supplement definitions for flags that do not have global default values in vanilla.
+
+```{hint}
+Unless otherwise specified, the definition is the same as the name of the micro-level definition flag.
+```
+
+In `rulesmd.ini`:
+```ini
+[General]
+DefaultToGuardArea=false    ; boolean
+
+[AudioVisual]
+LeptonMindControlOffset=70  ; integer, in leptons
+MindControlRingOffset=140   ; integer, in leptons
 ```
 
 ### Customizing effect of level lighting on air units

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -619,6 +619,7 @@ HideShakeEffects=false           ; boolean
 - [Customize the initial facing of buildings](Fixed-or-Improved-Logics.md#customize-the-initial-facing-of-buildings) (by Noble_Fish)
 - [New exception handler with a crash dialog, crash report and minidumps](Miscellanous.md#turning-offon-in-game-exception-handling) (by ZivDero, ported from Vinifera)
 - [Common Controls v6 visual styles for the game process](Miscellanous.md#visual-styles) (by ZivDero)
+- Global default value for `LeptonMindControlOffset` and `MindControlRingOffset` (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -72,6 +72,8 @@ void RulesExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	INI_EX exINI(pINI);
 
 	this->DefaultToGuardArea.Read(exINI, GameStrings::General, "DefaultToGuardArea");
+	this->LeptonMindControlOffset.Read(exINI, GameStrings::AudioVisual, "LeptonMindControlOffset");
+	this->MindControlRingOffset.Read(exINI, GameStrings::AudioVisual, "MindControlRingOffset");
 }
 
 void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
@@ -794,6 +796,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->ParadropDelay)
 		.Process(this->ParadropEndDelay)
 		.Process(this->DefaultToGuardArea)
+		.Process(this->LeptonMindControlOffset)
+		.Process(this->MindControlRingOffset)
 		.Process(this->CylinderRangefinding)
 		.Process(this->PenetratesTransport_Level)
 		.Process(this->UnitsUnsellable)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -346,6 +346,8 @@ public:
 		Valueable<int> ParadropEndDelay;
 
 		Valueable<bool> DefaultToGuardArea;
+		Valueable<int> LeptonMindControlOffset;
+		Valueable<int> MindControlRingOffset;
 
 		Valueable<bool> DisableOveroptimizationInTargeting;
     
@@ -686,6 +688,8 @@ public:
 			, ParadropEndDelay { 5 }
 
 			, DefaultToGuardArea { false }
+			, LeptonMindControlOffset { 70 }
+			, MindControlRingOffset { 140 }
 
 			, CylinderRangefinding { false }
 

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1760,6 +1760,8 @@ DEFINE_HOOK(0x711835, TechnoTypeClass_CTOR, 0x5)
 	// The extension is allocated by the concrete type leaf constructors
 	// (UnitType/InfantryType/BuildingType/AircraftType), not here at the TechnoTypeClass level.
 	pItem->DefaultToGuardArea = RulesExt::Global()->DefaultToGuardArea;
+	pItem->LeptonMindControlOffset = RulesExt::Global()->LeptonMindControlOffset;
+	pItem->MindControlRingOffset = RulesExt::Global()->MindControlRingOffset;
 
 	return 0;
 }


### PR DESCRIPTION
> ## https://www.phoboscn.top/t/topic/669?u=noble_fish
> `LeptonMindControlOffset` and `MindControlRingOffset` only have micro-level definitions and no global flag defining default values.

In `rulesmd.ini`:
```ini
[AudioVisual]
LeptonMindControlOffset=70  ; integer, in leptons
MindControlRingOffset=140   ; integer, in leptons
```

---
Tested by: https://www.phoboscn.top/t/topic/673/2?u=noble_fish

![image](https://www.phoboscn.top/uploads/default/original/2X/d/d63647052956bfa25704023fd10de79c61a86230.gif)

```ini
[AudioVisual]
LeptonMindControlOffset=300
MindControlRingOffset=300
```

![image](https://www.phoboscn.top/uploads/default/original/2X/d/d887e415baf7987c2719df96e6b97f7f2cb04cd1.gif)

```ini
[AudioVisual]
LeptonMindControlOffset=300
MindControlRingOffset=300

[SPY]
LeptonMindControlOffset=70
MindControlRingOffset=140
```