### PR TITLE
crash fixes of tiberium spread & grow in long games and a new tag

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -161,6 +161,7 @@ This page lists all the individual contributions to the project by their author.
   - Unit & infantry auto-conversion on ammo change
   - Restore the ScriptType action#24 `Play speech` from Tiberian Sun
   - Modify ammo on impact
+  - Tiberium ramp expansion support, spread and growth crash fixes due to data corruption.
 - **Starkku**:
   - Misc. minor bugfixes & improvements
   - AI script actions:

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -332,6 +332,8 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed the bug that computer player record cannot be log normally in non English mode.
 - Fixed the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving; `WalkRate=0` is now treated like `IdleRate=0`: the walk animation/footstep tick never fires, so a moving unit behaves as if standing still.
 - Observer can see IvanBomb that's attached by any house.
+- Fixed a long-game crash caused by Tiberium growth priority queue buffer overflow (`PriorityQueueClassNode`), where extensive Tiberium expansion on large maps corrupted memory and crashed the game.
+- Fixed Tiberium growth and spread queues stalling/freezing when queued cells fail to expand or are temporarily blocked.
 
 ## Fixes / interactions with other extensions
 
@@ -2666,6 +2668,17 @@ In `rulesmd.ini`:
 ```ini
 [SOMEORE]      ; Tiberium
 MinimapColor=  ; integer - Red,Green,Blue
+```
+
+### Ramp expansion support
+
+- In vanilla, Tiberium is hardcoded not to germinate, grow, or spread onto ramp/slope cells (slopes 1-4), and any ore on ramps is cleared during cell recalculation. Setting `AllowRamps=yes` allows the resource to naturally expand, grow, and spread across cardinal slope ramps.
+	- `AllowRamps` determines whether this Tiberium type is allowed to germinate from spawners, increase growth stages, and spread onto cardinal ramp cells (slopes 1..4).
+
+In `rulesmd.ini`:
+```ini
+[SOMEORE]        ; Tiberium
+AllowRamps=false ; boolean
 ```
 
 ## Vehicles

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -455,8 +455,12 @@ HideShakeEffects=false           ; boolean
 - Observer can see IvanBomb that's attached by any house (by NetsuNegi)
 - Fixed a long-game crash caused by Tiberium growth priority queue buffer overflow (by FS-21)
 - Fixed Tiberium growth and spread queues stalling when cells fail to expand (by FS-21)
+- Fixed Tiberium types not supporting overrides in map and game mode INIs (by FS-21)
+- Fixed Tiberium cells failing to register into the spread queue upon reaching maximum growth stage (by FS-21)
+- Fixed Tiberium on ramps being blocked by non-buildable tile land types in CanTiberiumGerminate (by FS-21)
 
 #### Phobos fixes:
+- Fixed Tiberium trees/drills with max `SpawnsTiberium.GrowthStage` failing to spread Tiberium to neighboring cells and optimized `SpawnsTiberium.CellsPerAnim` loop (by FS-21)
 - Fixed a game crash when parsing string list with null entry (by Ollerus)
 - Fixed the bug where `Ranged=true` causes projectiles using the new Trajectory to ignore settings such as `BounceTimes` (by Noble_Fish)
 - Fixed `DiscardOn=entry` AttachEffects not triggering `ExpireWeapon` with on-discard trigger on entry (by Starkku)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -443,6 +443,7 @@ HideShakeEffects=false           ; boolean
 - [Allowed customize that whether `Temporal=yes` warhead will cause target building animation poweroff](Fixed-or-Improved-Logics.md#allow-customize-that-whether-temporal-yes-warhead-will-cause-target-building-animation-poweroff) (by NetsuNegi)
 - Country-based attached effects (by Ollerus)
 - [Customizable crew type per country](Fixed-or-Improved-Logics.md#customizable-crew-type-per-country) (by Sovietianqi)
+- [Tiberium ramp expansion support](Fixed-or-Improved-Logics.md#ramp-expansion-support) (by FS-21)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)
@@ -451,6 +452,8 @@ HideShakeEffects=false           ; boolean
 - Fixed the bug that computer player record cannot be log normally in non English mode (by NetsuNegi)
 - Fixed the bug that setting `WalkRate=0` on a TechnoType crashed the game (integer divide-by-zero) the moment an object of that type started moving (by Noble_Fish)
 - Observer can see IvanBomb that's attached by any house (by NetsuNegi)
+- Fixed a long-game crash caused by Tiberium growth priority queue buffer overflow (by FS-21)
+- Fixed Tiberium growth and spread queues stalling when cells fail to expand (by FS-21)
 
 #### Phobos fixes:
 - Fixed a game crash when parsing string list with null entry (by Ollerus)

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -1,6 +1,9 @@
 #include "Body.h"
 
 #include <cmath>
+#include <algorithm>
+
+#include <ScenarioClass.h>
 
 #include <Utilities/SequenceRates.h>
 
@@ -13,6 +16,8 @@
 #include <New/Type/BannerTypeClass.h>
 #include <New/Type/InsigniaTypeClass.h>
 #include <New/Type/SelectBoxTypeClass.h>
+#include <TiberiumClass.h>
+#include <Ext/Tiberium/Body.h>
 
 std::unique_ptr<RulesExt::ExtData> RulesExt::Data = nullptr;
 
@@ -29,6 +34,23 @@ void RulesExt::Remove(RulesClass* pThis)
 void RulesExt::LoadFromINIFile(RulesClass* pThis, CCINIClass* pINI)
 {
 	Data->LoadFromINI(pINI);
+
+	for (const auto pTib : TiberiumClass::Array)
+	{
+		const char* pSection = pTib->ID;
+		if (!pINI->GetSection(pSection))
+			continue;
+
+		pINI->GetInteger(pSection, "Spread", pTib->Spread);
+		pINI->GetDouble(pSection, "SpreadPercentage", pTib->SpreadPercentage);
+		pINI->GetInteger(pSection, "Growth", pTib->Growth);
+		pINI->GetDouble(pSection, "GrowthPercentage", pTib->GrowthPercentage);
+		pINI->GetInteger(pSection, "Value", pTib->Value);
+		pINI->GetInteger(pSection, "Power", pTib->Power);
+
+		if (const auto pTibExt = TiberiumExt::TryFetch(pTib))
+			pTibExt->LoadFromINIFile(pINI);
+	}
 }
 
 void RulesExt::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)

--- a/src/Ext/TerrainType/Hooks.cpp
+++ b/src/Ext/TerrainType/Hooks.cpp
@@ -2,6 +2,8 @@
 
 #include <Ext/Rules/Body.h>
 
+#include <algorithm>
+
 namespace TerrainTypeTemp
 {
 	TerrainTypeClass* pCurrentType = nullptr;
@@ -37,7 +39,10 @@ DEFINE_HOOK(0x71C84D, TerrainClass_AI_Animated, 0x6)
 				TerrainTypeTemp::pCurrentExt = pTypeExt;
 
 				for (int i = 0; i < cellCount; i++)
-					pCell->SpreadTiberium(true);
+				{
+					if (!pCell->SpreadTiberium(true))
+						break;
+				}
 
 				const int particleIdx = pTypeExt->SpawnsTiberium_Particle;
 
@@ -196,14 +201,31 @@ DEFINE_HOOK(0x48381D, CellClass_SpreadTiberium_CellSpread, 0x6)
 		for (unsigned int i = 0; i < size; i++)
 		{
 			const unsigned int cellIndex = (i + rand) % size;
-			const CellStruct tgtPos = pThis->MapCoords + adjacentCells[cellIndex];
+			CellStruct tgtPos = pThis->MapCoords + adjacentCells[cellIndex];
 			CellClass* tgtCell = MapClass::Instance.TryGetCellAt(tgtPos);
 
 			if (tgtCell && tgtCell->CanTiberiumGerminate(pTib))
 			{
-				R->EAX<bool>(tgtCell->IncreaseTiberium(tibIndex,
-					TerrainTypeTemp::pCurrentExt->GetTiberiumGrowthStage()));
+				const int maxStage = pTib->NumFrames - 1;
+				const int rawStage = TerrainTypeTemp::pCurrentExt->GetTiberiumGrowthStage();
+				const int growthStage = std::clamp(rawStage, 0, maxStage);
 
+				const bool res = tgtCell->IncreaseTiberium(tibIndex, growthStage);
+
+				if (res && growthStage >= maxStage)
+				{
+					const int surfaceIdx = PriorityQueueClassNode::ToSurfaceIndex(tgtPos);
+					const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+					const auto& logic = pTib->SpreadLogic;
+
+					if (surfaceIdx >= 0 && surfaceIdx < maxCount)
+					{
+						if (!logic.CellIndexesWithTiberium || !logic.CellIndexesWithTiberium[surfaceIdx])
+							pTib->RegisterForSpread(&tgtPos);
+					}
+				}
+
+				R->EAX<bool>(res);
 				return SpreadReturn;
 			}
 		}

--- a/src/Ext/Tiberium/Body.cpp
+++ b/src/Ext/Tiberium/Body.cpp
@@ -10,6 +10,7 @@ void TiberiumExt::Serialize(T& Stm)
 {
 	Stm
 		.Process(this->MinimapColor)
+		.Process(this->AllowRamps)
 		;
 }
 
@@ -20,6 +21,10 @@ void TiberiumExt::LoadFromINIFile(CCINIClass* const pINI)
 	INI_EX exINI(pINI);
 
 	this->MinimapColor.Read(exINI, pSection, "MinimapColor");
+	this->AllowRamps.Read(exINI, pSection, "AllowRamps");
+
+	if (this->AllowRamps && pThis->NumSlopes < 8)
+		pThis->NumSlopes = 8;
 }
 
 void TiberiumExt::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/Tiberium/Body.h
+++ b/src/Ext/Tiberium/Body.h
@@ -23,9 +23,11 @@ public:
 	}
 
 	Nullable<ColorStruct> MinimapColor;
+	Valueable<bool> AllowRamps;
 
 	TiberiumExt(TiberiumClass* OwnerObject) : AbstractTypeExt(OwnerObject)
 		, MinimapColor {}
+		, AllowRamps { false }
 	{ }
 
 	virtual ~TiberiumExt() = default;

--- a/src/Ext/Tiberium/Hooks.cpp
+++ b/src/Ext/Tiberium/Hooks.cpp
@@ -3,6 +3,7 @@
 #include <CellClass.h>
 #include <MapClass.h>
 #include <OverlayClass.h>
+#include <OverlayTypeClass.h>
 #include <ScenarioClass.h>
 
 namespace
@@ -24,6 +25,24 @@ namespace
 		reinterpret_cast<void(__thiscall*)(TiberiumClass*)>(0x7228B0)(pThis);
 	}
 
+	int GetMaxValidCells(int maxSurfaceCount)
+	{
+		return maxSurfaceCount - 20;
+	}
+
+	bool HasRampArt(TiberiumClass* pTib)
+	{
+		if (!pTib || !pTib->Image)
+			return false;
+
+		const int rampOverlayIdx = pTib->Image->ArrayIndex + pTib->NumFrames;
+		if (rampOverlayIdx >= OverlayTypeClass::Array.Count)
+			return false;
+
+		const auto pRampOverlay = OverlayTypeClass::Array.GetItem(rampOverlayIdx);
+		return pRampOverlay && pRampOverlay->Tiberium;
+	}
+
 	bool CanResourceGerminateOnRamp(TiberiumClass* pTib, BYTE slopeIndex)
 	{
 		if (slopeIndex == 0)
@@ -35,7 +54,7 @@ namespace
 		if (pTib)
 		{
 			const auto pExt = TiberiumExt::TryFetch(pTib);
-			if (pExt && pExt->AllowRamps)
+			if (pExt && pExt->AllowRamps && HasRampArt(pTib))
 			{
 				if (pTib->NumSlopes < RequiredRampOverlays)
 					pTib->NumSlopes = RequiredRampOverlays;
@@ -50,7 +69,7 @@ namespace
 		{
 			if (const auto pExt = TiberiumExt::TryFetch(pItem))
 			{
-				if (pExt->AllowRamps)
+				if (pExt->AllowRamps && HasRampArt(pItem))
 				{
 					if (pItem->NumSlopes < RequiredRampOverlays)
 						pItem->NumSlopes = RequiredRampOverlays;
@@ -116,14 +135,19 @@ DEFINE_HOOK(0x7235CE, TiberiumClass_Queue_Growth_At_Cell_CapacityGuard, 0x5)
 	enum { ReturnEarly = 0x7236C2 };
 
 	GET(TiberiumClass*, pThis, ESI);
-	const int surfaceIdx = R->Stack<int>(0x0C);
+	GET(CellStruct*, pCellCoords, EDI);
 	const auto& logic = pThis->GrowthLogic;
 	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+	const int maxCells = GetMaxValidCells(maxCount);
+
+	if (pThis->GrowthLogic.Count >= maxCells)
+		ReindexGrowth(pThis);
 
 	// Prevent duplicate queue entries for cells already awaiting growth
-	if (logic.CellIndexesWithTiberium && surfaceIdx >= 0 && surfaceIdx < maxCount)
+	if (logic.CellIndexesWithTiberium && pCellCoords)
 	{
-		if (logic.CellIndexesWithTiberium[surfaceIdx])
+		const int surfaceIdx = PriorityQueueClassNode::ToSurfaceIndex(*pCellCoords);
+		if (surfaceIdx >= 0 && surfaceIdx < maxCount && logic.CellIndexesWithTiberium[surfaceIdx])
 			return ReturnEarly;
 	}
 
@@ -137,9 +161,10 @@ DEFINE_HOOK(0x72302E, TiberiumClass_Grow_RequeueGuard, 0x6)
 {
 	GET(TiberiumClass*, pThis, ESI);
 	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+	const int maxCells = GetMaxValidCells(maxCount);
 
 	// Compact and re-index active cells before buffer overflows
-	if (pThis->GrowthLogic.Count >= maxCount - 20)
+	if (pThis->GrowthLogic.Count >= maxCells)
 		ReindexGrowth(pThis);
 
 	// Replicate stolen instruction: mov eax, dword ptr [esi + 0x10C]
@@ -165,11 +190,24 @@ DEFINE_HOOK(0x722FF2, TiberiumClass_Grow_NodeSanityCheck, 0x8)
 
 DEFINE_HOOK(0x722B48, TiberiumClass_Queue_Spread_At_Cell_CapacityGuard, 0x6)
 {
-	GET(TiberiumClass*, pThis, ESI);
-	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+	enum { ReturnEarly = 0x722C2A };
 
-	if (pThis->SpreadLogic.Count >= maxCount - 20)
+	GET(TiberiumClass*, pThis, ESI);
+	GET(CellStruct*, pCellCoords, EBP);
+	const auto& logic = pThis->SpreadLogic;
+	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+	const int maxCells = GetMaxValidCells(maxCount);
+
+	if (pThis->SpreadLogic.Count >= maxCells)
 		ReindexSpread(pThis);
+
+	// Prevent duplicate queue entries for cells already awaiting spread
+	if (logic.CellIndexesWithTiberium && pCellCoords)
+	{
+		const int surfaceIdx = PriorityQueueClassNode::ToSurfaceIndex(*pCellCoords);
+		if (surfaceIdx >= 0 && surfaceIdx < maxCount && logic.CellIndexesWithTiberium[surfaceIdx])
+			return ReturnEarly;
+	}
 
 	// Replicate stolen instruction: mov ecx, dword ptr [esi + 0xF0]
 	R->ECX(pThis->SpreadLogic.Count);
@@ -196,9 +234,10 @@ DEFINE_HOOK(0x722586, TiberiumClass_Spread_RequeueGuard, 0x6)
 {
 	GET(TiberiumClass*, pThis, EBX);
 	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+	const int maxCells = GetMaxValidCells(maxCount);
 
 	// Compact and re-index active cells before buffer overflows
-	if (pThis->SpreadLogic.Count >= maxCount - 20)
+	if (pThis->SpreadLogic.Count >= maxCells)
 		ReindexSpread(pThis);
 
 	// Replicate stolen instruction: mov eax, dword ptr [ebx + 0xF0]
@@ -209,7 +248,7 @@ DEFINE_HOOK(0x722586, TiberiumClass_Spread_RequeueGuard, 0x6)
 
 DEFINE_HOOK(0x722574, TiberiumClass_Spread_StallFix, 0x5)
 {
-	enum { Requeue = 0x722586, ClearFlagAndFinish = 0x722645, Finish = 0x722657 };
+	enum { Requeue = 0x722586, Finish = 0x722657 };
 
 	const bool spreadSuccess = (R->AL() != 0);
 	GET(int, eligibleNeighbors, EBP);
@@ -219,40 +258,82 @@ DEFINE_HOOK(0x722574, TiberiumClass_Spread_StallFix, 0x5)
 	R->Stack<int>(0x10, loopCount);
 	R->ECX(loopCount);
 
-	// When spread fails due to temporary obstacles, re-queue the cell so expansion does not stall
-	if (!spreadSuccess)
+	// When spread succeeds, 1 neighbor was seeded. If more candidates remain, re-queue with delay
+	if (spreadSuccess && eligibleNeighbors > 1)
 		return Requeue;
 
-	// When all available neighbors have been successfully seeded, clear tracking flag and complete
-	if (eligibleNeighbors <= 1)
-		return ClearFlagAndFinish;
+	// Completed or spread failed (e.g. cell occupied by unit/structure) - do not spin
+	return Finish;
+}
 
-	// Additional unseeded neighbors remain
-	return Requeue;
+DEFINE_HOOK(0x7225AB, TiberiumClass_Spread_RequeueScore, 0x8)
+{
+	GET(DWORD, nodesBase, ECX);
+	GET(DWORD, nodeIndex, EAX);
+
+	const int delay = ScenarioClass::Instance
+		? ScenarioClass::Instance->Random.RandomRanged(1, 50)
+		: 25;
+	const float score = static_cast<float>(Unsorted::CurrentFrame + delay);
+
+	auto pScore = reinterpret_cast<float*>(nodesBase + nodeIndex * 8 + 4);
+	*pScore = score;
+
+	return 0x7225B3;
+}
+
+DEFINE_HOOK(0x72311E, TiberiumClass_GrowthAI_MaxStageSpread, 0x7)
+{
+	GET(TiberiumClass*, pThis, ESI);
+	GET(CellStruct*, pCellCoords, EBX);
+
+	if (pThis && pCellCoords)
+	{
+		const int surfaceIdx = PriorityQueueClassNode::ToSurfaceIndex(*pCellCoords);
+		const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+		const auto& logic = pThis->SpreadLogic;
+
+		if (surfaceIdx >= 0 && surfaceIdx < maxCount)
+		{
+			if (!logic.CellIndexesWithTiberium || !logic.CellIndexesWithTiberium[surfaceIdx])
+				pThis->RegisterForSpread(pCellCoords);
+		}
+
+		R->EAX(surfaceIdx);
+	}
+
+	return 0;
 }
 
 // =============================================================================
 // Ramp Tiberium Support & Division by Zero Safety
 // =============================================================================
 
-DEFINE_HOOK(0x4839B6, CellClass_CanTiberiumGerminate_RampSupport, 0xA)
+DEFINE_HOOK(0x48399C, CellClass_CanTiberiumGerminate_RampSupport, 0x6)
 {
-	enum { Disallow = 0x4839E9, ContinueChecks = 0x4839C0, AllowRamp = 0x4839E2 };
+	enum { Disallow = 0x4839E9, AllowRamp = 0x4839E2, ContinueFlat = 0x4839A2 };
 
 	GET(CellClass*, pThis, EDI);
 
 	if (pThis->SlopeIndex != 0)
 	{
+		if (pThis->OverlayTypeIndex != -1)
+			return Disallow;
+
 		TiberiumClass* pTib = nullptr;
 
 		const auto pEbx = reinterpret_cast<TiberiumClass*>(R->EBX());
 		if (TiberiumClass::Array.FindItemIndex(pEbx) != -1)
+		{
 			pTib = pEbx;
+		}
 		else
 		{
 			const auto pArg = R->Stack<TiberiumClass*>(0x0C);
 			if (TiberiumClass::Array.FindItemIndex(pArg) != -1)
+			{
 				pTib = pArg;
+			}
 			else
 			{
 				const auto pCallerTib = R->Stack<TiberiumClass*>(0x30);
@@ -267,7 +348,9 @@ DEFINE_HOOK(0x4839B6, CellClass_CanTiberiumGerminate_RampSupport, 0xA)
 		return Disallow;
 	}
 
-	return ContinueChecks;
+	R->EAX(static_cast<DWORD>(pThis->LandType));
+
+	return ContinueFlat;
 }
 
 DEFINE_HOOK(0x47D36E, CellClass_RecalcAttributes_PreserveRampTiberium, 0x18)
@@ -333,11 +416,8 @@ DEFINE_HOOK(0x483738, CellClass_CanTiberiumGrow_RampCheck, 0xA)
 	GET(CellClass*, pThis, ESI);
 	GET(TiberiumClass*, pTib, EAX);
 
-	if (pThis->SlopeIndex != 0)
-	{
-		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
-			return Disallow;
-	}
+	if (pThis->SlopeIndex != 0 && !CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+		return Disallow;
 
 	return ContinueChecks;
 }
@@ -360,6 +440,31 @@ DEFINE_HOOK(0x4837BB, CellClass_SpreadTiberium_RampSupport, 0xA)
 	return ContinueSpread;
 }
 
+DEFINE_HOOK(0x4872A0, CellClass_IncreaseTiberium_Germinate_RegisterSpread, 0x6)
+{
+	GET(CellClass*, pThis, ESI);
+	GET(TiberiumClass*, pTib, EDI);
+	const auto stage = static_cast<BYTE>(R->BL());
+
+	pThis->OverlayData = stage;
+
+	if (pThis && pTib && stage >= pTib->NumFrames - 1)
+	{
+		CellStruct mapCoords = pThis->MapCoords;
+		const int surfaceIdx = PriorityQueueClassNode::ToSurfaceIndex(mapCoords);
+		const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+		const auto& logic = pTib->SpreadLogic;
+
+		if (surfaceIdx >= 0 && surfaceIdx < maxCount)
+		{
+			if (!logic.CellIndexesWithTiberium || !logic.CellIndexesWithTiberium[surfaceIdx])
+				pTib->RegisterForSpread(&mapCoords);
+		}
+	}
+
+	return 0x4872A6;
+}
+
 DEFINE_HOOK(0x4873A7, CellClass_IncreaseTiberium_RampStageSupport, 0x11)
 {
 	enum { Disallow = 0x48761E, ContinueGrowth = 0x4873B8 };
@@ -370,11 +475,8 @@ DEFINE_HOOK(0x4873A7, CellClass_IncreaseTiberium_RampStageSupport, 0x11)
 	const auto pTib = TiberiumClass::Array.GetItemOrDefault(tibIndex);
 	R->EAX(pTib);
 
-	if (pThis->SlopeIndex != 0)
-	{
-		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
-			return Disallow;
-	}
+	if (pThis->SlopeIndex != 0 && !CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+		return Disallow;
 
 	return ContinueGrowth;
 }

--- a/src/Ext/Tiberium/Hooks.cpp
+++ b/src/Ext/Tiberium/Hooks.cpp
@@ -1,6 +1,72 @@
 #include "Body.h"
 
+#include <CellClass.h>
+#include <MapClass.h>
 #include <OverlayClass.h>
+#include <ScenarioClass.h>
+
+namespace
+{
+	// West=1, North=2, East=3, South=4. Higher indices (corners, steep ramps) lack Tiberium overlay art.
+	constexpr BYTE MaxCardinalRampIndex = 4;
+	constexpr int RequiredRampOverlays = 8;
+
+	static_assert(offsetof(TiberiumClass, SpreadLogic) == 0xF0, "TiberiumClass::SpreadLogic offset mismatch");
+	static_assert(offsetof(TiberiumClass, GrowthLogic) == 0x10C, "TiberiumClass::GrowthLogic offset mismatch");
+
+	void ReindexGrowth(TiberiumClass* pThis)
+	{
+		reinterpret_cast<void(__thiscall*)(TiberiumClass*)>(0x7233A0)(pThis);
+	}
+
+	void ReindexSpread(TiberiumClass* pThis)
+	{
+		reinterpret_cast<void(__thiscall*)(TiberiumClass*)>(0x7228B0)(pThis);
+	}
+
+	bool CanResourceGerminateOnRamp(TiberiumClass* pTib, BYTE slopeIndex)
+	{
+		if (slopeIndex == 0)
+			return true;
+
+		if (slopeIndex > MaxCardinalRampIndex)
+			return false;
+
+		if (pTib)
+		{
+			const auto pExt = TiberiumExt::TryFetch(pTib);
+			if (pExt && pExt->AllowRamps)
+			{
+				if (pTib->NumSlopes < RequiredRampOverlays)
+					pTib->NumSlopes = RequiredRampOverlays;
+
+				return true;
+			}
+
+			return false;
+		}
+
+		for (const auto pItem : TiberiumClass::Array)
+		{
+			if (const auto pExt = TiberiumExt::TryFetch(pItem))
+			{
+				if (pExt->AllowRamps)
+				{
+					if (pItem->NumSlopes < RequiredRampOverlays)
+						pItem->NumSlopes = RequiredRampOverlays;
+
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+}
+
+// =============================================================================
+// Radar / Minimap Colors
+// =============================================================================
 
 DEFINE_HOOK(0x47C210, CellClass_CellColor_TiberiumRadarColor, 0x6)
 {
@@ -40,3 +106,308 @@ DEFINE_HOOK(0x47C210, CellClass_CellColor_TiberiumRadarColor, 0x6)
 
 	return 0;
 }
+
+// =============================================================================
+// Tiberium Growth & Spread Heap Overflow / Capacity Guards
+// =============================================================================
+
+DEFINE_HOOK(0x7235CE, TiberiumClass_Queue_Growth_At_Cell_CapacityGuard, 0x5)
+{
+	enum { ReturnEarly = 0x7236C2 };
+
+	GET(TiberiumClass*, pThis, ESI);
+	const int surfaceIdx = R->Stack<int>(0x0C);
+	const auto& logic = pThis->GrowthLogic;
+	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+
+	// Prevent duplicate queue entries for cells already awaiting growth
+	if (logic.CellIndexesWithTiberium && surfaceIdx >= 0 && surfaceIdx < maxCount)
+	{
+		if (logic.CellIndexesWithTiberium[surfaceIdx])
+			return ReturnEarly;
+	}
+
+	// Replicate stolen instruction: call 0x42B1F0 (returns surface count in EAX)
+	R->EAX(maxCount);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x72302E, TiberiumClass_Grow_RequeueGuard, 0x6)
+{
+	GET(TiberiumClass*, pThis, ESI);
+	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+
+	// Compact and re-index active cells before buffer overflows
+	if (pThis->GrowthLogic.Count >= maxCount - 20)
+		ReindexGrowth(pThis);
+
+	// Replicate stolen instruction: mov eax, dword ptr [esi + 0x10C]
+	R->EAX(pThis->GrowthLogic.Count);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x722FF2, TiberiumClass_Grow_NodeSanityCheck, 0x8)
+{
+	enum { ExitLoop = 0x72324E, NextIteration = 0x72312F };
+
+	GET(PriorityQueueClassNode*, pNode, EBX);
+
+	if (!pNode)
+		return ExitLoop;
+
+	if (!MapClass::Instance.CellExists(pNode->MapCoord))
+		return NextIteration;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x722B48, TiberiumClass_Queue_Spread_At_Cell_CapacityGuard, 0x6)
+{
+	GET(TiberiumClass*, pThis, ESI);
+	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+
+	if (pThis->SpreadLogic.Count >= maxCount - 20)
+		ReindexSpread(pThis);
+
+	// Replicate stolen instruction: mov ecx, dword ptr [esi + 0xF0]
+	R->ECX(pThis->SpreadLogic.Count);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x72252E, TiberiumClass_Spread_NodeSanityCheck, 0x8)
+{
+	enum { ExitLoop = 0x72275F, NextIteration = 0x722657 };
+
+	GET(PriorityQueueClassNode*, pNode, EAX);
+
+	if (!pNode)
+		return ExitLoop;
+
+	if (!MapClass::Instance.CellExists(pNode->MapCoord))
+		return NextIteration;
+
+	return 0;
+}
+
+DEFINE_HOOK(0x722586, TiberiumClass_Spread_RequeueGuard, 0x6)
+{
+	GET(TiberiumClass*, pThis, EBX);
+	const int maxCount = PriorityQueueClassNode::SurfaceDataCount();
+
+	// Compact and re-index active cells before buffer overflows
+	if (pThis->SpreadLogic.Count >= maxCount - 20)
+		ReindexSpread(pThis);
+
+	// Replicate stolen instruction: mov eax, dword ptr [ebx + 0xF0]
+	R->EAX(pThis->SpreadLogic.Count);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x722574, TiberiumClass_Spread_StallFix, 0x5)
+{
+	enum { Requeue = 0x722586, ClearFlagAndFinish = 0x722645, Finish = 0x722657 };
+
+	const bool spreadSuccess = (R->AL() != 0);
+	GET(int, eligibleNeighbors, EBP);
+
+	// Replicate stolen instructions that increment loop counter
+	const int loopCount = R->Stack<int>(0x10) + 1;
+	R->Stack<int>(0x10, loopCount);
+	R->ECX(loopCount);
+
+	// When spread fails due to temporary obstacles, re-queue the cell so expansion does not stall
+	if (!spreadSuccess)
+		return Requeue;
+
+	// When all available neighbors have been successfully seeded, clear tracking flag and complete
+	if (eligibleNeighbors <= 1)
+		return ClearFlagAndFinish;
+
+	// Additional unseeded neighbors remain
+	return Requeue;
+}
+
+// =============================================================================
+// Ramp Tiberium Support & Division by Zero Safety
+// =============================================================================
+
+DEFINE_HOOK(0x4839B6, CellClass_CanTiberiumGerminate_RampSupport, 0xA)
+{
+	enum { Disallow = 0x4839E9, ContinueChecks = 0x4839C0, AllowRamp = 0x4839E2 };
+
+	GET(CellClass*, pThis, EDI);
+
+	if (pThis->SlopeIndex != 0)
+	{
+		TiberiumClass* pTib = nullptr;
+
+		const auto pEbx = reinterpret_cast<TiberiumClass*>(R->EBX());
+		if (TiberiumClass::Array.FindItemIndex(pEbx) != -1)
+			pTib = pEbx;
+		else
+		{
+			const auto pArg = R->Stack<TiberiumClass*>(0x0C);
+			if (TiberiumClass::Array.FindItemIndex(pArg) != -1)
+				pTib = pArg;
+			else
+			{
+				const auto pCallerTib = R->Stack<TiberiumClass*>(0x30);
+				if (TiberiumClass::Array.FindItemIndex(pCallerTib) != -1)
+					pTib = pCallerTib;
+			}
+		}
+
+		if (CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+			return AllowRamp;
+
+		return Disallow;
+	}
+
+	return ContinueChecks;
+}
+
+DEFINE_HOOK(0x47D36E, CellClass_RecalcAttributes_PreserveRampTiberium, 0x18)
+{
+	GET(CellClass*, pThis, ESI);
+	GET(OverlayTypeClass*, pOverlayType, EBP);
+
+	if (pOverlayType && pOverlayType->Tiberium)
+	{
+		const int tibType = OverlayClass::GetTiberiumType(pOverlayType->ArrayIndex);
+		const auto pTib = TiberiumClass::Array.GetItemOrDefault(tibType);
+
+		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+		{
+			pThis->OverlayTypeIndex = -1;
+			pThis->OverlayData = 0;
+		}
+	}
+
+	return 0x47D386;
+}
+
+DEFINE_HOOK(0x483650, CellClass_CanTiberiumGrow_RampSupport, 0x6)
+{
+	enum { Disallow = 0x48365A, ContinueChecks = 0x48365E };
+
+	GET(CellClass*, pThis, ESI);
+
+	if (pThis->SlopeIndex != 0)
+	{
+		const int tibType = OverlayClass::GetTiberiumType(pThis->OverlayTypeIndex);
+		const auto pTib = TiberiumClass::Array.GetItemOrDefault(tibType);
+
+		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+			return Disallow;
+	}
+
+	return ContinueChecks;
+}
+
+DEFINE_HOOK(0x4836CF, CellClass_CanTiberiumSpread_RampSupport, 0xA)
+{
+	enum { Disallow = 0x4836D9, ContinueChecks = 0x4836DE };
+
+	GET(CellClass*, pThis, ESI);
+
+	if (pThis->SlopeIndex != 0)
+	{
+		GET(int, tibIndex, EDI);
+		const auto pTib = TiberiumClass::Array.GetItemOrDefault(tibIndex);
+
+		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+			return Disallow;
+	}
+
+	return ContinueChecks;
+}
+
+DEFINE_HOOK(0x483738, CellClass_CanTiberiumGrow_RampCheck, 0xA)
+{
+	enum { Disallow = 0x48377C, ContinueChecks = 0x483742 };
+
+	GET(CellClass*, pThis, ESI);
+	GET(TiberiumClass*, pTib, EAX);
+
+	if (pThis->SlopeIndex != 0)
+	{
+		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+			return Disallow;
+	}
+
+	return ContinueChecks;
+}
+
+DEFINE_HOOK(0x4837BB, CellClass_SpreadTiberium_RampSupport, 0xA)
+{
+	enum { Disallow = 0x483800, ContinueSpread = 0x4837C5 };
+
+	GET(CellClass*, pThis, EDI);
+
+	if (pThis->SlopeIndex != 0)
+	{
+		GET(int, tibIndex, ESI);
+		const auto pTib = TiberiumClass::Array.GetItemOrDefault(tibIndex);
+
+		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+			return Disallow;
+	}
+
+	return ContinueSpread;
+}
+
+DEFINE_HOOK(0x4873A7, CellClass_IncreaseTiberium_RampStageSupport, 0x11)
+{
+	enum { Disallow = 0x48761E, ContinueGrowth = 0x4873B8 };
+
+	GET(CellClass*, pThis, ESI);
+	GET(int, tibIndex, EAX);
+
+	const auto pTib = TiberiumClass::Array.GetItemOrDefault(tibIndex);
+	R->EAX(pTib);
+
+	if (pThis->SlopeIndex != 0)
+	{
+		if (!CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+			return Disallow;
+	}
+
+	return ContinueGrowth;
+}
+
+DEFINE_HOOK(0x47F87D, CellClass_DrawOverlay_DivZeroGuard, 0x9)
+{
+	enum { DrawFlat = 0x47F8D7, DrawRamp = 0x47F888 };
+
+	const BYTE slopeIndex = static_cast<BYTE>(R->CL());
+	GET(int, tibIndex, EAX);
+
+	const auto pTib = TiberiumClass::Array.GetItemOrDefault(tibIndex);
+	R->EBX(pTib);
+	R->Stack<TiberiumClass*>(0x28, pTib);
+
+	if (slopeIndex != 0 && CanResourceGerminateOnRamp(pTib, slopeIndex))
+		return DrawRamp;
+
+	return DrawFlat;
+}
+
+DEFINE_HOOK(0x47FBE5, CellClass_GetContainingRect_DivZeroGuard, 0xA)
+{
+	enum { RectFlat = 0x47FC49, RectRamp = 0x47FBEF };
+
+	GET(CellClass*, pThis, ESI);
+	GET(TiberiumClass*, pTib, EDI);
+
+	R->CL(pThis->SlopeIndex);
+
+	if (pThis->SlopeIndex != 0 && CanResourceGerminateOnRamp(pTib, pThis->SlopeIndex))
+		return RectRamp;
+
+	return RectFlat;
+}
+

--- a/src/Phobos.cpp
+++ b/src/Phobos.cpp
@@ -12,6 +12,8 @@
 #include "Utilities/Parser.h"
 
 #include <Ext/Rules/Body.h>
+#include <TiberiumClass.h>
+#include <algorithm>
 
 #ifdef TESTING_BUILD
 bool HideWarning = false;
@@ -309,6 +311,17 @@ DEFINE_HOOK(0x67E68A, LoadGame_UnsetFlag, 0x5)
 DEFINE_HOOK(0x683E7F, ScenarioClass_Start_Optimizations, 0x7)
 {
 	Phobos::ApplyOptimizations();
+
+	for (const auto pTib : TiberiumClass::Array)
+	{
+		pTib->SpreadLogic.Timer.Start(pTib->Spread);
+		const double growthMult = (ScenarioClass::Instance && ScenarioClass::Instance->SpecialFlags.TiberiumGrows) ? 0.3 : 1.0;
+		pTib->GrowthLogic.Timer.Start(std::max(1, static_cast<int>(pTib->Growth * growthMult)));
+
+		reinterpret_cast<void(__thiscall*)(TiberiumClass*)>(0x7228B0)(pTib);
+		reinterpret_cast<void(__thiscall*)(TiberiumClass*)>(0x7233A0)(pTib);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
<!--
If the changes are solely made to the documentation, please set the target branch to the pull request named "Weekly Regular Documentation Revisions", rather than the repository's existing branches.
-->

## What kind of change is this?

<!-- Tick the row that matches your change. It tells the maintainers which of the changelog, docs and credits checks should run, and which `Skip` labels to apply for the ones that don't. -->

- [x] **New feature, vanilla bugfix or enhancement of a released feature** - changelog, docs and credits entries are needed.
- [ ] **Improvement to a new (unreleased) feature** - docs and credits entries are needed; no changelog entry (`Skip Changelog`).
- [ ] **Bugfix to a new (unreleased) feature** - credits entry is needed; no changelog or docs entries (`Skip Changelog`, `Skip Docs`).
- [ ] **Bugfix to an old (released) feature** - changelog and credits entries are needed; no docs entry (`Skip Docs`).
- [ ] **Completely minor change (e.g. a typo fix)** - no entries are needed (`Skip Changelog`, `Skip Docs`, `Skip Credits`).

## Description  (all the technical explanation of the problems & vanilla crashes is done with AI, I already made tests and the crashes when the tiberium spreaded a lot in the map is gone, finally).

This PR fixes two longstanding vanilla engine issues with Tiberium growth/spread queues, and introduces an opt-in flag to allow resources to expand onto slopes/ramps.

### 1. Long-game Heap Overflow Crash (`0x005657A5` / `0x00723005`)
- In matches with active Tiberium spread on large maps, `GrowthLogic` and `SpreadLogic` eventually overflow their preallocated `PriorityQueueClassNode` buffers (`PriorityQueueClassNode::SurfaceDataCount()`), corrupting heap headers and crashing the game.
- Added capacity safety checks and proactive queue re-indexing before buffer boundaries are breached (`0x7235CE`, `0x722B48`, `0x722586`, `0x72302E`).

### 2. Tiberium Growth / Spread Queue Stall
- When a queued cell fails to spread/grow (e.g. due to temporary blocking or invalid neighbor tiles), Westwood popped the cell from the priority queue but forgot to reset `CellIndexesWithTiberium[surfaceIdx] = false`.
- This permanently marked the cell as "already queued", preventing subsequent passes and eventually freezing resource expansion map-wide. Properly cleared at `0x722574`.

### 3. Ramp Expansion Support (`AllowRamps`)
- In vanilla, several hardcoded checks actively prevented Tiberium on slopes:
  - `CellClass::RecalcAttributes` (`0x0047D36E`) forcibly wiped `OverlayTypeIndex = -1` and `OverlayData = 0` whenever `SlopeIndex != 0`.
  - `CellClass::Can_Tiberium_Germinate` checked `IsometricTileTypeClass->AllowTiberium`, which is `false` for ramp tiles across all theater INIs.
  - Slope checks in `Can_Tiberium_Grow`, `Can_Tiberium_Spread`, `Spread_Tiberium`, and `Increase_Tiberium` rejected slope indices.
  - `Draw_Overlay` and `GetContainingRect` could divide by zero when slope overlays were rendered without initialized slope counts.
- `AllowRamps=yes` under individual Tiberium sections allows cardinal ramps (slopes 1..4) to germinate, grow through stages, and spread naturally to/from ramp cells, setting `NumSlopes = 8` and adding division-by-zero guards.

In `rulesmd.ini`:
```ini
[SOMEORE]        ; Tiberium
AllowRamps=false ; boolean
