### PR TITLE
 Tiberium Custom Image

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -918,3 +918,5 @@ This page lists all the individual contributions to the project by their author.
 - **Chang_zhi**:
   - Interop export interface for accessing scenario local/global variables
   - Add `ClampToScreen` tag for `BannerType` to control whether banner position is clamped to the visible area
+- **GrayVacuum**:
+  - Tiberium Custom Image - per-Tiberium and global overlay image configuration with customizable `NumFrames`, `NumImages`, and `NumSlopes`

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -551,35 +551,46 @@ CustomImage.NumSlopes=8        ; integer, number of slopes
 
 ; Global configuration - placed under [General]
 [General]
-Tiberium.Image1=                ; OverlayType for Type 1 (Riparius)
+Tiberium.Image1=TIB01          ; OverlayType for Type 1 (Riparius), default: TIB01
 Tiberium.Image1.NumFrames=12    ; integer
 Tiberium.Image1.NumImages=12    ; integer
 Tiberium.Image1.NumSlopes=8     ; integer
 
-Tiberium.Image2=                ; OverlayType for Type 2 (Cruentus)
+Tiberium.Image2=GEM01          ; OverlayType for Type 2 (Cruentus), default: GEM01
 Tiberium.Image2.NumFrames=12    ; integer
 Tiberium.Image2.NumImages=12    ; integer
 Tiberium.Image2.NumSlopes=0     ; integer
 
-Tiberium.Image3=                ; OverlayType for Type 3 (Vinifera)
+Tiberium.Image3=TIB2_01        ; OverlayType for Type 3 (Vinifera), default: TIB2_01
 Tiberium.Image3.NumFrames=12    ; integer
 Tiberium.Image3.NumImages=12    ; integer
 Tiberium.Image3.NumSlopes=8     ; integer
 
-Tiberium.Image4=                ; OverlayType for Type 4 (Aboreus)
+Tiberium.Image4=TIB3_01        ; OverlayType for Type 4 (Aboreus), default: TIB3_01
 Tiberium.Image4.NumFrames=12    ; integer
 Tiberium.Image4.NumImages=12    ; integer
 Tiberium.Image4.NumSlopes=8     ; integer
 ```
 
-Default values per Tiberium type:
+Default values:
 
-| Tiberium Type | NumFrames | NumImages | NumSlopes |
-|---------------|-----------|-----------|-----------|
-| Type 1 (Riparius) | 12 | 12 | 8 |
-| Type 2 (Cruentus) | 12 | 12 | 0 |
-| Type 3 (Vinifera) | 12 | 12 | 8 |
-| Type 4 (Aboreus) | 12 | 12 | 8 |
+- `CustomImage` / `Tiberium.ImageX` (OverlayType name): Defaults to the game's hardcoded image for that Tiberium type if not set. The default OverlayType assigned to each Tiberium type by the game engine is listed below.
+- `NumFrames`, `NumImages`, `NumSlopes`: Defaults to the game's hardcoded values per Tiberium type as listed below.
+
+| Tiberium Type | Default Image | Default ID | NumFrames | NumImages | NumSlopes |
+|---------------|---------------|------------|-----------|-----------|-----------|
+| Type 1 (Riparius) | `TIB01` | 105 | 12 | 12 | 8 |
+| Type 2 (Cruentus) | `GEM01` | 28 | 12 | 12 | 0 |
+| Type 3 (Vinifera) | `TIB2_01` | 130 | 12 | 12 | 8 |
+| Type 4 (Aboreus) | `TIB3_01` | 150 | 12 | 12 | 8 |
+
+```{note}
+The `Default ID` column refers to the ID number in `rulesmd.ini` under the `[OverlayTypes]` section. Due to IDs 40 and 41 being skipped, the `ArrayIndex` (used internally by the game engine) is calculated differently:
+- For IDs 1-39: `ArrayIndex = ID - 1`
+- For IDs >= 42: `ArrayIndex = ID - 3`
+
+For example, `GEM01` has ID 28 in `[OverlayTypes]`, but its `ArrayIndex` is 27 (28 - 1). Similarly, `TIB01` has ID 105, but its `ArrayIndex` is 102 (105 - 3).
+```
 
 ```{note}
 The `Tiberium.ImageX` numbering uses 1-based indexing (Image1 = Riparius, Image2 = Cruentus, Image3 = Vinifera, Image4 = Aboreus), matching the game's internal Tiberium type numbering.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -543,11 +543,37 @@ Shield.InheritStateOnReplace=false          ; boolean
 In `rulesmd.ini`:
 ```ini
 ; Per-Tiberium configuration - placed under individual Tiberium section
+; First register the Tiberium type in [Tiberiums], then configure under its ID name
+
+[Tiberiums]
+0=Riparius
+1=Cruentus
+2=Vinifera
+3=Aboreus
+
 [Riparius]
-CustomImage=SOME_OVERLAY       ; OverlayType image to use
-CustomImage.NumFrames=12       ; integer, number of frames
-CustomImage.NumImages=12       ; integer, number of images
-CustomImage.NumSlopes=8        ; integer, number of slopes
+CustomImage=TIB01              ; OverlayType image to use, default: TIB01
+CustomImage.NumFrames=12       ; integer, number of frames, default: 12
+CustomImage.NumImages=12       ; integer, number of images, default: 12
+CustomImage.NumSlopes=8        ; integer, number of slopes, default: 8
+
+[Cruentus]
+CustomImage=GEM01              ; OverlayType image to use, default: GEM01
+CustomImage.NumFrames=12       ; integer, default: 12
+CustomImage.NumImages=12       ; integer, default: 12
+CustomImage.NumSlopes=0        ; integer, default: 0
+
+[Vinifera]
+CustomImage=TIB2_01            ; OverlayType image to use, default: TIB2_01
+CustomImage.NumFrames=12       ; integer, default: 12
+CustomImage.NumImages=12       ; integer, default: 12
+CustomImage.NumSlopes=8        ; integer, default: 8
+
+[Aboreus]
+CustomImage=TIB3_01            ; OverlayType image to use, default: TIB3_01
+CustomImage.NumFrames=12       ; integer, default: 12
+CustomImage.NumImages=12       ; integer, default: 12
+CustomImage.NumSlopes=8        ; integer, default: 8
 
 ; Global configuration - placed under [General]
 [General]

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -557,7 +557,7 @@ In `rulesmd.ini`:
 ; [Riparius] - Tiberium Type 1
 [Riparius]
 Image=1                         ; native game setting, 1-4 refers to Tiberium type
-CustomImage=TIB01               ; Phobos enhanced: OverlayType name, default: TIB01
+CustomImage=TIB01               ; Custom: OverlayType name, default: TIB01
 CustomImage.NumFrames=12        ; integer, default: 12
 CustomImage.NumImages=12        ; integer, default: 12
 CustomImage.NumSlopes=8         ; integer, default: 8
@@ -565,7 +565,7 @@ CustomImage.NumSlopes=8         ; integer, default: 8
 ; [Cruentus] - Tiberium Type 2
 [Cruentus]
 Image=2                         ; native game setting
-CustomImage=GEM01               ; Phobos enhanced: OverlayType name, default: GEM01
+CustomImage=GEM01               ; Custom: OverlayType name, default: GEM01
 CustomImage.NumFrames=12        ; integer, default: 12
 CustomImage.NumImages=12        ; integer, default: 12
 CustomImage.NumSlopes=0         ; integer, default: 0
@@ -573,7 +573,7 @@ CustomImage.NumSlopes=0         ; integer, default: 0
 ; [Vinifera] - Tiberium Type 3
 [Vinifera]
 Image=3                         ; native game setting
-CustomImage=TIB2_01             ; Phobos enhanced: OverlayType name, default: TIB2_01
+CustomImage=TIB2_01             ; Custom: OverlayType name, default: TIB2_01
 CustomImage.NumFrames=12        ; integer, default: 12
 CustomImage.NumImages=12        ; integer, default: 12
 CustomImage.NumSlopes=8         ; integer, default: 8
@@ -581,7 +581,7 @@ CustomImage.NumSlopes=8         ; integer, default: 8
 ; [Aboreus] - Tiberium Type 4
 [Aboreus]
 Image=4                         ; native game setting
-CustomImage=TIB3_01             ; Phobos enhanced: OverlayType name, default: TIB3_01
+CustomImage=TIB3_01             ; Custom: OverlayType name, default: TIB3_01
 CustomImage.NumFrames=12        ; integer, default: 12
 CustomImage.NumImages=12        ; integer, default: 12
 CustomImage.NumSlopes=8         ; integer, default: 8

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -542,8 +542,11 @@ Shield.InheritStateOnReplace=false          ; boolean
 
 In `rulesmd.ini`:
 ```ini
-; Per-Tiberium configuration - placed under individual Tiberium section
-; First register the Tiberium type in [Tiberiums], then configure under its ID name
+; ============================================================
+; Per-Tiberium configuration
+; First register the Tiberium type in [Tiberiums]
+; Then configure under its ID name
+; ============================================================
 
 [Tiberiums]
 0=Riparius
@@ -551,29 +554,37 @@ In `rulesmd.ini`:
 2=Vinifera
 3=Aboreus
 
+; [Riparius] - Tiberium Type 1
 [Riparius]
-CustomImage=TIB01              ; OverlayType image to use, default: TIB01
-CustomImage.NumFrames=12       ; integer, number of frames, default: 12
-CustomImage.NumImages=12       ; integer, number of images, default: 12
-CustomImage.NumSlopes=8        ; integer, number of slopes, default: 8
+Image=1                         ; native game setting, 1-4 refers to Tiberium type
+CustomImage=TIB01               ; Phobos enhanced: OverlayType name, default: TIB01
+CustomImage.NumFrames=12        ; integer, default: 12
+CustomImage.NumImages=12        ; integer, default: 12
+CustomImage.NumSlopes=8         ; integer, default: 8
 
+; [Cruentus] - Tiberium Type 2
 [Cruentus]
-CustomImage=GEM01              ; OverlayType image to use, default: GEM01
-CustomImage.NumFrames=12       ; integer, default: 12
-CustomImage.NumImages=12       ; integer, default: 12
-CustomImage.NumSlopes=0        ; integer, default: 0
+Image=2                         ; native game setting
+CustomImage=GEM01               ; Phobos enhanced: OverlayType name, default: GEM01
+CustomImage.NumFrames=12        ; integer, default: 12
+CustomImage.NumImages=12        ; integer, default: 12
+CustomImage.NumSlopes=0         ; integer, default: 0
 
+; [Vinifera] - Tiberium Type 3
 [Vinifera]
-CustomImage=TIB2_01            ; OverlayType image to use, default: TIB2_01
-CustomImage.NumFrames=12       ; integer, default: 12
-CustomImage.NumImages=12       ; integer, default: 12
-CustomImage.NumSlopes=8        ; integer, default: 8
+Image=3                         ; native game setting
+CustomImage=TIB2_01             ; Phobos enhanced: OverlayType name, default: TIB2_01
+CustomImage.NumFrames=12        ; integer, default: 12
+CustomImage.NumImages=12        ; integer, default: 12
+CustomImage.NumSlopes=8         ; integer, default: 8
 
+; [Aboreus] - Tiberium Type 4
 [Aboreus]
-CustomImage=TIB3_01            ; OverlayType image to use, default: TIB3_01
-CustomImage.NumFrames=12       ; integer, default: 12
-CustomImage.NumImages=12       ; integer, default: 12
-CustomImage.NumSlopes=8        ; integer, default: 8
+Image=4                         ; native game setting
+CustomImage=TIB3_01             ; Phobos enhanced: OverlayType name, default: TIB3_01
+CustomImage.NumFrames=12        ; integer, default: 12
+CustomImage.NumImages=12        ; integer, default: 12
+CustomImage.NumSlopes=8         ; integer, default: 8
 
 ; Global configuration - placed under [General]
 [General]
@@ -620,6 +631,10 @@ For example, `GEM01` has ID 28 in `[OverlayTypes]`, but its `ArrayIndex` is 27 (
 
 ```{note}
 The `Tiberium.ImageX` numbering uses 1-based indexing (Image1 = Riparius, Image2 = Cruentus, Image3 = Vinifera, Image4 = Aboreus), matching the game's internal Tiberium type numbering.
+```
+
+```{note}
+**How `CustomImage` overrides the image**: When `CustomImage` is set in a per-Tiberium section, Phobos looks up the OverlayType by name (via `OverlayTypeClass::Find()`). If found, it replaces the `Image` pointer with the new OverlayType. If the name is invalid (not found in `[OverlayTypes]`), the image will **not** be overridden and the original image is preserved. The same logic applies to the global `Tiberium.ImageX` configuration.
 ```
 
 ## Aircraft

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -536,105 +536,49 @@ Shield.InheritStateOnReplace=false          ; boolean
 
 ### Tiberium Custom Image
 
-- Tiberium types (Riparius, Cruentus, Vinifera, Aboreus) can now have custom overlay images and override `NumFrames`, `NumImages`, and `NumSlopes` settings.
-- Supports both per-Tiberium (micro) configuration and global configuration via `[General]`.
-- Priority: Per-Tiberium `CustomImage` > Global `Tiberium.ImageX` > Game engine defaults.
+Tiberium types can now use custom overlay images and override `NumFrames`, `NumImages`, and `NumSlopes` values.
 
-In `rulesmd.ini`:
+**Priority**: Per-Tiberium `CustomImage` > Global `Tiberium.ImageX` > Game engine defaults.
+
+**Per-Tiberium configuration** (in `rulesmd.ini`):
 ```ini
-; ============================================================
-; Per-Tiberium configuration
-; First register the Tiberium type in [Tiberiums]
-; Then configure under its ID name
-; ============================================================
+[SOMETIBERIUM]  ; Tiberium type name
+CustomImage=                   ; OverlayType name, default: game engine default
+CustomImage.NumFrames=         ; integer, default: game engine default
+CustomImage.NumImages=         ; integer, default: game engine default
+CustomImage.NumSlopes=         ; integer, default: game engine default
+```
 
-[Tiberiums]
-0=Riparius
-1=Cruentus
-2=Vinifera
-3=Aboreus
-
-; [Riparius] - Tiberium Type 1
-[Riparius]
-Image=1                         ; native game setting, 1-4 refers to Tiberium type
-CustomImage=TIB01               ; Custom: OverlayType name, default: TIB01
-CustomImage.NumFrames=12        ; integer, default: 12
-CustomImage.NumImages=12        ; integer, default: 12
-CustomImage.NumSlopes=8         ; integer, default: 8
-
-; [Cruentus] - Tiberium Type 2
-[Cruentus]
-Image=2                         ; native game setting
-CustomImage=GEM01               ; Custom: OverlayType name, default: GEM01
-CustomImage.NumFrames=12        ; integer, default: 12
-CustomImage.NumImages=12        ; integer, default: 12
-CustomImage.NumSlopes=0         ; integer, default: 0
-
-; [Vinifera] - Tiberium Type 3
-[Vinifera]
-Image=3                         ; native game setting
-CustomImage=TIB2_01             ; Custom: OverlayType name, default: TIB2_01
-CustomImage.NumFrames=12        ; integer, default: 12
-CustomImage.NumImages=12        ; integer, default: 12
-CustomImage.NumSlopes=8         ; integer, default: 8
-
-; [Aboreus] - Tiberium Type 4
-[Aboreus]
-Image=4                         ; native game setting
-CustomImage=TIB3_01             ; Custom: OverlayType name, default: TIB3_01
-CustomImage.NumFrames=12        ; integer, default: 12
-CustomImage.NumImages=12        ; integer, default: 12
-CustomImage.NumSlopes=8         ; integer, default: 8
-
-; Global configuration - placed under [General]
+**Global configuration** (only applies to built-in Tiberium types Image1-4, in `[General]` section):
+```ini
 [General]
-Tiberium.Image1=TIB01          ; OverlayType for Type 1 (Riparius), default: TIB01
-Tiberium.Image1.NumFrames=12    ; integer
-Tiberium.Image1.NumImages=12    ; integer
-Tiberium.Image1.NumSlopes=8     ; integer
+Tiberium.Image1=               ; OverlayType name, default: game engine default
+Tiberium.Image1.NumFrames=     ; integer, default: game engine default
+Tiberium.Image1.NumImages=     ; integer, default: game engine default
+Tiberium.Image1.NumSlopes=     ; integer, default: game engine default
 
-Tiberium.Image2=GEM01          ; OverlayType for Type 2 (Cruentus), default: GEM01
-Tiberium.Image2.NumFrames=12    ; integer
-Tiberium.Image2.NumImages=12    ; integer
-Tiberium.Image2.NumSlopes=0     ; integer
+Tiberium.Image2=               ; OverlayType name, default: game engine default
+Tiberium.Image2.NumFrames=     ; integer, default: game engine default
+Tiberium.Image2.NumImages=     ; integer, default: game engine default
+Tiberium.Image2.NumSlopes=     ; integer, default: game engine default
 
-Tiberium.Image3=TIB2_01        ; OverlayType for Type 3 (Vinifera), default: TIB2_01
-Tiberium.Image3.NumFrames=12    ; integer
-Tiberium.Image3.NumImages=12    ; integer
-Tiberium.Image3.NumSlopes=8     ; integer
+Tiberium.Image3=               ; OverlayType name, default: game engine default
+Tiberium.Image3.NumFrames=     ; integer, default: game engine default
+Tiberium.Image3.NumImages=     ; integer, default: game engine default
+Tiberium.Image3.NumSlopes=     ; integer, default: game engine default
 
-Tiberium.Image4=TIB3_01        ; OverlayType for Type 4 (Aboreus), default: TIB3_01
-Tiberium.Image4.NumFrames=12    ; integer
-Tiberium.Image4.NumImages=12    ; integer
-Tiberium.Image4.NumSlopes=8     ; integer
-```
-
-Default values:
-
-- `CustomImage` / `Tiberium.ImageX` (OverlayType name): Defaults to the game's hardcoded image for that Tiberium type if not set. The default OverlayType assigned to each Tiberium type by the game engine is listed below.
-- `NumFrames`, `NumImages`, `NumSlopes`: Defaults to the game's hardcoded values per Tiberium type as listed below.
-
-| Tiberium Type | Default Image | Default ID | NumFrames | NumImages | NumSlopes |
-|---------------|---------------|------------|-----------|-----------|-----------|
-| Type 1 (Riparius) | `TIB01` | 105 | 12 | 12 | 8 |
-| Type 2 (Cruentus) | `GEM01` | 28 | 12 | 12 | 0 |
-| Type 3 (Vinifera) | `TIB2_01` | 130 | 12 | 12 | 8 |
-| Type 4 (Aboreus) | `TIB3_01` | 150 | 12 | 12 | 8 |
-
-```{note}
-The `Default ID` column refers to the ID number in `rulesmd.ini` under the `[OverlayTypes]` section. Due to IDs 40 and 41 being skipped, the `ArrayIndex` (used internally by the game engine) is calculated differently:
-- For IDs 1-39: `ArrayIndex = ID - 1`
-- For IDs >= 42: `ArrayIndex = ID - 3`
-
-For example, `GEM01` has ID 28 in `[OverlayTypes]`, but its `ArrayIndex` is 27 (28 - 1). Similarly, `TIB01` has ID 105, but its `ArrayIndex` is 102 (105 - 3).
+Tiberium.Image4=               ; OverlayType name, default: game engine default
+Tiberium.Image4.NumFrames=     ; integer, default: game engine default
+Tiberium.Image4.NumImages=     ; integer, default: game engine default
+Tiberium.Image4.NumSlopes=     ; integer, default: game engine default
 ```
 
 ```{note}
-The `Tiberium.ImageX` numbering uses 1-based indexing (Image1 = Riparius, Image2 = Cruentus, Image3 = Vinifera, Image4 = Aboreus), matching the game's internal Tiberium type numbering.
-```
-
-```{note}
-**How `CustomImage` overrides the image**: When `CustomImage` is set in a per-Tiberium section, Phobos looks up the OverlayType by name (via `OverlayTypeClass::Find()`). If found, it replaces the `Image` pointer with the new OverlayType. If the name is invalid (not found in `[OverlayTypes]`), the image will **not** be overridden and the original image is preserved. The same logic applies to the global `Tiberium.ImageX` configuration.
+**About global vs. per-Tiberium configuration**:
+- Global `Tiberium.ImageX` settings only apply to the 4 built-in Tiberium types (Image1-4).
+- For custom Tiberium types, use `CustomImage` under the individual type's section.
+- `Image=1-4` is the game's native setting that refers to a built-in Tiberium type.
+- `CustomImage=Name` is a Phobos feature that replaces the image with a custom OverlayType by name.
 ```
 
 ## Aircraft

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -518,6 +518,57 @@ Shield.InheritStateOnReplace=false          ; boolean
     - `Shield.MinimumReplaceDelay` can be used to control how long after the shield has been broken (in game frames) can it be replaced. If not enough frames have passed, it won't be replaced.
     - If `Shield.InheritStateOnReplace` is set, shields replaced via `Shield.ReplaceOnly` inherit the current strength (relative to ShieldType `Strength`) of the previous shield and whether or not the shield was currently broken. Self-healing and respawn timers are always reset.
 
+### Tiberium Custom Image
+
+- Tiberium types (Riparius, Cruentus, Vinifera, Aboreus) can now have custom overlay images and override `NumFrames`, `NumImages`, and `NumSlopes` settings.
+- Supports both per-Tiberium (micro) configuration and global configuration via `[General]`.
+- Priority: Per-Tiberium `CustomImage` > Global `Tiberium.ImageX` > Game engine defaults.
+
+In `rulesmd.ini`:
+```ini
+; Per-Tiberium configuration - placed under individual Tiberium section
+[Riparius]
+CustomImage=SOME_OVERLAY       ; OverlayType image to use
+CustomImage.NumFrames=12       ; integer, number of frames
+CustomImage.NumImages=12       ; integer, number of images
+CustomImage.NumSlopes=8        ; integer, number of slopes
+
+; Global configuration - placed under [General]
+[General]
+Tiberium.Image1=                ; OverlayType for Type 1 (Riparius)
+Tiberium.Image1.NumFrames=12    ; integer
+Tiberium.Image1.NumImages=12    ; integer
+Tiberium.Image1.NumSlopes=8     ; integer
+
+Tiberium.Image2=                ; OverlayType for Type 2 (Cruentus)
+Tiberium.Image2.NumFrames=12    ; integer
+Tiberium.Image2.NumImages=12    ; integer
+Tiberium.Image2.NumSlopes=0     ; integer
+
+Tiberium.Image3=                ; OverlayType for Type 3 (Vinifera)
+Tiberium.Image3.NumFrames=12    ; integer
+Tiberium.Image3.NumImages=12    ; integer
+Tiberium.Image3.NumSlopes=8     ; integer
+
+Tiberium.Image4=                ; OverlayType for Type 4 (Aboreus)
+Tiberium.Image4.NumFrames=12    ; integer
+Tiberium.Image4.NumImages=12    ; integer
+Tiberium.Image4.NumSlopes=8     ; integer
+```
+
+Default values per Tiberium type:
+
+| Tiberium Type | NumFrames | NumImages | NumSlopes |
+|---------------|-----------|-----------|-----------|
+| Type 1 (Riparius) | 12 | 12 | 8 |
+| Type 2 (Cruentus) | 12 | 12 | 0 |
+| Type 3 (Vinifera) | 12 | 12 | 8 |
+| Type 4 (Aboreus) | 12 | 12 | 8 |
+
+```{note}
+The `Tiberium.ImageX` numbering uses 1-based indexing (Image1 = Riparius, Image2 = Cruentus, Image3 = Vinifera, Image4 = Aboreus), matching the game's internal Tiberium type numbering.
+```
+
 ## Aircraft
 
 ### Custom cruise missiles

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -35,6 +35,7 @@ This serves as a changelog for when you just need to drop the new version in wit
 - Combat light customizations introduced a bug that removed vanilla behaviour of ignoring detail level / framerate checks for colored combat light. This bug has been fixed but the previous behaviour can be restored by setting `CombatLightDetailLevel.CheckColored` on Warhead or globally under `[AudioVisual]`.
 - `[TechnoType] -> WarpAway=` has now been changed to set the animation when units are erased to maintain semantic consistency with `[General] -> WarpAway=`. The animation that was originally controlled by `[TechnoType] -> WarpAway=`, which played instead of `[General] -> WarpOut=` when a Techno is chronowarped by chronosphere, now needs to be specified using `[TechnoType] -> Chronoshift.WarpOut=`, which defaults to the value of `[TechnoType] -> WarpOut=`.
 - `UseCenterCoordsIfAttached` has been replaced by enumeration key `AttachedAnimPosition`. Set `AttachedAnimPosition=center` to replicate effects of `UseCenterCoordsIfAttached=true`.
+- Tiberium types can now have custom overlay images via `CustomImage` (per-Tiberium) or `Tiberium.ImageX` (global `[General]`), with overrides for `NumFrames`, `NumImages`, and `NumSlopes`. See [Tiberium Custom Image](New-or-Enhanced-Logics.md#tiberium-custom-image) for details.
 - Units' `LaserTrails` will no longer lag behind by one frame, so it needs to be repositioned if the position was corrected to account for the bug.
 - `DeployingAnim.AllowAnyDirection` has been superceded by `DeployDir`. Use value of -1 to re-enable the no facing restriction.
 - The following tags were renamed for consistency:
@@ -463,6 +464,7 @@ HideShakeEffects=false           ; boolean
 - [Passenger-based insignias](Fixed-or-Improved-Logics.md#customizable-veterancy-insignias) (by Ollerus)
 - [Use `InsigniaType` to set the properties of insignia in a batch](Miscellanous.md#insignia-type) (by Ollerus)
 - [Tiberium eater logic](New-or-Enhanced-Logics.md#tiberium-eater) (by NetsuNegi)
+- [Tiberium Custom Image](New-or-Enhanced-Logics.md#tiberium-custom-image) - per-Tiberium and global overlay image configuration with customizable `NumFrames`, `NumImages`, and `NumSlopes` (by GrayVacuum)
 - [Customize the damage taken when falling from a bridge](Fixed-or-Improved-Logics.md#customize-bridge-falling-down-damage) (by FlyStar)
 - Dehardcoded 255 limit of `OverlayType` (by secsome & ZivDero)
 - [Customizable airstrike flare colors](Fixed-or-Improved-Logics.md#airstrike-flare-customizations) (by Starkku)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -464,7 +464,7 @@ HideShakeEffects=false           ; boolean
 - [Passenger-based insignias](Fixed-or-Improved-Logics.md#customizable-veterancy-insignias) (by Ollerus)
 - [Use `InsigniaType` to set the properties of insignia in a batch](Miscellanous.md#insignia-type) (by Ollerus)
 - [Tiberium eater logic](New-or-Enhanced-Logics.md#tiberium-eater) (by NetsuNegi)
-- [Tiberium Custom Image](New-or-Enhanced-Logics.md#tiberium-custom-image) - per-Tiberium and global overlay image configuration with customizable `NumFrames`, `NumImages`, and `NumSlopes` (by GrayVacuum)
+- [Tiberium Custom Image](New-or-Enhanced-Logics.md#tiberium-custom-image) (by GrayVacuum)
 - [Customize the damage taken when falling from a bridge](Fixed-or-Improved-Logics.md#customize-bridge-falling-down-damage) (by FlyStar)
 - Dehardcoded 255 limit of `OverlayType` (by secsome & ZivDero)
 - [Customizable airstrike flare colors](Fixed-or-Improved-Logics.md#airstrike-flare-customizations) (by Starkku)

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -1405,44 +1405,6 @@ msgstr ""
 "如果设置 `Shield.InheritStateOnReplace` 则通过 `Shield.ReplaceOnly` "
 "替换的护盾将继承前一个护盾的当前强度（护盾类型的 `Strength`）以及是否已被击碎的状态。恢复和重生计时器将始终被重置。"
 
-msgid "Tiberium Custom Image"
-msgstr "泰矿自定义图像"
-
-msgid ""
-"Tiberium types (Riparius, Cruentus, Vinifera, Aboreus) can now have custom "
-"overlay images and override `NumFrames`, `NumImages`, and `NumSlopes` settings."
-msgstr "泰矿类型（Riparius、Cruentus、Vinifera、Aboreus）现在可以自定义覆盖图像并覆盖 `NumFrames`、`NumImages` 和 `NumSlopes` 设置。"
-
-msgid ""
-"Supports both per-Tiberium (micro) configuration and global configuration via `[General]`."
-msgstr "支持单个泰矿（微观）配置和通过 `[General]` 进行的全局配置。"
-
-msgid ""
-"Priority: Per-Tiberium `CustomImage` > Global `Tiberium.ImageX` > Game engine defaults."
-msgstr "优先级：单个泰矿 `CustomImage` > 全局 `Tiberium.ImageX` > 游戏引擎默认值。"
-
-msgid ""
-"In `rulesmd.ini`:"
-msgstr "在 `rulesmd.ini` 中："
-
-msgid ""
-"; Per-Tiberium configuration - placed under individual Tiberium section"
-msgstr "; 单个泰矿配置 - 放在对应泰矿的独立小节下"
-
-msgid ""
-"; Global configuration - placed under [General]"
-msgstr "; 全局配置 - 放在 [General] 下"
-
-msgid ""
-"Default values per Tiberium type:"
-msgstr "每种泰矿类型的默认值："
-
-msgid ""
-"The `Tiberium.ImageX` numbering uses 1-based indexing (Image1 = Riparius, "
-"Image2 = Cruentus, Image3 = Vinifera, Image4 = Aboreus), matching the game's "
-"internal Tiberium type numbering."
-msgstr "`Tiberium.ImageX` 编号采用从 1 开始的索引（Image1 = Riparius，Image2 = Cruentus，Image3 = Vinifera，Image4 = Aboreus），与游戏内部的泰矿类型编号一致。"
-
 msgid "Aircraft"
 msgstr "战机"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -1405,6 +1405,44 @@ msgstr ""
 "如果设置 `Shield.InheritStateOnReplace` 则通过 `Shield.ReplaceOnly` "
 "替换的护盾将继承前一个护盾的当前强度（护盾类型的 `Strength`）以及是否已被击碎的状态。恢复和重生计时器将始终被重置。"
 
+msgid "Tiberium Custom Image"
+msgstr "泰矿自定义图像"
+
+msgid ""
+"Tiberium types (Riparius, Cruentus, Vinifera, Aboreus) can now have custom "
+"overlay images and override `NumFrames`, `NumImages`, and `NumSlopes` settings."
+msgstr "泰矿类型（Riparius、Cruentus、Vinifera、Aboreus）现在可以自定义覆盖图像并覆盖 `NumFrames`、`NumImages` 和 `NumSlopes` 设置。"
+
+msgid ""
+"Supports both per-Tiberium (micro) configuration and global configuration via `[General]`."
+msgstr "支持单个泰矿（微观）配置和通过 `[General]` 进行的全局配置。"
+
+msgid ""
+"Priority: Per-Tiberium `CustomImage` > Global `Tiberium.ImageX` > Game engine defaults."
+msgstr "优先级：单个泰矿 `CustomImage` > 全局 `Tiberium.ImageX` > 游戏引擎默认值。"
+
+msgid ""
+"In `rulesmd.ini`:"
+msgstr "在 `rulesmd.ini` 中："
+
+msgid ""
+"; Per-Tiberium configuration - placed under individual Tiberium section"
+msgstr "; 单个泰矿配置 - 放在对应泰矿的独立小节下"
+
+msgid ""
+"; Global configuration - placed under [General]"
+msgstr "; 全局配置 - 放在 [General] 下"
+
+msgid ""
+"Default values per Tiberium type:"
+msgstr "每种泰矿类型的默认值："
+
+msgid ""
+"The `Tiberium.ImageX` numbering uses 1-based indexing (Image1 = Riparius, "
+"Image2 = Cruentus, Image3 = Vinifera, Image4 = Aboreus), matching the game's "
+"internal Tiberium type numbering."
+msgstr "`Tiberium.ImageX` 编号采用从 1 开始的索引（Image1 = Riparius，Image2 = Cruentus，Image3 = Vinifera，Image4 = Aboreus），与游戏内部的泰矿类型编号一致。"
+
 msgid "Aircraft"
 msgstr "战机"
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -74,6 +74,28 @@ void RulesExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->DefaultToGuardArea.Read(exINI, GameStrings::General, "DefaultToGuardArea");
 	this->LeptonMindControlOffset.Read(exINI, GameStrings::AudioVisual, "LeptonMindControlOffset");
 	this->MindControlRingOffset.Read(exINI, GameStrings::AudioVisual, "MindControlRingOffset");
+
+	// Load global Tiberium image config (Image1-4)
+	char imgBuf[64];
+	for (int i = 0; i < 4; i++)
+	{
+		_snprintf_s(imgBuf, sizeof(imgBuf), "Tiberium.Image%d", i + 1);
+		this->TiberiumImages[i].DefaultImage.Read(pINI, GameStrings::General, imgBuf);
+
+		auto readField = [&](Nullable<int>& field, const char* suffix)
+		{
+			_snprintf_s(imgBuf, sizeof(imgBuf), "Tiberium.Image%d.%s", i + 1, suffix);
+			Phobos::readBuffer[0] = '\0';
+			if (pINI->ReadString(GameStrings::General, imgBuf, "", Phobos::readBuffer) > 0)
+				field.Read(exINI, GameStrings::General, imgBuf);
+			else
+				field.Reset();
+		};
+
+		readField(this->TiberiumImages[i].NumFrames, "NumFrames");
+		readField(this->TiberiumImages[i].NumImages, "NumImages");
+		readField(this->TiberiumImages[i].NumSlopes, "NumSlopes");
+	}
 }
 
 void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
@@ -1058,7 +1080,17 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AircraftDockingDir_DefaultToPoseDir)
 		.Process(this->PoseDir_Production)
 		.Process(this->PoseDir_Field)
-    ;
+		;
+
+	for (int i = 0; i < 4; i++)
+	{
+		Stm
+			.Process(this->TiberiumImages[i].DefaultImage)
+			.Process(this->TiberiumImages[i].NumFrames)
+			.Process(this->TiberiumImages[i].NumImages)
+			.Process(this->TiberiumImages[i].NumSlopes)
+			;
+	}
 }
 
 void RulesExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -76,26 +76,26 @@ void RulesExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->MindControlRingOffset.Read(exINI, GameStrings::AudioVisual, "MindControlRingOffset");
 
 	// Load global Tiberium image config (Image1-4)
-	char imgBuf[64];
-	for (int i = 0; i < 4; i++)
-	{
-		_snprintf_s(imgBuf, sizeof(imgBuf), "Tiberium.Image%d", i + 1);
-		this->TiberiumImages[i].DefaultImage.Read(pINI, GameStrings::General, imgBuf);
+	// Must be loaded here (earliest stage) because Tiberium types need these configs when they are loaded
+	this->TiberiumImage1.DefaultImage.Read(pINI, GameStrings::General, "Tiberium.Image1");
+	this->TiberiumImage1.NumFrames.Read(exINI, GameStrings::General, "Tiberium.Image1.NumFrames");
+	this->TiberiumImage1.NumImages.Read(exINI, GameStrings::General, "Tiberium.Image1.NumImages");
+	this->TiberiumImage1.NumSlopes.Read(exINI, GameStrings::General, "Tiberium.Image1.NumSlopes");
 
-		auto readField = [&](Nullable<int>& field, const char* suffix)
-		{
-			_snprintf_s(imgBuf, sizeof(imgBuf), "Tiberium.Image%d.%s", i + 1, suffix);
-			Phobos::readBuffer[0] = '\0';
-			if (pINI->ReadString(GameStrings::General, imgBuf, "", Phobos::readBuffer) > 0)
-				field.Read(exINI, GameStrings::General, imgBuf);
-			else
-				field.Reset();
-		};
+	this->TiberiumImage2.DefaultImage.Read(pINI, GameStrings::General, "Tiberium.Image2");
+	this->TiberiumImage2.NumFrames.Read(exINI, GameStrings::General, "Tiberium.Image2.NumFrames");
+	this->TiberiumImage2.NumImages.Read(exINI, GameStrings::General, "Tiberium.Image2.NumImages");
+	this->TiberiumImage2.NumSlopes.Read(exINI, GameStrings::General, "Tiberium.Image2.NumSlopes");
 
-		readField(this->TiberiumImages[i].NumFrames, "NumFrames");
-		readField(this->TiberiumImages[i].NumImages, "NumImages");
-		readField(this->TiberiumImages[i].NumSlopes, "NumSlopes");
-	}
+	this->TiberiumImage3.DefaultImage.Read(pINI, GameStrings::General, "Tiberium.Image3");
+	this->TiberiumImage3.NumFrames.Read(exINI, GameStrings::General, "Tiberium.Image3.NumFrames");
+	this->TiberiumImage3.NumImages.Read(exINI, GameStrings::General, "Tiberium.Image3.NumImages");
+	this->TiberiumImage3.NumSlopes.Read(exINI, GameStrings::General, "Tiberium.Image3.NumSlopes");
+
+	this->TiberiumImage4.DefaultImage.Read(pINI, GameStrings::General, "Tiberium.Image4");
+	this->TiberiumImage4.NumFrames.Read(exINI, GameStrings::General, "Tiberium.Image4.NumFrames");
+	this->TiberiumImage4.NumImages.Read(exINI, GameStrings::General, "Tiberium.Image4.NumImages");
+	this->TiberiumImage4.NumSlopes.Read(exINI, GameStrings::General, "Tiberium.Image4.NumSlopes");
 }
 
 void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
@@ -718,6 +718,22 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->JumpjetRotateOnCrash)
 		.Process(this->VeinholeWarhead)
+		.Process(this->TiberiumImage1.DefaultImage)
+		.Process(this->TiberiumImage1.NumFrames)
+		.Process(this->TiberiumImage1.NumImages)
+		.Process(this->TiberiumImage1.NumSlopes)
+		.Process(this->TiberiumImage2.DefaultImage)
+		.Process(this->TiberiumImage2.NumFrames)
+		.Process(this->TiberiumImage2.NumImages)
+		.Process(this->TiberiumImage2.NumSlopes)
+		.Process(this->TiberiumImage3.DefaultImage)
+		.Process(this->TiberiumImage3.NumFrames)
+		.Process(this->TiberiumImage3.NumImages)
+		.Process(this->TiberiumImage3.NumSlopes)
+		.Process(this->TiberiumImage4.DefaultImage)
+		.Process(this->TiberiumImage4.NumFrames)
+		.Process(this->TiberiumImage4.NumImages)
+		.Process(this->TiberiumImage4.NumSlopes)
 		.Process(this->MissingCameo)
 		.Process(this->PlacementGrid_Translucency)
 		.Process(this->PlacementGrid_TranslucencyWithPreview)
@@ -1086,16 +1102,6 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->PoseDir_Production)
 		.Process(this->PoseDir_Field)
 		;
-
-	for (int i = 0; i < 4; i++)
-	{
-		Stm
-			.Process(this->TiberiumImages[i].DefaultImage)
-			.Process(this->TiberiumImages[i].NumFrames)
-			.Process(this->TiberiumImages[i].NumImages)
-			.Process(this->TiberiumImages[i].NumSlopes)
-			;
-	}
 }
 
 void RulesExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -12,6 +12,15 @@ class WarheadTypeClass;
 class DigitalDisplayTypeClass;
 class SelectBoxTypeClass;
 
+// Tiberium global image configuration struct
+struct TiberiumImageConfig
+{
+	PhobosFixedString<32u> DefaultImage;
+	Nullable<int> NumFrames;
+	Nullable<int> NumImages;
+	Nullable<int> NumSlopes;
+};
+
 class RulesExt
 {
 public:
@@ -178,6 +187,9 @@ public:
 		Valueable<bool> ColorAddUse8BitRGB;
 		Valueable<ColorStruct> AirstrikeLineColor;
 		Valueable<int> AirstrikeLineZAdjust;
+
+		// Global Tiberium image configuration (Image1-4, mapped by ArrayIndex+1)
+		TiberiumImageConfig TiberiumImages[4];
 
 		Valueable<bool> Strafing_SimulateBurst;
 		Valueable<bool> Strafing_UseAmmoPerShot;
@@ -902,6 +914,7 @@ public:
 			, DriverKilled_KeptPassengers { false }
 			, DriverKilled_KillPassengers { false }
 			, DisableOveroptimizationInTargeting { false }
+			, TiberiumImages {}
 			, ExtraThreat_IsThreat { 0.0 }
 			, ExtraThreat_InRange { 0.0 }
 			, ExtraThreatCoefficient_InRangeDistance { 0.0 }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -13,6 +13,7 @@ class DigitalDisplayTypeClass;
 class SelectBoxTypeClass;
 
 // Tiberium global image configuration struct
+// Used to manage 4 Tiberium types (Image1-4) with the same structure
 struct TiberiumImageConfig
 {
 	PhobosFixedString<32u> DefaultImage;
@@ -188,8 +189,11 @@ public:
 		Valueable<ColorStruct> AirstrikeLineColor;
 		Valueable<int> AirstrikeLineZAdjust;
 
-		// Global Tiberium image configuration (Image1-4, mapped by ArrayIndex+1)
-		TiberiumImageConfig TiberiumImages[4];
+		// Global Tiberium image configuration (Image1-4)
+		TiberiumImageConfig TiberiumImage1;
+		TiberiumImageConfig TiberiumImage2;
+		TiberiumImageConfig TiberiumImage3;
+		TiberiumImageConfig TiberiumImage4;
 
 		Valueable<bool> Strafing_SimulateBurst;
 		Valueable<bool> Strafing_UseAmmoPerShot;
@@ -569,6 +573,10 @@ public:
 			, JumpjetNoWobbles { false }
 			, JumpjetRotateOnCrash { true }
 			, VeinholeWarhead {}
+			, TiberiumImage1 {}
+			, TiberiumImage2 {}
+			, TiberiumImage3 {}
+			, TiberiumImage4 {}
 			, MissingCameo { GameStrings::XXICON_SHP }
 
 			, PlacementGrid_Translucency { 0 }
@@ -917,7 +925,6 @@ public:
 			, DriverKilled_KeptPassengers { false }
 			, DriverKilled_KillPassengers { false }
 			, DisableOveroptimizationInTargeting { false }
-			, TiberiumImages {}
 			, ExtraThreat_IsThreat { 0.0 }
 			, ExtraThreat_InRange { 0.0 }
 			, ExtraThreatCoefficient_InRangeDistance { 0.0 }

--- a/src/Ext/Tiberium/Body.cpp
+++ b/src/Ext/Tiberium/Body.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
 
 #include <OverlayTypeClass.h>
+#include <Ext/Rules/Body.h>
 
 TiberiumExt::ExtContainer TiberiumExt::ExtMap;
 
@@ -87,27 +88,45 @@ DEFINE_HOOK(0x721888, TiberiumClass_DTOR, 0x6)
 
 //DEFINE_HOOK_AGAIN(0x721CE9, TiberiumClass_LoadFromINI, 0xA)// Section dont exist!
 
-// Helper function to apply CustomImage to a TiberiumClass
 static void ApplyCustomImage(TiberiumClass* pItem)
 {
-	if (auto pExt = TiberiumExt::TryFetch(pItem))
+	auto pExt = TiberiumExt::TryFetch(pItem);
+	if (!pExt)
+		return;
+
+	auto apply = [](Nullable<int>& val, int& target)
 	{
-		if (pExt->CustomImageName)
+		if (val.isset())
+			target = val.Get();
+	};
+
+	int idx = pItem->ArrayIndex;
+
+	// Apply global Tiberium.ImageX config
+	if (idx >= 0 && idx < 4)
+	{
+		auto& g = RulesExt::Global()->TiberiumImages[idx];
+
+		if (g.DefaultImage)
 		{
-			auto pOverlayType = OverlayTypeClass::Find(pExt->CustomImageName);
-			if (pOverlayType)
-			{
-				pItem->Image = pOverlayType;
+			if (auto pImg = OverlayTypeClass::Find(g.DefaultImage))
+				pItem->Image = pImg;
+		}
 
-				pItem->NumFrames = pExt->CustomImageNumFrames.isset()
-					? pExt->CustomImageNumFrames.Get() : 12;
+		apply(g.NumFrames, pItem->NumFrames);
+		apply(g.NumImages, pItem->NumImages);
+		apply(g.NumSlopes, pItem->NumSlopes);
+	}
 
-				pItem->NumImages = pExt->CustomImageNumImages.isset()
-					? pExt->CustomImageNumImages.Get() : 12;
-
-				pItem->NumSlopes = pExt->CustomImageNumSlopes.isset()
-					? pExt->CustomImageNumSlopes.Get() : 0;
-			}
+	// Override with per-Tiberium CustomImage
+	if (pExt->CustomImageName)
+	{
+		if (auto pImg = OverlayTypeClass::Find(pExt->CustomImageName))
+		{
+			pItem->Image = pImg;
+			apply(pExt->CustomImageNumFrames, pItem->NumFrames);
+			apply(pExt->CustomImageNumImages, pItem->NumImages);
+			apply(pExt->CustomImageNumSlopes, pItem->NumSlopes);
 		}
 	}
 }

--- a/src/Ext/Tiberium/Body.cpp
+++ b/src/Ext/Tiberium/Body.cpp
@@ -1,5 +1,7 @@
 #include "Body.h"
 
+#include <OverlayTypeClass.h>
+
 TiberiumExt::ExtContainer TiberiumExt::ExtMap;
 
 // =============================
@@ -10,6 +12,10 @@ void TiberiumExt::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->MinimapColor)
+		.Process(this->CustomImageName)
+		.Process(this->CustomImageNumFrames)
+		.Process(this->CustomImageNumImages)
+		.Process(this->CustomImageNumSlopes)
 		;
 }
 
@@ -20,6 +26,12 @@ void TiberiumExt::LoadFromINIFile(CCINIClass* const pINI)
 	INI_EX exINI(pINI);
 
 	this->MinimapColor.Read(exINI, pSection, "MinimapColor");
+
+	// Load CustomImage settings
+	this->CustomImageName.Read(pINI, pSection, "CustomImage");
+	this->CustomImageNumFrames.Read(exINI, pSection, "CustomImage.NumFrames");
+	this->CustomImageNumImages.Read(exINI, pSection, "CustomImage.NumImages");
+	this->CustomImageNumSlopes.Read(exINI, pSection, "CustomImage.NumSlopes");
 }
 
 void TiberiumExt::LoadFromStream(PhobosStreamReader& Stm)
@@ -74,6 +86,32 @@ DEFINE_HOOK(0x721888, TiberiumClass_DTOR, 0x6)
 }
 
 //DEFINE_HOOK_AGAIN(0x721CE9, TiberiumClass_LoadFromINI, 0xA)// Section dont exist!
+
+// Helper function to apply CustomImage to a TiberiumClass
+static void ApplyCustomImage(TiberiumClass* pItem)
+{
+	if (auto pExt = TiberiumExt::TryFetch(pItem))
+	{
+		if (pExt->CustomImageName)
+		{
+			auto pOverlayType = OverlayTypeClass::Find(pExt->CustomImageName);
+			if (pOverlayType)
+			{
+				pItem->Image = pOverlayType;
+
+				pItem->NumFrames = pExt->CustomImageNumFrames.isset()
+					? pExt->CustomImageNumFrames.Get() : 12;
+
+				pItem->NumImages = pExt->CustomImageNumImages.isset()
+					? pExt->CustomImageNumImages.Get() : 12;
+
+				pItem->NumSlopes = pExt->CustomImageNumSlopes.isset()
+					? pExt->CustomImageNumSlopes.Get() : 0;
+			}
+		}
+	}
+}
+
 DEFINE_HOOK_AGAIN(0x721CDC, TiberiumClass_LoadFromINI, 0xA)
 DEFINE_HOOK(0x721C7B, TiberiumClass_LoadFromINI, 0xA)
 {
@@ -81,6 +119,9 @@ DEFINE_HOOK(0x721C7B, TiberiumClass_LoadFromINI, 0xA)
 	GET_STACK(CCINIClass*, pINI, STACK_OFFSET(0xC4, 0x4));
 
 	TiberiumExt::ExtMap.LoadFromINI(pItem, pINI);
+
+	// Apply CustomImage after game sets Image
+	ApplyCustomImage(pItem);
 
 	return 0;
 }

--- a/src/Ext/Tiberium/Body.cpp
+++ b/src/Ext/Tiberium/Body.cpp
@@ -105,17 +105,26 @@ static void ApplyCustomImage(TiberiumClass* pItem)
 	// Apply global Tiberium.ImageX config
 	if (idx >= 0 && idx < 4)
 	{
-		auto& g = RulesExt::Global()->TiberiumImages[idx];
+		auto pGlobal = RulesExt::Global();
+		TiberiumImageConfig* g = nullptr;
 
-		if (g.DefaultImage)
+		switch (idx)
 		{
-			if (auto pImg = OverlayTypeClass::Find(g.DefaultImage))
-				pItem->Image = pImg;
+		case 0: g = &pGlobal->TiberiumImage1; break;
+		case 1: g = &pGlobal->TiberiumImage2; break;
+		case 2: g = &pGlobal->TiberiumImage3; break;
+		case 3: g = &pGlobal->TiberiumImage4; break;
 		}
 
-		apply(g.NumFrames, pItem->NumFrames);
-		apply(g.NumImages, pItem->NumImages);
-		apply(g.NumSlopes, pItem->NumSlopes);
+		if (g && g->DefaultImage)
+		{
+			if (auto pImg = OverlayTypeClass::Find(g->DefaultImage))
+				pItem->Image = pImg;
+
+			apply(g->NumFrames, pItem->NumFrames);
+			apply(g->NumImages, pItem->NumImages);
+			apply(g->NumSlopes, pItem->NumSlopes);
+		}
 	}
 
 	// Override with per-Tiberium CustomImage

--- a/src/Ext/Tiberium/Body.h
+++ b/src/Ext/Tiberium/Body.h
@@ -24,8 +24,18 @@ public:
 
 	Nullable<ColorStruct> MinimapColor;
 
+	// CustomImage extension
+	PhobosFixedString<32u> CustomImageName;
+	Nullable<int> CustomImageNumFrames;
+	Nullable<int> CustomImageNumImages;
+	Nullable<int> CustomImageNumSlopes;
+
 	TiberiumExt(TiberiumClass* OwnerObject) : AbstractTypeExt(OwnerObject)
 		, MinimapColor {}
+		, CustomImageName {}
+		, CustomImageNumFrames {}
+		, CustomImageNumImages {}
+		, CustomImageNumSlopes {}
 	{ }
 
 	virtual ~TiberiumExt() = default;


### PR DESCRIPTION
### Tiberium Custom Image

Tiberium types can now use custom overlay images and override `NumFrames`, `NumImages`, and `NumSlopes` values.

**Priority**: Per-Tiberium `CustomImage` > Global `Tiberium.ImageX` > Game engine defaults.

**Per-Tiberium configuration** (in `rulesmd.ini`):
```ini
[SOMETIBERIUM]  ; Tiberium type name
CustomImage=                   ; OverlayType name, default: game engine default
CustomImage.NumFrames=         ; integer, default: game engine default
CustomImage.NumImages=         ; integer, default: game engine default
CustomImage.NumSlopes=         ; integer, default: game engine default
```

**Global configuration** (only applies to built-in Tiberium types Image1-4, in `[General]` section):
```ini
[General]
Tiberium.Image1=               ; OverlayType name, default: game engine default
Tiberium.Image1.NumFrames=     ; integer, default: game engine default
Tiberium.Image1.NumImages=     ; integer, default: game engine default
Tiberium.Image1.NumSlopes=     ; integer, default: game engine default

Tiberium.Image2=               ; OverlayType name, default: game engine default
Tiberium.Image2.NumFrames=     ; integer, default: game engine default
Tiberium.Image2.NumImages=     ; integer, default: game engine default
Tiberium.Image2.NumSlopes=     ; integer, default: game engine default

Tiberium.Image3=               ; OverlayType name, default: game engine default
Tiberium.Image3.NumFrames=     ; integer, default: game engine default
Tiberium.Image3.NumImages=     ; integer, default: game engine default
Tiberium.Image3.NumSlopes=     ; integer, default: game engine default

Tiberium.Image4=               ; OverlayType name, default: game engine default
Tiberium.Image4.NumFrames=     ; integer, default: game engine default
Tiberium.Image4.NumImages=     ; integer, default: game engine default
Tiberium.Image4.NumSlopes=     ; integer, default: game engine default
```

```{note}
**About global vs. per-Tiberium configuration**:
- Global `Tiberium.ImageX` settings only apply to the 4 built-in Tiberium types (Image1-4).
- For custom Tiberium types, use `CustomImage` under the individual type's section.
- `Image=1-4` is the game's native setting that refers to a built-in Tiberium type.
- `CustomImage=Name` is a Phobos feature that replaces the image with a custom OverlayType by name.
```