### PR TITLE
Customizable damage divider for default `AnimList` picker

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -607,6 +607,7 @@ This page lists all the individual contributions to the project by their author.
   - Damaged aircraft image changes
   - Change target Owner on warhead impact
   - Set sidebar tab by selecting factory
+  - Customizable damage divider for default `AnimList` picker
 - **ZivDero**:
   - Re-enable the Veinhole Monster and Weeds from TS
   - Recreate the weed-charging of SWs like the TS Chemical Missile

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1097,7 +1097,7 @@ Crater.DestroyTiberium=         ; boolean, default to [General] -> AnimCraterDes
   - By default Y axis shift will only apply if the bracket position is negative e.g it is moved upwards from the object center. If `YDrawOffset.InvertBracketShift` is set to true, the opposite is true and negative shift is ignored.
   - For X axis the shift direction can also be switched by setting `XDrawOffset.InvertBracketShift=true`. The default is positive shift, towards right-hand side of the screen.
   - The bracket-based shift can be further adjusted with offset from `X/YDrawOffset.BracketAdjust`, overridden by `X/YDrawOffset.BracketAdjust.Buildings` for buildings only.
- 
+
 In `artmd.ini`:
 ```ini
 [SOMEANIM]                            ; AnimationType
@@ -3103,6 +3103,7 @@ Rocker.AmplitudeOverride=       ; integer
 
 ### Customizable Warhead animation behaviour
 
+- By default animation from `AnimList` is acquired by dividing the weapon's delivered damage by `25` and truncating the result. Now this value can be customized per warhead by setting `AnimList.DamageDivider`.
 - It is possible to make game play random animation from `AnimList` by setting `AnimList.PickRandom` to true. The result is similar to what `EMEffect=true` produces, however it comes with no side-effects (`EMEffect=true` prevents `Inviso=true` projectiles from snapping on targets, making them miss moving targets).
 - If `AnimList.CreateAll` is set to true, all animations from `AnimList` are created, instead of a single anim based on damage or random if `AnimList.PickRandom` is set to true.
 - If `AnimList.CreationInterval` is set to a value higher than 0, there will be that number of detonations of the Warhead before animations from `AnimList` will be created again. If the Warhead had a TechnoType firing it, this number is remembered by the TechnoType across all Warheads fired by it, otherwise it is shared between all detonations of same WarheadType period. This can be useful for things like `Airburst` with large spread where one might want uniform distribution of animations to appear but not on every detonation.
@@ -3119,6 +3120,7 @@ CreateAnimsOnZeroDamage=false   ; boolean
 Conventional.IgnoreUnits=false  ; boolean
 
 [SOMEWARHEAD]                   ; WarheadType
+AnimList.DamageDivider=         ; integer
 AnimList.PickRandom=false       ; boolean
 AnimList.CreateAll=false        ; boolean
 AnimList.CreationInterval=0     ; integer

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -441,6 +441,7 @@ HideShakeEffects=false           ; boolean
 - [Attached animation draw offset customizations](Fixed-or-Improved-Logics.md#draw-offset-customization) (by Starkku)
 - [Draw offset rules for AttachEffect animations](New-or-Enhanced-Logics.md#attached-effects) (by Starkku)
 - [Allowed customize that whether `Temporal=yes` warhead will cause target building animation poweroff](Fixed-or-Improved-Logics.md#allow-customize-that-whether-temporal-yes-warhead-will-cause-target-building-animation-poweroff) (by NetsuNegi)
+- Customizable damage divider for default `AnimList` picker (by Fryone)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -167,6 +167,7 @@ void WarheadTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->SplashList_CreationInterval.Read(exINI, pSection, "SplashList.CreationInterval");
 	this->SplashList_ScatterMin.Read(exINI, pSection, "SplashList.ScatterMin");
 	this->SplashList_ScatterMax.Read(exINI, pSection, "SplashList.ScatterMax");
+	this->AnimList_DamageDivider.Read(exINI, pSection, "AnimList.DamageDivider");
 	this->AnimList_PickRandom.Read(exINI, pSection, "AnimList.PickRandom");
 	this->AnimList_CreateAll.Read(exINI, pSection, "AnimList.CreateAll");
 	this->AnimList_CreationInterval.Read(exINI, pSection, "AnimList.CreationInterval");
@@ -575,6 +576,7 @@ void WarheadTypeExt::Serialize(T& Stm)
 		.Process(this->SplashList_CreationInterval)
 		.Process(this->SplashList_ScatterMin)
 		.Process(this->SplashList_ScatterMax)
+		.Process(this->AnimList_DamageDivider)
 		.Process(this->AnimList_PickRandom)
 		.Process(this->AnimList_CreateAll)
 		.Process(this->AnimList_CreationInterval)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -38,6 +38,7 @@ public:
 	Valueable<int> SplashList_CreationInterval;
 	Valueable<Leptons> SplashList_ScatterMin;
 	Valueable<Leptons> SplashList_ScatterMax;
+	Nullable<int> AnimList_DamageDivider;
 	Valueable<bool> AnimList_PickRandom;
 	Valueable<bool> AnimList_CreateAll;
 	Valueable<int> AnimList_CreationInterval;
@@ -317,6 +318,7 @@ public:
 		, SplashList_CreationInterval { 0 }
 		, SplashList_ScatterMin { Leptons(-1) }
 		, SplashList_ScatterMax { Leptons(-1) }
+		, AnimList_DamageDivider {}
 		, AnimList_PickRandom { false }
 		, AnimList_CreateAll { false }
 		, AnimList_CreationInterval { 0 }

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -230,13 +230,18 @@ DEFINE_HOOK(0x48A5B3, SelectDamageAnimation_CritAnim, 0x6)
 	return 0;
 }
 
-DEFINE_HOOK(0x48A5F8, SelectDamageAnimation_AnimList_CustomCoefficient, 0x5)
+DEFINE_HOOK(0x48A5EB, SelectDamageAnimation_AnimList_CustomCoefficient, 0x7)
 {
 	GET(WarheadTypeClass* const, pThis, ESI);
+	GET(const int, nDamage, EDI);
+
 	auto const pWHExt = WarheadTypeExt::Fetch(pThis);
 
-	R->EAX(pWHExt->AnimList_DamageDivider ? pWHExt->AnimList_DamageDivider : 25);
-	return 0x48A5FD;
+	const int divider = pWHExt->AnimList_DamageDivider ? pWHExt->AnimList_DamageDivider : 25;
+	const int idx = std::min((size_t)(pThis->AnimList.Count * divider - 1), (size_t)nDamage) / divider;
+
+	R->EAX(pThis->AnimList.GetItemOrDefault(idx));
+	return 0x48A5AD;
 }
 
 DEFINE_HOOK(0x4896EC, Explosion_Damage_DamageSelf, 0x6)

--- a/src/Ext/WarheadType/Hooks.cpp
+++ b/src/Ext/WarheadType/Hooks.cpp
@@ -230,6 +230,15 @@ DEFINE_HOOK(0x48A5B3, SelectDamageAnimation_CritAnim, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x48A5F8, SelectDamageAnimation_AnimList_CustomCoefficient, 0x5)
+{
+	GET(WarheadTypeClass* const, pThis, ESI);
+	auto const pWHExt = WarheadTypeExt::Fetch(pThis);
+
+	R->EAX(pWHExt->AnimList_DamageDivider ? pWHExt->AnimList_DamageDivider : 25);
+	return 0x48A5FD;
+}
+
 DEFINE_HOOK(0x4896EC, Explosion_Damage_DamageSelf, 0x6)
 {
 	enum { SkipCheck = 0x489702 };


### PR DESCRIPTION
`AnimList.DamageDivider` per warhead instead of hardcoded '25'.
`Crit_AnimList.DamageDivider` per warhead instead of hardcoded '25'.
`SplashList.DamageDivider` per warhead instead of hardcoded '35'.
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [ ] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description

<!-- Write your description below. Usually this is your improvement documentation copy, but you may add extra notes or sections or whatever you feel is important for reviewing. -->
