### PR TITLE
[Customization] Allow customize that whether `Temporal=yes` warhead will cause target building animation poweroff

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -572,6 +572,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the issue where vehicles always finish turret resetting first before turn to a new attack target, now it should turn to new target immediately
   - Fix a bug that computer player record cannot be log normally in non English mode
   - Cloak Enhancement
+  - Fix the bug that `Temporal=yes` warhead will cause target building animation poweroff
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -572,7 +572,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the issue where vehicles always finish turret resetting first before turn to a new attack target, now it should turn to new target immediately
   - Fix a bug that computer player record cannot be log normally in non English mode
   - Cloak Enhancement
-  - Fix the bug that `Temporal=yes` warhead will cause target building animation poweroff
+  - Allow customize that whether `Temporal=yes` warhead will cause target building animation poweroff
 - **Apollo** - Translucent SHP drawing patches
 - **ststl**:
   - Customizable `ShowTimer` priority of superweapons

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -332,7 +332,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the issue where vehicles always finish turret resetting first before turn to a new attack target, now it should turn to new target immediately.
 - Fixed the bug that computer player record cannot be log normally in non English mode.
 - Fixed the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving; `WalkRate=0` is now treated like `IdleRate=0`: the walk animation/footstep tick never fires, so a moving unit behaves as if standing still.
-- Fixed the bug that `Temporal=yes` warhead will cause target building animation poweroff.
 
 ## Fixes / interactions with other extensions
 
@@ -830,6 +829,14 @@ In `rulesmd.ini`:
 ```ini
 [General]
 BuildingWaypoints=false  ; boolean
+```
+
+### Allow customize that whether `Temporal=yes` warhead will cause target building animation poweroff
+
+In `rulesmd.ini`:
+```ini
+[General]
+Temporal.KillPoweredAnim=true   ; boolean
 ```
 
 ## Aircraft

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -332,6 +332,7 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the issue where vehicles always finish turret resetting first before turn to a new attack target, now it should turn to new target immediately.
 - Fixed the bug that computer player record cannot be log normally in non English mode.
 - Fixed the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving; `WalkRate=0` is now treated like `IdleRate=0`: the walk animation/footstep tick never fires, so a moving unit behaves as if standing still.
+- Fixed the bug that `Temporal=yes` warhead will cause target building animation poweroff.
 
 ## Fixes / interactions with other extensions
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -814,6 +814,7 @@ HideShakeEffects=false           ; boolean
 - Fixed an issue where `OmniFire` was ineffective on buildings with `Turret=yes` (by FlyStar)
 - Fixed an issue where setting a production building as `Primary` could cause it to enter an unload state (by FlyStar)
 - Fixed the issue of significant lagging caused by frequent lighting updates due to the accumulation of a large amount of radsite in a short time (by NetsuNegi)
+- Fixed the bug that `Temporal=yes` warhead will cause target building animation poweroff (by NetsuNegi)
 
 #### Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -723,6 +723,7 @@ HideShakeEffects=false           ; boolean
 - [Disable AlphaImage during Buildup](Fixed-or-Improved-Logics.md#disable-alphaimage-during-buildup) (by Noble_Fish)
 - [Reload speed adjustment on promotion](New-or-Enhanced-Logics.md#reload-speed-adjustment-on-promotion) (by Nuke)
 - Allowed `(Pre)ProductionAnim` animations to use `Powered` & `PoweredLight/Effect/Special` keys (by Noble_Fish)
+- Allow customize that whether `Temporal=yes` warhead will cause target building animation poweroff (by NetsuNegi)
 
 #### Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)
@@ -814,7 +815,6 @@ HideShakeEffects=false           ; boolean
 - Fixed an issue where `OmniFire` was ineffective on buildings with `Turret=yes` (by FlyStar)
 - Fixed an issue where setting a production building as `Primary` could cause it to enter an unload state (by FlyStar)
 - Fixed the issue of significant lagging caused by frequent lighting updates due to the accumulation of a large amount of radsite in a short time (by NetsuNegi)
-- Fixed the bug that `Temporal=yes` warhead will cause target building animation poweroff (by NetsuNegi)
 
 #### Phobos fixes:
 - Fixed the bug that `AllowAirstrike=no` cannot completely prevent air strikes from being launched against it (by NetsuNegi)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1900,9 +1900,9 @@ msgid "Cloak Enhancement"
 msgstr "隐形增强"
 
 msgid ""
-"Fix the bug that `Temporal=yes` warhead will cause target building "
-"animation poweroff"
-msgstr "修复了 `Temporal=yes` 弹头会触发目标建筑动画停电的 Bug"
+"Allow customize that whether `Temporal=yes` warhead will cause "
+"target building animation poweroff"
+msgstr "允许自定义 `Temporal=yes` 弹头是否会触发目标建筑动画停电"
 
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -1899,6 +1899,11 @@ msgstr "修复了非英文模式下，电脑玩家的战绩数据无法正常录
 msgid "Cloak Enhancement"
 msgstr "隐形增强"
 
+msgid ""
+"Fix the bug that `Temporal=yes` warhead will cause target building "
+"animation poweroff"
+msgstr "修复了 `Temporal=yes` 弹头会触发目标建筑动画停电的 Bug"
+
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1731,11 +1731,6 @@ msgid ""
 msgstr ""
 "修复了单位设置 `WalkRate=0` 时一开始移动游戏就会崩溃的 Bug（整数除零）；现在 `WalkRate=0` 与 `IdleRate=0` 同样处理——移动动画／移动音效永不触发，移动中的单位表现为静止（滑行）。"
 
-msgid ""
-"Fixed the bug that `Temporal=yes` warhead will cause target building "
-"animation poweroff."
-msgstr "修复了 `Temporal=yes` 弹头会触发目标建筑动画停电的 Bug。"
-
 msgid "Fixes / interactions with other extensions"
 msgstr "修复或与其他扩展的交互"
 
@@ -2654,6 +2649,11 @@ msgid ""
 "In vanilla, buildings are forbidden to use waypoints. Now you can allow "
 "that using the following flag."
 msgstr "在原版中，建筑被禁止使用路径点。现在你可以使用以下标签来允许使用。"
+
+msgid ""
+"Allow customize that whether `Temporal=yes` warhead will cause "
+"target building animation poweroff"
+msgstr "允许自定义 `Temporal=yes` 弹头是否会触发目标建筑动画停电"
 
 msgid "Aircraft"
 msgstr "战机类型"

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -1731,6 +1731,11 @@ msgid ""
 msgstr ""
 "修复了单位设置 `WalkRate=0` 时一开始移动游戏就会崩溃的 Bug（整数除零）；现在 `WalkRate=0` 与 `IdleRate=0` 同样处理——移动动画／移动音效永不触发，移动中的单位表现为静止（滑行）。"
 
+msgid ""
+"Fixed the bug that `Temporal=yes` warhead will cause target building "
+"animation poweroff."
+msgstr "修复了 `Temporal=yes` 弹头会触发目标建筑动画停电的 Bug。"
+
 msgid "Fixes / interactions with other extensions"
 msgstr "修复或与其他扩展的交互"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -2647,6 +2647,11 @@ msgstr ""
 "类的标签（by Noble_Fish）"
 
 msgid ""
+"Allow customize that whether `Temporal=yes` warhead will cause "
+"target building animation poweroff (by NetsuNegi)"
+msgstr "允许自定义 `Temporal=yes` 弹头是否会触发目标建筑动画停电（by NetsuNegi）"
+
+msgid ""
 "Fixed sidebar not updating queued unit numbers when adding or removing "
 "units when the production is on hold (by CrimRecya)"
 msgstr "修复侧边栏在生产暂停时添加或去除订单未能更新预购单位队列数量的问题（by CrimRecya）"
@@ -3128,11 +3133,6 @@ msgid ""
 "updates due to the accumulation of a large amount of radsite in a short "
 "time (by NetsuNegi)"
 msgstr "修复了短时间内叠加大量辐射场会因为频繁的光照更新导致显著卡顿的问题（by NetsuNegi）"
-
-msgid ""
-"Fixed the bug that `Temporal=yes` warhead will cause target building "
-"animation poweroff (by NetsuNegi)"
-msgstr "修复了 `Temporal=yes` 弹头会触发目标建筑动画停电的 Bug（by NetsuNegi）"
 
 msgid ""
 "Fixed the bug that `AllowAirstrike=no` cannot completely prevent air "

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -3130,6 +3130,11 @@ msgid ""
 msgstr "修复了短时间内叠加大量辐射场会因为频繁的光照更新导致显著卡顿的问题（by NetsuNegi）"
 
 msgid ""
+"Fixed the bug that `Temporal=yes` warhead will cause target building "
+"animation poweroff (by NetsuNegi)"
+msgstr "修复了 `Temporal=yes` 弹头会触发目标建筑动画停电的 Bug（by NetsuNegi）"
+
+msgid ""
 "Fixed the bug that `AllowAirstrike=no` cannot completely prevent air "
 "strikes from being launched against it (by NetsuNegi)"
 msgstr "修复了 `AllowAirstrike=no` 未能完全阻止对某个单位进行空袭的 Bug（by NetsuNegi）"

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -560,6 +560,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->Temporal_ApplyVersus.Read(exINI, GameStrings::CombatDamage, "Temporal.ApplyVersus");
 	this->Temporal_ApplyMultiplier.Read(exINI, GameStrings::CombatDamage, "Temporal.ApplyMultiplier");
+	this->Temporal_KillPoweredAnim.Read(exINI, GameStrings::General, "Temporal.KillPoweredAnim");
 
 	ValueableIdx<VocClass> deploySound { pThis->DeploySound };
 	deploySound.Read(exINI, GameStrings::AudioVisual, "DeploySound");
@@ -1094,6 +1095,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Vertical_AircraftFix)
 		.Process(this->Temporal_ApplyVersus)
 		.Process(this->Temporal_ApplyMultiplier)
+		.Process(this->Temporal_KillPoweredAnim)
 		.Process(this->DiscardOn_Sequences_Immediate)
 		.Process(this->DiscardOn_MoveBasedOnDestination)
 		.Process(this->DiscardOn_ConsiderHarvestingAsStationary)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -493,6 +493,7 @@ public:
 
 		Valueable<bool> Temporal_ApplyVersus;
 		Valueable<bool> Temporal_ApplyMultiplier;
+		Valueable<bool> Temporal_KillPoweredAnim;
 
 		Valueable<bool> DiscardOn_Sequences_Immediate;
 		Valueable<bool> DiscardOn_MoveBasedOnDestination;
@@ -984,6 +985,7 @@ public:
 			, Vertical_AircraftFix { true }
 			, Temporal_ApplyVersus { false }
 			, Temporal_ApplyMultiplier { false }
+			, Temporal_KillPoweredAnim { true }
 			, DiscardOn_Sequences_Immediate { true }
 			, DiscardOn_MoveBasedOnDestination { false }
 			, DiscardOn_ConsiderHarvestingAsStationary { true }

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3653,3 +3653,12 @@ DEFINE_HOOK(0x4DA90E, FootClass_AI_WalkRateZeroProtect, 0x6)
 	R->EDX(1);
 	return 0x4DA914;
 }
+
+DEFINE_HOOK(0x454BF1, BuildingClass_UpdatePoweredAnim_Temporal, 0x6)
+{
+	enum { ReturnFromFunction = 0x454CD3 };
+
+	GET(BuildingClass*, pThis, ESI);
+
+	return pThis->TemporalTargetingMe ? ReturnFromFunction : 0;
+}

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -3660,5 +3660,5 @@ DEFINE_HOOK(0x454BF1, BuildingClass_UpdatePoweredAnim_Temporal, 0x6)
 
 	GET(BuildingClass*, pThis, ESI);
 
-	return pThis->TemporalTargetingMe ? ReturnFromFunction : 0;
+	return pThis->TemporalTargetingMe && !RulesExt::Global()->Temporal_KillPoweredAnim ? ReturnFromFunction : 0;
 }


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [ ] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

<!-- Write your description below. Usually this is your improvement documentation copy, but you may add extra notes or sections or whatever you feel is important for reviewing. -->

In `rulesmd.ini`:
```ini
[General]
Temporal.KillPoweredAnim=true   ; boolean
```