### PR TITLE
Case insensitive map file names in missionmd.ini

### DIFF
--- a/src/Ext/Scenario/Hooks.cpp
+++ b/src/Ext/Scenario/Hooks.cpp
@@ -8,7 +8,7 @@ DEFINE_HOOK(0x6870D7, ReadScenario_MissionINI, 0x5)
 
 	auto const pScenario = ScenarioClass::Instance;
 	auto const pScenarioExt = ScenarioExt::Global();
-	auto const scenarioName = pScenario->FileName;
+	auto scenarioName = pScenario->FileName;
 	auto const defaultsSection = "Defaults";
 
 	CCINIClass ini_missionmd {};
@@ -17,6 +17,18 @@ DEFINE_HOOK(0x6870D7, ReadScenario_MissionINI, 0x5)
 	pScenarioExt->DefaultLS640BkgdName.Read(&ini_missionmd, defaultsSection, "DefaultLS640BkgdName");
 	pScenarioExt->DefaultLS800BkgdName.Read(&ini_missionmd, defaultsSection, "DefaultLS800BkgdName");
 	pScenarioExt->DefaultLS800BkgdPal.Read(&ini_missionmd, defaultsSection, "DefaultLS800BkgdPal");
+
+	if (ini_missionmd.GetSection(scenarioName) == nullptr)
+	{
+		for (auto pNode = ini_missionmd.Sections.First(); pNode && pNode->IsValid(); pNode = pNode->Next())
+		{
+			if (pNode->Name && _stricmp(pNode->Name, scenarioName) == 0)
+			{
+				scenarioName = pNode->Name;
+				break;
+			}
+		}
+	}
 
 	pScenarioExt->ShowBriefing = pINI->ReadBool(scenarioName, "ShowBriefing", pScenarioExt->ShowBriefing);
 	pScenarioExt->BriefingTheme = pINI->ReadTheme(scenarioName, "BriefingTheme", pScenarioExt->BriefingTheme);


### PR DESCRIPTION
Text generated with AI for explaining the proposed fix/change:

"When transitioning between campaign missions (such as when using `SkipMapSelect=yes`), the game engine uppercases `ScenarioClass::Instance->FileName` via `_strupr`.
Because Westwood's `CCINIClass::GetSection` relies on a case-sensitive CRC32 hash of section headers, looking up the uppercased scenario path fails if `missionmd.ini` defines the section with mixed casing (e.g., `[Maps/Missions/Red Alert 2/ALL02S.MAP]`). As a result, `LS800BkgdName` and related loading screen parameters are not read, causing the engine to skip the loading screen background and only render a progress bar over a black screen.
### Solution
In `ReadScenario_MissionINI` (`0x6870D7`), if `ini_missionmd.GetSection(scenarioName)` returns `nullptr`, iterate through the loaded sections list in `missionmd.ini` using `_stricmp` to resolve the section name case-insensitively before reading scenario metadata."