### PR TITLE
[Map] SkipMapSelect Enhancement

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -440,6 +440,7 @@ This page lists all the individual contributions to the project by their author.
   - DeployFire supports buildings
   - `OmniFire` supports buildings with `Turret=yes`
   - Fixed an issue where setting a production building as `Primary` could cause it to enter an unload state
+  - SkipMapSelect Enhancement
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -159,6 +159,12 @@ In `RA2MD.INI`:
 ShowBriefing=true  ; boolean
 ```
 
+### SkipMapSelect Enhancement
+
+- Using `SkipMapSelect=yes` in the map file allows you to bypass the restriction in mapselmd.ini—which requires that the player's faction in the current campaign must match the faction in the next new campaign.
+  - You can use `NextScenario` and `AltNextScenario` to specify the map names required to enter a new campaign, thereby forcing the game to proceed to the next campaign.
+
+
 ## Script Actions
 
 ### `10000-10999` Ingame Actions

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -830,7 +830,7 @@ Team delay change will take effect for a house after its next AI team is created
 ### `611` Set Next Scenario
 
 - Set the next campaign to load after winning the current one.
-  - Works only in `Campaign Mode` and requires setting `[Basic]>SkipMapSelect=yes`.
+  - Works only in `Campaign Mode` and requires setting `[Basic] -> SkipMapSelect=yes`.
 
 In `mycampaign.map`:
 ```ini

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -163,7 +163,7 @@ ShowBriefing=true  ; boolean
 
 - Using `SkipMapSelect=yes` in the map file allows you to bypass the restriction in mapselmd.ini—which requires that the player's faction in the current campaign must match the faction in the next new campaign.
   - You can use `NextScenario` and `AltNextScenario` to specify the map names required to enter a new campaign, thereby forcing the game to proceed to the next campaign.
-
+  - Now, setting a local variable named `<Alternate Next Scenario>` will also trigger `AltNextScenario`.
 
 ## Script Actions
 

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -849,7 +849,7 @@ In `mycampaign.map`:
 ```ini
 [Actions]
 ...
-ID=ActionCount,[Action1],611,4,[FileName],0,0,0,0,A,[ActionX]
+ID=ActionCount,[Action1],611,4,[Map Filename],0,0,0,0,A,[ActionX]
 ...
 ```
 

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -821,6 +821,19 @@ ID=ActionCount,[Action1],610,0,0,[Number],0,0,0,A,[ActionX]
 Team delay change will take effect for a house after its next AI team is created.
 ```
 
+### `611` Set Next Scenario
+
+- Set the next campaign to load after winning the current one.
+  - Works only in `Campaign Mode` and requires setting `[Basic]>SkipMapSelect=yes`.
+
+In `mycampaign.map`:
+```ini
+[Actions]
+...
+ID=ActionCount,[Action1],611,-4,[FileName],0,0,0,0,A,[ActionX]
+...
+```
+
 ### `800-802` Display Banner
 
 - Display a 'banner' at a fixed location that is relative to the screen.

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -836,7 +836,7 @@ In `mycampaign.map`:
 ```ini
 [Actions]
 ...
-ID=ActionCount,[Action1],611,-4,[FileName],0,0,0,0,A,[ActionX]
+ID=ActionCount,[Action1],611,4,[FileName],0,0,0,0,A,[ActionX]
 ...
 ```
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -257,8 +257,8 @@ HideShakeEffects=false           ; boolean
   607=Clear hate-value... (Phobos),0,2,0,0,0,0,0,0,0, Clear the hate-value that trigger houses to other houses. -1 works for all houses.,0,1,607
   608=Set force enemy... (Phobos),0,0,2,0,0,0,0,0,0, Force an enemy, it will not change with the change of hate-value. -1 will remove the forced enemy, -2 will never have any enemies.,0,1,608
   609=Set radar mode... (Phobos),0,0,15,0,0,0,0,0,0, Trigger's house can modify the current radar mode. 0 for requires full-power and building, 1 for free radar, 2 for forced enable, 3 for forced disable.,0,1,609
-  610=Set team delay... (Phobos),0,0,6,0,0,0,0,0,0, Trigger's house can customize TeamDelay. When the value is less than 0 in `[General]>TeamDelays`.,0,1,610
-  611=Set next scenario... (Phobos),-4,105,0,0,0,0,0,0,0, Set the next campaign to load after winning the current one. Works only in `Campaign Mode` and requires setting `[Basic]>SkipMapSelect=yes`.,0,1,611
+  610=Set team delay... (Phobos),0,0,6,0,0,0,0,0,0, Trigger's house can customize TeamDelay. When the value is less than 0 in [General] ->TeamDelays.,0,1,610
+  611=Set next scenario... (Phobos),-4,105,0,0,0,0,0,0,0, Set the next campaign to load after winning the current one. Works only in Campaign Mode and requires setting [Basic] -> SkipMapSelect=yes.,0,1,611
   800=Display banner and local variable... (Phobos),-4,101,104,102,103,3,0,0,0,Draw banner on screen and replace banner with same ID,0,1,800
   801=Display banner and global variable... (Phobos),-4,101,104,102,103,35,0,0,0,Draw banner on screen and replace banner with same ID,0,1,801
   802=Delete banner... (Phobos),0,104,0,0,0,0,0,0,0,Delete banner with ID,0,1,802

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -194,6 +194,7 @@ HideShakeEffects=false           ; boolean
   102=Horizontal position,0
   103=Vertical position,0
   104=Banner ID,0
+  105=Map Filename,0
 
   [EventsRA2]
   500=Local variable is greater than...,48,6,0,0,[LONG DESC],0,1,500,1
@@ -257,6 +258,7 @@ HideShakeEffects=false           ; boolean
   608=Set force enemy... (Phobos),0,0,2,0,0,0,0,0,0, Force an enemy, it will not change with the change of hate-value. -1 will remove the forced enemy, -2 will never have any enemies.,0,1,608
   609=Set radar mode... (Phobos),0,0,15,0,0,0,0,0,0, Trigger's house can modify the current radar mode. 0 for requires full-power and building, 1 for free radar, 2 for forced enable, 3 for forced disable.,0,1,609
   610=Set team delay... (Phobos),0,0,6,0,0,0,0,0,0, Trigger's house can customize TeamDelay. When the value is less than 0 in `[General]>TeamDelays`.,0,1,610
+  611=Set next scenario... (Phobos),-4,105,0,0,0,0,0,0,0, Set the next campaign to load after winning the current one. Works only in `Campaign Mode` and requires setting `[Basic]>SkipMapSelect=yes`.,0,1,611
   800=Display banner and local variable... (Phobos),-4,101,104,102,103,3,0,0,0,Draw banner on screen and replace banner with same ID,0,1,800
   801=Display banner and global variable... (Phobos),-4,101,104,102,103,35,0,0,0,Draw banner on screen and replace banner with same ID,0,1,801
   802=Delete banner... (Phobos),0,104,0,0,0,0,0,0,0,Delete banner with ID,0,1,802
@@ -651,11 +653,12 @@ HideShakeEffects=false           ; boolean
 - Keep Syringe open until the game exits (by 11EJDE11, ported from Vinifera, original by ZivDero & secsome)
 - [Drop crates on death](New-or-Enhanced-Logics.md#drop-crates-on-death) (by FS-21)
 - [`600` Configure Drop Crate](AI-Scripting-and-Mapping.md#configure-drop-crate) (by FS-21)
-- [DeployFire supports buildings](New-or-Enhanced-Logics.md#deployfire-supports) (By FlyStar)
+- [DeployFire supports buildings](New-or-Enhanced-Logics.md#deployfire-supports) (by FlyStar)
 - `OmniFire` supports buildings with `Turret=yes` (by FlyStar)
 - [Automatic conversion based on health](New-or-Enhanced-Logics.md#automatic-conversion-based-on-health) (by obsidianus)
 - Add `ammo`, `health`, `mission`, `landtype` and `sequence` conditions to `DiscardOn` (by Noble_Fish)
 - [Berzerk / `Psychedelic` duration stacking customization](Fixed-or-Improved-Logics.md#berzerk-psychedelic-duration-stacking-customization) (by Starkku)
+- SkipMapSelect Enhancement (by FlyStar)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/src/Ext/Scenario/Hooks.Variables.cpp
+++ b/src/Ext/Scenario/Hooks.Variables.cpp
@@ -114,46 +114,86 @@ DEFINE_HOOK(0x685EB1, PhobosSaveVariables, 0x5)//Lose
 	return 0;
 }
 
-DEFINE_HOOK(0x685A38, ScenarioClass_sub_685670_SetNextScenario, 0x6)
+#pragma region MapSelectExtension
+
+// It might be the function for moving on to the next level. I'm not sure about the details, but it works.
+static bool __fastcall sub_5AE100(void* pThis, void* _, ScenarioClass* pItem)
 {
-	enum { AltNextScenario = 0x685A4C, NextScenario = 0x685A59, Continue = 0x685A63 };
+	JMP_STD(0x5AE100);
+}
 
-	if (ScenarioClass::Instance->SkipMapSelect)
+static bool __fastcall sub_5AE100_CustomMission(void* pThis, void* _, ScenarioClass* pItem)
+{
+	// It can be directly filled in the map file name without being restricted by mapselmd.ini.
+	if (pItem->SkipMapSelect)
 	{
-		if (strcmp(ScenarioClass::Instance->AltNextScenario, ""))
+		std::string scenario {};
+		auto const pGlobal = ScenarioExt::Global();
+
+		do
 		{
-			auto const& LocalVariables = ScenarioExt::Global()->Variables[false];
-			auto const& GlobalVariables = ScenarioExt::Global()->Variables[true];
-
-			if (!LocalVariables.empty())
+			if (strcmp(ScenarioClass::Instance->AltNextScenario, ""))
 			{
-				for (auto const& itr : LocalVariables)
-				{
-					if (strcmp(itr.second.Name, "<Alternate Next Scenario>") || itr.second.Value <= 0)
-						continue;
+				const auto& localVariables = pGlobal->Variables[false];
+				const auto& globalVariables = pGlobal->Variables[true];
+				bool success = false;
 
-					return AltNextScenario;
+				if (!localVariables.empty())
+				{
+					for (const auto& itr : localVariables)
+					{
+						if (strcmp(itr.second.Name, "<Alternate Next Scenario>") || itr.second.Value <= 0)
+							continue;
+
+						success = true;
+						break;
+					}
+				}
+
+				if (!success && !globalVariables.empty())
+				{
+					for (const auto& itr : globalVariables)
+					{
+						if (strcmp(itr.second.Name, "<Alternate Next Scenario>") || itr.second.Value <= 0)
+							continue;
+
+						success = true;
+						break;
+					}
+
+					if (!success && globalVariables.contains(1) && globalVariables.find(1)->second.Value > 0)
+						success = true;
+				}
+
+				if (success)
+				{
+					scenario = pItem->AltNextScenario;
+					break;
 				}
 			}
 
-			if (!GlobalVariables.empty())
-			{
-				for (auto const& itr : GlobalVariables)
-				{
-					if (strcmp(itr.second.Name, "<Alternate Next Scenario>") || itr.second.Value <= 0)
-						continue;
+			scenario = pItem->NextScenario;
+		}
+		while (false);
 
-					return AltNextScenario;
-				}
+		if (!scenario.empty())
+		{
+			// Does this Stage have any function ? If anyone knows, please let me know.
+			pItem->Stage = 0;
+			strncpy(pItem->FileName, scenario.c_str(), 0x104u);
+			pItem->FileName[259] = '\0';
 
-				if (GlobalVariables.contains(1) && GlobalVariables.find(1)->second.Value > 0)
-					return AltNextScenario;
-			}
+			return true;
 		}
 
-		if (strcmp(ScenarioClass::Instance->NextScenario, ""))
-			return NextScenario;
+		return false;
 	}
 
-	return Continue;
+	// Return to the original function.
+	return sub_5AE100(pThis, _, pItem);
 }
+
+DEFINE_JUMP(LJMP, 0x685A38, 0x685A63)	// Skip the original code
+DEFINE_FUNCTION_JUMP(CALL, 0x5ADD63, sub_5AE100_CustomMission)
+
+#pragma endregion

--- a/src/Ext/Scenario/Hooks.Variables.cpp
+++ b/src/Ext/Scenario/Hooks.Variables.cpp
@@ -116,13 +116,7 @@ DEFINE_HOOK(0x685EB1, PhobosSaveVariables, 0x5)//Lose
 
 #pragma region MapSelectExtension
 
-// It might be the function for moving on to the next level. I'm not sure about the details, but it works.
-static bool __fastcall sub_5AE100(void* pThis, void* _, ScenarioClass* pItem)
-{
-	JMP_STD(0x5AE100);
-}
-
-static bool __fastcall sub_5AE100_CustomMission(void* pThis, void* _, ScenarioClass* pItem)
+static bool __fastcall MapSelectClass_SetNextScenario_CustomMission(MapSelectClass* pThis, void* _, ScenarioClass* pItem)
 {
 	// It can be directly filled in the map file name without being restricted by mapselmd.ini.
 	if (pItem->SkipMapSelect)
@@ -190,10 +184,10 @@ static bool __fastcall sub_5AE100_CustomMission(void* pThis, void* _, ScenarioCl
 	}
 
 	// Return to the original function.
-	return sub_5AE100(pThis, _, pItem);
+	return pThis->SetNextScenario(pItem);
 }
 
 DEFINE_JUMP(LJMP, 0x685A38, 0x685A63)	// Skip the original code
-DEFINE_FUNCTION_JUMP(CALL, 0x5ADD63, sub_5AE100_CustomMission)
+DEFINE_FUNCTION_JUMP(CALL, 0x5ADD63, MapSelectClass_SetNextScenario_CustomMission)
 
 #pragma endregion

--- a/src/Ext/TAction/Body.cpp
+++ b/src/Ext/TAction/Body.cpp
@@ -1,5 +1,6 @@
 #include "Body.h"
 
+#include <ScenarioClass.h>
 #include <TriggerTypeClass.h>
 #include <Ext/House/Body.h>
 #include <Ext/Scenario/Body.h>
@@ -81,6 +82,8 @@ bool TActionExt::Execute(TActionClass* pThis, HouseClass* pHouse, ObjectClass* p
 		return TActionExt::SetFreeRadar(pThis, pHouse, pObject, pTrigger, location);
 	case PhobosTriggerAction::SetTeamDelay:
 		return TActionExt::SetTeamDelay(pThis, pHouse, pObject, pTrigger, location);
+	case PhobosTriggerAction::SetNextScanario:
+		return TActionExt::SetNextScanario(pThis, pHouse, pObject, pTrigger, location);
 
 	case PhobosTriggerAction::CreateBannerLocal:
 		return TActionExt::CreateBannerLocal(pThis, pHouse, pObject, pTrigger, location);
@@ -751,6 +754,24 @@ bool TActionExt::SetTeamDelay(TActionClass* const pThis, HouseClass* const pHous
 	else if (Timer.InProgress())
 	{
 		Timer.Start(time);
+	}
+
+	return true;
+}
+
+bool TActionExt::SetNextScanario(TActionClass* const pThis, HouseClass* const pHouse, ObjectClass* const pObject, TriggerClass* const pTrigger, const CellStruct& location)
+{
+	if (SessionClass::Instance.IsCampaign())
+	{
+		const char* pText = pThis->Text;
+
+		if (strcmp(pText, "") && strcmp(pText, "0"))
+		{
+			// When you can customize it as you like, there’s no longer a need for additional branches.
+			ScenarioClass* const pScenario = ScenarioClass::Instance;
+			_snprintf_s(pScenario->AltNextScenario, sizeof(pScenario->AltNextScenario), pText);
+			_snprintf_s(pScenario->NextScenario, sizeof(pScenario->NextScenario), pText);
+		}
 	}
 
 	return true;

--- a/src/Ext/TAction/Body.h
+++ b/src/Ext/TAction/Body.h
@@ -26,6 +26,7 @@ enum class PhobosTriggerAction : unsigned int
 	SetForceEnemy = 608,
 	SetFreeRadar = 609,
 	SetTeamDelay = 610,
+	SetNextScanario = 611,
 
 	CreateBannerLocal = 800, // any banner w/ local variable
 	CreateBannerGlobal = 801, // any banner w/ global variable
@@ -89,6 +90,7 @@ public:
 	ACTION_FUNC(SetForceEnemy);
 	ACTION_FUNC(SetFreeRadar);
 	ACTION_FUNC(SetTeamDelay);
+	ACTION_FUNC(SetNextScanario);
 
 	ACTION_FUNC(CreateBannerLocal);
 	ACTION_FUNC(CreateBannerGlobal);


### PR DESCRIPTION
Using `SkipMapSelect=yes` in the map file allows you to bypass the restriction in `mapselmd.ini`—which requires that the player's faction in the current campaign must match the faction in the next new campaign. You can use `NextScenario` and `AltNextScenario` to specify the map names required to enter a new campaign, thereby forcing the game to proceed to the next campaign.
现在在地图文件中使用`SkipMapSelect=yes`可以绕过`mapselmd.ini`中的限制——该限制要求当前战役中玩家所属的阵营必须与下一个新战役中的阵营一致。你可以使用`NextScenario`和`AltNextScenario`来指定进入新战役所需的地图名称强制游戏进入下一个战役。

Now, setting a local variable named `<Alternate Next Scenario>` will also trigger `AltNextScenario`.
现在启用一个名为`<Alternate Next Scenario>`的局部变量也可以触发`AltNextScenario`。

---------

### `611` Set Next Scenario

- Set the next campaign to load after winning the current one.
  - Works only in `Campaign Mode` and requires setting `[Basic]>SkipMapSelect=yes`.

In `mycampaign.map`:
```ini
[Actions]
...
ID=ActionCount,[Action1],611,4,[Map Filename],0,0,0,0,A,[ActionX]
...
```

