### PR TITLE
Fix the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -741,7 +741,7 @@ This page lists all the individual contributions to the project by their author.
   - Disable AlphaImage during Buildup
   - Allow customizing the default value of `[Warhead] -> PreventScatter` via `[CombatDamage] -> Warhead.PreventScatter`
   - Allow `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys
-  - Fix the bug where the building with `Factory=BuildingType` does not play `ProductionAnim` when the AI side places a building
+  - Fix the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -741,6 +741,7 @@ This page lists all the individual contributions to the project by their author.
   - Disable AlphaImage during Buildup
   - Allow customizing the default value of `[Warhead] -> PreventScatter` via `[CombatDamage] -> Warhead.PreventScatter`
   - Allow `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys
+  - Fix the bug where the building with `Factory=BuildingType` does not play `ProductionAnim` when the AI side places a building
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -328,7 +328,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue where setting a production building as `Primary` could cause it to enter an unload state.
 - Fixed the issue of significant lagging caused by frequent lighting updates due to the accumulation of a large amount of radsite in a short time.
 - `(Pre)ProductionAnim` building animations can now use `Powered` & `PoweredLight/Effect/Special` keys.
-- Fixed the bug where the building with `Factory=BuildingType` does not play `ProductionAnim` when the AI side places a building.
+- Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -328,6 +328,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed an issue where setting a production building as `Primary` could cause it to enter an unload state.
 - Fixed the issue of significant lagging caused by frequent lighting updates due to the accumulation of a large amount of radsite in a short time.
 - `(Pre)ProductionAnim` building animations can now use `Powered` & `PoweredLight/Effect/Special` keys.
+- Fixed the bug where the building with `Factory=BuildingType` does not play `ProductionAnim` when the AI side places a building.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -421,7 +421,7 @@ HideShakeEffects=false           ; boolean
 #### New:
 
 #### Vanilla fixes:
-- Fixed the bug where the building with `Factory=BuildingType` does not play `ProductionAnim` when the AI side places a building (by Noble_Fish)
+- Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)
 
 #### Phobos fixes:
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -421,6 +421,7 @@ HideShakeEffects=false           ; boolean
 #### New:
 
 #### Vanilla fixes:
+- Fixed the bug where the building with `Factory=BuildingType` does not play `ProductionAnim` when the AI side places a building (by Noble_Fish)
 
 #### Phobos fixes:
 

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1084,7 +1084,7 @@ DEFINE_HOOK(0x4501AF, AI_ConYard_CompleteProduction_ProductionAnim, 0x5)
 	GET(BuildingClass*, pBuilding, ESI);
 	GET(TechnoClass*, pObject, EDI);
 
-	if (pBuilding->Owner->IsHumanPlayer)
+	if (pBuilding->Owner->IsControlledByHuman())
 		return 0;
 
 	if (!pObject || pObject->WhatAmI() != AbstractType::Building)

--- a/src/Ext/Building/Hooks.cpp
+++ b/src/Ext/Building/Hooks.cpp
@@ -1079,6 +1079,22 @@ DEFINE_HOOK(0x444D11, BuildingClass_ExitObject_ProductionAnimForInfantryFactory,
 	return 0;
 }
 
+DEFINE_HOOK(0x4501AF, AI_ConYard_CompleteProduction_ProductionAnim, 0x5)
+{
+	GET(BuildingClass*, pBuilding, ESI);
+	GET(TechnoClass*, pObject, EDI);
+
+	if (pBuilding->Owner->IsHumanPlayer)
+		return 0;
+
+	if (!pObject || pObject->WhatAmI() != AbstractType::Building)
+		return 0;
+
+	pBuilding->SendCommand(RadioCommand::RequestEndProduction, pBuilding);
+
+	return 0;
+}
+
 #pragma endregion
 
 DEFINE_HOOK(0x45670D, BuildingClass_GetRadialIndicatorRange_Extras, 0x7)


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [X] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

<!-- Write your description below. Usually this is your improvement documentation copy, but you may add extra notes or sections or whatever you feel is important for reviewing. -->


https://github.com/user-attachments/assets/3bc25195-7ad1-4f6f-bcf4-1e029a9b78d3

