### PR TITLE
Customize whether aircraft is a cargo plane

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -851,6 +851,7 @@ This page lists all the individual contributions to the project by their author.
   - Adjust recruitable status on team member discharge
   - RA1-Style multi-turret and multi-barrel
   - New hotkey to select the units within the current screen that are captured by non-permanent mind-controller
+  - Customize whether aircraft is a cargo plane
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -844,6 +844,17 @@ AircraftFiringForceScatter=true     ; boolean
 FiringForceScatter=                 ; boolean, default to [General] -> AircraftFiringForceScatter
 ```
 
+### Customize whether aircraft is a cargo plane
+
+- In vanilla, the `Spawned` flag of an aircraft is determined by the game's own logic during `UnLimbo`. Now, you can explicitly control this flag per AircraftType.
+  - `IsCargoPlane` determines the value of the aircraft's `Spawned` flag when it is unlimboed. If left unset, the vanilla behavior is preserved.
+
+In `rulesmd.ini`:
+```ini
+[SOMEAIRCRAFT]      ; AircraftType
+IsCargoPlane=       ; boolean
+```
+
 ### Extended Aircraft Missions
 
 - Aircraft will now be able to use waypoints.

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -846,13 +846,13 @@ FiringForceScatter=                 ; boolean, default to [General] -> AircraftF
 
 ### Customize whether aircraft is a cargo plane
 
-- In vanilla, the `Spawned` flag of an aircraft is determined by the game's own logic during `UnLimbo`. Now, you can explicitly control this flag per AircraftType.
-  - `IsCargoPlane` determines the value of the aircraft's `Spawned` flag when it is unlimboed. If left unset, the vanilla behavior is preserved.
+- In vanilla, the `IsALoaner` flag of an aircraft is determined by the game's own logic during `UnLimbo`. Now, you can explicitly control this flag per AircraftType.
+  - The key `IsALoaner` determines the value of the aircraft's `IsALoaner` flag when it is unlimboed. If left unset, the vanilla behavior is preserved.
 
 In `rulesmd.ini`:
 ```ini
 [SOMEAIRCRAFT]      ; AircraftType
-IsCargoPlane=       ; boolean
+IsALoaner=       ; boolean
 ```
 
 ### Extended Aircraft Missions

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -634,6 +634,7 @@ HideShakeEffects=false           ; boolean
 - Change target Owner on warhead impact (by Fryone)
 - New hotkey to select the units within the current screen that are captured by non-permanent mind-controller. (by TaranDahl)
 - Separately define the global default values of TerrainTypes' `IsPassable` and `CanBeBuiltOn` based on `SpawnsTiberium` (by Noble_Fish)
+- [Customize whether aircraft is a cargo plane](Fixed-or-Improved-Logics.md#customize-whether-aircraft-is-a-cargo-plane) (by TaranDahl)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -2880,6 +2880,9 @@ msgstr "允许在单人模式下使用信标放置快捷键"
 msgid "Adjust recruitable status on team member discharge"
 msgstr "小队成员解散时调整可招募性"
 
+msgid "Customize whether aircraft is a cargo plane"
+msgstr "自定义飞机是否是cargo plane"
+
 msgid "**solar-III (凤九歌)**"
 msgstr "**solar-III（凤九歌）**"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -2586,6 +2586,20 @@ msgid ""
 "following flag to `false`."
 msgstr "在原版中当一架战机发起攻击它会强制触发目标单元格上的分散效果。现在你可以通过将下面的语句设为 `false` 来禁用该行为。"
 
+msgid "Customize whether aircraft is a cargo plane"
+msgstr "自定义飞机是否是cargo plane"
+
+msgid ""
+"In vanilla, the `Spawned` flag of an aircraft is determined by the game's "
+"own logic during `UnLimbo`. Now, you can explicitly control this flag per "
+"AircraftType."
+msgstr "在原版中，战机的 `Spawned` 标志由游戏自身逻辑在 `UnLimbo` 期间决定。现在你可以按 AircraftType 显式控制此标志。"
+
+msgid ""
+"`IsCargoPlane` determines the value of the aircraft's `Spawned` flag when "
+"it is unlimboed. If left unset, the vanilla behavior is preserved."
+msgstr "`IsCargoPlane` 决定战机被 unlimbo 时的 `Spawned` 标志值。若未设置则保留原版行为。"
+
 msgid "Extended Aircraft Missions"
 msgstr "拓展的战机任务"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -2596,9 +2596,9 @@ msgid ""
 msgstr "在原版中，战机的 `Spawned` 标志由游戏自身逻辑在 `UnLimbo` 期间决定。现在你可以按 AircraftType 显式控制此标志。"
 
 msgid ""
-"`IsCargoPlane` determines the value of the aircraft's `Spawned` flag when "
+"`IsALoaner` determines the value of the aircraft's `IsALoaner` flag when "
 "it is unlimboed. If left unset, the vanilla behavior is preserved."
-msgstr "`IsCargoPlane` 决定战机被 unlimbo 时的 `Spawned` 标志值。若未设置则保留原版行为。"
+msgstr "`IsCargoPlane` 决定战机被 unlimbo 时的 `IsALoaner` 标志值。若未设置则保留原版行为。"
 
 msgid "Extended Aircraft Missions"
 msgstr "拓展的战机任务"

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2288,6 +2288,13 @@ msgstr ""
 "definitions-of-default-direction-for-aircraft-production-and-landing-in-"
 "the-field)（by Noble_Fish）"
 
+msgid ""
+"[Customize whether aircraft is a cargo plane](Fixed-or-Improved-Logics.md"
+"#customize-whether-aircraft-is-a-cargo-plane) (by TaranDahl)"
+msgstr ""
+"[自定义飞机是否是cargo plane](Fixed-or-Improved-Logics.md#customize-whether-"
+"aircraft-is-a-cargo-plane)（by TaranDahl）"
+
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："
 

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -1304,3 +1304,24 @@ DEFINE_HOOK(0x4CD54C, FlyLocomotionClass_EdgeOfTheWorldAI_Paradrop, 0x8)
 }
 
 #pragma endregion
+
+#pragma region CargoPlane
+
+DEFINE_HOOK(0x4143A8, AircraftClass_UnLimbo_CargoPlane, 0x6)
+{
+	enum { SkipGameCode = 0x4143F2 };
+
+	GET(AircraftClass*, pThis, ESI);
+
+	auto const pTypeExt = AircraftTypeExt::Fetch(pThis->Type);
+
+	if (pTypeExt->IsCargoPlane.isset())
+	{
+		pThis->Spawned = pTypeExt->IsCargoPlane.Get();
+		return SkipGameCode;
+	}
+
+	return 0;
+}
+
+#pragma endregion

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -1315,9 +1315,9 @@ DEFINE_HOOK(0x4143A8, AircraftClass_UnLimbo_CargoPlane, 0x6)
 
 	auto const pTypeExt = AircraftTypeExt::Fetch(pThis->Type);
 
-	if (pTypeExt->IsCargoPlane.isset())
+	if (pTypeExt->IsALoaner.isset() || pThis->Type->Spawned)
 	{
-		pThis->Spawned = pTypeExt->IsCargoPlane.Get();
+		pThis->IsALoaner = pTypeExt->IsALoaner.Get(false);
 		return SkipGameCode;
 	}
 

--- a/src/Ext/Aircraft/Hooks.cpp
+++ b/src/Ext/Aircraft/Hooks.cpp
@@ -501,7 +501,7 @@ DEFINE_HOOK(0x416A0A, AircraftClass_Mission_Move_SmoothMoving, 0x5)
 	GET(AircraftClass* const, pThis, ESI);
 	GET(CoordStruct const* const, pCoords, EAX);
 
-	if (pThis->Team || pThis->Airstrike || pThis->Spawned)
+	if (pThis->Team || pThis->Airstrike || pThis->IsALoaner)
 		return 0;
 
 	const auto pType = pThis->Type;
@@ -727,7 +727,7 @@ DEFINE_HOOK(0x4CE42A, FlyLocomotionClass_StateUpdate_NoLanding, 0x6) // Prevent 
 	if (!pAircraft || !AircraftTypeExt::Fetch(pAircraft->Type)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions))
 		return 0;
 
-	if (pAircraft->Airstrike || pAircraft->Spawned || pAircraft->GetCurrentMission() == Mission::Enter)
+	if (pAircraft->Airstrike || pAircraft->IsALoaner || pAircraft->GetCurrentMission() == Mission::Enter)
 		return 0;
 
 	return SkipGameCode;
@@ -739,7 +739,7 @@ DEFINE_HOOK(0x414DA8, AircraftClass_Update_UnlandableDamage, 0x6) // After FootC
 
 	const auto pType = pThis->Type;
 
-	if (pThis->IsAlive && pType->AirportBound && !pThis->Airstrike && !pThis->Spawned)
+	if (pThis->IsAlive && pType->AirportBound && !pThis->Airstrike && !pThis->IsALoaner)
 	{
 		const bool extendedMissions = AircraftTypeExt::Fetch(pType)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions);
 
@@ -802,7 +802,7 @@ DEFINE_HOOK(0x41A5C7, AircraftClass_Mission_Guard_StartAreaGuard, 0x6)
 	GET(AircraftClass* const, pThis, ESI);
 
 	if (!AircraftTypeExt::Fetch(pThis->Type)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions)
-		|| pThis->Team || !pThis->IsArmed() || pThis->Airstrike || pThis->Spawned)
+		|| pThis->Team || !pThis->IsArmed() || pThis->Airstrike || pThis->IsALoaner)
 	{
 		return 0;
 	}
@@ -826,7 +826,7 @@ DEFINE_HOOK(0x41A96C, AircraftClass_Mission_AreaGuard, 0x6)
 	GET(AircraftClass* const, pThis, ESI);
 
 	if (!AircraftTypeExt::Fetch(pThis->Type)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions)
-		|| pThis->Team || !pThis->IsArmed() || pThis->Airstrike || pThis->Spawned)
+		|| pThis->Team || !pThis->IsArmed() || pThis->Airstrike || pThis->IsALoaner)
 	{
 		return 0;
 	}
@@ -983,7 +983,7 @@ DEFINE_HOOK(0x418CD1, AircraftClass_Mission_Attack_ContinueFlyToDestination, 0x6
 
 	if (!pThis->Target)
 	{
-		if (!AircraftTypeExt::Fetch(pThis->Type)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions) || pThis->Airstrike || pThis->Spawned)
+		if (!AircraftTypeExt::Fetch(pThis->Type)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions) || pThis->Airstrike || pThis->IsALoaner)
 			return Continue;
 
 		if (pThis->MegaMissionIsAttackMove() && pThis->MegaDestination)
@@ -1022,7 +1022,7 @@ DEFINE_HOOK(0x414D4D, AircraftClass_Update_ClearTargetIfNoAmmo, 0x6)
 	GET(AircraftClass* const, pThis, ESI);
 
 	if (AircraftTypeExt::Fetch(pThis->Type)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions)
-		&& !pThis->Ammo && !pThis->Airstrike && !pThis->Spawned)
+		&& !pThis->Ammo && !pThis->Airstrike && !pThis->IsALoaner)
 	{
 		if (!SessionClass::IsCampaign()) // To avoid AI's aircrafts team repeatedly attempting to attack the target when no ammo
 		{
@@ -1044,7 +1044,7 @@ DEFINE_HOOK(0x4179F7, AircraftClass_EnterIdleMode_NoCrash, 0x6)
 
 	GET(AircraftClass* const, pThis, ESI);
 
-	if (pThis->Airstrike || pThis->Spawned)
+	if (pThis->Airstrike || pThis->IsALoaner)
 		return 0;
 
 	if (AircraftTypeExt::Fetch(pThis->Type)->ExtendedAircraftMissions_UnlandDamage.Get(RulesExt::Global()->ExtendedAircraftMissions_UnlandDamage) < 0)
@@ -1098,7 +1098,7 @@ DEFINE_HOOK(0x4425B6, BuildingClass_ReceiveDamage_NoDestroyLink, 0xA)
 static AbstractClass* __fastcall AircraftClass_GreatestThreat(AircraftClass* pThis, void* _, ThreatType threatType, CoordStruct* pSelectCoords, bool onlyTargetHouseEnemy)
 {
 	if (AircraftTypeExt::Fetch(pThis->Type)->ExtendedAircraftMissions.Get(RulesExt::Global()->ExtendedAircraftMissions)
-		&& !pThis->Team && pThis->Ammo && !pThis->Airstrike && !pThis->Spawned)
+		&& !pThis->Team && pThis->Ammo && !pThis->Airstrike && !pThis->IsALoaner)
 	{
 		if (const auto pPrimaryWeapon = pThis->GetWeapon(0)->WeaponType)
 			threatType |= pPrimaryWeapon->AllowedThreats();

--- a/src/Ext/AircraftType/Body.cpp
+++ b/src/Ext/AircraftType/Body.cpp
@@ -37,6 +37,7 @@ void AircraftTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->ParadropDelay.Read(exINI, pSection, "ParadropDelay");
 	this->ParadropEndDelay.Read(exINI, pSection, "ParadropEndDelay");
 	this->FlyNoWobbles.Read(exINI, pSection, "FlyNoWobbles");
+	this->IsCargoPlane.Read(exINI, pSection, "IsCargoPlane");
 	this->LandingAnim.Read(exINI, pSection, "LandingAnim");
 	this->Missile_Cruise.Read(exINI, pSection, "Missile.Cruise");
 	this->Missile_TakeOffSeparation.Read(exINI, pSection, "Missile.TakeOffSeparation");
@@ -64,6 +65,7 @@ void AircraftTypeExt::Serialize(T& Stm)
 		.Process(this->ParadropDelay)
 		.Process(this->ParadropEndDelay)
 		.Process(this->FlyNoWobbles)
+		.Process(this->IsCargoPlane)
 		.Process(this->LandingAnim)
 		.Process(this->Missile_Cruise)
 		.Process(this->Missile_TakeOffAnim)

--- a/src/Ext/AircraftType/Body.cpp
+++ b/src/Ext/AircraftType/Body.cpp
@@ -37,7 +37,7 @@ void AircraftTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->ParadropDelay.Read(exINI, pSection, "ParadropDelay");
 	this->ParadropEndDelay.Read(exINI, pSection, "ParadropEndDelay");
 	this->FlyNoWobbles.Read(exINI, pSection, "FlyNoWobbles");
-	this->IsCargoPlane.Read(exINI, pSection, "IsCargoPlane");
+	this->IsALoaner.Read(exINI, pSection, "IsALoaner");
 	this->LandingAnim.Read(exINI, pSection, "LandingAnim");
 	this->Missile_Cruise.Read(exINI, pSection, "Missile.Cruise");
 	this->Missile_TakeOffSeparation.Read(exINI, pSection, "Missile.TakeOffSeparation");
@@ -65,7 +65,7 @@ void AircraftTypeExt::Serialize(T& Stm)
 		.Process(this->ParadropDelay)
 		.Process(this->ParadropEndDelay)
 		.Process(this->FlyNoWobbles)
-		.Process(this->IsCargoPlane)
+		.Process(this->IsALoaner)
 		.Process(this->LandingAnim)
 		.Process(this->Missile_Cruise)
 		.Process(this->Missile_TakeOffAnim)

--- a/src/Ext/AircraftType/Body.h
+++ b/src/Ext/AircraftType/Body.h
@@ -28,7 +28,7 @@ public:
 	Nullable<int> ParadropDelay;
 	Nullable<int> ParadropEndDelay;
 	Nullable<bool> FlyNoWobbles;
-	Nullable<bool> IsCargoPlane;
+	Nullable<bool> IsALoaner;
 	Nullable<AnimTypeClass*> LandingAnim;
 	Valueable<bool> Missile_Cruise;
 	Valueable<AnimTypeClass*> Missile_TakeOffAnim;
@@ -52,7 +52,7 @@ public:
 		, ParadropDelay {}
 		, ParadropEndDelay {}
 		, FlyNoWobbles {}
-		, IsCargoPlane {}
+		, IsALoaner {}
 		, LandingAnim {}
 		, Missile_Cruise { false }
 		, Missile_TakeOffAnim { nullptr }

--- a/src/Ext/AircraftType/Body.h
+++ b/src/Ext/AircraftType/Body.h
@@ -28,6 +28,7 @@ public:
 	Nullable<int> ParadropDelay;
 	Nullable<int> ParadropEndDelay;
 	Nullable<bool> FlyNoWobbles;
+	Nullable<bool> IsCargoPlane;
 	Nullable<AnimTypeClass*> LandingAnim;
 	Valueable<bool> Missile_Cruise;
 	Valueable<AnimTypeClass*> Missile_TakeOffAnim;
@@ -51,6 +52,7 @@ public:
 		, ParadropDelay {}
 		, ParadropEndDelay {}
 		, FlyNoWobbles {}
+		, IsCargoPlane {}
 		, LandingAnim {}
 		, Missile_Cruise { false }
 		, Missile_TakeOffAnim { nullptr }

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -1245,7 +1245,7 @@ DEFINE_HOOK(0x4C75DA, EventClass_RespondToEvent_Stop, 0x6)
 
 	// Check aircraft
 	const auto pAircraft = abstract_cast<AircraftClass*>(pTechno);
-	const bool commonAircraft = pAircraft && !pAircraft->Airstrike && !pAircraft->Spawned;
+	const bool commonAircraft = pAircraft && !pAircraft->Airstrike && !pAircraft->IsALoaner;
 	const auto mission = pTechno->CurrentMission;
 
 	// To avoid aircraft overlap by keep link if is returning or is in airport now.


### PR DESCRIPTION
### Customize whether aircraft is a cargo plane

- In vanilla, the `IsALoaner` flag of an aircraft is determined by the game's own logic during `UnLimbo`. Now, you can explicitly control this flag per AircraftType.
  - The key `IsALoaner` determines the value of the aircraft's `IsALoaner` flag when it is unlimboed. If left unset, the vanilla behavior is preserved.

In `rulesmd.ini`:
```ini
[SOMEAIRCRAFT]      ; AircraftType
IsALoaner=       ; boolean
```