### PR TITLE
Extended jumpjet hovering

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -881,6 +881,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize whether aircraft is a cargo plane
   - Allow the unit to stop immediately if the target enters the range during ApproachTarget
   - Allow the unit to keep pursuing the target during ApproachTarget
+  - Extended Jumpjet Hovering
 - **solar-III (凤九歌)**
   - Target scanning delay customization (documentation)
   - Skip target scanning function calling for unarmed technos (documentation)

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2586,6 +2586,18 @@ In `rulesmd.ini`:
 DefaultMirageDisguises=    ; List of TerrainTypes
 ```
 
+### Extended Jumpjet Hovering
+
+- In vanilla, jumpjets scatter while hovering by randomly setting a destination to a nearby cell. This approach is inefficient when many jumpjets are crowded around, and it forces the unit to turn, which interferes with firing for non-omni-firing units.
+- Now you can enable a new hovering scatter behaviour via the following switch, which disperses units more efficiently and without requiring the unit to turn.
+  - `ExtendedJumpjetHovering` controls whether the new hovering scatter behaviour is enabled.
+
+In `rulesmd.ini`:
+```ini
+[JumpjetControls]                ; global section
+ExtendedJumpjetHovering=false   ; boolean
+```
+
 ### Independent SHP Vehicle Turret Files
 
 - SHP turret vehicles support the use of `*tur.shp` files.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -420,6 +420,7 @@ HideShakeEffects=false           ; boolean
 
 #### New:
 - Customized transport plane for teams (by FlyStar)
+- [Extended Jumpjet Hovering](New-or-Enhanced-Logics.md#extended-jumpjet-hovering) (by TaranDahl)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -2990,6 +2990,9 @@ msgstr "允许单位在接近目标期间若目标进入射程则立即停止"
 msgid "Allow the unit to keep pursuing the target during ApproachTarget"
 msgstr "允许单位在接近目标期间持续追踪目标"
 
+msgid "Extended Jumpjet Hovering"
+msgstr "扩展的 Jumpjet 悬浮"
+
 msgid "**solar-III (凤九歌)**"
 msgstr "**solar-III（凤九歌）**"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -5404,6 +5404,18 @@ msgstr "载具类型默认幻影伪装"
 msgid "Vehicle can now have its `DefaultMirageDisguises` overridden per-type."
 msgstr "现在可以单独为每个载具类型设置其 `DefaultMirageDisguises`。"
 
+msgid "Extended Jumpjet Hovering"
+msgstr "扩展的 Jumpjet 悬浮"
+
+msgid "In vanilla, jumpjets scatter while hovering by randomly setting a destination to a nearby cell. This approach is inefficient when many jumpjets are crowded around, and it forces the unit to turn, which interferes with firing for non-omni-firing units."
+msgstr "在原版中，jumpjet 在悬浮时通过随机设置到周围单元格的目的地来实现分散。这种分散方式在周围有大量 jumpjet 时效率很低，并且会强制单位转向，这对不能全向开火的单位来说会影响开火。"
+
+msgid "Now you can enable a new hovering scatter behaviour via the following switch, which disperses units more efficiently and without requiring the unit to turn."
+msgstr "现在你可以通过以下开关启用一个新的悬浮时分散行为，它能以更高效的方式散开单位，并且无需单位转向。"
+
+msgid "`ExtendedJumpjetHovering` controls whether the new hovering scatter behaviour is enabled."
+msgstr "`ExtendedJumpjetHovering` 控制是否启用新的悬浮时分散行为。"
+
 msgid "Independent SHP Vehicle Turret Files"
 msgstr "独立的 Shape 载具炮塔文件"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -6511,6 +6511,9 @@ msgstr "现在侧边栏拓展工具条可以超出侧边栏边界（by Belonit�
 msgid "Lifted stupidly small limit for tooltip character amount (by Belonit)"
 msgstr "解除了拓展工具条字符数量小得愚蠢的上限（by Belonit）"
 
+msgid "[Extended Jumpjet Hovering](New-or-Enhanced-Logics.md#extended-jumpjet-hovering) (by TaranDahl)"
+msgstr "[扩展的 Jumpjet 悬浮](New-or-Enhanced-Logics.md#extended-jumpjet-hovering)（by TaranDahl）"
+
 #~ msgid "Migrating"
 #~ msgstr "迁移"
 

--- a/src/Ext/Cell/Body.cpp
+++ b/src/Ext/Cell/Body.cpp
@@ -1,6 +1,13 @@
 #include "Body.h"
 
+#include <algorithm>
 #include <memory>
+#include <FootClass.h>
+#include <Ext/Techno/Body.h>
+#include <CellSpread.h>
+#include <MapClass.h>
+#include <Unsorted.h>
+#include <JumpjetLocomotionClass.h>
 
 CellExt::ExtContainer CellExt::ExtMap;
 
@@ -14,6 +21,8 @@ void CellExt::Serialize(T& Stm)
 		.Process(this->RadSites)
 		.Process(this->RadLevels)
 		.Process(this->InfantryCount)
+		.Process(this->InAirJumpjets)
+		.Process(this->Jumpjet_LastScatterAffectedFrame)
 		;
 }
 
@@ -95,6 +104,8 @@ void CellExt::ExtContainer::LoadInline(CellClass* pCell, IStream* pStm)
 	PhobosSwizzle::RegisterChange(oldPtr, pExt);
 
 	pExt->LoadFromStream(reader);
+
+	pExt->InAirJumpjets.erase(std::remove(pExt->InAirJumpjets.begin(), pExt->InAirJumpjets.end(), nullptr), pExt->InAirJumpjets.end());
 
 	if (!reader.ExpectEndOfBlock())
 		Debug::FatalErrorAndExit("LoadInline - cell extension block size mismatch!\n");
@@ -235,4 +246,186 @@ DEFINE_HOOK(0x566AB7, MapClass_SetMapDimensions_PostRestore, 0x6)
 
 	return 0;
 }
+// =============================
+// ExtendedJumpjetHovering
+
+static int GetJumpjetCollisionRange(FootClass* pFoot)
+{
+	return pFoot->WhatAmI() == AbstractType::Infantry ? 64 : 128;
+}
+
+static bool IsCloseEnoughToScatter(FootClass* p1, FootClass* p2)
+{
+	int minDist = GetJumpjetCollisionRange(p1) + GetJumpjetCollisionRange(p2);
+	CoordStruct c1 = p1->GetCoords();
+	c1.Z = 0;
+	CoordStruct c2 = p2->GetCoords();
+	c2.Z = 0;
+	return c1.DistanceFrom(c2) < minDist;
+}
+
+static inline bool IsJumpjet(FootClass* pFoot)
+{
+	return locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor) != nullptr;
+}
+
+int CellExt::GetWeightedJumpjetCount(FootClass* pHov, bool* shouldScatter)
+{
+	if (!shouldScatter)
+		return 0;
+
+	bool scatter = *shouldScatter;
+	int count = 0;
+
+	for (size_t i = 0; i < this->InAirJumpjets.size(); )
+	{
+		FootClass* pFoot = this->InAirJumpjets[i];
+
+		if (!pFoot)
+		{
+			// null entries can remain after savegame swizzling - drop them
+			this->InAirJumpjets.erase(this->InAirJumpjets.begin() + i);
+			continue;
+		}
+
+		if (pFoot == pHov || pFoot->InLimbo || !IsJumpjet(pFoot))
+		{
+			++i;
+			continue;
+		}
+
+		count += (pFoot->WhatAmI() == AbstractType::Infantry ? 1 : 4);
+		if (!scatter && IsCloseEnoughToScatter(pFoot, pHov))
+			scatter = true;
+		if (count > 11)
+			break;
+		++i;
+	}
+
+	*shouldScatter = scatter;
+	return count;
+}
+
+// ExtendedJumpjetHovering - per-cell pointer invalidation. The Detach funnel notifies every
+// cell extension when a foot is removed from the game; each cell cleans its own
+// InAirJumpjets list, so a destroyed unit never leaves a dangling pointer behind.
+//
+// TEMPORARY: this OnDetach cleanup is the active crash-safe path while the dtor
+// cleanup in TechnoExt::~TechnoExt is commented out. The dtor cleanup only looks
+// at Jumpjet_LastCell, so if the foot was registered in a cell that is NOT its
+// LastCell, the dtor would have missed it - report that case with LogAndMessage.
+void CellExt::OnDetach(FootClass* pFoot, bool removed)
+{
+	if (!pFoot || !removed)
+		return;
+
+	auto& vec = this->InAirJumpjets;
+	auto const it = std::find(vec.begin(), vec.end(), pFoot);
+	if (it == vec.end())
+		return;
+
+	vec.erase(it);
+
+	// Diagnostic: the foot was registered in THIS cell, so its Jumpjet_LastCell is
+	// expected to point here. If it does not, the dtor-based cleanup would have
+	// missed this entry -> log it so the mismatch can be tracked down.
+	CellClass* pLastCell = nullptr;
+	const char* typeId = "?";
+	if (auto pTechnoExt = TechnoExt::TryFetch(pFoot))
+	{
+		pLastCell = pTechnoExt->Jumpjet_LastCell;
+		if (pTechnoExt->TypeExtData)
+			typeId = pTechnoExt->TypeExtData->OwnerObject()->ID;
+	}
+
+	if (pLastCell != this->OwnerObject())
+	{
+		CellStruct thisCoords = this->OwnerObject()->MapCoords;
+		CellStruct lastCoords { -1, -1 };
+		if (pLastCell)
+			lastCoords = pLastCell->MapCoords;
+		Debug::LogAndMessage("[ExtendedJumpjetHovering] MISMATCH: '%s'(0x%08X) was in cell(%d,%d) but LastCell=%s(%d,%d)\n",
+			typeId, pFoot, thisCoords.X, thisCoords.Y,
+			pLastCell ? "cell" : "NULL", lastCoords.X, lastCoords.Y);
+	}
+}
+
+void CellExt::MarkJumpjetScatterCell()
+{
+	if (auto pExt = CellExt::TryFetch(this->OwnerObject()))
+		pExt->Jumpjet_LastScatterAffectedFrame = Unsorted::CurrentFrame;
+	CellStruct pos = this->OwnerObject()->MapCoords;
+	for (int dir = 0; dir < 8; ++dir)
+	{
+		CellStruct off = CellSpread::GetNeighbourOffset(dir);
+		if (auto pCell = MapClass::Instance.GetCellAt(pos + off))
+			if (auto pCellExt = CellExt::TryFetch(pCell))
+				pCellExt->Jumpjet_LastScatterAffectedFrame = Unsorted::CurrentFrame;
+	}
+}
+
+void CellExt::UpdateJumpjet(FootClass* pFoot, int curHeight, int oldHeight)
+{
+	if (this->OwnerObject()->MapCoords.X == 0 && this->OwnerObject()->MapCoords.Y == 0)
+		return;
+	if (oldHeight == curHeight)
+		return;
+	bool wasInAir = oldHeight >= Unsorted::CellHeight;
+	bool nowInAir = curHeight >= Unsorted::CellHeight;
+	if (wasInAir == nowInAir)
+		return;
+	if (wasInAir)
+	{
+		// symmetric removal: whatever was added to this cell's list must leave it,
+		// even if the unit is no longer a jumpjet (e.g. its locomotor changed)
+		for (size_t i = 0; i < this->InAirJumpjets.size(); ++i)
+		{
+			if (this->InAirJumpjets[i] == pFoot)
+			{
+				this->InAirJumpjets.erase(this->InAirJumpjets.begin() + i);
+				break;
+			}
+		}
+	}
+	else if (nowInAir && IsJumpjet(pFoot))
+	{
+		// only in-air jumpjets are ever tracked (see AddJumpjet)
+		if (std::find(this->InAirJumpjets.begin(), this->InAirJumpjets.end(), pFoot) == this->InAirJumpjets.end())
+			this->InAirJumpjets.push_back(pFoot);
+	}
+}
+
+void CellExt::AddJumpjet(FootClass* pFoot, int curHeight)
+{
+	if (!IsJumpjet(pFoot))
+		return;
+	if (this->OwnerObject()->MapCoords.X == 0 && this->OwnerObject()->MapCoords.Y == 0)
+		return;
+	this->MarkJumpjetScatterCell();
+	if (curHeight >= Unsorted::CellHeight)
+	{
+		if (std::find(this->InAirJumpjets.begin(), this->InAirJumpjets.end(), pFoot) == this->InAirJumpjets.end())
+			this->InAirJumpjets.push_back(pFoot);
+	}
+}
+
+void CellExt::RemoveJumpjet(FootClass* pFoot, int oldHeight)
+{
+	// no IsJumpjet gate here on purpose: removal must be symmetric with AddJumpjet,
+	// even if the unit's locomotor changed after it was added, otherwise stale
+	// entries linger in the lists and dangle once the unit is destroyed.
+	if (this->OwnerObject()->MapCoords.X == 0 && this->OwnerObject()->MapCoords.Y == 0)
+		return;
+	if (oldHeight < Unsorted::CellHeight)
+		return;
+	for (size_t i = 0; i < this->InAirJumpjets.size(); ++i)
+	{
+		if (this->InAirJumpjets[i] == pFoot)
+		{
+			this->InAirJumpjets.erase(this->InAirJumpjets.begin() + i);
+			break;
+		}
+	}
+}
+
 

--- a/src/Ext/Cell/Body.h
+++ b/src/Ext/Cell/Body.h
@@ -2,9 +2,13 @@
 #include <CellClass.h>
 
 #include <Utilities/Container.h>
+#include <Utilities/Detach.h>
+#include <vector>
+
+class FootClass;
 #include <Utilities/TemplateDef.h>
 
-class CellExt final : public AbstractExt
+class CellExt final : public AbstractExt, public Detach::Listener<FootClass>
 {
 public:
 	using base_type = CellClass;
@@ -46,6 +50,17 @@ public:
 	std::vector<RadSiteClass*> RadSites {};
 	std::vector<RadLevel> RadLevels { };
 	int InfantryCount{ 0 };
+
+	std::vector<FootClass*> InAirJumpjets {};
+	int Jumpjet_LastScatterAffectedFrame { 0 };
+
+	int GetWeightedJumpjetCount(FootClass* pHov, bool* shouldScatter);
+	void MarkJumpjetScatterCell();
+	void UpdateJumpjet(FootClass* pFoot, int curHeight, int oldHeight);
+	void AddJumpjet(FootClass* pFoot, int curHeight);
+	void RemoveJumpjet(FootClass* pFoot, int oldHeight);
+
+	virtual void OnDetach(FootClass* pFoot, bool removed) override;
 
 	CellExt(CellClass* OwnerObject) : AbstractExt(OwnerObject)
 	{ }

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -721,6 +721,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetCrash)
 		.Process(this->JumpjetNoWobbles)
 		.Process(this->JumpjetRotateOnCrash)
+		.Process(this->ExtendedJumpjetHovering)
 		.Process(this->VeinholeWarhead)
 		.Process(this->MissingCameo)
 		.Process(this->PlacementGrid_Translucency)
@@ -1286,6 +1287,7 @@ DEFINE_HOOK(0x6744E4, RulesClass_ReadJumpjetControls_Extra, 0x7)
 	pRulesExt->JumpjetCrash.Read(exINI, GameStrings::JumpjetControls, "Crash");
 	pRulesExt->JumpjetNoWobbles.Read(exINI, GameStrings::JumpjetControls, "NoWobbles");
 	pRulesExt->JumpjetRotateOnCrash.Read(exINI, GameStrings::JumpjetControls, "RotateOnCrash");
+	pRulesExt->ExtendedJumpjetHovering.Read(exINI, GameStrings::JumpjetControls, "ExtendedJumpjetHovering");
 
 	return 0;
 }

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -54,6 +54,7 @@ public:
 		Valueable<double> JumpjetCrash;
 		Valueable<bool> JumpjetNoWobbles;
 		Valueable<bool> JumpjetRotateOnCrash;
+		Valueable<bool> ExtendedJumpjetHovering;
 
 		Nullable<WarheadTypeClass*> VeinholeWarhead;
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -6,11 +6,14 @@
 #include <Ext/Infantry/Body.h>
 #include <Ext/Unit/Body.h>
 #include <Ext/Scenario/Body.h>
+#include <Ext/Cell/Body.h>
 #include <Ext/WeaponType/Body.h>
 #include <Ext/Event/Body.h>
 
 #include <Utilities/AresFunctions.h>
+#include <algorithm>
 #include <Utilities/AresHelper.h>
+#include <Unsorted.h>
 #include <Interop/TechnoExt.h>
 
 TechnoExt::~TechnoExt()
@@ -55,6 +58,21 @@ TechnoExt::~TechnoExt()
 	}
 
 	this->ElectricBolts.clear();
+
+	// ExtendedJumpjetHovering - remove this foot from its last cell's tracking
+	// list. DISABLED FOR NOW: the OnDetach full-map purge (CellExt::PurgeJumpjet)
+	// is the active cleanup. Re-enable this once the LastCell/current-cell
+	// mismatch diagnostics in PurgeJumpjet show no more problems.
+	/*
+	if (this->Jumpjet_LastCell)
+	{
+		if (auto pCellExt = CellExt::TryFetch(this->Jumpjet_LastCell))
+		{
+			auto& vec = pCellExt->InAirJumpjets;
+			vec.erase(std::remove(vec.begin(), vec.end(), pThis), vec.end());
+		}
+	}
+	*/
 
 	if (this->SpecialTracked)
 		ScenarioExt::Global()->SpecialTracker.Remove(pThis);
@@ -1218,6 +1236,10 @@ void TechnoExt::Serialize(T& Stm)
 		.Process(this->LastTargetCrdClearTimer)
 		.Process(this->ShouldBeDead)
 		.Process(this->PreventCrewEscape)
+		.Process(this->Jumpjet_ScatterFinishFrame)
+		.Process(this->Jumpjet_ScatterDir)
+		.Process(this->Jumpjet_LastCell)
+		.Process(this->Jumpjet_LastHeight)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -88,6 +88,11 @@ public:
 
 	bool PreventCrewEscape;
 
+	int Jumpjet_ScatterFinishFrame { 0 };
+	int Jumpjet_ScatterDir { -1 };
+	CellClass* Jumpjet_LastCell { nullptr };
+	int Jumpjet_LastHeight { 0 };
+
 	TechnoExt(TechnoClass* OwnerObject) : RadioExt(OwnerObject)
 		, TypeExtData { nullptr }
 		, Shield {}
@@ -137,6 +142,10 @@ public:
 		, DropCrate { -1 }
 		, DropCrateType { Powerup::Money }
 		, PreventCrewEscape { false }
+		, Jumpjet_ScatterFinishFrame { 0 }
+		, Jumpjet_ScatterDir { -1 }
+		, Jumpjet_LastCell { nullptr }
+		, Jumpjet_LastHeight { 0 }
 	{ }
 
 	void OnEarlyUpdate();

--- a/src/Ext/Unit/Hooks.Jumpjet.cpp
+++ b/src/Ext/Unit/Hooks.Jumpjet.cpp
@@ -1,4 +1,16 @@
+#pragma warning(disable: 4996)
 #include <JumpjetLocomotionClass.h>
+#include <AircraftTrackerClass.h>
+#include <CellSpread.h>
+#include <ScenarioClass.h>
+#include <FootClass.h>
+#include <InfantryClass.h>
+#include <MapClass.h>
+#include <Unsorted.h>
+#include <Ext/Rules/Body.h>
+#include <Ext/Techno/Body.h>
+#include <Ext/Cell/Body.h>
+#include <Utilities/GeneralUtils.h>
 
 #include <Ext/Foot/Body.h>
 #include <Ext/UnitType/Body.h>
@@ -496,3 +508,225 @@ DEFINE_HOOK(0x54AD41, JumpjetLocomotionClass_Link_To_Object_LocomotorWarhead, 0x
 
 	return SkipGameCode;
 }
+
+// ============================================================================
+// ExtendedJumpjetHovering
+// ============================================================================
+
+static void ProcessJumpjetScatter(JumpjetLocomotionClass* pLoco, int dir)
+{
+	if (dir < 0 || dir > 7)
+		return;
+
+	double dist = static_cast<double>(pLoco->Speed);
+	FootClass* pFoot = pLoco->LinkedTo;
+	CoordStruct oldPos = pFoot->GetCoords();
+	auto pTechnoExt = TechnoExt::Fetch(pFoot);
+	CellStruct off = CellSpread::GetNeighbourOffset(dir);
+	if (off.X && off.Y)
+		dist /= Math::Sqrt2;
+
+	CoordStruct newPos { oldPos.X + static_cast<int>(static_cast<double>(off.X) * dist),
+	                     oldPos.Y + static_cast<int>(static_cast<double>(off.Y) * dist),
+	                     oldPos.Z };
+
+	AircraftTrackerClass::Instance.Update(pFoot, CellClass::Coord2Cell(oldPos), CellClass::Coord2Cell(newPos));
+	bool onMap = pFoot->IsOnMap;
+	pFoot->IsOnMap = false;
+	pFoot->SetLocation(newPos);
+	pFoot->IsOnMap = onMap;
+	pLoco->DestinationCoords.X = newPos.X;
+	pLoco->DestinationCoords.Y = newPos.Y;
+
+	if (pTechnoExt->Jumpjet_ScatterFinishFrame - Unsorted::CurrentFrame <= 0)
+		pTechnoExt->Jumpjet_ScatterFinishFrame = Unsorted::CurrentFrame + static_cast<int>(std::ceil(128.0 / dist));
+}
+
+static bool ShouldScatter(FootClass* pHov, int* outDir)
+{
+	bool should = false;
+	int scatterDir = -1;
+	std::vector<std::pair<int,int>> vec;
+
+	CellClass* pCell = pHov->GetCell();
+	int cellCount = 0;
+	if (auto pCellExt = CellExt::TryFetch(pCell))
+	{
+		if (Unsorted::CurrentFrame - pCellExt->Jumpjet_LastScatterAffectedFrame > 2)
+			return false;
+		if (pCellExt->InAirJumpjets.size())
+			cellCount += pCellExt->GetWeightedJumpjetCount(pHov, &should);
+	}
+
+	CellStruct cellPos = pCell->MapCoords;
+
+	if (auto pTarget = pHov->Target)
+	{
+		int targetDir = pHov->GetTargetDirection(pTarget).GetFacing<8>();
+		int d1 = (targetDir + 2) % 8;
+		int d2 = (targetDir - 2 + 8) % 8;
+		int c1 = 0, c2 = 0;
+		CellStruct off1 = CellSpread::GetNeighbourOffset(d1);
+		if (auto pC1 = MapClass::Instance.GetCellAt(cellPos + off1))
+			if (auto pE1 = CellExt::TryFetch(pC1))
+				if (pE1->InAirJumpjets.size())
+					c1 += pE1->GetWeightedJumpjetCount(pHov, &should);
+		CellStruct off2 = CellSpread::GetNeighbourOffset(d2);
+		if (auto pC2 = MapClass::Instance.GetCellAt(cellPos + off2))
+			if (auto pE2 = CellExt::TryFetch(pC2))
+				if (pE2->InAirJumpjets.size())
+					c2 += pE2->GetWeightedJumpjetCount(pHov, &should);
+
+		int c3 = 27;
+		int c4 = 27;
+		int d3 = (targetDir + 1) % 8;
+		int d4 = (targetDir - 1 + 8) % 8;
+		vec = { {cellCount, -1}, {c1, d1}, {c2, d2}, {c3, d3}, {c4, d4} };
+		const int maxPlus = 30;
+		for (auto& pr : vec)
+			pr.first = maxPlus - pr.first;
+	}
+	else
+	{
+		int counts[8] = {0};
+		for (int i = 0; i < 8; ++i)
+		{
+			CellStruct off = CellSpread::GetNeighbourOffset(i);
+			if (auto pC = MapClass::Instance.GetCellAt(cellPos + off))
+				if (auto pE = CellExt::TryFetch(pC))
+					if (pE->InAirJumpjets.size())
+						counts[i] += pE->GetWeightedJumpjetCount(pHov, &should);
+		}
+		vec = { {cellCount, -1},
+		        {counts[0],0},{counts[1],1},{counts[2],2},{counts[3],3},
+		        {counts[4],4},{counts[5],5},{counts[6],6},{counts[7],7} };
+		int maxVal = cellCount;
+		for (int i = 0; i < 8; ++i) maxVal = std::max(maxVal, counts[i]);
+		int maxPlus = 3 + maxVal;
+		for (auto& pr : vec)
+			pr.first = maxPlus - pr.first;
+	}
+
+	auto pExt = TechnoExt::Fetch(pHov);
+	if (pExt->Jumpjet_ScatterFinishFrame - Unsorted::CurrentFrame <= 0)
+	{
+		// build weight list for GeneralUtils::ChooseOneWeighted
+		std::vector<int> weights;
+		weights.reserve(vec.size());
+		for (auto& pr : vec) weights.push_back(pr.first);
+		double dice = ScenarioClass::Instance->Random.RandomDouble();
+		int idx = GeneralUtils::ChooseOneWeighted(dice, &weights);
+		if (idx >= 0 && idx < static_cast<int>(vec.size()))
+			scatterDir = vec[idx].second;
+		else
+			scatterDir = vec[0].second;
+		pExt->Jumpjet_ScatterDir = scatterDir;
+		*outDir = scatterDir;
+	}
+	else
+	{
+		*outDir = pExt->Jumpjet_ScatterDir;
+	}
+	return should;
+}
+
+DEFINE_HOOK(0x4135A0, AircraftTracker_JumpjetShouldScatter, 0x5)
+{
+	if (!RulesExt::Global()->ExtendedJumpjetHovering)
+		return 0;
+	R->EAX(false);
+	return 0x4135C6;
+}
+
+DEFINE_HOOK(0x54BD93, JumpjetLocomotion_ProcessHovering_Scatter, 0x6)
+{
+	if (!RulesExt::Global()->ExtendedJumpjetHovering)
+		return 0;
+	GET(JumpjetLocomotionClass*, pLoco, ESI);
+	int dir = -1;
+	if (ShouldScatter(pLoco->LinkedTo, &dir))
+		ProcessJumpjetScatter(pLoco, dir);
+	else
+	{
+		FootClass* pFoot = pLoco->LinkedTo;
+		auto pExt = TechnoExt::Fetch(pFoot);
+		if (pExt->Jumpjet_LastCell && pExt->Jumpjet_LastCell != pFoot->Destination)
+			pFoot->Destination = pExt->Jumpjet_LastCell;
+	}
+	return 0;
+}
+
+// Foot tracking for ExtendedJumpjetHovering
+DEFINE_HOOK(0x4DB83F, FootClass_SetLocation_ExtendedJumpjet, 0x5)
+{
+	GET(bool, changed, EBX);
+	if (!changed)
+		return 0;
+	GET(FootClass*, pFoot, ESI);
+	GET_STACK(CoordStruct*, pTargetPos, STACK_OFFSET(0xC, 0x4));
+
+	auto pTechnoExt = TechnoExt::Fetch(pFoot);
+	CellClass* pOldCell = pTechnoExt->Jumpjet_LastCell;
+	CellClass* pNewCell = MapClass::Instance.GetCellAt(*pTargetPos);
+	auto pNewExt = CellExt::TryFetch(pNewCell);
+
+	int bridgeAdj = pFoot->OnBridge ? -CellClass::BridgeHeight : 0;
+	int oldHeight = pTechnoExt->Jumpjet_LastHeight;
+	int newHeight = pTargetPos->Z - MapClass::Instance.GetCellFloorHeight(*pTargetPos) + bridgeAdj;
+	pTechnoExt->Jumpjet_LastHeight = newHeight;
+
+	if (pNewCell == pOldCell)
+	{
+		if (pNewExt)
+		{
+			pNewExt->UpdateJumpjet(pFoot, newHeight, oldHeight);
+			if (pFoot->Location.X != pTargetPos->X || pFoot->Location.Y != pTargetPos->Y)
+				pNewExt->MarkJumpjetScatterCell();
+		}
+	}
+	else
+	{
+		pTechnoExt->Jumpjet_LastCell = pNewCell;
+		if (auto pOldExt = CellExt::TryFetch(pOldCell))
+			pOldExt->RemoveJumpjet(pFoot, oldHeight);
+		if (pNewExt)
+			pNewExt->AddJumpjet(pFoot, newHeight);
+	}
+	return 0;
+}
+
+DEFINE_HOOK(0x5F5FBB, ObjectClass_SetHeight_ExtendedJumpjet, 0x5)
+{
+	GET(FootClass*, pFoot, ESI);
+	if ((pFoot->AbstractFlags & AbstractFlags::Foot) == AbstractFlags::None)
+		return 0;
+	GET(int, curHeight, EDI);
+	auto pExt = TechnoExt::Fetch(pFoot);
+	int oldHeight = pExt->Jumpjet_LastHeight;
+	pExt->Jumpjet_LastHeight = curHeight;
+	if (auto pCellExt = CellExt::TryFetch(pExt->Jumpjet_LastCell))
+		pCellExt->UpdateJumpjet(pFoot, curHeight, oldHeight);
+	return 0;
+}
+
+// ExtendedJumpjetHovering - Skip Jumpjet StopMoving when hovering
+DEFINE_HOOK(0x54B4F2, JumpjetLocomotion_StopMoving_Skip, 0x9)
+{
+    GET(ILocomotion*, pILoco, EDI);
+
+    if (!RulesExt::Global()->ExtendedJumpjetHovering)
+        return 0;
+	
+    auto pLoco = static_cast<JumpjetLocomotionClass*>(pILoco);
+    auto pFoot = pLoco->LinkedTo;
+    auto crd = pFoot->GetCoords();
+    pLoco->DestinationCoords.X = crd.X;
+    pLoco->DestinationCoords.Y = crd.Y;
+    pLoco->CurrentSpeed = 0;
+    pLoco->MaxSpeed = 0;
+    pLoco->State = JumpjetLocomotionClass::State::Hovering;
+    pFoot->AbortMotion();
+    return 0x54B6D6;
+}
+
+


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [x] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

<!-- Write your description below. Usually this is your improvement documentation copy, but you may add extra notes or sections or whatever you feel is important for reviewing. -->

### Extended Jumpjet Hovering

- In vanilla, jumpjets scatter while hovering by randomly setting a destination to a nearby cell. This approach is inefficient when many jumpjets are crowded around, and it forces the unit to turn, which interferes with firing for non-omni-firing units.
- Now you can enable a new hovering scatter behaviour via the following switch, which disperses units more efficiently and without requiring the unit to turn.
  - `ExtendedJumpjetHovering` controls whether the new hovering scatter behaviour is enabled.

In `rulesmd.ini`:
```ini
[JumpjetControls]                ; global section
ExtendedJumpjetHovering=false   ; boolean
```