### PR TITLE
[Vanilla Fix] Fixed incorrect shadow rendering positions for non-Aircraft units with `Locomotor=Fly`, and for Aircraft units being dragged by warheads with `IsLocomotor=yes`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -548,6 +548,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug that techno will get stuck if change owner in tunnel
   - Fix the bug that the vanilla `SecondSpawnOffset` no longer takes effect
   - Fix the issue that `NoQueueUpToEnter` will clear passenger's planning tokens when entered transport
+  - Fix the bug where if a non-aircraft techno has `Locomotor=Fly`, it's shadow will draw at wrong position
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -548,7 +548,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug that techno will get stuck if change owner in tunnel
   - Fix the bug that the vanilla `SecondSpawnOffset` no longer takes effect
   - Fix the issue that `NoQueueUpToEnter` will clear passenger's planning tokens when entered transport
-  - Fix the bug where if a non-aircraft techno has `Locomotor=Fly`, it's shadow will draw at wrong position
+  - Fix incorrect shadow rendering positions for non-Aircraft units with `Locomotor=Fly`, and for Aircraft units being dragged by warheads with `IsLocomotor=yes`
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -323,7 +323,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that techno will get stuck if change owner in tunnel.
 - Restored the original Tiberian Sun behavior of playing the `[AudioVisual] -> DeploySound=` sound effect when clicking the sidebar to execute `Deploy`.
 - Whether or not a passenger's weapon can fire out from an `OpenTopped=yes` transport will now respect the weapon's `FireWhileMoving` setting.
-- Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, it's shadow will draw at wrong position.
+- Fixed incorrect shadow rendering positions for non-Aircraft units with `Locomotor=Fly`, and for Aircraft units being dragged by warheads with `IsLocomotor=yes`.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -323,6 +323,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that techno will get stuck if change owner in tunnel.
 - Restored the original Tiberian Sun behavior of playing the `[AudioVisual] -> DeploySound=` sound effect when clicking the sidebar to execute `Deploy`.
 - Whether or not a passenger's weapon can fire out from an `OpenTopped=yes` transport will now respect the weapon's `FireWhileMoving` setting.
+- Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, it's shadow will draw at wrong position.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -706,7 +706,7 @@ HideShakeEffects=false           ; boolean
 - Fixed the bug that low-air taking off / landing objects will receive twice damage (by NetsuNegi)
 - Fixed voxel projectile and animation lighting issues (by TaranDahl)
 - Fixed the bug that techno will get stuck if change owner in tunnel (by NetsuNegi)
-- Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, it's shadow will draw at wrong position (by NetsuNegi)
+- Fixed incorrect shadow rendering positions for non-Aircraft units with `Locomotor=Fly`, and for Aircraft units being dragged by warheads with `IsLocomotor=yes` (by NetsuNegi)
 
 #### Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -706,6 +706,7 @@ HideShakeEffects=false           ; boolean
 - Fixed the bug that low-air taking off / landing objects will receive twice damage (by NetsuNegi)
 - Fixed voxel projectile and animation lighting issues (by TaranDahl)
 - Fixed the bug that techno will get stuck if change owner in tunnel (by NetsuNegi)
+- Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, it's shadow will draw at wrong position (by NetsuNegi)
 
 #### Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1815,6 +1815,11 @@ msgid ""
 "tokens when entered transport"
 msgstr "修复了 `NoQueueUpToEnter` 会在乘客进入载具时清除计划节点的问题"
 
+msgid ""
+"Fix the bug where if a non-aircraft techno has `Locomotor=Fly`, "
+"it's shadow will draw at wrong position"
+msgstr "修复了具有 `Locomotor=Fly` 的非Aircraft科技类型的影子会绘制在错误位置的 Bug"
+
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1816,9 +1816,9 @@ msgid ""
 msgstr "修复了 `NoQueueUpToEnter` 会在乘客进入载具时清除计划节点的问题"
 
 msgid ""
-"Fix the bug where if a non-aircraft techno has `Locomotor=Fly`, "
-"it's shadow will draw at wrong position"
-msgstr "修复了具有 `Locomotor=Fly` 的非Aircraft科技类型的影子会绘制在错误位置的 Bug"
+"Fix incorrect shadow rendering positions for non-Aircraft units with `Locomotor=Fly`,"
+" and for Aircraft units being dragged by warheads with `IsLocomotor=yes`"
+msgstr "修复了 `Locomotor=Fly` 的非Aircraft单位与被 `IsLocomotor=yes` 弹头拖拽的Aircraft单位的阴影绘制位置不正确的问题"
 
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1665,6 +1665,11 @@ msgid ""
 " transport will now respect the weapon's `FireWhileMoving` setting."
 msgstr "现在乘客的武器能否在 `OpenTopped=yes` 的运输工具中向外开火将尊重武器的 `FireWhileMoving` 设置。"
 
+msgid ""
+"Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, "
+"it's shadow will draw at wrong position."
+msgstr "修复了具有 `Locomotor=Fly` 的非Aircraft科技类型的影子会绘制在错误位置的 Bug。"
+
 msgid "Fixes / interactions with other extensions"
 msgstr "修复或与其他扩展的交互"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1666,9 +1666,9 @@ msgid ""
 msgstr "现在乘客的武器能否在 `OpenTopped=yes` 的运输工具中向外开火将尊重武器的 `FireWhileMoving` 设置。"
 
 msgid ""
-"Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, "
-"it's shadow will draw at wrong position."
-msgstr "修复了具有 `Locomotor=Fly` 的非Aircraft科技类型的影子会绘制在错误位置的 Bug。"
+"Fixed incorrect shadow rendering positions for non-Aircraft units with `Locomotor=Fly`,"
+" and for Aircraft units being dragged by warheads with `IsLocomotor=yes`."
+msgstr "修复了 `Locomotor=Fly` 的非Aircraft单位与被 `IsLocomotor=yes` 弹头拖拽的Aircraft单位的阴影绘制位置不正确的问题。"
 
 msgid "Fixes / interactions with other extensions"
 msgstr "修复或与其他扩展的交互"

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2644,9 +2644,9 @@ msgid ""
 msgstr "修复了科技类型在隧道中变更所属方会导致卡住的 Bug（by NetsuNegi）"
 
 msgid ""
-"Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, "
-"it's shadow will draw at wrong position (by NetsuNegi)"
-msgstr "修复了具有 `Locomotor=Fly` 的非Aircraft科技类型的影子会绘制在错误位置的 Bug（by NetsuNegi）"
+"Fixed incorrect shadow rendering positions for non-Aircraft units with `Locomotor=Fly`,"
+" and for Aircraft units being dragged by warheads with `IsLocomotor=yes` (by NetsuNegi)"
+msgstr "修复了 `Locomotor=Fly` 的非Aircraft单位与被 `IsLocomotor=yes` 弹头拖拽的Aircraft单位的阴影绘制位置不正确的问题（by NetsuNegi）"
 
 msgid "Phobos fixes:"
 msgstr "Phobos 过往版本问题修复："

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2643,6 +2643,11 @@ msgid ""
 "NetsuNegi)"
 msgstr "修复了科技类型在隧道中变更所属方会导致卡住的 Bug（by NetsuNegi）"
 
+msgid ""
+"Fixed the bug where if a non-aircraft techno has `Locomotor=Fly`, "
+"it's shadow will draw at wrong position (by NetsuNegi)"
+msgstr "修复了具有 `Locomotor=Fly` 的非Aircraft科技类型的影子会绘制在错误位置的 Bug（by NetsuNegi）"
+
 msgid "Phobos fixes:"
 msgstr "Phobos 过往版本问题修复："
 

--- a/src/Ext/TechnoType/Hooks.MatrixOp.cpp
+++ b/src/Ext/TechnoType/Hooks.MatrixOp.cpp
@@ -1033,7 +1033,6 @@ DEFINE_HOOK(0x4147F9, AircraftClass_Draw_Shadow, 0x6)
 	return FinishDrawing;
 }
 
-DEFINE_JUMP(VTABLE, 0x7F0B4C, 0x4CF940);// Shadow_Point of RocketLoco was forgotten to be set to {0,0}. It was an oversight.
 DEFINE_JUMP(LJMP, 0x706BDD, 0x706C01); // I checked it a priori
 
 /*

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2735,6 +2735,27 @@ DEFINE_HOOK(0x5194EF, InfantryClass_DrawIt_DrawShadow, 0x5)
 	return pThis->CloakState != CloakState::Uncloaked ? SkipDraw : 0;
 }
 
+#pragma region Locomotor=Fly shadow fix
+
+DEFINE_HOOK(0x4146EA, AircraftClass_DrawIt_SkipShadowPoint, 0x7)
+{
+	enum { SkipGameCode = 0x4146F1 };
+
+	GET(Point2D*, pBuffer, ECX);
+
+	*pBuffer = Point2D::Empty;
+	R->EAX(pBuffer);
+	return SkipGameCode;
+}
+
+DEFINE_JUMP(LJMP, 0x41476F, 0x4147F9)
+DEFINE_JUMP(LJMP, 0x4148A5, 0x4148B1)
+
+// Redirect FlyLocomotionClass::Shadow_Point to LocomotionClass::Shadow_Point
+DEFINE_JUMP(VTABLE, 0x7E8A24, 0x55A8C0)
+
+#pragma endregion
+
 // Fix the issue that the jumpjet vehicles cannot stop correctly after going berserk
 DEFINE_HOOK(0x74431F, UnitClass_ReadyToNextMission_HuntCheck, 0x6)
 {


### PR DESCRIPTION
<!-- Please manually add a label named [No Documentation Needed] if this change should not be mentioned in documentation, what's new and no credit needs to be given.
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches. -->
