### PR TITLE
Fix slaves not respecting Slaved.OwnerWhenMasterKilled when master is sold or self-destructed

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -937,3 +937,5 @@ This page lists all the individual contributions to the project by their author.
   - Add `ClampToScreen` tag for `BannerType` to control whether banner position is clamped to the visible area
 - **obsidianus** - Automatic conversion based on health
 - **Nuke** - Reload speed adjustment on promotion
+- **frg2089 (舰队的偶像-岛风酱!)**:
+  - Fix `Slaved.OwnerWhenMasterKilled` not being respected when the master is sold or self-destructed

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -329,6 +329,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the issue of significant lagging caused by frequent lighting updates due to the accumulation of a large amount of radsite in a short time.
 - `(Pre)ProductionAnim` building animations can now use `Powered` & `PoweredLight/Effect/Special` keys.
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building.
+- Fixed the bug that `Slaved.OwnerWhenMasterKilled` was not respected when the slave miner was sold or self-destructed, as the slaves would be handed over to the neutral house (the vanilla fallback) instead.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -425,6 +425,7 @@ HideShakeEffects=false           ; boolean
 
 #### Phobos fixes:
 - Fixed a game crash when parsing string list with null entry (by Ollerus)
+- Fixed the bug that slaves would be handed over to the neutral house instead of respecting `Slaved.OwnerWhenMasterKilled` when their master was sold or self-destructed (by frg2089)
 
 #### Fixes / interactions with other extensions:
 - Allowed `SW.ShowCameo` and `SW.ManualFire` to work independently of `SW.AutoFire` (by Noble_Fish)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -3201,3 +3201,9 @@ msgstr "**obsidianus** - 自动根据血量变形"
 msgid "**Nuke** - Reload speed adjustment on promotion"
 msgstr "**Nuke** - 升级时调整装填速率"
 
+msgid "**frg2089 (舰队的偶像-岛风酱!)**:"
+msgstr "**frg2089 (舰队的偶像-岛风酱!)**："
+
+msgid "Fix `Slaved.OwnerWhenMasterKilled` not being respected when the master is sold or self-destructed"
+msgstr "修复了奴隶矿场被出售或自毁时 `Slaved.OwnerWhenMasterKilled` 不被遵守的问题"
+

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1700,6 +1700,12 @@ msgstr ""
 "`(Pre)ProductionAnim` 建筑动画现在可以使用 `Powered` 与 "
 "`PoweredLight/Effect/Special` 类的标签。"
 
+msgid ""
+"Fixed the bug that `Slaved.OwnerWhenMasterKilled` was not respected when "
+"the slave miner was sold or self-destructed, as the slaves would be "
+"handed over to the neutral house (the vanilla fallback) instead."
+msgstr "修复了奴隶矿场被出售或自毁时，奴隶会归于中立阵营而不是遵守 `Slaved.OwnerWhenMasterKilled` 设置的问题。"
+
 msgid "Fixes / interactions with other extensions"
 msgstr "修复或与其他扩展的交互"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -832,6 +832,12 @@ msgstr "在 `FAData.ini`："
 msgid "Changelog"
 msgstr "更新日志"
 
+msgid ""
+"Fixed the bug that slaves would be handed over to the neutral house "
+"instead of respecting `Slaved.OwnerWhenMasterKilled` when their master "
+"was sold or self-destructed (by frg2089)"
+msgstr "修复了奴隶矿场被出售或自毁时，奴隶会归于中立阵营而不是遵守 `Slaved.OwnerWhenMasterKilled` 设置的问题（by frg2089）"
+
 msgid "New:"
 msgstr "新增内容："
 

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -56,8 +56,8 @@ DEFINE_HOOK(0x6B0B9C, SlaveManagerClass_Killed_DecideOwner, 0x6)
 	{
 		// 0x6B0BA4: master sold / self-destroyed (killer == 0).
 		// Replicate the vanilla fallback: give the slave to the neutral house,
-		// otherwise destroy it. Never return 0 here, since the patched
-		// mov eax,[esp+arg_4]; test eax,eax would leave flags/EAX undefined.
+		// otherwise destroy it. Avoid `return 0` here so we bypass the vanilla
+		// `mov eax,[esp+arg_4]; test eax,eax` sequence and branch explicitly.
 		if (const auto pNeutral = HouseClass::FindNeutral())
 		{
 			R->EAX(pNeutral);

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -23,6 +23,7 @@ DEFINE_HOOK(0x6B0C2C, SlaveManagerClass_FreeSlaves_SlavesFreeSound, 0x5)
 	return 0x6B0C65;
 }
 
+DEFINE_HOOK_AGAIN(0x6B0BA4, SlaveManagerClass_Killed_DecideOwner, 0x6)
 DEFINE_HOOK(0x6B0B9C, SlaveManagerClass_Killed_DecideOwner, 0x6)
 {
 	enum { KillTheSlave = 0x6B0BDF, ChangeSlaveOwner = 0x6B0BB4 };
@@ -51,7 +52,22 @@ DEFINE_HOOK(0x6B0B9C, SlaveManagerClass_Killed_DecideOwner, 0x6)
 		break;
 	}
 
-	return 0x0;
+	if (R->Origin() == 0x6B0BA4)
+	{
+		// 0x6B0BA4: master sold / self-destroyed (killer == 0).
+		// Replicate the vanilla fallback: give the slave to the neutral house,
+		// otherwise destroy it. Never return 0 here, since the patched
+		// mov eax,[esp+arg_4]; test eax,eax would leave flags/EAX undefined.
+		if (const auto pNeutral = HouseClass::FindNeutral())
+		{
+			R->EAX(pNeutral);
+			return ChangeSlaveOwner;
+		}
+		return KillTheSlave;
+
+	}
+
+	return 0;
 }
 
 // Fix slaves cannot always suicide due to armor multiplier or something


### PR DESCRIPTION
## What kind of change is this?

- [ ] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [x] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

`Slaved.OwnerWhenMasterKilled` was not respected when the slave miner (master) was sold or self-destructed, i.e. destroyed with no killer. The existing `SlaveManagerClass_Killed_DecideOwner` hook only covered the "killed by someone" path (0x6B0B9C), so in the sold/self-destructed case the game fell through to the vanilla fallback at 0x6B0BA4 and always handed the slaves over to the neutral house.

This PR adds a hook at 0x6B0BA4 (`DEFINE_HOOK_AGAIN`) so the `Slaved.OwnerWhenMasterKilled` setting is now applied in this case too (`suicide` / `master` / `neutral` / `killer`). For the default `killer` option, the vanilla fallback (transfer to the neutral house, or destroy the slave) is preserved, and the patch no longer leaves EAX/flags in an undefined state on that path.

Changes included:
- Code fix: `src/Ext/Techno/Hooks.Misc.cpp`
- Changelog entry under `### 0.6` -> `#### Phobos fixes:` in `docs/Whats-New.md`
- Bugfix bullet in `docs/Fixed-or-Improved-Logics.md`
- Credits entry for `frg2089 (舰队的偶像-岛风酱!)` in `CREDITS.md`
- Chinese translations in the corresponding `.po` files