### PR TITLE
Enter the grinder voice && Fix the voice error caused by `NoQueueUpToEnter`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -448,6 +448,7 @@ This page lists all the individual contributions to the project by their author.
   - Add a global default value for `KeepAlive`
   - Customized transport plane for teams
   - Fix the bug where *Customizable crew type per country* overrides the pre-techno settings
+  - Enter the grinder voice
 - **NetsuNegi**:
   - Forbidding parallel AI queues by type
   - Jumpjet crash speed fix when crashing onto building

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -2053,6 +2053,16 @@ In `rulesmd.ini`:
 DropCrate=    ; Powerup crate type enum (money|unit|healbase|cloak|explosion|napalm|squad|reveal|armor|speed|firepower|icbm|invulnerability|veteran|ionstorm|gas|tiberium|pod)
 ```
 
+### Enter the grinder voice
+
+- Now, you can customize the new voice that plays when entering the grinder to override the original `VoiceSpecialAttack`.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]               ; TechnoType
+VoiceEnterGrinder=         ; Sound entry
+```
+
 ### Exclusion from base center calculations
 
 - It is possible to exclude TechnoType from base center calculations (used for number of things such as certain AI scripts and AI superweapon targeting modes etc). Normally only buildings are factored in, but the initial base center does count house's starting technos which this does affect.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -446,6 +446,7 @@ HideShakeEffects=false           ; boolean
 - [Country-specific veteran buildings](Fixed-or-Improved-Logics.md#country-specific-veteran-buildings) (by Noble_Fish)
 - [Tiberium ramp expansion support](Fixed-or-Improved-Logics.md#ramp-expansion-support) (by FS-21)
 - [Customize `IdleActionFrequency`](Fixed-or-Improved-Logics.md#customize-idleactionfrequency) (by Noble_Fish)
+- Enter the grinder voice (by FlyStar)
 
 #### Vanilla fixes:
 - Fixed the bug where a building with `Factory=BuildingType` owned by the AI did not play `ProductionAnim` when placing a produced building (by Noble_Fish)
@@ -466,6 +467,7 @@ HideShakeEffects=false           ; boolean
 - Fixed the bug where `Ranged=true` causes projectiles using the new Trajectory to ignore settings such as `BounceTimes` (by Noble_Fish)
 - Fixed `DiscardOn=entry` AttachEffects not triggering `ExpireWeapon` with on-discard trigger on entry (by Starkku)
 - Fixed several shield respawn/self heal issues (by Ollerus)
+- Fixed a bug where `VoiceEnter` and `VoiceMove` were not played correctly when a unit entered a building with `NoQueueUpToEnter=yes` (by FlyStar)
 
 #### Fixes / interactions with other extensions:
 - Allowed `SW.ShowCameo` and `SW.ManualFire` to work independently of `SW.AutoFire` (by Noble_Fish)

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -2496,3 +2496,65 @@ DEFINE_FUNCTION_JUMP(VTABLE, 0x7E418C, CrewTemp::BuildingClassFake::_GetCrewCoun
 // UnitClass::UpdateRotation
 // Allow turret turn to target immediately
 DEFINE_JUMP(LJMP, 0x7369A5, 0x7369B3)
+
+DEFINE_HOOK(0x6FFD4C, TechnoClass_ClickedMission_VoiceSpecialAttack, 0x6)
+{
+	enum { SkipVoice = 0x6FFDA5, VoiceEnter = 0x6FFD11 };
+
+	GET(TechnoClass* const, pThis, ESI);
+	GET(const Mission, mission, EDI);
+	GET_STACK(ObjectClass* const, pTarget, STACK_OFFSET(0x98, 0xC));
+
+	auto const pBuilding = abstract_cast<BuildingClass*>(pTarget);
+
+	if (pBuilding && mission == Mission::Eaten)
+	{
+		auto const pBuildingType = pBuilding->Type;
+
+		if (pBuildingType->Grinding)
+		{
+			GET(TechnoTypeClass* const, pType, EAX);
+
+			auto const pTypeExt = TechnoTypeExt::Fetch(pType);
+
+			if (pTypeExt->VoiceEnterGrinder.isset())
+			{
+				const int vocIndex = pTypeExt->VoiceEnterGrinder.Get();
+
+				if (vocIndex != -1)
+					pThis->QueueVoice(vocIndex);
+
+				return SkipVoice;
+			}
+		}
+		else if (pBuildingType->Passengers > 0 ||
+			(AresHelper::CanUseAres && BuildingTypeExt::Fetch(pBuildingType)->Tunnel))
+		{
+			const auto RulesExt = RulesExt::Global();
+			const bool noQueueUpToEnter = TechnoTypeExt::Fetch(pBuildingType)->NoQueueUpToEnter.Get(
+				RulesExt->NoQueueUpToEnter_Buildings.Get(RulesExt->NoQueueUpToEnter));
+
+			if (noQueueUpToEnter)
+			{
+				bool canEnter = false;
+
+				switch (pThis->WhatAmI())
+				{
+				case AbstractType::Infantry:
+					canEnter = pBuildingType->InfantryAbsorb;
+					break;
+				case AbstractType::Unit:
+					canEnter = pBuildingType->UnitAbsorb;
+					break;
+				default:
+					break;
+				}
+
+				if (canEnter)
+					return VoiceEnter;
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -1206,6 +1206,8 @@ void TechnoTypeExt::LoadFromINIFile(CCINIClass* const pINI)
 
 	exINI.ReadSpeed(pSection, "SubterraneanSpeed", &this->SubterraneanSpeed);
 	this->SubterraneanHeight.Read(exINI, pSection, "SubterraneanHeight");
+	
+	this->VoiceEnterGrinder.Read(exINI, pSection, "VoiceEnterGrinder");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1843,6 +1845,8 @@ void TechnoTypeExt::Serialize(T& Stm)
 
 		.Process(this->SubterraneanSpeed)
 		.Process(this->SubterraneanHeight)
+
+		.Process(this->VoiceEnterGrinder)
 
 		// Ares 0.2
 		.Process(this->RadarJamRadius)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -444,6 +444,8 @@ public:
 	int SubterraneanSpeed;
 	Nullable<int> SubterraneanHeight;
 
+	NullableIdx<VocClass> VoiceEnterGrinder;
+
 	// Ares 0.2
 	Valueable<int> RadarJamRadius;
 
@@ -860,6 +862,8 @@ public:
 
 		, SubterraneanSpeed { -1 }
 		, SubterraneanHeight {}
+
+		, VoiceEnterGrinder {}
 
 		// Ares 0.2
 		, RadarJamRadius { 0 }


### PR DESCRIPTION
- Fixed a bug where `VoiceEnter` and `VoiceMove` were not played correctly when a unit entered a building with `NoQueueUpToEnter=yes`.
- 修复单位进入`NoQueueUpToEnter=yes`的建筑物时没有正常播放`VoiceEnter`和`VoiceMove`的错误。

---------

- Now, you can customize the new voice that plays when entering the grinder to override the original `VoiceSpecialAttack`.
- 现在你可以自定义单位进入部队回收站时播放的语音以覆盖原来的`VoiceSpecialAttack`。

In `rulesmd.ini`:
```ini
[SOMETECHNO]               ; TechnoType
VoiceEnterGrinder=         ; Sound entry
```
