### PR TITLE
[Vanilla Enhancement] Customize whether warhead can prevent crew escape from techno

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -562,6 +562,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize crash spin multiplier
   - Customize reveal radius of `RevealToAll`
   - Fix the bug that technos do not reset their link with the linked building when deactivated
+  - Customize whether warhead can prevent crew escape from techno
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -3295,6 +3295,7 @@ In `rulesmd.ini`:
 ```ini
 [SOMEWARHEAD]                          ; WarheadType
 PreventCrew=false                      ; boolean
+KillPassengers=false                   ; boolean
 ```
 
 ## Weapons

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -3289,6 +3289,14 @@ UnlimboDetonate.KeepSelected=true      ; boolean
 `UnlimboDetonate` cannot be used in conjunction with `Parasite`.
 ```
 
+### Customize whether warhead can prevent crew escape from techno
+
+In `rulesmd.ini`:
+```ini
+[SOMEWARHEAD]                          ; WarheadType
+PreventCrew=false                      ; boolean
+```
+
 ## Weapons
 
 ### Allow Laser drawing position update

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -3295,7 +3295,8 @@ In `rulesmd.ini`:
 ```ini
 [SOMEWARHEAD]                          ; WarheadType
 PreventCrew=false                      ; boolean
-KillPassengers=false                   ; boolean
+PreventPassengerEscape=false           ; boolean
+PreventOccupantEscape=false            ; boolean
 ```
 
 ## Weapons

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -657,6 +657,7 @@ HideShakeEffects=false           ; boolean
 - Add `ammo`, `health`, `mission`, `landtype` and `sequence` conditions to `DiscardOn` (by Noble_Fish)
 - [Berzerk / `Psychedelic` duration stacking customization](Fixed-or-Improved-Logics.md#berzerk-psychedelic-duration-stacking-customization) (by Starkku)
 - ScriptType action `Play speech` (by FS-21)
+- Customize whether warhead can prevent crew escape from techno (by NetsuNegi)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -660,6 +660,7 @@ HideShakeEffects=false           ; boolean
 - [Berzerk / `Psychedelic` duration stacking customization](Fixed-or-Improved-Logics.md#berzerk-psychedelic-duration-stacking-customization) (by Starkku)
 - ScriptType action `Play speech` (by FS-21)
 - SkipMapSelect Enhancement (by FlyStar)
+- [Customize whether warhead can prevent crew escape from techno](New-or-Enhanced-Logics.md#customize-whether-warhead-can-prevent-crew-escape-from-techno) (by NetsuNegi)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1848,6 +1848,10 @@ msgid ""
 " when deactivated"
 msgstr "修复了单位失灵时不会重置其与相链接建筑链接状态的 Bug"
 
+msgid ""
+"Customize whether warhead can prevent crew escape from techno"
+msgstr "自定义弹头是否阻止生还者逃出"
+
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -6559,6 +6559,10 @@ msgstr "`UnlimboDetonate.KeepSelected` 允许单位进出 Limbo 状态前保留�
 msgid "`UnlimboDetonate` cannot be used in conjunction with `Parasite`."
 msgstr "`UnlimboDetonate` 不能与 `Parasite` 共用。"
 
+msgid ""
+"Customize whether warhead can prevent crew escape from techno"
+msgstr "自定义弹头是否阻止生还者逃出"
+
 msgid "Weapons"
 msgstr "武器"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2384,9 +2384,9 @@ msgstr ""
 "FS-21）"
 
 msgid ""
-"Customize whether warhead can prevent crew escape from techno (by NetsuNegi)"
+"[Customize whether warhead can prevent crew escape from techno](New-or-Enhanced-Logics.md#customize-whether-warhead-can-prevent-crew-escape-from-techno) (by NetsuNegi)"
 msgstr ""
-"自定义弹头是否阻止生还者逃出（by NetsuNegi）"
+"[自定义弹头是否阻止生还者逃出](New-or-Enhanced-Logics.md#customize-whether-warhead-can-prevent-crew-escape-from-techno)（by NetsuNegi）"
 
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2383,6 +2383,11 @@ msgstr ""
 "[`600` 配置掉落箱子行为](AI-Scripting-and-Mapping.md#configure-drop-crate)（by "
 "FS-21）"
 
+msgid ""
+"Customize whether warhead can prevent crew escape from techno (by NetsuNegi)"
+msgstr ""
+"自定义弹头是否阻止生还者逃出（by NetsuNegi）"
+
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1206,6 +1206,7 @@ void TechnoExt::Serialize(T& Stm)
 		.Process(this->LastTargetCrd)
 		.Process(this->LastTargetCrdClearTimer)
 		.Process(this->ShouldBeDead)
+		.Process(this->PreventCrew)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -86,6 +86,8 @@ public:
 	int DropCrate; // Drop crate on death, modified by map action
 	Powerup DropCrateType;
 
+	bool PreventCrew;
+
 	TechnoExt(TechnoClass* OwnerObject) : RadioExt(OwnerObject)
 		, TypeExtData { nullptr }
 		, Shield {}
@@ -134,6 +136,7 @@ public:
 		, ShouldBeDead { false }
 		, DropCrate { -1 }
 		, DropCrateType { Powerup::Money }
+		, PreventCrew { false }
 	{ }
 
 	void OnEarlyUpdate();

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -261,7 +261,7 @@ DEFINE_HOOK(0x702672, TechnoClass_ReceiveDamage_RevengeWeapon, 0x5)
 	if (pWHExt->PreventCrew)
 		TechnoExt::Fetch(pThis)->PreventCrew = true;
 
-	if (pWHExt->KillPassengers)
+	if (pWHExt->PreventPassengerEscape)
 		pThis->KillPassengers(pSource);
 
 	return 0;

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -256,6 +256,9 @@ DEFINE_HOOK(0x702672, TechnoClass_ReceiveDamage_RevengeWeapon, 0x5)
 	if (pSource)
 		TechnoExt::ApplyRevengeWeapon(pThis, pSource, pWarhead);
 
+	if (WarheadTypeExt::Fetch(pWarhead)->PreventCrew)
+		TechnoExt::Fetch(pThis)->PreventCrew = true;
+
 	return 0;
 }
 

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -248,8 +248,8 @@ DEFINE_HOOK(0x702603, TechnoClass_ReceiveDamage_Explodes, 0x6)
 DEFINE_HOOK(0x702672, TechnoClass_ReceiveDamage_RevengeWeapon, 0x5)
 {
 	GET(TechnoClass*, pThis, ESI);
-	GET_STACK(TechnoClass*, pSource, STACK_OFFSET(0xC4, 0x10));
 	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0xC4, 0xC));
+	GET_STACK(TechnoClass*, pSource, STACK_OFFSET(0xC4, 0x10));
 
 	TechnoExt::ApplyKillWeapon(pThis, pSource, pWarhead);
 
@@ -263,6 +263,23 @@ DEFINE_HOOK(0x702672, TechnoClass_ReceiveDamage_RevengeWeapon, 0x5)
 
 	if (pWHExt->PreventPassengerEscape)
 		pThis->KillPassengers(pSource);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x442635, BuildingClass_ReceiveDamage_PreventOccupantEscape, 0x6)
+{
+	enum { SkipClearOccupants = 0x442640 };
+
+	GET_STACK(WarheadTypeClass*, pWarhead, STACK_OFFSET(0x9C, 0xC));
+
+	if (WarheadTypeExt::Fetch(pWarhead)->PreventOccupantEscape)
+	{
+		GET(BuildingClass*, pThis, ESI);
+		GET_STACK(TechnoClass*, pSource, STACK_OFFSET(0x9C, 0x10));
+		pThis->KillOccupants(pSource);
+		return SkipClearOccupants;
+	}
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -256,8 +256,13 @@ DEFINE_HOOK(0x702672, TechnoClass_ReceiveDamage_RevengeWeapon, 0x5)
 	if (pSource)
 		TechnoExt::ApplyRevengeWeapon(pThis, pSource, pWarhead);
 
-	if (WarheadTypeExt::Fetch(pWarhead)->PreventCrew)
+	const auto pWHExt = WarheadTypeExt::Fetch(pWarhead);
+
+	if (pWHExt->PreventCrew)
 		TechnoExt::Fetch(pThis)->PreventCrew = true;
+
+	if (pWHExt->KillPassengers)
+		pThis->KillPassengers(pSource);
 
 	return 0;
 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2375,3 +2375,37 @@ void DeactivateTemp::TechnoClassFake::_Deactivate()
 	}
 }
 DEFINE_FUNCTION_JUMP(LJMP, 0x70FC90, DeactivateTemp::TechnoClassFake::_Deactivate)
+
+#pragma region Crew
+
+namespace CrewTemp
+{
+	class TechnoClassFake final : public TechnoClass
+	{
+		int _GetCrewCount() const
+		{
+			const auto pThis = static_cast<const TechnoClass*>(this);
+			const auto pExt = TechnoExt::Fetch(pThis);
+			const auto GetCrewCount = reinterpret_cast<int(__thiscall*)(const TechnoClass*)>(0x6F3950);
+			return pExt->PreventCrew ? 0 : GetCrewCount(pThis);
+		}
+	};
+
+	class BuildingClassFake final : public BuildingClass
+	{
+		int _GetCrewCount() const
+		{
+			const auto pThis = static_cast<const BuildingClass*>(this);
+			const auto pExt = TechnoExt::Fetch(pThis);
+			const auto GetCrewCount = reinterpret_cast<int(__thiscall*)(const TechnoClass*)>(0x451330);
+			return pExt->PreventCrew ? 0 : GetCrewCount(pThis);
+		}
+	};
+}
+
+DEFINE_FUNCTION_JUMP(VTABLE, 0x7E2574, CrewTemp::TechnoClassFake::_GetCrewCount) // AircraftClass
+DEFINE_FUNCTION_JUMP(VTABLE, 0x7EB328, CrewTemp::TechnoClassFake::_GetCrewCount) // InfantryClass
+DEFINE_FUNCTION_JUMP(VTABLE, 0x7F5F40, CrewTemp::TechnoClassFake::_GetCrewCount) // UnitClass
+DEFINE_FUNCTION_JUMP(VTABLE, 0x7E418C, CrewTemp::BuildingClassFake::_GetCrewCount) // BuildingClass
+
+#pragma endregion

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2386,8 +2386,7 @@ namespace CrewTemp
 		{
 			const auto pThis = static_cast<const TechnoClass*>(this);
 			const auto pExt = TechnoExt::Fetch(pThis);
-			const auto GetCrewCount = reinterpret_cast<int(__thiscall*)(const TechnoClass*)>(0x6F3950);
-			return pExt->PreventCrew ? 0 : GetCrewCount(pThis);
+			return pExt->PreventCrew ? 0 : pThis->TechnoClass::GetCrewCount();
 		}
 	};
 
@@ -2397,8 +2396,7 @@ namespace CrewTemp
 		{
 			const auto pThis = static_cast<const BuildingClass*>(this);
 			const auto pExt = TechnoExt::Fetch(pThis);
-			const auto GetCrewCount = reinterpret_cast<int(__thiscall*)(const TechnoClass*)>(0x451330);
-			return pExt->PreventCrew ? 0 : GetCrewCount(pThis);
+			return pExt->PreventCrew ? 0 : pThis->BuildingClass::GetCrewCount();
 		}
 	};
 }

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -446,7 +446,7 @@ void WarheadTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->Psychedelic_StackingMode.Read(exINI, pSection, "Psychedelic.StackingMode");
 
 	this->PreventCrew.Read(exINI, pSection, "PreventCrew");
-	this->KillPassengers.Read(exINI, pSection, "KillPassengers");
+	this->PreventPassengerEscape.Read(exINI, pSection, "PreventPassengerEscape");
 
 	// Convert.From & Convert.To
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::All);
@@ -797,7 +797,7 @@ void WarheadTypeExt::Serialize(T& Stm)
 		.Process(this->Psychedelic_StackingMode)
 
 		.Process(this->PreventCrew)
-		.Process(this->KillPassengers)
+		.Process(this->PreventPassengerEscape)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -446,6 +446,7 @@ void WarheadTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->Psychedelic_StackingMode.Read(exINI, pSection, "Psychedelic.StackingMode");
 
 	this->PreventCrew.Read(exINI, pSection, "PreventCrew");
+	this->KillPassengers.Read(exINI, pSection, "KillPassengers");
 
 	// Convert.From & Convert.To
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::All);
@@ -796,6 +797,7 @@ void WarheadTypeExt::Serialize(T& Stm)
 		.Process(this->Psychedelic_StackingMode)
 
 		.Process(this->PreventCrew)
+		.Process(this->KillPassengers)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -445,6 +445,8 @@ void WarheadTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Psychedelic_StackingMode.Read(exINI, pSection, "Psychedelic.StackingMode");
 
+	this->PreventCrew.Read(exINI, pSection, "PreventCrew");
+
 	// Convert.From & Convert.To
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::All);
 
@@ -792,6 +794,8 @@ void WarheadTypeExt::Serialize(T& Stm)
 		.Process(this->Taunt)
 
 		.Process(this->Psychedelic_StackingMode)
+
+		.Process(this->PreventCrew)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -447,6 +447,7 @@ void WarheadTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->PreventCrew.Read(exINI, pSection, "PreventCrew");
 	this->PreventPassengerEscape.Read(exINI, pSection, "PreventPassengerEscape");
+	this->PreventOccupantEscape.Read(exINI, pSection, "PreventOccupantEscape");
 
 	// Convert.From & Convert.To
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::All);
@@ -798,6 +799,7 @@ void WarheadTypeExt::Serialize(T& Stm)
 
 		.Process(this->PreventCrew)
 		.Process(this->PreventPassengerEscape)
+		.Process(this->PreventOccupantEscape)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -267,6 +267,7 @@ public:
 	Nullable<StackingMode> Psychedelic_StackingMode;
 
 	Valueable<bool> PreventCrew { false };
+	Valueable<bool> KillPassengers { false };
 
 	// Ares tags
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -266,6 +266,8 @@ public:
 
 	Nullable<StackingMode> Psychedelic_StackingMode;
 
+	Valueable<bool> PreventCrew { false };
+
 	// Ares tags
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 	Valueable<bool> AffectsEnemies;

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -268,6 +268,7 @@ public:
 
 	Valueable<bool> PreventCrew;
 	Valueable<bool> PreventPassengerEscape;
+	Valueable<bool> PreventOccupantEscape;
 
 	// Ares tags
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
@@ -562,6 +563,7 @@ public:
 
 		, PreventCrew { false }
 		, PreventPassengerEscape { false }
+		, PreventOccupantEscape { false }
 	{ }
 
 	void ApplyConvert(HouseClass* pHouse, TechnoClass* pTarget);

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -266,8 +266,8 @@ public:
 
 	Nullable<StackingMode> Psychedelic_StackingMode;
 
-	Valueable<bool> PreventCrew { false };
-	Valueable<bool> KillPassengers { false };
+	Valueable<bool> PreventCrew;
+	Valueable<bool> PreventPassengerEscape;
 
 	// Ares tags
 	// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
@@ -559,6 +559,9 @@ public:
 		, Taunt { false }
 
 		, Psychedelic_StackingMode {}
+
+		, PreventCrew { false }
+		, PreventPassengerEscape { false }
 	{ }
 
 	void ApplyConvert(HouseClass* pHouse, TechnoClass* pTarget);


### PR DESCRIPTION
In `rulesmd.ini`:
```ini
[SOMEWARHEAD]                          ; WarheadType
PreventCrew=false                      ; boolean
PreventPassengerEscape=false           ; boolean
PreventOccupantEscape=false            ; boolean
```