### PR TITLE
Remove the restriction that prohibits InfantryTypes from using the InitialPayload logic

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -723,6 +723,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug where incorrect calculation of `[AudioVisual] -> PoseDir` caused the landing direction of aircraft to behave incorrectly under vanilla configuration
   - Fix the bug where landing direction cannot be correctly converted when set to a value exceeding 256
   - Separately define the global default values of TerrainTypes' `IsPassable` and `CanBeBuiltOn` based on `SpawnsTiberium`
+  - Remove the restriction that prohibits InfantryTypes from using the InitialPayload logic
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -378,6 +378,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Allowed infantry to use `Convert.Deploy` without requiring `IsSimpleDeployer=true`.
 - Allowed adding custom cruise missiles, so that Ares' `Missile.RaiseRate` is no longer meaningless.
 - Fix the issue of Ares' EMP not suspending the production of AI factories.
+- Removed the restriction that prohibits InfantryTypes from using the InitialPayload logic.
 
 ## Newly added global settings
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -793,6 +793,7 @@ HideShakeEffects=false           ; boolean
 - Added the scenario where `Missile.Raise` can be applied by custom missiles (by Noble_Fish)
 - Fixed a bug where passengers created by the InitialPayload logic or TeamType with `Full=true` would fail to execute the auto death logic (by Noble_Fish)
 - Fixed the issue of Ares' EMP not suspending the production of AI factories (by CrimRecya)
+- Removed the restriction that prohibits InfantryTypes from using the InitialPayload logic (by Noble_Fish)
 ```
 
 ### 0.4.0.3

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -208,7 +208,7 @@ void Apply_Ares3_0_Patches()
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x02BDD0, GET_OFFSET(SidebarExt::AresTabCameo_RemoveCameo));
 
 	// Remove Ares' WhatAmI() != AbstractType::Infantry check.
-	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x491C2, { 0x90, 0x90 });
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x491B8, AresHelper::AresBaseAddress + 0x491C4);
 	// InitialPayload creation:
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x43D5D, &CreateInitialPayload);
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x43E4F, GET_OFFSET(InitialPayloadFix));
@@ -316,7 +316,7 @@ void Apply_Ares3_0p1_Patches()
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x02C910, GET_OFFSET(SidebarExt::AresTabCameo_RemoveCameo));
 
 	// Remove Ares' WhatAmI() != AbstractType::Infantry check.
-	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x49E12, { 0x90, 0x90 });
+	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x49E08, AresHelper::AresBaseAddress + 0x49E14);
 	// InitialPayload creation:
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x4483D, &CreateInitialPayload);
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x4492F, GET_OFFSET(InitialPayloadFix));

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -207,6 +207,8 @@ void Apply_Ares3_0_Patches()
 	// Redirect Ares's RemoveCameo to our implementation:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x02BDD0, GET_OFFSET(SidebarExt::AresTabCameo_RemoveCameo));
 
+	// Remove Ares' WhatAmI() != AbstractType::Infantry check.
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x491C2, { 0x90, 0x90 });
 	// InitialPayload creation:
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x43D5D, &CreateInitialPayload);
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x43E4F, GET_OFFSET(InitialPayloadFix));
@@ -313,6 +315,8 @@ void Apply_Ares3_0p1_Patches()
 	// Redirect Ares's RemoveCameo to our implementation:
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x02C910, GET_OFFSET(SidebarExt::AresTabCameo_RemoveCameo));
 
+	// Remove Ares' WhatAmI() != AbstractType::Infantry check.
+	Patch::Apply_RAW(AresHelper::AresBaseAddress + 0x49E12, { 0x90, 0x90 });
 	// InitialPayload creation:
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x4483D, &CreateInitialPayload);
 	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x4492F, GET_OFFSET(InitialPayloadFix));


### PR DESCRIPTION
In the past, in order to use `OpenTopped` with Infantry as a transport, it was necessary to graft/temporarily substitute with an `Abductor` weapon whose invoker is that Infantry; now you can directly use the InitialPayload logic to create passengers, just like other FootClass objects.

<img width="242" height="167" alt="image" src="https://github.com/user-attachments/assets/3d7e6c43-952c-4163-97a9-89545af44af0" />
