### PR TITLE
[Phobos Fix] Fixed a bug that percentage sw timer shows `-nan(ind)%` when `RechargeTime` is too short

### DIFF
--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -836,6 +836,7 @@ HideShakeEffects=false           ; boolean
 - Fixed the bug where incorrect calculation of `[AudioVisual] -> PoseDir` caused the landing direction of aircraft to behave incorrectly under vanilla configuration (by Noble_Fish)
 - Fixed the bug where landing direction cannot be correctly converted when set to a value exceeding 256 (by Noble_Fish)
 - Fixed a bug with some keys relating to `Interceptor` and `PassengerDeletion` not having correct default values (by Starkku)
+- Fixed a bug that percentage sw timer shows `-nan(ind)%` when `RechargeTime` is too short (by NetsuNegi)
 
 #### Fixes / interactions with other extensions:
 - Taking over Ares' AlphaImage respawn logic to reduce lags from it (by NetsuNegi)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -836,7 +836,6 @@ HideShakeEffects=false           ; boolean
 - Fixed the bug where incorrect calculation of `[AudioVisual] -> PoseDir` caused the landing direction of aircraft to behave incorrectly under vanilla configuration (by Noble_Fish)
 - Fixed the bug where landing direction cannot be correctly converted when set to a value exceeding 256 (by Noble_Fish)
 - Fixed a bug with some keys relating to `Interceptor` and `PassengerDeletion` not having correct default values (by Starkku)
-- Fixed a bug that percentage sw timer shows `-nan(ind)%` when `RechargeTime` is too short (by NetsuNegi)
 
 #### Fixes / interactions with other extensions:
 - Taking over Ares' AlphaImage respawn logic to reduce lags from it (by NetsuNegi)

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -569,7 +569,7 @@ DEFINE_HOOK(0x6D4A10, TacticalClass_Render_DrawSuperTimer_PercentageTimer, 0x6)
 	{
 		DrawTimerTemp::IsPercentage = true;
 		const int recharge = pSuper->GetRechargeTime();
-		const double percentage = DrawTimerTemp::Percentage = std::min(static_cast<double>(recharge - timeLeft) / recharge, 1.0);
+		const double percentage = DrawTimerTemp::Percentage = recharge > 0 ? static_cast<double>(recharge - timeLeft) / recharge : 1.0;
 		R->ESI(percentage >= 1.0 ? 0 : 15);
 	}
 	else

--- a/src/Misc/Hooks.UI.cpp
+++ b/src/Misc/Hooks.UI.cpp
@@ -569,8 +569,8 @@ DEFINE_HOOK(0x6D4A10, TacticalClass_Render_DrawSuperTimer_PercentageTimer, 0x6)
 	{
 		DrawTimerTemp::IsPercentage = true;
 		const int recharge = pSuper->GetRechargeTime();
-		const double percentage = DrawTimerTemp::Percentage = recharge > 0 ? static_cast<double>(recharge - timeLeft) / recharge : 1.0;
-		R->ESI(percentage >= 1.0 ? 0 : 15);
+		const double percentage = DrawTimerTemp::Percentage = recharge > 0 ? std::min(static_cast<double>(recharge - timeLeft) / recharge, 1.0) : 1.0;
+		R->ESI(percentage == 1.0 ? 0 : 15);
 	}
 	else
 	{


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [ ] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [x] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

<!-- Write your description below. Usually this is your improvement documentation copy, but you may add extra notes or sections or whatever you feel is important for reviewing. -->
