### PR TITLE
Customize Flying spawn when the unit is produced

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -161,6 +161,7 @@ This page lists all the individual contributions to the project by their author.
   - Unit & infantry auto-conversion on ammo change
   - Restore the ScriptType action#24 `Play speech` from Tiberian Sun
   - Modify ammo on impact
+  - Flying production
 - **Starkku**:
   - Misc. minor bugfixes & improvements
   - AI script actions:
@@ -962,3 +963,4 @@ This page lists all the individual contributions to the project by their author.
 - **Nuke** - Reload speed adjustment on promotion
 - **frg2089 (舰队的偶像-岛风酱!)** - Fix `Slaved.OwnerWhenMasterKilled` not being respected when the master is sold or self-destructed
 - **weiyongxuan** - Extended `CanTargetHouses` to allow targeting neutral houses
+

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2127,8 +2127,10 @@ FLHKEY.BurstN=  ; integer - Forward,Lateral,Height. FLHKey refers to weapon-spec
 ### Flying production
 
 - Now you can allow produced units to spawn directly in the air at customizable altitudes and locations without being constrained by traditional factory ground exit paths.
-  - `FlyingProduction` controls whether this unit type uses flying production.
-  - `FlyingProduction.SpawnHeight` determines the initial spawn altitude in leptons along the Z-axis. If resolved to 0 or negative, flying production will not be used and the unit exits normally.
+  - `FlyingProduction.Jumpjet` on `[General]` sets the global default for whether units with locomotor `Jumpjet` use flying production. Defaults to `false`.
+  - `FlyingProduction.Aircraft` on `[General]` sets the global default for whether units with locomotor `Fly` (or AircraftTypes) use flying production. Defaults to `false`.
+  - `FlyingProduction` controls whether this unit type uses flying production. Defaults to `[General] -> FlyingProduction.Jumpjet` for jumpjets, `[General] -> FlyingProduction.Aircraft` for aircraft/fly units, or `false` for others.
+  - `FlyingProduction.SpawnHeight` determines the initial spawn altitude in leptons along the Z-axis. Defaults to `JumpjetHeight` (or `[JumpjetControls] -> CruiseHeight`) for Jumpjets, and `FlightLevel` (or `[General] -> FlightLevel`) for aircraft. If the spawn altitude is greater than the unit's normal cruising altitude, the unit will descend vertically in place to its cruising altitude before executing its move order to the rally point. If resolved to 0 or negative, flying production will not be used and the unit exits normally.
   - `FlyingProduction.PlayFactoryAnim` controls whether the producing factory plays its unloading door/exit animation.
   - `FlyingProduction.SpawnAnim` specifies an animation to play at the aerial spawn coordinates when the unit is created.
   - `FlyingProduction.SpawnAnim.AttachedToObject` determines whether `FlyingProduction.SpawnAnim` is attached to the spawned unit and follows its movement.
@@ -2137,13 +2139,17 @@ FLHKEY.BurstN=  ; integer - Forward,Lateral,Height. FLHKey refers to weapon-spec
   - `FlyingProduction.SpawnOffset` on `[BuildingType]` sets a 2D coordinate offset in leptons (X, Y) relative to the center of the structure for positioning the spawn point.
   - `FlyingProduction.SpawnHeight` on `[BuildingType]` overrides the spawn altitude for units appearing at this structure.
   - `FlyingProduction.SpawnFacing` on `[BuildingType]` specifies the facing (0-255) the unit takes upon spawning, as well as the exit direction if no rally point exists.
-  - `FlyingProduction.RallyPoint` on `[BuildingType]` enables rally point placement on structures that are not standard vehicle or infantry factories (e.g. helipads or towers), allowing them to establish a rally point with EVA confirmation and tactical line.
+  - `HasRallyPoint` on `[BuildingType]` controls whether the building can establish a rally point. If set to `true`, enables rally point placement on structures that are not standard vehicle or infantry factories (e.g. helipads or towers), allowing them to establish a rally point with EVA confirmation and tactical line. If set to `false`, disables rally point capability even on factories. If omitted, standard vanilla factory behavior is preserved.
 
 In `rulesmd.ini`:
 ```ini
+[General]
+FlyingProduction.Jumpjet=false             ; boolean
+FlyingProduction.Aircraft=false            ; boolean
+
 [SOMETECHNO]                               ; TechnoType
-FlyingProduction=false                     ; boolean
-FlyingProduction.SpawnHeight=              ; integer, defaults to FlightLevel or [General] -> FlightLevel
+FlyingProduction=                          ; boolean, defaults to [General] -> FlyingProduction.Jumpjet / FlyingProduction.Aircraft
+FlyingProduction.SpawnHeight=              ; integer, defaults to JumpjetHeight or FlightLevel
 FlyingProduction.PlayFactoryAnim=false     ; boolean
 FlyingProduction.SpawnAnim=                ; AnimType
 FlyingProduction.SpawnAnim.AttachedToObject=false ; boolean
@@ -2154,7 +2160,7 @@ FlyingProduction.RallyPointFromSpawnBuilding=false ; boolean
 FlyingProduction.SpawnOffset=0,0           ; Point2D, leptons
 FlyingProduction.SpawnHeight=              ; integer, defaults to the spawned unit's FlyingProduction.SpawnHeight
 FlyingProduction.SpawnFacing=              ; DirType (0-255), defaults to the building's facing (128 / South)
-FlyingProduction.RallyPoint=false          ; boolean
+HasRallyPoint=                             ; boolean, defaults to vanilla behavior
 ```
 
 ### Forcing specific weapon against certain targets

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2103,6 +2103,39 @@ In `artmd.ini`:
 FLHKEY.BurstN=  ; integer - Forward,Lateral,Height. FLHKey refers to weapon-specific FLH key name and N is zero-based burst shot index.
 ```
 
+### Flying production
+
+- Now you can allow produced units to spawn directly in the air at customizable altitudes and locations without being constrained by traditional factory ground exit paths.
+  - `FlyingProduction` controls whether this unit type uses flying production.
+  - `FlyingProduction.SpawnHeight` determines the initial spawn altitude in leptons along the Z-axis. If resolved to 0 or negative, flying production will not be used and the unit exits normally.
+  - `FlyingProduction.PlayFactoryAnim` controls whether the producing factory plays its unloading door/exit animation.
+  - `FlyingProduction.SpawnAnim` specifies an animation to play at the aerial spawn coordinates when the unit is created.
+  - `FlyingProduction.SpawnAnim.AttachedToObject` determines whether `FlyingProduction.SpawnAnim` is attached to the spawned unit and follows its movement.
+  - `FlyingProduction.SpawnAt` accepts a list of BuildingTypes indicating where the unit should spawn, evaluated in priority order from left to right. When multiple buildings of that type exist, it prioritizes the producing factory itself if it matches, then any building marked as primary, and otherwise the closest one to the producing factory. If none of the candidate buildings exist or are alive, it falls back to the producing factory.
+  - `FlyingProduction.RallyPointFromSpawnBuilding` determines whether the unit targets the spawn building's rally point instead of the producing factory's rally point.
+  - `FlyingProduction.SpawnOffset` on `[BuildingType]` sets a 2D coordinate offset in leptons (X, Y) relative to the center of the structure for positioning the spawn point.
+  - `FlyingProduction.SpawnHeight` on `[BuildingType]` overrides the spawn altitude for units appearing at this structure.
+  - `FlyingProduction.SpawnFacing` on `[BuildingType]` specifies the facing (0-255) the unit takes upon spawning, as well as the exit direction if no rally point exists.
+  - `FlyingProduction.RallyPoint` on `[BuildingType]` enables rally point placement on structures that are not standard vehicle or infantry factories (e.g. helipads or towers), allowing them to establish a rally point with EVA confirmation and tactical line.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                               ; TechnoType
+FlyingProduction=false                     ; boolean
+FlyingProduction.SpawnHeight=              ; integer, defaults to FlightLevel or [General] -> FlightLevel
+FlyingProduction.PlayFactoryAnim=false     ; boolean
+FlyingProduction.SpawnAnim=                ; AnimType
+FlyingProduction.SpawnAnim.AttachedToObject=false ; boolean
+FlyingProduction.SpawnAt=                  ; List of BuildingTypes
+FlyingProduction.RallyPointFromSpawnBuilding=false ; boolean
+
+[SOMEBUILDING]                             ; BuildingType
+FlyingProduction.SpawnOffset=0,0           ; Point2D, leptons
+FlyingProduction.SpawnHeight=              ; integer, defaults to the spawned unit's FlyingProduction.SpawnHeight
+FlyingProduction.SpawnFacing=              ; DirType (0-255), defaults to the building's facing (128 / South)
+FlyingProduction.RallyPoint=false          ; boolean
+```
+
 ### Forcing specific weapon against certain targets
 
 ![image](_static/images/underwater-new-attack-tag.gif)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -424,6 +424,7 @@ HideShakeEffects=false           ; boolean
 :open:
 
 #### New:
+- [Flying production](New-or-Enhanced-Logics.md#flying-production) (by FS-21)
 - [Customized transport plane for teams](AI-Scripting-and-Mapping.md#customized-transport-plane-for-teams) (by FlyStar)
 - [Modify ammo on impact](New-or-Enhanced-Logics.md#modify-ammo-on-impact) (by FS-21)
 - [Customize ivan bomb visibility](Fixed-or-Improved-Logics.md#customize-ivan-bomb-visibility) (by NetsuNegi)

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -477,6 +477,9 @@ msgstr "复原了《泰伯利亚之日》中的动作脚本 `24 - 播放语音`"
 msgid "Modify ammo on impact"
 msgstr "修改弹药弹头"
 
+msgid "Flying production"
+msgstr "飞行生产"
+
 msgid "**Starkku**:"
 msgstr "**Starkku**："
 
@@ -3307,4 +3310,5 @@ msgid ""
 "**weiyongxuan** - Extended `CanTargetHouses` to allow targeting neutral "
 "houses"
 msgstr "**weiyongxuan** - 扩展 `CanTargetHouses` 以允许瞄准中立所属方"
+
 

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -7580,11 +7580,17 @@ msgid ""
 msgstr ""
 "现在你可以允许生产出的单位直接在空中指定高度和位置生成，而不再受传统工厂地面出厂路径的限制。"
 
-msgid "`FlyingProduction` controls whether this unit type uses flying production."
-msgstr "`FlyingProduction` 控制此单位类型是否启用飞行生产逻辑。"
+msgid "`FlyingProduction.Jumpjet` on `[General]` sets the global default for whether units with locomotor `Jumpjet` use flying production. Defaults to `false`."
+msgstr "`[General]` 上的 `FlyingProduction.Jumpjet` 设置具有 `Jumpjet` 移动类型的单位是否默认启用飞行生产逻辑。默认为 `false`。"
 
-msgid "`FlyingProduction.SpawnHeight` determines the initial spawn altitude in leptons along the Z-axis. If resolved to 0 or negative, flying production will not be used and the unit exits normally."
-msgstr "`FlyingProduction.SpawnHeight` 决定沿 Z 轴的初始生成高度（以 lepton 为单位）。如果最终解析为 0 或负数，则不会使用飞行生产逻辑（单位将正常从地面出厂）。"
+msgid "`FlyingProduction.Aircraft` on `[General]` sets the global default for whether units with locomotor `Fly` (or AircraftTypes) use flying production. Defaults to `false`."
+msgstr "`[General]` 上的 `FlyingProduction.Aircraft` 设置具有 `Fly` 移动类型的单位（或飞机类型）是否默认启用飞行生产逻辑。默认为 `false`。"
+
+msgid "`FlyingProduction` controls whether this unit type uses flying production. Defaults to `[General] -> FlyingProduction.Jumpjet` for jumpjets, `[General] -> FlyingProduction.Aircraft` for aircraft/fly units, or `false` for others."
+msgstr "`FlyingProduction` 控制此单位类型是否启用飞行生产逻辑。火箭飞行兵单位默认遵循 `[General] -> FlyingProduction.Jumpjet`，飞机/飞行单位默认遵循 `[General] -> FlyingProduction.Aircraft`，其余单位默认为 `false`。"
+
+msgid "`FlyingProduction.SpawnHeight` determines the initial spawn altitude in leptons along the Z-axis. Defaults to `JumpjetHeight` (or `[JumpjetControls] -> CruiseHeight`) for Jumpjets, and `FlightLevel` (or `[General] -> FlightLevel`) for aircraft. If the spawn altitude is greater than the unit's normal cruising altitude, the unit will descend vertically in place to its cruising altitude before executing its move order to the rally point. If resolved to 0 or negative, flying production will not be used and the unit exits normally."
+msgstr "`FlyingProduction.SpawnHeight` 决定沿 Z 轴的初始生成高度（以 lepton 为单位）。火箭飞行兵默认遵循 `JumpjetHeight`（或 `[JumpjetControls] -> CruiseHeight`），飞机默认遵循 `FlightLevel`（或 `[General] -> FlightLevel`）。若生成高度高于单位的正常巡航高度，单位将先在原地垂直下降至巡航高度，再执行前往集结点的移动指令。如果最终解析为 0 或负数，则不会使用飞行生产逻辑（单位将正常从地面出厂）。"
 
 msgid "`FlyingProduction.PlayFactoryAnim` controls whether the producing factory plays its unloading door/exit animation."
 msgstr "`FlyingProduction.PlayFactoryAnim` 控制生产该单位的工厂是否播放卸载/开门动画。"
@@ -7610,7 +7616,7 @@ msgstr "`[BuildingType]` 上的 `FlyingProduction.SpawnHeight` 覆盖在此建�
 msgid "`FlyingProduction.SpawnFacing` on `[BuildingType]` specifies the facing (0-255) the unit takes upon spawning, as well as the exit direction if no rally point exists."
 msgstr "`[BuildingType]` 上的 `FlyingProduction.SpawnFacing` 指定单位生成时的朝向（0-255），若无集结点则同时作为离开建筑的移动方向。"
 
-msgid "`FlyingProduction.RallyPoint` on `[BuildingType]` enables rally point placement on structures that are not standard vehicle or infantry factories (e.g. helipads or towers), allowing them to establish a rally point with EVA confirmation and tactical line."
-msgstr "`[BuildingType]` 上的 `FlyingProduction.RallyPoint` 允许在非传统车辆或步兵工厂的建筑（如停机坪、防御塔等）上设置集结点，支持 EVA 语音确认及战术虚线显示。"
+msgid "`HasRallyPoint` on `[BuildingType]` controls whether the building can establish a rally point. If set to `true`, enables rally point placement on structures that are not standard vehicle or infantry factories (e.g. helipads or towers), allowing them to establish a rally point with EVA confirmation and tactical line. If set to `false`, disables rally point capability even on factories. If omitted, standard vanilla factory behavior is preserved."
+msgstr "`[BuildingType]` 上的 `HasRallyPoint` 控制该建筑是否可以设置集结点。设为 `true` 时，允许在非标准车辆或步兵工厂的建筑（如停机坪或防御塔）上设置集结点，支持 EVA 语音确认及战术虚线；设为 `false` 时，即使是工厂也会禁用集结点功能；若省略，则保留原版工厂的默认行为。"
 
 

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -7572,3 +7572,45 @@ msgid ""
 "the weapon to be able to fire at cells containing no TechnoTypes."
 msgstr "`CanTarget` 要求明确列出 `all` 或 `empty` 才能对不包含任何科技类型的单元格开火。"
 
+msgid "Flying production"
+msgstr "飞行生产"
+
+msgid ""
+"Now you can allow produced units to spawn directly in the air at customizable altitudes and locations without being constrained by traditional factory ground exit paths."
+msgstr ""
+"现在你可以允许生产出的单位直接在空中指定高度和位置生成，而不再受传统工厂地面出厂路径的限制。"
+
+msgid "`FlyingProduction` controls whether this unit type uses flying production."
+msgstr "`FlyingProduction` 控制此单位类型是否启用飞行生产逻辑。"
+
+msgid "`FlyingProduction.SpawnHeight` determines the initial spawn altitude in leptons along the Z-axis. If resolved to 0 or negative, flying production will not be used and the unit exits normally."
+msgstr "`FlyingProduction.SpawnHeight` 决定沿 Z 轴的初始生成高度（以 lepton 为单位）。如果最终解析为 0 或负数，则不会使用飞行生产逻辑（单位将正常从地面出厂）。"
+
+msgid "`FlyingProduction.PlayFactoryAnim` controls whether the producing factory plays its unloading door/exit animation."
+msgstr "`FlyingProduction.PlayFactoryAnim` 控制生产该单位的工厂是否播放卸载/开门动画。"
+
+msgid "`FlyingProduction.SpawnAnim` specifies an animation to play at the aerial spawn coordinates when the unit is created."
+msgstr "`FlyingProduction.SpawnAnim` 指定单位生成时在空中生成坐标处播放的动画。"
+
+msgid "`FlyingProduction.SpawnAnim.AttachedToObject` determines whether `FlyingProduction.SpawnAnim` is attached to the spawned unit and follows its movement."
+msgstr "`FlyingProduction.SpawnAnim.AttachedToObject` 决定 `FlyingProduction.SpawnAnim` 是否附加到生成的单位上并随其移动。"
+
+msgid "`FlyingProduction.SpawnAt` accepts a list of BuildingTypes indicating where the unit should spawn, evaluated in priority order from left to right. When multiple buildings of that type exist, it prioritizes the producing factory itself if it matches, then any building marked as primary, and otherwise the closest one to the producing factory. If none of the candidate buildings exist or are alive, it falls back to the producing factory."
+msgstr "`FlyingProduction.SpawnAt` 接受一个 BuildingType 列表，按从左至右的优先级顺序判断单位应在哪些建筑处生成。当存在多个该类型的建筑时，若生产该单位的工厂自身匹配则直接优先使用，其次优先选择被设为主要建筑（Primary）的建筑，否则选择距生产工厂最近的建筑。如果列表中候选建筑均不存在或已损毁，则回退至生产该单位的工厂。"
+
+msgid "`FlyingProduction.RallyPointFromSpawnBuilding` determines whether the unit targets the spawn building's rally point instead of the producing factory's rally point."
+msgstr "`FlyingProduction.RallyPointFromSpawnBuilding` 决定单位是否以实际生成建筑的集结点（Rally Point）为目标，而不是生产工厂的集结点。"
+
+msgid "`FlyingProduction.SpawnOffset` on `[BuildingType]` sets a 2D coordinate offset in leptons (X, Y) relative to the center of the structure for positioning the spawn point."
+msgstr "`[BuildingType]` 上的 `FlyingProduction.SpawnOffset` 设置相对于建筑中心的 2D 坐标偏移（X, Y，以 lepton 为单位），用于精确定位生成点。"
+
+msgid "`FlyingProduction.SpawnHeight` on `[BuildingType]` overrides the spawn altitude for units appearing at this structure."
+msgstr "`[BuildingType]` 上的 `FlyingProduction.SpawnHeight` 覆盖在此建筑处生成的单位的生成高度。"
+
+msgid "`FlyingProduction.SpawnFacing` on `[BuildingType]` specifies the facing (0-255) the unit takes upon spawning, as well as the exit direction if no rally point exists."
+msgstr "`[BuildingType]` 上的 `FlyingProduction.SpawnFacing` 指定单位生成时的朝向（0-255），若无集结点则同时作为离开建筑的移动方向。"
+
+msgid "`FlyingProduction.RallyPoint` on `[BuildingType]` enables rally point placement on structures that are not standard vehicle or infantry factories (e.g. helipads or towers), allowing them to establish a rally point with EVA confirmation and tactical line."
+msgstr "`[BuildingType]` 上的 `FlyingProduction.RallyPoint` 允许在非传统车辆或步兵工厂的建筑（如停机坪、防御塔等）上设置集结点，支持 EVA 语音确认及战术虚线显示。"
+
+

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -6696,3 +6696,7 @@ msgstr "现在侧边栏拓展工具条可以超出侧边栏边界（by Belonit�
 msgid "Lifted stupidly small limit for tooltip character amount (by Belonit)"
 msgstr "解除了拓展工具条字符数量小得愚蠢的上限（by Belonit）"
 
+msgid "[Flying production](New-or-Enhanced-Logics.md#flying-production) (by FS-21)"
+msgstr "[飞行生产](New-or-Enhanced-Logics.md#flying-production)（by FS-21）"
+
+

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -123,6 +123,6 @@ public:
 	static void __fastcall KickOutClone(std::pair<TechnoTypeClass*, HouseClass*>& info, void*, BuildingClass* pFactory);
 	static int GetTurretFrame(BuildingClass* pThis);
 	static bool BuildingOnline(BuildingClass* pThis);
-	static bool TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass* pProduction);
+	static KickOutResult TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass* pProduction);
 };
 

--- a/src/Ext/Building/Body.h
+++ b/src/Ext/Building/Body.h
@@ -123,5 +123,6 @@ public:
 	static void __fastcall KickOutClone(std::pair<TechnoTypeClass*, HouseClass*>& info, void*, BuildingClass* pFactory);
 	static int GetTurretFrame(BuildingClass* pThis);
 	static bool BuildingOnline(BuildingClass* pThis);
+	static bool TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass* pProduction);
 };
 

--- a/src/Ext/Building/Hooks.Production.cpp
+++ b/src/Ext/Building/Hooks.Production.cpp
@@ -1,6 +1,15 @@
 #include "Body.h"
 
+#include <Ext/Foot/Body.h>
 #include <Ext/House/Body.h>
+#include <Ext/TechnoType/Body.h>
+#include <AircraftClass.h>
+#include <AnimClass.h>
+#include <CellClass.h>
+#include <FlyLocomotionClass.h>
+#include <JumpjetLocomotionClass.h>
+#include <Unsorted.h>
+#include <Utilities/Debug.h>
 
 DEFINE_HOOK(0x4401BB, BuildingClass_AI_PickWithFreeDocks, 0x6)
 {
@@ -246,3 +255,291 @@ DEFINE_HOOK(0x4449FB, BuildingClass_KickOutUnit_CloningVats, 0x8)
 
 	return SkipGameCode;
 }
+
+bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass* pProduction)
+{
+	if (!pFactory || !pProduction)
+		return false;
+
+	if (pFactory->GetCurrentMission() == Mission::Construction)
+		return false;
+
+	auto const pType = pProduction->GetTechnoType();
+	if (!pType)
+		return false;
+
+	auto const pTypeExt = TechnoTypeExt::Fetch(pType);
+	if (!pTypeExt || !pTypeExt->FlyingProduction)
+		return false;
+
+	BuildingClass* pSpawnBuilding = nullptr;
+
+	if (!pTypeExt->FlyingProduction_SpawnAt.empty())
+	{
+		for (auto const pTargetType : pTypeExt->FlyingProduction_SpawnAt)
+		{
+			if (!pTargetType)
+				continue;
+
+			if (pFactory->Type == pTargetType)
+			{
+				pSpawnBuilding = pFactory;
+				break;
+			}
+
+			BuildingClass* pPrimaryCandidate = nullptr;
+			BuildingClass* pClosestCandidate = nullptr;
+			int minDistance = (std::numeric_limits<int>::max)();
+
+			for (auto const pBld : pFactory->Owner->Buildings)
+			{
+				if (!pBld || !pBld->IsAlive || pBld->InLimbo || pBld->Health <= 0 || pBld->GetCurrentMission() == Mission::Selling)
+					continue;
+
+				if (pBld->Type == pTargetType)
+				{
+					if (pBld->IsPrimaryFactory && !pPrimaryCandidate)
+						pPrimaryCandidate = pBld;
+
+					const int dist = pFactory->DistanceFrom(pBld);
+					if (dist < minDistance)
+					{
+						minDistance = dist;
+						pClosestCandidate = pBld;
+					}
+				}
+			}
+
+			if (auto const pCandidate = pPrimaryCandidate ? pPrimaryCandidate : pClosestCandidate)
+			{
+				pSpawnBuilding = pCandidate;
+				break;
+			}
+		}
+	}
+
+	if (!pSpawnBuilding)
+		pSpawnBuilding = pFactory;
+
+	auto const pSpawnBldTypeExt = BuildingTypeExt::Fetch(pSpawnBuilding->Type);
+
+	int height = pTypeExt->FlyingProduction_SpawnHeight.Get();
+	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnHeight.isset())
+		height = pSpawnBldTypeExt->FlyingProduction_SpawnHeight.Get();
+
+	if (height <= 0)
+		return false;
+
+	CoordStruct spawnCoords = pSpawnBuilding->GetCoords();
+	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnOffset.isset())
+	{
+		const auto& offset = pSpawnBldTypeExt->FlyingProduction_SpawnOffset.Get();
+		spawnCoords.X += offset.X;
+		spawnCoords.Y += offset.Y;
+	}
+	spawnCoords.Z += height;
+
+	DirStruct facing = pSpawnBuilding->PrimaryFacing.Current();
+	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnFacing.isset())
+		facing = DirStruct(pSpawnBldTypeExt->FlyingProduction_SpawnFacing.Get());
+
+	pProduction->SetOwningHouse(pFactory->Owner, true);
+
+	bool unlimboSuccess = false;
+	{
+		struct ScenarioInitGuard
+		{
+			ScenarioInitGuard() { ++Unsorted::ScenarioInit; }
+			~ScenarioInitGuard() { --Unsorted::ScenarioInit; }
+		} guard;
+
+		unlimboSuccess = pProduction->Unlimbo(spawnCoords, facing.GetDir());
+	}
+
+	if (!unlimboSuccess)
+		return false;
+
+	pProduction->SetLocation(spawnCoords);
+	pProduction->Location = spawnCoords;
+	pProduction->InAir = true;
+	pProduction->IsALoaner = false;
+	pProduction->UnmarkAllOccupationBits(spawnCoords);
+	pProduction->PrimaryFacing.SetCurrent(facing);
+	pProduction->PrimaryFacing.SetDesired(facing);
+
+	if (auto const pFoot = abstract_cast<FootClass*>(pProduction))
+	{
+		if (auto const pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor))
+		{
+			pJJLoco->CurrentHeight = height;
+			pJJLoco->LocomotionFacing.SetCurrent(facing);
+			pJJLoco->LocomotionFacing.SetDesired(facing);
+			pFoot->Jumpjet_OccupyCell(CellClass::Coord2Cell(spawnCoords));
+
+			if (height < pJJLoco->Height)
+			{
+				pJJLoco->State = JumpjetLocomotionClass::State::Ascending;
+				FootExt::Fetch(pFoot)->JumpjetStraightAscend = true;
+			}
+			else
+			{
+				pJJLoco->State = JumpjetLocomotionClass::State::Hovering;
+			}
+		}
+		else if (auto const pFlyLoco = locomotion_cast<FlyLocomotionClass*>(pFoot->Locomotor))
+		{
+			const auto pFootType = pFoot->GetTechnoType();
+			const int cruiseFlightLevel = pFootType->GetFlightLevel();
+			const int targetFlightLevel = cruiseFlightLevel > 0 ? cruiseFlightLevel : (RulesClass::Instance ? RulesClass::Instance->FlightLevel : height);
+			pFlyLoco->FlightLevel = targetFlightLevel;
+			pFlyLoco->CurrentSpeed = 0.0;
+			pFlyLoco->TargetSpeed = 0.0;
+			pFlyLoco->IsTakingOff = height < targetFlightLevel ? 1 : 0;
+			pFlyLoco->IsLanding = false;
+		}
+	}
+
+	if (auto const pAircraft = abstract_cast<AircraftClass*>(pProduction))
+		pAircraft->SetHeight(height);
+
+	if (auto const pAnimType = pTypeExt->FlyingProduction_SpawnAnim.Get())
+	{
+		if (auto const pAnim = GameCreate<AnimClass>(pAnimType, spawnCoords))
+		{
+			if (pTypeExt->FlyingProduction_SpawnAnim_AttachedToObject.Get())
+				pAnim->SetOwnerObject(pProduction);
+		}
+	}
+
+	AbstractClass* pRallyTarget = nullptr;
+	if (pTypeExt->FlyingProduction_RallyPointFromSpawnBuilding.Get() && pSpawnBuilding->ArchiveTarget)
+		pRallyTarget = pSpawnBuilding->ArchiveTarget;
+	else
+		pRallyTarget = pFactory->ArchiveTarget;
+
+	if (pRallyTarget && pRallyTarget != pSpawnBuilding)
+	{
+		pProduction->SetDestination(pRallyTarget, true);
+		pProduction->QueueMission(Mission::Move, true);
+	}
+	else
+	{
+		// No rally point set: give an exit nudge away from the spawn building in the facing direction
+		// to prevent units from remaining frozen directly over the building or blocking subsequent spawns.
+		const auto pBldType = pSpawnBuilding->Type;
+		const int nudgeDistance = std::max({ static_cast<int>(pBldType->GetFoundationWidth()), static_cast<int>(pBldType->GetFoundationHeight(true)), 2 }) / 2 + 1;
+		auto pDestCell = MapClass::Instance.GetCellAt(spawnCoords);
+		const auto facingType = static_cast<FacingType>(facing.GetValue<3>());
+
+		for (int i = 0; i < nudgeDistance; ++i)
+		{
+			if (auto const pNext = pDestCell->GetNeighbourCell(facingType))
+				pDestCell = pNext;
+		}
+
+		if (pDestCell)
+		{
+			pProduction->SetDestination(pDestCell, true);
+			pProduction->QueueMission(Mission::Move, true);
+		}
+		else
+		{
+			pProduction->Scatter(CoordStruct::Empty, true, false);
+			pProduction->QueueMission(Mission::Guard, true);
+		}
+	}
+
+	if (pTypeExt->FlyingProduction_PlayFactoryAnim.Get())
+		pFactory->QueueMission(Mission::Unload, false);
+
+	if (auto const pOwner = pFactory->Owner)
+	{
+		auto const pHouseExt = HouseExt::Fetch(pOwner);
+		auto const abs = pProduction->WhatAmI();
+
+		if (abs == AbstractType::Unit)
+		{
+			if (auto const pUnit = abstract_cast<UnitClass*>(pProduction))
+			{
+				if (pUnit->Type->Naval)
+				{
+					if (pHouseExt)
+						pHouseExt->ProducingNavalUnitTypeIndex = -1;
+				}
+				else
+				{
+					pOwner->ProducingUnitTypeIndex = -1;
+				}
+			}
+		}
+		else if (abs == AbstractType::Aircraft)
+		{
+			pOwner->ProducingAircraftTypeIndex = -1;
+		}
+		else if (abs == AbstractType::Infantry)
+		{
+			pOwner->ProducingInfantryTypeIndex = -1;
+		}
+		else if (abs == AbstractType::Building)
+		{
+			pOwner->ProducingBuildingTypeIndex = -1;
+		}
+
+		if (pHouseExt)
+		{
+			if (pHouseExt->Factory_VehicleType == pFactory)
+				pHouseExt->Factory_VehicleType = nullptr;
+			if (pHouseExt->Factory_NavyType == pFactory)
+				pHouseExt->Factory_NavyType = nullptr;
+			if (pHouseExt->Factory_InfantryType == pFactory)
+				pHouseExt->Factory_InfantryType = nullptr;
+			if (pHouseExt->Factory_AircraftType == pFactory)
+				pHouseExt->Factory_AircraftType = nullptr;
+			if (pHouseExt->Factory_BuildingType == pFactory)
+				pHouseExt->Factory_BuildingType = nullptr;
+		}
+
+		if (!pFactory->Type->Cloning)
+		{
+			auto info = std::make_pair(pType, pOwner);
+			for (const auto pVat : pOwner->CloningVats)
+				BuildingExt::KickOutClone(info, 0, pVat);
+		}
+	}
+
+	return true;
+}
+
+DEFINE_HOOK(0x443C60, BuildingClass_KickOutUnit_FlyingProduction, 0x6)
+{
+	enum { DoneSucceeded = 0x4456A2 };
+
+	GET(BuildingClass*, pFactory, ECX);
+	GET_STACK(TechnoClass*, pProduction, 0x4);
+
+	if (BuildingExt::TrySpawnFlyingProduction(pFactory, pProduction))
+	{
+		R->EAX(static_cast<int>(KickOutResult::Succeeded));
+		return DoneSucceeded;
+	}
+
+	return 0;
+}
+
+DEFINE_HOOK(0x455DA0, BuildingClass_IsUnitFactory_FlyingProduction, 0x6)
+{
+	enum { ReturnTrue = 0x455DCD };
+
+	GET(BuildingClass*, pThis, ECX);
+
+	if (auto const pTypeExt = BuildingTypeExt::Fetch(pThis->Type))
+	{
+		if (pTypeExt->FlyingProduction_RallyPoint.Get())
+			return ReturnTrue;
+	}
+
+	return 0;
+}
+
+
+

--- a/src/Ext/Building/Hooks.Production.cpp
+++ b/src/Ext/Building/Hooks.Production.cpp
@@ -258,10 +258,7 @@ DEFINE_HOOK(0x4449FB, BuildingClass_KickOutUnit_CloningVats, 0x8)
 
 bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass* pProduction)
 {
-	if (!pFactory || !pProduction)
-		return false;
-
-	if (pFactory->GetCurrentMission() == Mission::Construction)
+	if (!pFactory || !pProduction || pFactory->GetCurrentMission() == Mission::Construction)
 		return false;
 
 	auto const pType = pProduction->GetTechnoType();
@@ -272,6 +269,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	if (!pTypeExt || !pTypeExt->FlyingProduction)
 		return false;
 
+	// Resolve which building should physically spawn the unit
 	BuildingClass* pSpawnBuilding = nullptr;
 
 	if (!pTypeExt->FlyingProduction_SpawnAt.empty())
@@ -281,6 +279,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 			if (!pTargetType)
 				continue;
 
+			// If the factory itself matches this target type, it takes immediate precedence
 			if (pFactory->Type == pTargetType)
 			{
 				pSpawnBuilding = pFactory;
@@ -298,8 +297,12 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 
 				if (pBld->Type == pTargetType)
 				{
-					if (pBld->IsPrimaryFactory && !pPrimaryCandidate)
+					if (pBld->IsPrimaryFactory)
+					{
+						// Primary factory has absolute priority; no need to evaluate remaining buildings
 						pPrimaryCandidate = pBld;
+						break;
+					}
 
 					const int dist = pFactory->DistanceFrom(pBld);
 					if (dist < minDistance)
@@ -323,6 +326,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 
 	auto const pSpawnBldTypeExt = BuildingTypeExt::Fetch(pSpawnBuilding->Type);
 
+	// Determine spawn height, offset, and facing
 	int height = pTypeExt->FlyingProduction_SpawnHeight.Get();
 	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnHeight.isset())
 		height = pSpawnBldTypeExt->FlyingProduction_SpawnHeight.Get();
@@ -343,6 +347,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnFacing.isset())
 		facing = DirStruct(pSpawnBldTypeExt->FlyingProduction_SpawnFacing.Get());
 
+	// Unlimbo unit in the air safely using ScenarioInitGuard
 	pProduction->SetOwningHouse(pFactory->Owner, true);
 
 	bool unlimboSuccess = false;
@@ -359,6 +364,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	if (!unlimboSuccess)
 		return false;
 
+	// Establish aerial state and position
 	pProduction->SetLocation(spawnCoords);
 	pProduction->Location = spawnCoords;
 	pProduction->InAir = true;
@@ -367,6 +373,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	pProduction->PrimaryFacing.SetCurrent(facing);
 	pProduction->PrimaryFacing.SetDesired(facing);
 
+	// Configure locomotor (Jumpjet / Aircraft)
 	if (auto const pFoot = abstract_cast<FootClass*>(pProduction))
 	{
 		if (auto const pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor))
@@ -402,6 +409,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	if (auto const pAircraft = abstract_cast<AircraftClass*>(pProduction))
 		pAircraft->SetHeight(height);
 
+	// Spawn visual effects
 	if (auto const pAnimType = pTypeExt->FlyingProduction_SpawnAnim.Get())
 	{
 		if (auto const pAnim = GameCreate<AnimClass>(pAnimType, spawnCoords))
@@ -411,6 +419,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 		}
 	}
 
+	// Direct unit towards rally point or nudge away from factory
 	AbstractClass* pRallyTarget = nullptr;
 	if (pTypeExt->FlyingProduction_RallyPointFromSpawnBuilding.Get() && pSpawnBuilding->ArchiveTarget)
 		pRallyTarget = pSpawnBuilding->ArchiveTarget;
@@ -449,9 +458,11 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 		}
 	}
 
+	// Trigger factory door/unload animation if requested
 	if (pTypeExt->FlyingProduction_PlayFactoryAnim.Get())
 		pFactory->QueueMission(Mission::Unload, false);
 
+	// Reset house production indices, factory pointers, and replicate via cloning vats
 	if (auto const pOwner = pFactory->Owner)
 	{
 		auto const pHouseExt = HouseExt::Fetch(pOwner);

--- a/src/Ext/Building/Hooks.Production.cpp
+++ b/src/Ext/Building/Hooks.Production.cpp
@@ -256,18 +256,18 @@ DEFINE_HOOK(0x4449FB, BuildingClass_KickOutUnit_CloningVats, 0x8)
 	return SkipGameCode;
 }
 
-bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass* pProduction)
+KickOutResult BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass* pProduction)
 {
 	if (!pFactory || !pProduction || pFactory->GetCurrentMission() == Mission::Construction)
-		return false;
+		return KickOutResult::Failed;
 
 	auto const pType = pProduction->GetTechnoType();
 	if (!pType)
-		return false;
+		return KickOutResult::Failed;
 
 	auto const pTypeExt = TechnoTypeExt::Fetch(pType);
-	if (!pTypeExt || !pTypeExt->FlyingProduction)
-		return false;
+	if (!pTypeExt || !pTypeExt->IsFlyingProductionEnabled())
+		return KickOutResult::Failed;
 
 	// Resolve which building should physically spawn the unit
 	BuildingClass* pSpawnBuilding = nullptr;
@@ -279,11 +279,14 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 			if (!pTargetType)
 				continue;
 
-			// If the factory itself matches this target type, it takes immediate precedence
+			// If the factory itself matches this target type and has free dock (or doesn't need docks), it takes immediate precedence
 			if (pFactory->Type == pTargetType)
 			{
-				pSpawnBuilding = pFactory;
-				break;
+				if (pProduction->WhatAmI() != AbstractType::Aircraft || pFactory->Type->NumberOfDocks <= 0 || pFactory->HasFreeLink())
+				{
+					pSpawnBuilding = pFactory;
+					break;
+				}
 			}
 
 			BuildingClass* pPrimaryCandidate = nullptr;
@@ -297,9 +300,11 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 
 				if (pBld->Type == pTargetType)
 				{
+					if (pProduction->WhatAmI() == AbstractType::Aircraft && pBld->Type->NumberOfDocks > 0 && !pBld->HasFreeLink())
+						continue;
+
 					if (pBld->IsPrimaryFactory)
 					{
-						// Primary factory has absolute priority; no need to evaluate remaining buildings
 						pPrimaryCandidate = pBld;
 						break;
 					}
@@ -324,15 +329,22 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	if (!pSpawnBuilding)
 		pSpawnBuilding = pFactory;
 
+	// If this is an aircraft and the spawn building has docks, ensure there is an available dock slot
+	if (pProduction->WhatAmI() == AbstractType::Aircraft && pSpawnBuilding->Type->NumberOfDocks > 0)
+	{
+		if (!pSpawnBuilding->HasFreeLink())
+			return KickOutResult::Busy;
+	}
+
 	auto const pSpawnBldTypeExt = BuildingTypeExt::Fetch(pSpawnBuilding->Type);
 
 	// Determine spawn height, offset, and facing
-	int height = pTypeExt->FlyingProduction_SpawnHeight.Get();
+	int height = pTypeExt->GetFlyingProductionSpawnHeight();
 	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnHeight.isset())
 		height = pSpawnBldTypeExt->FlyingProduction_SpawnHeight.Get();
 
 	if (height <= 0)
-		return false;
+		return KickOutResult::Failed;
 
 	CoordStruct spawnCoords = pSpawnBuilding->GetCoords();
 	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnOffset.isset())
@@ -343,9 +355,11 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	}
 	spawnCoords.Z += height;
 
-	DirStruct facing = pSpawnBuilding->PrimaryFacing.Current();
+	DirStruct facing = DirStruct(128); // Default facing South
 	if (pSpawnBldTypeExt && pSpawnBldTypeExt->FlyingProduction_SpawnFacing.isset())
 		facing = DirStruct(pSpawnBldTypeExt->FlyingProduction_SpawnFacing.Get());
+	else if (pSpawnBuilding->PrimaryFacing.Current().Raw != 0)
+		facing = pSpawnBuilding->PrimaryFacing.Current();
 
 	// Unlimbo unit in the air safely using ScenarioInitGuard
 	pProduction->SetOwningHouse(pFactory->Owner, true);
@@ -362,7 +376,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	}
 
 	if (!unlimboSuccess)
-		return false;
+		return KickOutResult::Busy;
 
 	// Establish aerial state and position
 	pProduction->SetLocation(spawnCoords);
@@ -398,7 +412,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 			const auto pFootType = pFoot->GetTechnoType();
 			const int cruiseFlightLevel = pFootType->GetFlightLevel();
 			const int targetFlightLevel = cruiseFlightLevel > 0 ? cruiseFlightLevel : (RulesClass::Instance ? RulesClass::Instance->FlightLevel : height);
-			pFlyLoco->FlightLevel = targetFlightLevel;
+			pFlyLoco->FlightLevel = (height > targetFlightLevel) ? height : targetFlightLevel;
 			pFlyLoco->CurrentSpeed = 0.0;
 			pFlyLoco->TargetSpeed = 0.0;
 			pFlyLoco->IsTakingOff = height < targetFlightLevel ? 1 : 0;
@@ -407,7 +421,26 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	}
 
 	if (auto const pAircraft = abstract_cast<AircraftClass*>(pProduction))
+	{
+		if (pSpawnBuilding->Type->NumberOfDocks > 0)
+		{
+			pSpawnBuilding->SendCommand(RadioCommand::RequestLink, pAircraft);
+			pSpawnBuilding->SendCommand(RadioCommand::RequestTether, pAircraft);
+			pAircraft->DockNowHeadingTo = pSpawnBuilding;
+
+			if (!pSpawnBldTypeExt || !pSpawnBldTypeExt->FlyingProduction_SpawnOffset.isset())
+			{
+				CoordStruct dockCoords = spawnCoords;
+				pSpawnBuilding->GetDockCoords(&dockCoords, pAircraft);
+				dockCoords.Z = pSpawnBuilding->GetCoords().Z + height;
+				pAircraft->SetLocation(dockCoords);
+				pAircraft->Location = dockCoords;
+				spawnCoords = dockCoords;
+			}
+		}
+
 		pAircraft->SetHeight(height);
+	}
 
 	// Spawn visual effects
 	if (auto const pAnimType = pTypeExt->FlyingProduction_SpawnAnim.Get())
@@ -426,35 +459,41 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 	else
 		pRallyTarget = pFactory->ArchiveTarget;
 
-	if (pRallyTarget && pRallyTarget != pSpawnBuilding)
+	if (auto const pFoot = abstract_cast<FootClass*>(pProduction))
 	{
-		pProduction->SetDestination(pRallyTarget, true);
-		pProduction->QueueMission(Mission::Move, true);
-	}
-	else
-	{
-		// No rally point set: give an exit nudge away from the spawn building in the facing direction
-		// to prevent units from remaining frozen directly over the building or blocking subsequent spawns.
-		const auto pBldType = pSpawnBuilding->Type;
-		const int nudgeDistance = std::max({ static_cast<int>(pBldType->GetFoundationWidth()), static_cast<int>(pBldType->GetFoundationHeight(true)), 2 }) / 2 + 1;
-		auto pDestCell = MapClass::Instance.GetCellAt(spawnCoords);
-		const auto facingType = static_cast<FacingType>(facing.GetValue<3>());
+		auto const pFootExt = FootExt::Fetch(pFoot);
+		int cruiseHeight = 0;
 
-		for (int i = 0; i < nudgeDistance; ++i)
+		if (auto const pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pFoot->Locomotor))
+			cruiseHeight = pJJLoco->Height;
+		else if (auto const pFlyLoco = locomotion_cast<FlyLocomotionClass*>(pFoot->Locomotor))
 		{
-			if (auto const pNext = pDestCell->GetNeighbourCell(facingType))
-				pDestCell = pNext;
+			const int cfl = pFoot->GetTechnoType()->GetFlightLevel();
+			cruiseHeight = cfl > 0 ? cfl : (RulesClass::Instance ? RulesClass::Instance->FlightLevel : 0);
 		}
 
-		if (pDestCell)
+		if (cruiseHeight > 0 && height > cruiseHeight)
 		{
-			pProduction->SetDestination(pDestCell, true);
-			pProduction->QueueMission(Mission::Move, true);
+			// Unit spawned higher than cruise altitude: descend straight down in place first
+			pFootExt->FlyingProduction_Descending = true;
+			pFootExt->FlyingProduction_TargetHeight = cruiseHeight;
+			pFootExt->FlyingProduction_RallyTarget = pRallyTarget;
+			pFootExt->FlyingProduction_SpawnBuilding = pSpawnBuilding;
+			pFootExt->FlyingProduction_ExitFacing = facing;
+
+			pProduction->QueueMission(Mission::Guard, true);
 		}
 		else
 		{
-			pProduction->Scatter(CoordStruct::Empty, true, false);
-			pProduction->QueueMission(Mission::Guard, true);
+			pFootExt->FlyingProduction_DispatchMove(pRallyTarget, pSpawnBuilding, facing);
+		}
+	}
+	else
+	{
+		if (pRallyTarget && pRallyTarget != pSpawnBuilding)
+		{
+			pProduction->SetDestination(pRallyTarget, true);
+			pProduction->QueueMission(Mission::Move, true);
 		}
 	}
 
@@ -518,7 +557,7 @@ bool BuildingExt::TrySpawnFlyingProduction(BuildingClass* pFactory, TechnoClass*
 		}
 	}
 
-	return true;
+	return KickOutResult::Succeeded;
 }
 
 DEFINE_HOOK(0x443C60, BuildingClass_KickOutUnit_FlyingProduction, 0x6)
@@ -528,25 +567,26 @@ DEFINE_HOOK(0x443C60, BuildingClass_KickOutUnit_FlyingProduction, 0x6)
 	GET(BuildingClass*, pFactory, ECX);
 	GET_STACK(TechnoClass*, pProduction, 0x4);
 
-	if (BuildingExt::TrySpawnFlyingProduction(pFactory, pProduction))
+	const auto result = BuildingExt::TrySpawnFlyingProduction(pFactory, pProduction);
+	if (result != KickOutResult::Failed)
 	{
-		R->EAX(static_cast<int>(KickOutResult::Succeeded));
+		R->EAX(static_cast<int>(result));
 		return DoneSucceeded;
 	}
 
 	return 0;
 }
 
-DEFINE_HOOK(0x455DA0, BuildingClass_IsUnitFactory_FlyingProduction, 0x6)
+DEFINE_HOOK(0x455DA0, BuildingClass_IsUnitFactory_HasRallyPoint, 0x6)
 {
-	enum { ReturnTrue = 0x455DCD };
+	enum { ReturnFalse = 0x455DCB, ReturnTrue = 0x455DCD };
 
 	GET(BuildingClass*, pThis, ECX);
 
 	if (auto const pTypeExt = BuildingTypeExt::Fetch(pThis->Type))
 	{
-		if (pTypeExt->FlyingProduction_RallyPoint.Get())
-			return ReturnTrue;
+		if (pTypeExt->HasRallyPoint.isset())
+			return pTypeExt->HasRallyPoint.Get() ? ReturnTrue : ReturnFalse;
 	}
 
 	return 0;

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -386,6 +386,11 @@ void BuildingTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 
 	// Ares 3.0
 	this->UnitSell.Read(exINI, pSection, "UnitSell");
+
+	this->FlyingProduction_SpawnOffset.Read(exINI, pSection, "FlyingProduction.SpawnOffset");
+	this->FlyingProduction_SpawnHeight.Read(exINI, pSection, "FlyingProduction.SpawnHeight");
+	this->FlyingProduction_SpawnFacing.Read(exINI, pSection, "FlyingProduction.SpawnFacing");
+	this->FlyingProduction_RallyPoint.Read(exINI, pSection, "FlyingProduction.RallyPoint");
 }
 
 void BuildingTypeExt::CompleteInitialization()
@@ -509,6 +514,11 @@ void BuildingTypeExt::Serialize(T& Stm)
 
 		// Ares 3.0
 		.Process(this->UnitSell)
+
+		.Process(this->FlyingProduction_SpawnOffset)
+		.Process(this->FlyingProduction_SpawnHeight)
+		.Process(this->FlyingProduction_SpawnFacing)
+		.Process(this->FlyingProduction_RallyPoint)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -390,7 +390,7 @@ void BuildingTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->FlyingProduction_SpawnOffset.Read(exINI, pSection, "FlyingProduction.SpawnOffset");
 	this->FlyingProduction_SpawnHeight.Read(exINI, pSection, "FlyingProduction.SpawnHeight");
 	this->FlyingProduction_SpawnFacing.Read(exINI, pSection, "FlyingProduction.SpawnFacing");
-	this->FlyingProduction_RallyPoint.Read(exINI, pSection, "FlyingProduction.RallyPoint");
+	this->HasRallyPoint.Read(exINI, pSection, "HasRallyPoint");
 }
 
 void BuildingTypeExt::CompleteInitialization()
@@ -518,7 +518,7 @@ void BuildingTypeExt::Serialize(T& Stm)
 		.Process(this->FlyingProduction_SpawnOffset)
 		.Process(this->FlyingProduction_SpawnHeight)
 		.Process(this->FlyingProduction_SpawnFacing)
-		.Process(this->FlyingProduction_RallyPoint)
+		.Process(this->HasRallyPoint)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -154,6 +154,11 @@ public:
 	// Ares 3.0
 	Nullable<bool> UnitSell;
 
+	Nullable<Point2D> FlyingProduction_SpawnOffset;
+	Nullable<int> FlyingProduction_SpawnHeight;
+	Nullable<DirType> FlyingProduction_SpawnFacing;
+	Valueable<bool> FlyingProduction_RallyPoint;
+
 	BuildingTypeExt(BuildingTypeClass* OwnerObject) : TechnoTypeExt(OwnerObject)
 		, PowersUp_Owner { AffectedHouse::Owner }
 		, PowersUp_Buildings {}
@@ -265,6 +270,11 @@ public:
 
 		// Ares 3.0
 		, UnitSell {}
+
+		, FlyingProduction_SpawnOffset {}
+		, FlyingProduction_SpawnHeight {}
+		, FlyingProduction_SpawnFacing {}
+		, FlyingProduction_RallyPoint { false }
 	{ }
 
 	// typed owner accessor (shadows the TechnoTypeClass one from the base)

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -157,7 +157,7 @@ public:
 	Nullable<Point2D> FlyingProduction_SpawnOffset;
 	Nullable<int> FlyingProduction_SpawnHeight;
 	Nullable<DirType> FlyingProduction_SpawnFacing;
-	Valueable<bool> FlyingProduction_RallyPoint;
+	Nullable<bool> HasRallyPoint;
 
 	BuildingTypeExt(BuildingTypeClass* OwnerObject) : TechnoTypeExt(OwnerObject)
 		, PowersUp_Owner { AffectedHouse::Owner }
@@ -274,7 +274,7 @@ public:
 		, FlyingProduction_SpawnOffset {}
 		, FlyingProduction_SpawnHeight {}
 		, FlyingProduction_SpawnFacing {}
-		, FlyingProduction_RallyPoint { false }
+		, HasRallyPoint {}
 	{ }
 
 	// typed owner accessor (shadows the TechnoTypeClass one from the base)

--- a/src/Ext/Foot/Body.cpp
+++ b/src/Ext/Foot/Body.cpp
@@ -1,6 +1,10 @@
 #include <Kamikaze.h>
 
 #include <JumpjetLocomotionClass.h>
+#include <FlyLocomotionClass.h>
+#include <AircraftClass.h>
+#include <BuildingClass.h>
+#include <MapClass.h>
 
 #include <Ext/Anim/Body.h>
 #include <Ext/House/Body.h>
@@ -865,6 +869,152 @@ void FootExt::HealthAutoConvertActions()
 		TechnoExt::ConvertToType(pThis, pTypeExt->Convert_Health);
 }
 
+void FootExt::FlyingProduction_DispatchMove(AbstractClass* pRallyTarget, BuildingClass* pSpawnBuilding, DirStruct facing)
+{
+	auto const pThis = this->OwnerObject();
+	if (!pThis || !pThis->IsAlive || pThis->InLimbo || pThis->Health <= 0)
+		return;
+
+	if (pRallyTarget && pRallyTarget != pSpawnBuilding)
+	{
+		pThis->SetDestination(pRallyTarget, true);
+		pThis->QueueMission(Mission::Move, true);
+	}
+	else if (auto const pAir = abstract_cast<AircraftClass*>(pThis))
+	{
+		if (pAir->DockNowHeadingTo && pAir->Type->AirportBound)
+		{
+			pAir->SetDestination(pAir->DockNowHeadingTo, true);
+			pAir->QueueMission(Mission::Enter, true);
+			return;
+		}
+	}
+	else if (pSpawnBuilding && pSpawnBuilding->IsAlive)
+	{
+		// No rally point set: give an exit nudge away from the spawn building in the facing direction
+		// to prevent units from remaining frozen directly over the building or blocking subsequent spawns.
+		const auto pBldType = pSpawnBuilding->Type;
+		const int nudgeDistance = std::max({ static_cast<int>(pBldType->GetFoundationWidth()), static_cast<int>(pBldType->GetFoundationHeight(true)), 2 }) / 2 + 1;
+		auto pDestCell = MapClass::Instance.GetCellAt(pThis->GetCoords());
+		const auto facingType = static_cast<FacingType>(facing.GetValue<3>());
+
+		for (int i = 0; i < nudgeDistance; ++i)
+		{
+			if (auto const pNext = pDestCell->GetNeighbourCell(facingType))
+				pDestCell = pNext;
+		}
+
+		if (pDestCell)
+		{
+			pThis->SetDestination(pDestCell, true);
+			pThis->QueueMission(Mission::Move, true);
+		}
+		else
+		{
+			pThis->Scatter(CoordStruct::Empty, true, false);
+			pThis->QueueMission(Mission::Guard, true);
+		}
+	}
+	else
+	{
+		pThis->QueueMission(Mission::Guard, true);
+	}
+}
+
+void FootExt::UpdateFlyingProductionDescent()
+{
+	if (!this->FlyingProduction_Descending)
+		return;
+
+	auto const pThis = this->OwnerObject();
+	if (!pThis || !pThis->IsAlive || pThis->InLimbo || pThis->Health <= 0)
+	{
+		this->FlyingProduction_Descending = false;
+		this->FlyingProduction_RallyTarget = nullptr;
+		this->FlyingProduction_SpawnBuilding = nullptr;
+		return;
+	}
+
+	// If the unit has received an active order from player or AI, cancel automated descent
+	if (pThis->GetCurrentMission() != Mission::Guard)
+	{
+		this->FlyingProduction_Descending = false;
+		this->FlyingProduction_RallyTarget = nullptr;
+		this->FlyingProduction_SpawnBuilding = nullptr;
+		return;
+	}
+
+	CoordStruct curLoc = pThis->GetCoords();
+	const int groundZ = MapClass::Instance.GetCellFloorHeight(curLoc);
+	const int targetZ = groundZ + this->FlyingProduction_TargetHeight;
+
+	int descentSpeed = 16;
+	if (auto const pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
+	{
+		if (pJJLoco->Crash > 0.0f)
+			descentSpeed = static_cast<int>(pJJLoco->Crash);
+		else if (pJJLoco->Climb > 0.0f)
+			descentSpeed = static_cast<int>(pJJLoco->Climb);
+		else
+			descentSpeed = 16;
+	}
+	else if (auto const pAircraft = abstract_cast<AircraftClass*>(pThis))
+	{
+		descentSpeed = std::max(16, pAircraft->Type->Speed * 2);
+	}
+
+	if (curLoc.Z - descentSpeed > targetZ)
+	{
+		curLoc.Z -= descentSpeed;
+		pThis->SetLocation(curLoc);
+		pThis->Location = curLoc;
+
+		if (auto const pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
+		{
+			pJJLoco->CurrentHeight = curLoc.Z - groundZ;
+			pThis->Jumpjet_OccupyCell(CellClass::Coord2Cell(curLoc));
+		}
+		else if (auto const pAircraft = abstract_cast<AircraftClass*>(pThis))
+		{
+			pAircraft->SetHeight(curLoc.Z - groundZ);
+		}
+	}
+	else
+	{
+		// Arrived at target cruise altitude!
+		curLoc.Z = targetZ;
+		pThis->SetLocation(curLoc);
+		pThis->Location = curLoc;
+
+		if (auto const pJJLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
+		{
+			pJJLoco->CurrentHeight = this->FlyingProduction_TargetHeight;
+			pThis->Jumpjet_OccupyCell(CellClass::Coord2Cell(curLoc));
+		}
+		else if (auto const pFlyLoco = locomotion_cast<FlyLocomotionClass*>(pThis->Locomotor))
+		{
+			pFlyLoco->FlightLevel = this->FlyingProduction_TargetHeight;
+			if (auto const pAircraft = abstract_cast<AircraftClass*>(pThis))
+				pAircraft->SetHeight(this->FlyingProduction_TargetHeight);
+		}
+		else if (auto const pAircraft = abstract_cast<AircraftClass*>(pThis))
+		{
+			pAircraft->SetHeight(this->FlyingProduction_TargetHeight);
+		}
+
+		this->FlyingProduction_Descending = false;
+
+		AbstractClass* pRallyTarget = this->FlyingProduction_RallyTarget;
+		BuildingClass* pSpawnBuilding = this->FlyingProduction_SpawnBuilding;
+		DirStruct facing = this->FlyingProduction_ExitFacing;
+
+		this->FlyingProduction_RallyTarget = nullptr;
+		this->FlyingProduction_SpawnBuilding = nullptr;
+
+		this->FlyingProduction_DispatchMove(pRallyTarget, pSpawnBuilding, facing);
+	}
+}
+
 // =============================
 // load / save
 
@@ -886,6 +1036,11 @@ void FootExt::Serialize(T& Stm)
 		.Process(this->JumpjetStraightAscend)
 		.Process(this->AttackMoveFollowerTempCount)
 		//.Process(this->IsOwnerChangeFromRevertOnExit) Temporary flag, does not need to be serialized.
+		.Process(this->FlyingProduction_Descending)
+		.Process(this->FlyingProduction_TargetHeight)
+		.Process(this->FlyingProduction_RallyTarget)
+		.Process(this->FlyingProduction_SpawnBuilding)
+		.Process(this->FlyingProduction_ExitFacing)
 		;
 }
 

--- a/src/Ext/Foot/Body.h
+++ b/src/Ext/Foot/Body.h
@@ -23,6 +23,11 @@ public:
 	bool JumpjetStraightAscend; // Is set to true jumpjet units will ascend straight and do not adjust rotation or position during it.
 	int AttackMoveFollowerTempCount;
 	bool IsOwnerChangeFromRevertOnExit;
+	bool FlyingProduction_Descending;
+	int FlyingProduction_TargetHeight;
+	AbstractClass* FlyingProduction_RallyTarget;
+	BuildingClass* FlyingProduction_SpawnBuilding;
+	DirStruct FlyingProduction_ExitFacing;
 
 	explicit FootExt(FootClass* const OwnerObject) : TechnoExt(OwnerObject)
 		, LastKillWasTeamTarget { false }
@@ -39,6 +44,11 @@ public:
 		, JumpjetStraightAscend { false }
 		, AttackMoveFollowerTempCount { 0 }
 		, IsOwnerChangeFromRevertOnExit { false }
+		, FlyingProduction_Descending { false }
+		, FlyingProduction_TargetHeight { 0 }
+		, FlyingProduction_RallyTarget { nullptr }
+		, FlyingProduction_SpawnBuilding { nullptr }
+		, FlyingProduction_ExitFacing { 0 }
 	{ }
 
 	FootClass* OwnerObject() const
@@ -65,6 +75,8 @@ public:
 	void UpdateTypeData(TechnoTypeClass* pCurrentType);
 	void HealthAutoConvertActions();
 	void AmmoAutoConvertActions();
+	void UpdateFlyingProductionDescent();
+	void FlyingProduction_DispatchMove(AbstractClass* pRallyTarget, BuildingClass* pSpawnBuilding, DirStruct facing);
 
 	virtual void LoadFromStream(PhobosStreamReader& Stm) override;
 	virtual void SaveToStream(PhobosStreamWriter& Stm) override;

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -314,6 +314,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->JumpjetClimbPredictHeight.Read(exINI, GameStrings::General, "JumpjetClimbPredictHeight");
 	this->JumpjetClimbWithoutCutOut.Read(exINI, GameStrings::General, "JumpjetClimbWithoutCutOut");
 	this->JumpjetClimbIgnoreBuilding.Read(exINI, GameStrings::General, "JumpjetClimbIgnoreBuilding");
+	this->FlyingProduction_Jumpjet.Read(exINI, GameStrings::General, "FlyingProduction.Jumpjet");
+	this->FlyingProduction_Aircraft.Read(exINI, GameStrings::General, "FlyingProduction.Aircraft");
 
 	this->DamageOwnerMultiplier.Read(exINI, GameStrings::CombatDamage, "DamageOwnerMultiplier");
 	this->DamageAlliesMultiplier.Read(exINI, GameStrings::CombatDamage, "DamageAlliesMultiplier");
@@ -910,6 +912,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->JumpjetClimbPredictHeight)
 		.Process(this->JumpjetClimbWithoutCutOut)
 		.Process(this->JumpjetClimbIgnoreBuilding)
+		.Process(this->FlyingProduction_Jumpjet)
+		.Process(this->FlyingProduction_Aircraft)
 		.Process(this->DamageOwnerMultiplier)
 		.Process(this->DamageAlliesMultiplier)
 		.Process(this->DamageEnemiesMultiplier)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -243,6 +243,9 @@ public:
 		Valueable<bool> JumpjetClimbWithoutCutOut;
 		Valueable<bool> JumpjetClimbIgnoreBuilding;
 
+		Valueable<bool> FlyingProduction_Jumpjet;
+		Valueable<bool> FlyingProduction_Aircraft;
+
 		Valueable<bool> MergeBuildingDamage;
 
 		Valueable<double> DamageOwnerMultiplier;
@@ -764,6 +767,8 @@ public:
 			, JumpjetClimbPredictHeight { false }
 			, JumpjetClimbWithoutCutOut { false }
 			, JumpjetClimbIgnoreBuilding { false }
+			, FlyingProduction_Jumpjet { false }
+			, FlyingProduction_Aircraft { false }
 
 			, DamageOwnerMultiplier { 1.0 }
 			, DamageAlliesMultiplier { 1.0 }

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -46,6 +46,7 @@ DEFINE_HOOK(0x4DA54E, FootClass_AI, 0x6)
 	pExt->UpdateTiberiumEater();
 	pExt->AmmoAutoConvertActions();
 	pExt->HealthAutoConvertActions();
+	pExt->UpdateFlyingProductionDescent();
 
 	if (pExt->AttackMoveFollowerTempCount)
 		pExt->AttackMoveFollowerTempCount--;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1,6 +1,8 @@
 #include <JumpjetLocomotionClass.h>
+#include <FlyLocomotionClass.h>
 
 #include <Ext/AircraftType/Body.h>
+#include <Ext/Rules/Body.h>
 #include <Ext/Anim/Body.h>
 #include <Ext/BuildingType/Body.h>
 #include <Ext/BulletType/Body.h>
@@ -1451,17 +1453,67 @@ void TechnoTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	this->FlyingProduction_SpawnAt.Read(exINI, pSection, "FlyingProduction.SpawnAt");
 	this->FlyingProduction_RallyPointFromSpawnBuilding.Read(exINI, pSection, "FlyingProduction.RallyPointFromSpawnBuilding");
 
-	if (this->FlyingProduction.Get())
+	if (this->IsFlyingProductionEnabled())
 	{
 		if (!this->FlyingProduction_SpawnHeight.isset())
 		{
-			const int defaultFlightLevel = RulesClass::Instance ? RulesClass::Instance->FlightLevel : 0;
-			this->FlyingProduction_SpawnHeight = defaultFlightLevel > 0 ? defaultFlightLevel : pThis->GetFlightLevel();
+			if (pThis->JumpJet || pThis->Locomotor == LocomotionClass::CLSIDs::Jumpjet)
+			{
+				const int defaultJJHeight = RulesClass::Instance ? RulesClass::Instance->CruiseHeight : 0;
+				this->FlyingProduction_SpawnHeight = pThis->JumpjetHeight > 0 ? pThis->JumpjetHeight : defaultJJHeight;
+			}
+			else
+			{
+				const int defaultFlightLevel = RulesClass::Instance ? RulesClass::Instance->FlightLevel : 0;
+				this->FlyingProduction_SpawnHeight = defaultFlightLevel > 0 ? defaultFlightLevel : pThis->GetFlightLevel();
+			}
 		}
 
 		if (this->FlyingProduction_SpawnHeight.Get() <= 0)
 			this->FlyingProduction = false;
 	}
+}
+
+bool TechnoTypeExt::IsFlyingProductionEnabled() const
+{
+	if (this->FlyingProduction.isset())
+		return this->FlyingProduction.Get();
+
+	if (this->FlyingProduction_SpawnHeight.isset() && this->FlyingProduction_SpawnHeight.Get() > 0)
+		return true;
+
+	if (const auto pRulesExt = RulesExt::Global())
+	{
+		const auto pThis = this->OwnerObject();
+		if (pThis->JumpJet || pThis->Locomotor == LocomotionClass::CLSIDs::Jumpjet)
+			return pRulesExt->FlyingProduction_Jumpjet.Get();
+
+		if (pThis->WhatAmI() == AbstractType::AircraftType || pThis->Locomotor == LocomotionClass::CLSIDs::Fly)
+			return pRulesExt->FlyingProduction_Aircraft.Get();
+	}
+
+	return false;
+}
+
+int TechnoTypeExt::GetFlyingProductionSpawnHeight() const
+{
+	if (this->FlyingProduction_SpawnHeight.isset())
+		return this->FlyingProduction_SpawnHeight.Get();
+
+	const auto pThis = this->OwnerObject();
+	if (pThis->JumpJet || pThis->Locomotor == LocomotionClass::CLSIDs::Jumpjet)
+	{
+		if (pThis->JumpjetHeight > 0)
+			return pThis->JumpjetHeight;
+
+		return RulesClass::Instance ? RulesClass::Instance->CruiseHeight : 0;
+	}
+
+	const int flightLevel = pThis->GetFlightLevel();
+	if (flightLevel > 0)
+		return flightLevel;
+
+	return RulesClass::Instance ? RulesClass::Instance->FlightLevel : 0;
 }
 
 template <typename T>

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1441,6 +1441,27 @@ void TechnoTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 	// VoiceIFVRepair from Ares 0.2
 	this->VoiceIFVRepair.Read(exINI, pSection, "VoiceIFVRepair");
 	this->ParseVoiceWeaponAttacks(exINI, pSection, this->VoiceWeaponAttacks, this->VoiceEliteWeaponAttacks);
+
+	this->FlyingProduction.Read(exINI, pSection, "FlyingProduction");
+	this->FlyingProduction_SpawnHeight.Read(exINI, pSection, "FlyingProduction.SpawnHeight");
+	this->FlyingProduction_PlayFactoryAnim.Read(exINI, pSection, "FlyingProduction.PlayFactoryAnim");
+	this->FlyingProduction_SpawnAnim.Read(exINI, pSection, "FlyingProduction.SpawnAnim");
+	this->FlyingProduction_SpawnAnim_AttachedToObject.Read(exINI, pSection, "FlyingProduction.SpawnAnim.AttachedToObject");
+	this->FlyingProduction_SpawnAnim_AttachedToObject.Read(exINI, pSection, "FlyingProduction.SpawnAnim_AttachedToObject");
+	this->FlyingProduction_SpawnAt.Read(exINI, pSection, "FlyingProduction.SpawnAt");
+	this->FlyingProduction_RallyPointFromSpawnBuilding.Read(exINI, pSection, "FlyingProduction.RallyPointFromSpawnBuilding");
+
+	if (this->FlyingProduction.Get())
+	{
+		if (!this->FlyingProduction_SpawnHeight.isset())
+		{
+			const int defaultFlightLevel = RulesClass::Instance ? RulesClass::Instance->FlightLevel : 0;
+			this->FlyingProduction_SpawnHeight = defaultFlightLevel > 0 ? defaultFlightLevel : pThis->GetFlightLevel();
+		}
+
+		if (this->FlyingProduction_SpawnHeight.Get() <= 0)
+			this->FlyingProduction = false;
+	}
 }
 
 template <typename T>
@@ -1859,6 +1880,14 @@ void TechnoTypeExt::Serialize(T& Stm)
 		// Ares 3.0
 		.Process(this->Unsellable)
 		.Process(this->KeepAlive)
+
+		.Process(this->FlyingProduction)
+		.Process(this->FlyingProduction_SpawnHeight)
+		.Process(this->FlyingProduction_PlayFactoryAnim)
+		.Process(this->FlyingProduction_SpawnAnim)
+		.Process(this->FlyingProduction_SpawnAnim_AttachedToObject)
+		.Process(this->FlyingProduction_SpawnAt)
+		.Process(this->FlyingProduction_RallyPointFromSpawnBuilding)
 		;
 }
 void TechnoTypeExt::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -343,7 +343,7 @@ public:
 
 	Nullable<AffectedHouse> RadarInvisibleToHouse;
 
-	Valueable<bool> FlyingProduction;
+	Nullable<bool> FlyingProduction;
 	Nullable<int> FlyingProduction_SpawnHeight;
 	Valueable<bool> FlyingProduction_PlayFactoryAnim;
 	Nullable<AnimTypeClass*> FlyingProduction_SpawnAnim;
@@ -885,7 +885,7 @@ public:
 		, Unsellable {}
 		, KeepAlive {}
 
-		, FlyingProduction { false }
+		, FlyingProduction {}
 		, FlyingProduction_SpawnHeight {}
 		, FlyingProduction_PlayFactoryAnim { false }
 		, FlyingProduction_SpawnAnim {}
@@ -909,6 +909,9 @@ public:
 	int SelectMultiWeapon(TechnoClass* const pThis, AbstractClass* const pTarget) const;
 
 	void UpdateAdditionalAttributes();
+
+	bool IsFlyingProductionEnabled() const;
+	int GetFlyingProductionSpawnHeight() const;
 
 	// Ares 0.2
 	bool CameoIsVeteran(HouseClass* pHouse) const;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -343,6 +343,14 @@ public:
 
 	Nullable<AffectedHouse> RadarInvisibleToHouse;
 
+	Valueable<bool> FlyingProduction;
+	Nullable<int> FlyingProduction_SpawnHeight;
+	Valueable<bool> FlyingProduction_PlayFactoryAnim;
+	Nullable<AnimTypeClass*> FlyingProduction_SpawnAnim;
+	Valueable<bool> FlyingProduction_SpawnAnim_AttachedToObject;
+	ValueableVector<BuildingTypeClass*> FlyingProduction_SpawnAt;
+	Valueable<bool> FlyingProduction_RallyPointFromSpawnBuilding;
+
 	struct LaserTrailDataEntry
 	{
 		ValueableIdx<LaserTrailTypeClass> idxType;
@@ -876,6 +884,14 @@ public:
 		// Ares 3.0
 		, Unsellable {}
 		, KeepAlive {}
+
+		, FlyingProduction { false }
+		, FlyingProduction_SpawnHeight {}
+		, FlyingProduction_PlayFactoryAnim { false }
+		, FlyingProduction_SpawnAnim {}
+		, FlyingProduction_SpawnAnim_AttachedToObject { false }
+		, FlyingProduction_SpawnAt {}
+		, FlyingProduction_RallyPointFromSpawnBuilding { false }
 	{ }
 
 	virtual ~TechnoTypeExt() = default;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -286,6 +286,16 @@ DEFINE_HOOK(0x4438B4, BuildingClass_SetRallyPoint_Naval, 0x6)
 		}
 	}
 
+	if (auto const pBldTypeExt = BuildingTypeExt::Fetch(pBuildingType))
+	{
+		if (pBldTypeExt->FlyingProduction_RallyPoint.Get())
+		{
+			R->ESI(static_cast<int>(MovementZone::Fly));
+			spdtp = SpeedType::Winged;
+			return NotNaval;
+		}
+	}
+
 	if (pBuildingType->Naval || pBuildingType->SpeedType == SpeedType::Float)
 		return IsNaval;
 

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -288,7 +288,7 @@ DEFINE_HOOK(0x4438B4, BuildingClass_SetRallyPoint_Naval, 0x6)
 
 	if (auto const pBldTypeExt = BuildingTypeExt::Fetch(pBuildingType))
 	{
-		if (pBldTypeExt->FlyingProduction_RallyPoint.Get())
+		if (pBldTypeExt->HasRallyPoint.Get(false))
 		{
 			R->ESI(static_cast<int>(MovementZone::Fly));
 			spdtp = SpeedType::Winged;


### PR DESCRIPTION

<img width="640" height="400" alt="flying production demo 01" src="https://github.com/user-attachments/assets/8ce9a807-853e-4da7-be80-3aaafab1b50a" /> <img width="266" height="281" alt="flying production demo 02" src="https://github.com/user-attachments/assets/7258c444-6a29-4de7-a070-6311d5480f8c" />


- Now you can allow produced units to spawn directly in the air at customizable altitudes and locations without being constrained by traditional factory ground exit paths.
  - `FlyingProduction` controls whether this unit type uses flying production.
  - `FlyingProduction.SpawnHeight` determines the initial spawn altitude in leptons along the Z-axis. If resolved to 0 or negative, flying production will not be used and the unit exits normally.
  - `FlyingProduction.PlayFactoryAnim` controls whether the producing factory plays its unloading door/exit animation.
  - `FlyingProduction.SpawnAnim` specifies an animation to play at the aerial spawn coordinates when the unit is created.
  - `FlyingProduction.SpawnAnim.AttachedToObject` determines whether `FlyingProduction.SpawnAnim` is attached to the spawned unit and follows its movement.
  - `FlyingProduction.SpawnAt` accepts a list of BuildingTypes indicating where the unit should spawn, evaluated in priority order from left to right. When multiple buildings of that type exist, it prioritizes the producing factory itself if it matches, then any building marked as primary, and otherwise the closest one to the producing factory. If none of the candidate buildings exist or are alive, it falls back to the producing factory.
  - `FlyingProduction.RallyPointFromSpawnBuilding` determines whether the unit targets the spawn building's rally point instead of the producing factory's rally point.
  - `FlyingProduction.SpawnOffset` on `[BuildingType]` sets a 2D coordinate offset in leptons (X, Y) relative to the center of the structure for positioning the spawn point.
  - `FlyingProduction.SpawnHeight` on `[BuildingType]` overrides the spawn altitude for units appearing at this structure.
  - `FlyingProduction.SpawnFacing` on `[BuildingType]` specifies the facing (0-255) the unit takes upon spawning, as well as the exit direction if no rally point exists.
  - `FlyingProduction.RallyPoint` on `[BuildingType]` enables rally point placement on structures that are not standard vehicle or infantry factories (e.g. helipads or towers), allowing them to establish a rally point with EVA confirmation and tactical line.

In `rulesmd.ini`:
```ini
[SOMETECHNO]                               ; TechnoType
FlyingProduction=false                     ; boolean
FlyingProduction.SpawnHeight=              ; integer, defaults to FlightLevel or [General] -> FlightLevel
FlyingProduction.PlayFactoryAnim=false     ; boolean
FlyingProduction.SpawnAnim=                ; AnimType
FlyingProduction.SpawnAnim.AttachedToObject=false ; boolean
FlyingProduction.SpawnAt=                  ; List of BuildingTypes
FlyingProduction.RallyPointFromSpawnBuilding=false ; boolean

[SOMEBUILDING]                             ; BuildingType
FlyingProduction.SpawnOffset=0,0           ; Point2D, leptons
FlyingProduction.SpawnHeight=              ; integer, defaults to the spawned unit's FlyingProduction.SpawnHeight
FlyingProduction.SpawnFacing=              ; DirType (0-255), defaults to the building's facing (128 / South)
FlyingProduction.RallyPoint=false          ; boolean