### PR TITLE
Fix AutoDeath not triggering after type replacement that bypasses ConvertToType

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -746,6 +746,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys
   - Allow `SW.ShowCameo` and `SW.ManualFire` to work independently of `SW.AutoFire`
   - Fix the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building
+  - Fix AutoDeath not triggering after type replacement that bypasses ConvertToType
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -427,6 +427,7 @@ HideShakeEffects=false           ; boolean
 
 #### Phobos fixes:
 - Fixed a game crash when parsing string list with null entry (by Ollerus)
+- Fixed AutoDeath not triggering after type replacement that bypasses ConvertToType (by Noble_Fish)
 
 #### Fixes / interactions with other extensions:
 - Allowed `SW.ShowCameo` and `SW.ManualFire` to work independently of `SW.AutoFire` (by Noble_Fish)

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -4,10 +4,12 @@
 #include <Ext/Bullet/Body.h>
 #include <Ext/Foot/Body.h>
 #include <Ext/House/Body.h>
+#include <Ext/Scenario/Body.h>
 #include <Ext/WeaponType/Body.h>
 #include <Misc/FlyingStrings.h>
 #include <Utilities/AresFunctions.h>
 #include <New/Type/Affiliated/TypeConvertGroup.h>
+#include <unordered_set>
 
 
 // TechnoClass_AI_0x6F9E50
@@ -137,7 +139,27 @@ void TechnoExt::ApplyInterceptor()
 // TODO : Merge into new AttachEffects
 bool TechnoExt::CheckDeathConditions(bool isInLimbo)
 {
-	auto const pTypeExt = this->TypeExtData;
+	auto pTypeExt = this->TypeExtData;
+
+	// Type replacement that bypasses ConvertToType (e.g. Ares visceroid merge) leaves the
+	// cached type extension stale. Resync it once per object so AutoDeath (and other
+	// per-type state) is evaluated against the new type.
+	auto const pObj = this->OwnerObject();
+	auto const pObjType = pTypeExt->OwnerObject();
+	auto const pCurType = pObj->GetTechnoType();
+	if (pObjType && pCurType && pObjType != pCurType)
+	{
+		static std::unordered_set<const TechnoClass*> s_resynced;
+		if (s_resynced.insert(pObj).second)
+		{
+			if (auto const pFoot = abstract_cast<FootClass*, true>(pObj))
+			{
+				FootExt::Fetch(pFoot)->UpdateTypeData(pCurType);
+				ScenarioExt::Global()->RegisterAutoDeath(pObj);
+				pTypeExt = this->TypeExtData; // refreshed by UpdateTypeData
+			}
+		}
+	}
 
 	if (!pTypeExt->AutoDeath_Behavior.isset())
 		return false;


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [ ] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [X] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

Resolve #2353

Type replacement that bypasses `ConvertToType` (e.g. visceroid merge) leaves `TechnoExt::TypeExtData` stale, so AutoDeath never fires. Resync the extension once per object via `UpdateTypeData` + `RegisterAutoDeath` in `CheckDeathConditions`.
