### PR TITLE
Separately define the global default values of TerrainTypes' `IsPassable` and `CanBeBuiltOn` based on `SpawnsTiberium`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -718,6 +718,7 @@ This page lists all the individual contributions to the project by their author.
   - Separate the definitions of default direction for aircraft production and landing in the field
   - Fix the bug where incorrect calculation of `[AudioVisual] -> PoseDir` caused the landing direction of aircraft to behave incorrectly under vanilla configuration
   - Fix the bug where landing direction cannot be correctly converted when set to a value exceeding 256
+  - Separately define the global default values of TerrainTypes' `IsPassable` and `CanBeBuiltOn` based on `SpawnsTiberium`
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -2439,15 +2439,21 @@ MinimapColor=      ; integer - Red,Green,Blue
   - Movement cursor is displayed on `IsPassable` TerrainTypes unless force-firing.
   - `CanBeBuiltOn=true` terrain objects are removed when building is placed on them.
 
+```{hint}
+The above two items use different default values according to `SpawnsTiberium`, so as to facilitate separate definitions for Tiberium Trees and regular TerrainTypes.
+```
+
 In `rulesmd.ini`:
 ```ini
 [General]
 Terrain.IsPassable=false    ; boolean
+Tibtree.IsPassable=false    ; boolean
 Terrain.CanBeBuiltOn=false  ; boolean
+Tibtree.CanBeBuiltOn=false  ; boolean
 
 [SOMETERRAINTYPE]           ; TerrainType
-IsPassable=                 ; boolean, default to [General] -> Terrain.IsPassable
-CanBeBuiltOn=               ; boolean, default to [General] -> Terrain.CanBeBuiltOn
+IsPassable=                 ; boolean, default to [General] -> Tibtree.IsPassable if SpawnsTiberium=true, otherwise [General] -> Terrain.IsPassable
+CanBeBuiltOn=               ; boolean, default to [General] -> Tibtree.CanBeBuiltOn if SpawnsTiberium=true, otherwise [General] -> Terrain.CanBeBuiltOn
 ```
 
 ## Tiberiums (ores)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -633,6 +633,7 @@ HideShakeEffects=false           ; boolean
 - [Separate the definitions of default direction for aircraft production and landing in the field](Fixed-or-Improved-Logics.md#separate-the-definitions-of-default-direction-for-aircraft-production-and-landing-in-the-field) (by Noble_Fish)
 - Change target Owner on warhead impact (by Fryone)
 - New hotkey to select the units within the current screen that are captured by non-permanent mind-controller. (by TaranDahl)
+- Separately define the global default values of TerrainTypes' `IsPassable` and `CanBeBuiltOn` based on `SpawnsTiberium` (by Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -432,7 +432,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->Arcing_AllowElevationInaccuracy.Read(exINI, GameStrings::CombatDamage, "Arcing.AllowElevationInaccuracy");
 
 	this->Terrain_IsPassable.Read(exINI, GameStrings::General, "Terrain.IsPassable");
+	this->Tibtree_IsPassable.Read(exINI, GameStrings::General, "Tibtree.IsPassable");
 	this->Terrain_CanBeBuiltOn.Read(exINI, GameStrings::General, "Terrain.CanBeBuiltOn");
+	this->Tibtree_CanBeBuiltOn.Read(exINI, GameStrings::General, "Tibtree.CanBeBuiltOn");
 
 	this->Sinkable.Read(exINI, GameStrings::General, "Sinkable");
 	this->Sinkable_SquidGrab.Read(exINI, GameStrings::General, "Sinkable.SquidGrab");
@@ -943,7 +945,9 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->HoverDrownable)
 		.Process(this->Arcing_AllowElevationInaccuracy)
 		.Process(this->Terrain_IsPassable)
+		.Process(this->Tibtree_IsPassable)
 		.Process(this->Terrain_CanBeBuiltOn)
+		.Process(this->Tibtree_CanBeBuiltOn)
 		.Process(this->Sinkable)
 		.Process(this->Sinkable_SquidGrab)
 		.Process(this->SinkSpeed)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -381,7 +381,9 @@ public:
 		Valueable<bool> Arcing_AllowElevationInaccuracy;
 
 		Valueable<bool> Terrain_IsPassable;
+		Valueable<bool> Tibtree_IsPassable;
 		Valueable<bool> Terrain_CanBeBuiltOn;
+		Valueable<bool> Tibtree_CanBeBuiltOn;
 
 		Nullable<bool> Sinkable;
 		Valueable<bool> Sinkable_SquidGrab;
@@ -842,7 +844,9 @@ public:
 			, Arcing_AllowElevationInaccuracy { true }
 
 			, Terrain_IsPassable { false }
+			, Tibtree_IsPassable { false }
 			, Terrain_CanBeBuiltOn { false }
+			, Tibtree_CanBeBuiltOn { false }
 
 			, Sinkable {}
 			, Sinkable_SquidGrab { true }

--- a/src/Ext/TerrainType/Hooks.Passable.cpp
+++ b/src/Ext/TerrainType/Hooks.Passable.cpp
@@ -9,9 +9,13 @@ DEFINE_HOOK(0x71C110, TerrainClass_SetOccupyBit_PassableTerrain, 0x6)
 
 	GET(TerrainClass*, pThis, ECX);
 
-	auto const pTypeExt = TerrainTypeExt::Fetch(pThis->Type);
+	auto const pType = pThis->Type;
+	auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+	bool const isPassable = pType->SpawnsTiberium
+		? pTypeExt->IsPassable.Get(RulesExt::Global()->Tibtree_IsPassable)
+		: pTypeExt->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable);
 
-	if (pTypeExt->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable))
+	if (isPassable)
 		return Skip;
 
 	return 0;
@@ -31,7 +35,13 @@ DEFINE_HOOK(0x7002E9, TechnoClass_WhatAction_PassableTerrain, 0x5)
 
 	if (const auto pTerrain = abstract_cast<TerrainClass*, true>(pTarget))
 	{
-		if (!isForceFire && TerrainTypeExt::Fetch(pTerrain->Type)->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable))
+		auto const pType = pTerrain->Type;
+		auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+		bool const isPassable = pType->SpawnsTiberium
+			? pTypeExt->IsPassable.Get(RulesExt::Global()->Tibtree_IsPassable)
+			: pTypeExt->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable);
+
+		if (!isForceFire && isPassable)
 		{
 			R->EBP(Action::Move);
 			return ReturnAction;
@@ -49,9 +59,13 @@ DEFINE_HOOK(0x483DDF, CellClass_CheckPassability_PassableTerrain, 0x6)
 	GET(CellClass*, pThis, EDI);
 	GET(TerrainClass*, pTerrain, ESI);
 
+	auto const pType = pTerrain->Type;
 	auto const pTypeExt = TerrainTypeExt::Fetch(pTerrain->Type);
+	bool const isPassable = pType->SpawnsTiberium
+		? pTypeExt->IsPassable.Get(RulesExt::Global()->Tibtree_IsPassable)
+		: pTypeExt->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable);
 
-	if (pTypeExt->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable))
+	if (isPassable)
 	{
 		pThis->Passability = PassabilityType::Passable;
 		return ReturnFromFunction;
@@ -69,9 +83,13 @@ DEFINE_HOOK(0x73FB71, UnitClass_CanEnterCell_PassableTerrain, 0x6)
 
 	if (auto const pTerrain = abstract_cast<TerrainClass*>(pTarget))
 	{
+		auto const pType = pTerrain->Type;
 		auto const pTypeExt = TerrainTypeExt::Fetch(pTerrain->Type);
+		bool const isPassable = pType->SpawnsTiberium
+			? pTypeExt->IsPassable.Get(RulesExt::Global()->Tibtree_IsPassable)
+			: pTypeExt->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable);
 
-		if (pTypeExt->IsPassable.Get(RulesExt::Global()->Terrain_IsPassable))
+		if (isPassable)
 			return SkipTerrainChecks;
 	}
 
@@ -89,7 +107,15 @@ DEFINE_HOOK(0x6D57C1, TacticalClass_DrawLaserFencePlacement_BuildableTerrain, 0x
 	GET(CellClass*, pCell, ESI);
 
 	if (auto const pTerrain = pCell->GetTerrain(false))
-		return TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn) ? ContinueChecks : DontDraw;
+	{
+		auto const pType = pTerrain->Type;
+		auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+		bool const canBuild = pType->SpawnsTiberium
+			? pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Tibtree_CanBeBuiltOn)
+			: pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn);
+
+		return canBuild ? ContinueChecks : DontDraw;
+	}
 
 	return ContinueChecks;
 }
@@ -104,7 +130,13 @@ DEFINE_HOOK(0x5684B1, MapClass_PlaceDown_BuildableTerrain, 0x6)
 	{
 		if (auto const pTerrain = pCell->GetTerrain(false))
 		{
-			if (TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn))
+			auto const pType = pTerrain->Type;
+			auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+			bool const canBuild = pType->SpawnsTiberium
+				? pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Tibtree_CanBeBuiltOn)
+				: pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn);
+
+			if (canBuild)
 			{
 				pCell->RemoveContent(pTerrain, false);
 				TerrainTypeExt::Remove(pTerrain);
@@ -127,7 +159,13 @@ DEFINE_HOOK(0x5FD2B6, OverlayClass_Unlimbo_SkipTerrainCheck, 0x9)
 
 	if (auto const pTerrain = pCell->GetTerrain(false))
 	{
-		if (!TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn))
+		auto const pType = pTerrain->Type;
+		auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+		bool const canBuild = pType->SpawnsTiberium
+			? pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Tibtree_CanBeBuiltOn)
+			: pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn);
+
+		if (!canBuild)
 			return NoUnlimbo;
 
 		pCell->RemoveContent(pTerrain, false);
@@ -146,7 +184,13 @@ DEFINE_HOOK(0x45EF3A, BuildingTypeClass_FlushForPlacement_BuildableTerrain, 0x7)
 
 	if (auto const pTerrain = abstract_cast<TerrainClass*>(pObject))
 	{
-		if (!TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn))
+		auto const pType = pTerrain->Type;
+		auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+		bool const canBuild = pType->SpawnsTiberium
+			? pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Tibtree_CanBeBuiltOn)
+			: pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn);
+
+		if (!canBuild)
 			return Disallow;
 	}
 
@@ -192,7 +236,13 @@ DEFINE_HOOK(0x586780, MapClass_IsAreaFree, 0x7)
 
 			if (pTerrain)
 			{
-				if (!FindBuildLocationTemp::EvaluatingBuildLocation || !TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn))
+				auto const pType = pTerrain->Type;
+				auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+				bool const canBuild = pType->SpawnsTiberium
+					? pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Tibtree_CanBeBuiltOn)
+					: pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn);
+
+				if (!FindBuildLocationTemp::EvaluatingBuildLocation || !canBuild)
 				{
 					R->EAX(false);
 					return ReturnFromFunction;

--- a/src/Ext/Unit/Hooks.DeploysInto.cpp
+++ b/src/Ext/Unit/Hooks.DeploysInto.cpp
@@ -169,6 +169,15 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 	if (!Game::IsActive)
 		return CanExistHere;
 
+	auto isTerrainBuildable = [](TerrainClass* pTerrain) -> bool
+	{
+		auto const pType = pTerrain->Type;
+		auto const pTypeExt = TerrainTypeExt::Fetch(pType);
+		return pType->SpawnsTiberium
+			? pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Tibtree_CanBeBuiltOn)
+			: pTypeExt->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn);
+	};
+
 	if (pBuildingType->LaserFence)
 	{
 		for (auto pObject = pCell->FirstObject; pObject; pObject = pObject->NextObject)
@@ -179,7 +188,7 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 			}
 			else if (const auto pTerrain = abstract_cast<TerrainClass*, true>(pObject))
 			{
-				if (!TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn))
+				if (!isTerrainBuildable(pTerrain))
 					return CanNotExistHere;
 			}
 		}
@@ -193,7 +202,7 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 		{
 			if (const auto pTerrain = abstract_cast<TerrainClass*, true>(pObject))
 			{
-				if (!TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn))
+				if (!isTerrainBuildable(pTerrain))
 					return CanNotExistHere;
 
 				builtOnCanBeBuiltOn = true;
@@ -249,7 +258,7 @@ DEFINE_HOOK(0x47C640, CellClass_CanThisExistHere_IgnoreSomething, 0x6)
 			}
 			else if (const auto pTerrain = abstract_cast<TerrainClass*, true>(pObject))
 			{
-				if (!TerrainTypeExt::Fetch(pTerrain->Type)->CanBeBuiltOn.Get(RulesExt::Global()->Terrain_CanBeBuiltOn))
+				if (!isTerrainBuildable(pTerrain))
 					return CanNotExistHere;
 
 				builtOnCanBeBuiltOn = true;


### PR DESCRIPTION
Supplement #2165

> ## @TaranDahl [commented on Apr 7](https://github.com/Phobos-developers/Phobos/pull/2165#issuecomment-4200311702)
> CanBeBuiltOn and IsPassable for TerrainTypes. This needs a smart default, smart to true for non-Tiber tree.

---

### Passable & buildable-upon TerrainTypes

- TerrainTypes can now be made passable or buildable upon by setting `IsPassable` or `CanBeBuiltOn`, respectively.
  - Movement cursor is displayed on `IsPassable` TerrainTypes unless force-firing.
  - `CanBeBuiltOn=true` terrain objects are removed when building is placed on them.

> [!Tip]
> The above two items use different default values according to `SpawnsTiberium`, so as to facilitate separate definitions for Tiberium Trees and regular TerrainTypes.

In `rulesmd.ini`:
```ini
[General]
Terrain.IsPassable=false    ; boolean
Tibtree.IsPassable=false    ; boolean
Terrain.CanBeBuiltOn=false  ; boolean
Tibtree.CanBeBuiltOn=false  ; boolean

[SOMETERRAINTYPE]           ; TerrainType
IsPassable=                 ; boolean, default to [General] -> Tibtree.IsPassable if SpawnsTiberium=true, otherwise [General] -> Terrain.IsPassable
CanBeBuiltOn=               ; boolean, default to [General] -> Tibtree.CanBeBuiltOn if SpawnsTiberium=true, otherwise [General] -> Terrain.CanBeBuiltOn
```