### PR TITLE
Fix the bug where `Ranged=true` causes projectiles using the new Trajectory to ignore settings such as `BounceTimes`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -757,6 +757,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize whether the unit exits from the roof
   - Customize whether the unit can be detected by psychic detector
   - Fix the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving
+  - Fix the bug where `Ranged=true` causes projectiles using the new Trajectory to ignore settings such as `BounceTimes`
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -442,6 +442,7 @@ HideShakeEffects=false           ; boolean
 #### Phobos fixes:
 - Fixed a game crash when parsing string list with null entry (by Ollerus)
 - Fixed the bug that slaves would be handed over to the neutral house instead of respecting `Slaved.OwnerWhenMasterKilled` when their master was sold or self-destructed (by frg2089)
+- Fixed the bug where `Ranged=true` causes projectiles using the new Trajectory to ignore settings such as `BounceTimes` (by Noble_Fish)
 
 #### Fixes / interactions with other extensions:
 - Allowed `SW.ShowCameo` and `SW.ManualFire` to work independently of `SW.AutoFire` (by Noble_Fish)

--- a/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
+++ b/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
@@ -451,6 +451,22 @@ DEFINE_HOOK(0x4666F7, BulletClass_AI_Trajectories, 0x6)
 	return 0;
 }
 
+// The vanilla Ranged check would override the trajectory's detonation decision, so trajectories opt out via ShouldSkipRangedCheck().
+DEFINE_HOOK(0x467C1C, BulletClass_AI_RangedCheck_Trajectories, 0x6)
+{
+	enum { SkipToNoRanged = 0x467C26 };
+
+	GET(BulletClass*, pThis, EBP);
+
+	if (auto const pExt = BulletExt::ExtMap.Find(pThis))
+	{
+		if (pExt->Trajectory && pExt->Trajectory->ShouldSkipRangedCheck())
+			return SkipToNoRanged;
+	}
+
+	return 0;
+}
+
 /* ROT > 0. We temporarily do not need to make changes to the Bridge interaction for this scenario, but we will leave it here for now, as it may be used later.
 DEFINE_HOOK(0x46703E, BulletClass_AI_SkipBridgeCheck1, 0x6)
 {

--- a/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
+++ b/src/Ext/Bullet/Trajectories/PhobosTrajectory.cpp
@@ -458,7 +458,7 @@ DEFINE_HOOK(0x467C1C, BulletClass_AI_RangedCheck_Trajectories, 0x6)
 
 	GET(BulletClass*, pThis, EBP);
 
-	if (auto const pExt = BulletExt::ExtMap.Find(pThis))
+	if (auto const pExt = BulletExt::TryFetch(pThis))
 	{
 		if (pExt->Trajectory && pExt->Trajectory->ShouldSkipRangedCheck())
 			return SkipToNoRanged;

--- a/src/Ext/Bullet/Trajectories/PhobosTrajectory.h
+++ b/src/Ext/Bullet/Trajectories/PhobosTrajectory.h
@@ -52,6 +52,7 @@ public:
 	virtual TrajectoryCheckReturnType OnAITargetCoordCheck(BulletClass* pBullet) = 0;
 	virtual TrajectoryCheckReturnType OnAITechnoCheck(BulletClass* pBullet, TechnoClass* pTechno) = 0;
 	virtual bool ShouldSkipBridgeCheck() const { return false; }
+	virtual bool ShouldSkipRangedCheck() const { return true; } // Whether to skip is declared as the trajectory's own policy.
 };
 
 /*


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [ ] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [X] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

In vanilla, `Ranged=true` runs a check that, once the fuse timer has expired, snaps the bullet onto the target coordinates and detonates it as soon as the projectile comes within 64 leptons of them. This check runs after the trajectory system has decided the projectile should keep flying (the trajectory `BulletClass_AI_Trajectories` hook at 0x4666F7) and bypasses all of the trajectory's detonation logic - including the shared `DetonationDistance` / `TargetSnapDistance` handling and the Parabola bouncing mechanism.
