### PR TITLE
[Vanilla Enhancement] Customized transport plane for teams

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -442,6 +442,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix an issue where `OmniFire` was ineffective on buildings with `Turret=yes`
   - Fix an issue where setting a production building as `Primary` could cause it to enter an unload state
   - SkipMapSelect Enhancement
+  - Customized transport plane for teams
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/Phobos.vcxproj
+++ b/Phobos.vcxproj
@@ -21,6 +21,7 @@
   <!-- Compiled files -->
   <ItemGroup>
     <!-- src/ -->
+    <ClCompile Include="src\Ext\TeamType\Hooks.cpp" />
     <ClCompile Include="src\Phobos.COM.cpp" />
     <ClCompile Include="src\Phobos.cpp" />
     <ClCompile Include="src\Phobos.CRT.cpp" />

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -1056,3 +1056,13 @@ SetRecruitableOnLiberate=-1  ; integer
 [SOMETEAMTYPE]               ; TeamType
 SetRecruitableOnLiberate=    ; integer, default to [General] -> SetRecruitableOnLiberate
 ```
+
+### Customized Transport Aircraft
+
+- You can now use `ParaDropPlane` to specify a new transport plane, which will override the global settings for both `Ares` and `Vanilla`.
+
+In `aimd.ini / mycampaign.map`:
+```ini
+[SOMETEAMTYPE]      ; TeamType
+ParaDropPlane=      ; AircraftType
+```

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -1059,7 +1059,7 @@ SetRecruitableOnLiberate=    ; integer, default to [General] -> SetRecruitableOn
 
 ### Customized Transport Aircraft
 
-- You can now use `ParaDropPlane` to specify a new transport plane, which will override the global settings for both `Ares` and `Vanilla`.
+- You can now use `ParaDropPlane` to specify a new transport aircraft type for teams with `Droppod=yes`, which will override the global settings for `Ares` and `Vanilla`.
 
 In `aimd.ini / mycampaign.map`:
 ```ini

--- a/docs/AI-Scripting-and-Mapping.md
+++ b/docs/AI-Scripting-and-Mapping.md
@@ -1059,10 +1059,10 @@ SetRecruitableOnLiberate=    ; integer, default to [General] -> SetRecruitableOn
 
 ### Customized Transport Aircraft
 
-- You can now use `ParaDropPlane` to specify a new transport aircraft type for teams with `Droppod=yes`, which will override the global settings for `Ares` and `Vanilla`.
+- You can now use `ParaDropAircraft` to specify a new transport aircraft type for teams with `Droppod=yes`, which will override the global settings for `Ares` and `Vanilla`.
 
 In `aimd.ini / mycampaign.map`:
 ```ini
 [SOMETEAMTYPE]      ; TeamType
-ParaDropPlane=      ; AircraftType
+ParaDropAircraft=   ; AircraftType
 ```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -419,6 +419,7 @@ HideShakeEffects=false           ; boolean
 :open:
 
 #### New:
+- Customized transport plane for teams (by FlyStar)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)

--- a/src/Ext/TeamType/Body.cpp
+++ b/src/Ext/TeamType/Body.cpp
@@ -12,7 +12,7 @@ void TeamTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	INI_EX exINI(pINI);
 
 	this->SetRecruitableOnLiberate.Read(exINI, pSection, "SetRecruitableOnLiberate");
-	this->ParaDropPlane.Read(exINI, pSection, "ParaDropPlane");
+	this->ParaDropAircraft.Read(exINI, pSection, "ParaDropAircraft");
 }
 
 template <typename T>
@@ -20,7 +20,7 @@ void TeamTypeExt::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->SetRecruitableOnLiberate)
-		.Process(this->ParaDropPlane)
+		.Process(this->ParaDropAircraft)
 		;
 }
 

--- a/src/Ext/TeamType/Body.cpp
+++ b/src/Ext/TeamType/Body.cpp
@@ -12,6 +12,7 @@ void TeamTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	INI_EX exINI(pINI);
 
 	this->SetRecruitableOnLiberate.Read(exINI, pSection, "SetRecruitableOnLiberate");
+	this->ParaDropPlane.Read(exINI, pSection, "ParaDropPlane");
 }
 
 template <typename T>
@@ -19,6 +20,7 @@ void TeamTypeExt::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->SetRecruitableOnLiberate)
+		.Process(this->ParaDropPlane)
 		;
 }
 

--- a/src/Ext/TeamType/Body.h
+++ b/src/Ext/TeamType/Body.h
@@ -22,16 +22,18 @@ public:
 		return static_cast<TeamTypeClass*>(this->GetAttachedObject());
 	}
 
+	Nullable<int> SetRecruitableOnLiberate;
+	Valueable<AircraftTypeClass*> ParaDropPlane;
+
 	TeamTypeExt(TeamTypeClass* OwnerObject) : AbstractTypeExt(OwnerObject)
-		, SetRecruitableOnLiberate { }
+		, SetRecruitableOnLiberate {}
+		, ParaDropPlane { nullptr }
 	{ }
 
 	virtual ~TeamTypeExt() = default;
 
 	virtual void LoadFromINIFile(CCINIClass* pINI) override;
 	// virtual void Initialize() override;
-
-	Nullable<int> SetRecruitableOnLiberate;
 
 	virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 	virtual void SaveToStream(PhobosStreamWriter& Stm) override;

--- a/src/Ext/TeamType/Body.h
+++ b/src/Ext/TeamType/Body.h
@@ -23,11 +23,11 @@ public:
 	}
 
 	Nullable<int> SetRecruitableOnLiberate;
-	Valueable<AircraftTypeClass*> ParaDropPlane;
+	Valueable<AircraftTypeClass*> ParaDropAircraft;
 
 	TeamTypeExt(TeamTypeClass* OwnerObject) : AbstractTypeExt(OwnerObject)
 		, SetRecruitableOnLiberate {}
-		, ParaDropPlane { nullptr }
+		, ParaDropAircraft { nullptr }
 	{ }
 
 	virtual ~TeamTypeExt() = default;

--- a/src/Ext/TeamType/Hooks.cpp
+++ b/src/Ext/TeamType/Hooks.cpp
@@ -1,0 +1,13 @@
+#include "Body.h"
+
+DEFINE_HOOK(0x65DBD0, TeamTypeClass_CreateInstance_Plane, 0x6)
+{
+	GET(TeamTypeClass*, pThis, EDI);
+
+	const auto pTeamTypeExt = TeamTypeExt::Fetch(pThis);
+
+	if (AircraftTypeClass* const pAircraftType = pTeamTypeExt->ParaDropPlane)
+		R->ECX(pAircraftType);
+
+	return 0;
+}

--- a/src/Ext/TeamType/Hooks.cpp
+++ b/src/Ext/TeamType/Hooks.cpp
@@ -6,8 +6,8 @@ DEFINE_HOOK(0x65DBD0, TeamTypeClass_CreateInstance_Plane, 0x6)
 
 	const auto pTeamTypeExt = TeamTypeExt::Fetch(pThis);
 
-	if (AircraftTypeClass* const pAircraftType = pTeamTypeExt->ParaDropPlane)
-		R->ECX(pAircraftType);
+	if (AircraftTypeClass* const pAircraftType = pTeamTypeExt->ParaDropAircraft)
+		R->ECX(ParaDropAircraft);
 
 	return 0;
 }

--- a/src/Ext/TeamType/Hooks.cpp
+++ b/src/Ext/TeamType/Hooks.cpp
@@ -7,7 +7,7 @@ DEFINE_HOOK(0x65DBD0, TeamTypeClass_CreateInstance_Plane, 0x6)
 	const auto pTeamTypeExt = TeamTypeExt::Fetch(pThis);
 
 	if (AircraftTypeClass* const pAircraftType = pTeamTypeExt->ParaDropAircraft)
-		R->ECX(ParaDropAircraft);
+		R->ECX(pAircraftType);
 
 	return 0;
 }

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -170,7 +170,7 @@ static CellStruct* __fastcall ParadropPickCellOnEdge(MapClass* pThis, void* _, C
 	return &buffer;
 }
 
-static bool __fastcall ParaDropAircraftUnlimbo(AircraftClass* pThis, void* _, const CoordStruct& coords, DirType direction)
+static bool __fastcall ParadropPlaneUnlimbo(AircraftClass* pThis, void* _, const CoordStruct& coords, DirType direction)
 {
 	return AircraftExt::PlaceReinforcementAircraft(pThis, coords);
 }
@@ -299,7 +299,7 @@ void Apply_Ares3_0_Patches()
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x74242, &ParadropPickCellOnEdge);
 
 	// Replace Ares paradrop plane Unlimbo call with our wrapper.
-	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x742AC, &ParaDropAircraftUnlimbo);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x742AC, &ParadropPlaneUnlimbo);
 
 	// Replace Ares factory update logic with our wrapper.
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x13FA7, &BuildingExt::UpdateFactoryQueues);
@@ -417,7 +417,7 @@ void Apply_Ares3_0p1_Patches()
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x752F2, &ParadropPickCellOnEdge);
 
 	// Replace Ares paradrop plane Unlimbo call with our wrapper.
-	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x7535C, &ParaDropAircraftUnlimbo);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x7535C, &ParadropPlaneUnlimbo);
 
 	// Replace Ares factory update logic with our wrapper.
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x14537, &BuildingExt::UpdateFactoryQueues);

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -170,7 +170,7 @@ static CellStruct* __fastcall ParadropPickCellOnEdge(MapClass* pThis, void* _, C
 	return &buffer;
 }
 
-static bool __fastcall ParadropPlaneUnlimbo(AircraftClass* pThis, void* _, const CoordStruct& coords, DirType direction)
+static bool __fastcall ParaDropAircraftUnlimbo(AircraftClass* pThis, void* _, const CoordStruct& coords, DirType direction)
 {
 	return AircraftExt::PlaceReinforcementAircraft(pThis, coords);
 }
@@ -299,7 +299,7 @@ void Apply_Ares3_0_Patches()
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x74242, &ParadropPickCellOnEdge);
 
 	// Replace Ares paradrop plane Unlimbo call with our wrapper.
-	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x742AC, &ParadropPlaneUnlimbo);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x742AC, &ParaDropAircraftUnlimbo);
 
 	// Replace Ares factory update logic with our wrapper.
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x13FA7, &BuildingExt::UpdateFactoryQueues);
@@ -417,7 +417,7 @@ void Apply_Ares3_0p1_Patches()
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x752F2, &ParadropPickCellOnEdge);
 
 	// Replace Ares paradrop plane Unlimbo call with our wrapper.
-	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x7535C, &ParadropPlaneUnlimbo);
+	Patch::Apply_CALL6(AresHelper::AresBaseAddress + 0x7535C, &ParaDropAircraftUnlimbo);
 
 	// Replace Ares factory update logic with our wrapper.
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x14537, &BuildingExt::UpdateFactoryQueues);


### PR DESCRIPTION
You can now use `ParaDropAircraft` to specify a new transport aircraft type for teams with `Droppod=yes`, which will override the global settings for `Ares` and `Vanilla`.

现在你可以使用`ParaDropAircraft`为`Droppod=yes`的作战小队指定新的运输机类型，它会覆盖`Ares`和`Vanilla`的全局设置。

In `aimd.ini / mycampaign.map`:
```ini
[SOMETEAMTYPE]      ; TeamType
ParaDropAircraft=      ; AircraftType
```
