### PR TITLE
Fixed a bug in PR `#2342` where `Survivor.Side#` was overridden

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -446,6 +446,7 @@ This page lists all the individual contributions to the project by their author.
   - SkipMapSelect Enhancement
   - Add a global default value for `KeepAlive`
   - Customized transport plane for teams
+  - Fix the bug where *Customizable crew type per country* overrides the pre-techno settings
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -763,6 +763,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving
   - Fix the bug where `Ranged=true` causes projectiles using the new Trajectory to ignore settings such as `BounceTimes`
   - Customizable infantry sequence rates
+  - Fix the issue that *Customizable crew type per country* not considering parsing order caused game parsing failure and a warning in the log
 - **Ollerus**:
   - Build limit group enhancement
   - Customizable rocker amplitude

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -442,7 +442,7 @@ HideShakeEffects=false           ; boolean
 - [Draw offset rules for AttachEffect animations](New-or-Enhanced-Logics.md#attached-effects) (by Starkku)
 - [Allowed customize that whether `Temporal=yes` warhead will cause target building animation poweroff](Fixed-or-Improved-Logics.md#allow-customize-that-whether-temporal-yes-warhead-will-cause-target-building-animation-poweroff) (by NetsuNegi)
 - Country-based attached effects (by Ollerus)
-- [Customizable crew type per country](Fixed-or-Improved-Logics.md#customizable-crew-type-per-country) (by Sovietianqi & FlyStar)
+- [Customizable crew type per country](Fixed-or-Improved-Logics.md#customizable-crew-type-per-country) (by Sovietianqi, FlyStar, Noble_Fish)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -442,7 +442,7 @@ HideShakeEffects=false           ; boolean
 - [Draw offset rules for AttachEffect animations](New-or-Enhanced-Logics.md#attached-effects) (by Starkku)
 - [Allowed customize that whether `Temporal=yes` warhead will cause target building animation poweroff](Fixed-or-Improved-Logics.md#allow-customize-that-whether-temporal-yes-warhead-will-cause-target-building-animation-poweroff) (by NetsuNegi)
 - Country-based attached effects (by Ollerus)
-- [Customizable crew type per country](Fixed-or-Improved-Logics.md#customizable-crew-type-per-country) (by Sovietianqi)
+- [Customizable crew type per country](Fixed-or-Improved-Logics.md#customizable-crew-type-per-country) (by Sovietianqi & FlyStar)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)

--- a/src/Ext/HouseType/Body.cpp
+++ b/src/Ext/HouseType/Body.cpp
@@ -22,7 +22,7 @@ void HouseTypeExt::LoadFromINIFile(CCINIClass* pINI)
 	this->AttachEffects.LoadFromINI(pINI, pSection);
 	this->AttachEffects_AttachOnOwnerChange.Read(exINI, pSection, "AttachEffect.AttachOnOwnerChange");
 
-	this->Crew.Read(exINI, pSection, "Crew");
+	this->Crew.Read<true>(exINI, pSection, "Crew");
 }
 
 template <typename T>

--- a/src/Ext/HouseType/Hooks.cpp
+++ b/src/Ext/HouseType/Hooks.cpp
@@ -43,7 +43,7 @@ DEFINE_HOOK(0x707D40, TechnoClass_GetCrew_NationalOverride, 0x6)
 
 	GET(HouseClass* const, pHouse, ECX);
 
-	auto const pHouseTypeExt = HouseTypeExt::ExtMap.Find(pHouse->Type);
+	auto const pHouseTypeExt = HouseTypeExt::Fetch(pHouse->Type);
 
 	if (pHouseTypeExt->Crew.isset())
 	{

--- a/src/Ext/HouseType/Hooks.cpp
+++ b/src/Ext/HouseType/Hooks.cpp
@@ -36,22 +36,20 @@ DEFINE_HOOK(0x68AD0C, ScenarioClass_ReadMap_SetEVAIndex, 0x7)
 	return 0;
 }
 
-DEFINE_HOOK(0x707DCF, TechnoClass_GetCrew_NationalOverride, 0x5)
+// It takes effect when `Ares.dll` does not exist.
+DEFINE_HOOK(0x707D40, TechnoClass_GetCrew_NationalOverride, 0x6)
 {
-	GET(TechnoClass*, pThis, ECX);
+	enum { SkipGameCode = 0x707D81 };
 
-	if (!pThis)
-		return 0;
+	GET(HouseClass* const, pHouse, ECX);
 
-	HouseClass* pHouse = pThis->Owner;
-
-	if (!pHouse)
-		return 0;
-
-	auto const pHouseTypeExt = HouseTypeExt::Fetch(pHouse->Type);
+	auto const pHouseTypeExt = HouseTypeExt::ExtMap.Find(pHouse->Type);
 
 	if (pHouseTypeExt->Crew.isset())
-		R->EAX(pHouseTypeExt->Crew.Get());
+	{
+		R->ESI(pHouseTypeExt->Crew.Get());
+		return SkipGameCode;
+	}
 
 	return 0;
 }

--- a/src/Ext/HouseType/Hooks.cpp
+++ b/src/Ext/HouseType/Hooks.cpp
@@ -36,7 +36,7 @@ DEFINE_HOOK(0x68AD0C, ScenarioClass_ReadMap_SetEVAIndex, 0x7)
 	return 0;
 }
 
-// It takes effect when `Ares.dll` does not exist.
+// Ares has taken over TechnoClass_GetCrew, so usually it won't work.
 DEFINE_HOOK(0x707D40, TechnoClass_GetCrew_NationalOverride, 0x6)
 {
 	enum { SkipGameCode = 0x707D81 };

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -4,6 +4,7 @@
 
 #include <Ext/Aircraft/Body.h>
 #include <Ext/Building/Body.h>
+#include <Ext/HouseType/Body.h>
 #include <Ext/WarheadType/Body.h>
 #include <Ext/Sidebar/Body.h>
 #include <Ext/EBolt/Body.h>
@@ -245,6 +246,20 @@ static bool __fastcall AresHouseExt_UpdateKeepAlive(AresHouseExt* pExt_Ares, voi
 
 #pragma endregion
 
+#pragma region AresGetCrew
+
+static InfantryTypeClass* __fastcall AresHouseExt_GetCrew(HouseClass** pExt_Ares, void*)
+{
+	auto const pTypeExt = HouseTypeExt::Fetch((*pExt_Ares)->Type);
+
+	if (pTypeExt->Crew.isset())
+		return pTypeExt->Crew.Get();
+
+	return AresFunctions::GetSideCrew(pExt_Ares);
+}
+
+#pragma endregion
+
 DEFINE_HOOK(0x440580, BuildingClass_Unlimbo_UnitDeliveryFix, 0x5)
 {
 	if (UnitDeliveryTemp::Placing)
@@ -383,6 +398,9 @@ void Apply_Ares3_0_Patches()
 
 	// Ares' `KeepAlive` adds global tags.
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x21F70, GET_OFFSET(AresHouseExt_UpdateKeepAlive));
+
+	// Add a new custom crew for a country.
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4C836, GET_OFFSET(AresHouseExt_GetCrew));
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -504,4 +522,7 @@ void Apply_Ares3_0p1_Patches()
 
 	// Ares' `KeepAlive` adds global tags.
 	Patch::Apply_LJMP(AresHelper::AresBaseAddress + 0x229F0, GET_OFFSET(AresHouseExt_UpdateKeepAlive));
+
+	// Add a new custom crew for a country.
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4D496, GET_OFFSET(AresHouseExt_GetCrew));
 }

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -255,7 +255,7 @@ static InfantryTypeClass* __fastcall AresHouseExt_GetCrew(HouseClass** pExt_Ares
 	if (pTypeExt->Crew.isset())
 		return pTypeExt->Crew.Get();
 
-	return AresFunctions::GetSideCrew(pExt_Ares);
+	return AresFunctions::GetCrew(pExt_Ares);
 }
 
 #pragma endregion

--- a/src/Utilities/AresAddressInit.cpp
+++ b/src/Utilities/AresAddressInit.cpp
@@ -21,7 +21,7 @@ decltype(AresFunctions::GetTunnel) AresFunctions::GetTunnel = nullptr;
 decltype(AresFunctions::AddPassengerFromTunnel) AresFunctions::AddPassengerFromTunnel = nullptr;
 
 decltype(AresFunctions::ReverseEngineer) AresFunctions::ReverseEngineer = nullptr;
-decltype(AresFunctions::GetSideCrew) AresFunctions::GetSideCrew = nullptr;
+decltype(AresFunctions::GetCrew) AresFunctions::GetCrew = nullptr;
 
 decltype(AresFunctions::FindEVAIndex) AresFunctions::FindEVAIndex = nullptr;
 
@@ -73,7 +73,7 @@ void AresFunctions::InitAres3_0()
 
 	// HouseExt
 	NOTE_ARES_FUN(ReverseEngineer, 0x022360);
-	NOTE_ARES_FUN(GetSideCrew, 0x021230);
+	NOTE_ARES_FUN(GetCrew, 0x021230);
 
 	// VoxClass
 	NOTE_ARES_FUN(AresFunctions::FindEVAIndex, 0x063560);
@@ -125,7 +125,7 @@ void AresFunctions::InitAres3_0p1()
 
 	// HouseExt
 	NOTE_ARES_FUN(ReverseEngineer, 0x022DE0);
-	NOTE_ARES_FUN(GetSideCrew, 0x021CB0);
+	NOTE_ARES_FUN(GetCrew, 0x021CB0);
 
 	// VoxClass
 	NOTE_ARES_FUN(AresFunctions::FindEVAIndex, 0x0642B0);

--- a/src/Utilities/AresAddressInit.cpp
+++ b/src/Utilities/AresAddressInit.cpp
@@ -7,7 +7,6 @@
 decltype(AresFunctions::ConvertTypeTo) AresFunctions::ConvertTypeTo = nullptr;
 decltype(AresFunctions::CreateAresEBolt) AresFunctions::CreateAresEBolt = nullptr;
 decltype(AresFunctions::SpawnSurvivors) AresFunctions::SpawnSurvivors = nullptr;
-decltype(AresFunctions::ReverseEngineer) AresFunctions::ReverseEngineer = nullptr;
 decltype(AresFunctions::IsTargetConstraintsEligible) AresFunctions::IsTargetConstraintsEligible = nullptr;
 decltype(AresFunctions::UnitDeliveryStateMachine_Update) AresFunctions::UnitDeliveryStateMachine_Update = nullptr;
 decltype(AresFunctions::SetSpotlight) AresFunctions::SetSpotlight = nullptr;
@@ -20,6 +19,9 @@ PhobosMap<BombClass*, WeaponTypeClass**>* AresFunctions::BombExtMap = nullptr;
 
 decltype(AresFunctions::GetTunnel) AresFunctions::GetTunnel = nullptr;
 decltype(AresFunctions::AddPassengerFromTunnel) AresFunctions::AddPassengerFromTunnel = nullptr;
+
+decltype(AresFunctions::ReverseEngineer) AresFunctions::ReverseEngineer = nullptr;
+decltype(AresFunctions::GetSideCrew) AresFunctions::GetSideCrew = nullptr;
 
 decltype(AresFunctions::FindEVAIndex) AresFunctions::FindEVAIndex = nullptr;
 
@@ -46,8 +48,6 @@ void AresFunctions::InitAres3_0()
 		NOTE_ARES_FUN(SpawnSurvivors, 0x464C0);
 	}
 
-	NOTE_ARES_FUN(ReverseEngineer, 0x022360);
-
 	NOTE_ARES_FUN(IsTargetConstraintsEligible, 0x032110);
 
 	NOTE_ARES_FUN(UnitDeliveryStateMachine_Update, 0x075DE0);
@@ -70,6 +70,10 @@ void AresFunctions::InitAres3_0()
 	// BuildingTypeExt
 	NOTE_ARES_FUN(AresFunctions::GetTunnel, 0x0D740);
 	NOTE_ARES_FUN(AresFunctions::AddPassengerFromTunnel, 0x09000);
+
+	// HouseExt
+	NOTE_ARES_FUN(ReverseEngineer, 0x022360);
+	NOTE_ARES_FUN(GetSideCrew, 0x021230);
 
 	// VoxClass
 	NOTE_ARES_FUN(AresFunctions::FindEVAIndex, 0x063560);
@@ -96,8 +100,6 @@ void AresFunctions::InitAres3_0p1()
 		NOTE_ARES_FUN(SpawnSurvivors, 0x47030);
 	}
 
-	NOTE_ARES_FUN(ReverseEngineer, 0x022DE0);
-
 	NOTE_ARES_FUN(IsTargetConstraintsEligible, 0x032AF0);
 
 	NOTE_ARES_FUN(UnitDeliveryStateMachine_Update, 0x076E90);
@@ -120,6 +122,10 @@ void AresFunctions::InitAres3_0p1()
 	// BuildingTypeExt
 	NOTE_ARES_FUN(AresFunctions::GetTunnel, 0x0DA30);
 	NOTE_ARES_FUN(AresFunctions::AddPassengerFromTunnel, 0x09040);
+
+	// HouseExt
+	NOTE_ARES_FUN(ReverseEngineer, 0x022DE0);
+	NOTE_ARES_FUN(GetSideCrew, 0x021CB0);
 
 	// VoxClass
 	NOTE_ARES_FUN(AresFunctions::FindEVAIndex, 0x0642B0);

--- a/src/Utilities/AresFunctions.h
+++ b/src/Utilities/AresFunctions.h
@@ -33,8 +33,6 @@ public:
 
 	static void(__stdcall* SpawnSurvivors)(FootClass* pThis, TechnoClass* pKiller, bool Select, bool PreventEscape);
 
-	static bool(__thiscall* ReverseEngineer)(void* pAresHouseExt, TechnoTypeClass* pType);
-
 	static bool(__thiscall* IsTargetConstraintsEligible)(void*, HouseClass*, bool);
 
 	static void(__thiscall* UnitDeliveryStateMachine_Update)(void*);
@@ -56,6 +54,10 @@ public:
 	// BuildingTypeExt
 	static void* (__thiscall* GetTunnel)(void*, HouseClass*);
 	static void(__thiscall* AddPassengerFromTunnel)(void*, BuildingClass*, FootClass*);
+
+	// HouseExt
+	static bool(__thiscall* ReverseEngineer)(void*, TechnoTypeClass* pType);
+	static InfantryTypeClass* (__thiscall* GetSideCrew)(void*);
 
 	// VoxClass
 	static int(__stdcall* FindEVAIndex)(const char* buffer);

--- a/src/Utilities/AresFunctions.h
+++ b/src/Utilities/AresFunctions.h
@@ -57,7 +57,7 @@ public:
 
 	// HouseExt
 	static bool(__thiscall* ReverseEngineer)(void*, TechnoTypeClass* pType);
-	static InfantryTypeClass* (__thiscall* GetSideCrew)(void*);
+	static InfantryTypeClass* (__thiscall* GetCrew)(void*);
 
 	// VoxClass
 	static int(__stdcall* FindEVAIndex)(const char* buffer);


### PR DESCRIPTION
Fixes an issue in PR [#2342](https://github.com/Phobos-developers/Phobos/pull/2342).

In fact, TechnoType has micro-level custom settings such as `Survivor.Side0`, `Survivor.Side1`, and so on; the `Crew` specified by the country should not override them.

