### PR TITLE
Fix the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -756,6 +756,7 @@ This page lists all the individual contributions to the project by their author.
   - Roof production anim
   - Customize whether the unit exits from the roof
   - Customize whether the unit can be detected by psychic detector
+  - Fix the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -332,6 +332,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that buildings with passengers cannot unload via the Deploy hotkey or command bar button.
 - Fixed the issue where vehicles always finish turret resetting first before turn to a new attack target, now it should turn to new target immediately.
 - Fixed the bug that computer player record cannot be log normally in non English mode.
+- Fixed the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving; `WalkRate=0` is now treated like `IdleRate=0`: the walk animation/footstep tick never fires, so a moving unit behaves as if standing still.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -437,6 +437,7 @@ HideShakeEffects=false           ; boolean
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)
 - Fixed the bug that buildings with passengers cannot unload via the Deploy hotkey or command bar button (by Noble_Fish)
+- Fixed the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving (by Noble_Fish)
 
 #### Phobos fixes:
 - Fixed a game crash when parsing string list with null entry (by Ollerus)

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3642,3 +3642,14 @@ DEFINE_HOOK(0x554AAD, LightSourceClass_ChangeLevels_CheckBefore, 0x6)
 	R->EDI(tint.Blue);
 	return ContinueIn;
 }
+
+DEFINE_HOOK(0x4DA90E, FootClass_AI_WalkRateZeroProtect, 0x6)
+{
+	GET(TechnoTypeClass*, pType, ECX);
+
+	if (pType->WalkRate != 0)
+		return 0;
+
+	R->EDX(1);
+	return 0x4DA914;
+}


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [X] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

`WalkRate` was introduced in Tiberian Sun; unlike `IdleRate`, which was newly introduced in Red Alert 2, it does not have zero-value protection (see `0x4DA94A`). This is now supplemented to align the semantics: when set to 0, playback will be disabled.
